### PR TITLE
Rework validation to improve submit of custom components

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-form",
-  "version": "3.9.0",
+  "version": "3.9.0-beta.3",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rollup": "^1.9.3",
     "rollup-plugin-typescript2": "^0.20.1",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.4.3",
+    "typescript": "3.4.3",
     "uglify-es": "^3.3.9"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export default function useForm<Data extends DataType>(
   const reRenderForm = useState({})[1];
   const validateAndStateUpdateRef = useRef<Function>();
 
-  const renderBaseOnError = (errors, error) => {
+  const renderBaseOnError = (errors, error, name) => {
     if (errors[name] && !error[name]) {
       delete errorsRef.current[name];
       reRenderForm({});
@@ -66,7 +66,7 @@ export default function useForm<Data extends DataType>(
     const errors = errorsRef.current;
 
     errorsRef.current = { ...filterUndefinedErrors(errorsRef.current), ...error };
-    renderBaseOnError(errors, error);
+    renderBaseOnError(errors, error, name);
     return error[name];
   };
 
@@ -123,7 +123,7 @@ export default function useForm<Data extends DataType>(
 
           if (shouldUpdate || shouldUpdateValidateMode || shouldUpdateWatchMode) {
             errorsRef.current = { ...filterUndefinedErrors(errors), ...error };
-            renderBaseOnError(errorsRef.current, error);
+            renderBaseOnError(errorsRef.current, error, name);
           }
         }
 

--- a/src/logic/validateField.test.ts
+++ b/src/logic/validateField.test.ts
@@ -271,6 +271,17 @@ describe('validateField', () => {
         {
           ref: { type: 'text', name: 'test', value: 'This is a long text input' },
           required: true,
+          validate: value => value.toString().length > 3,
+        },
+        {},
+      ),
+    ).toEqual({});
+
+    expect(
+      await validateField(
+        {
+          ref: { type: 'text', name: 'test', value: 'This is a long text input' },
+          required: true,
           validate: value => value.toString().length < 3,
         },
         {},

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -62,8 +62,10 @@ export default async <Data>(
       exceedMax = maxValue && valueNumber > maxValue;
       exceedMin = minValue && valueNumber < minValue;
     } else if (DATE_INPUTS.includes(type)) {
-      if (typeof maxValue === 'string') exceedMax = maxValue && new Date(value) > new Date(maxValue);
-      if (typeof minValue === 'string') exceedMin = minValue && new Date(value) < new Date(minValue);
+      if (typeof maxValue === 'string')
+        exceedMax = maxValue && new Date(value) > new Date(maxValue);
+      if (typeof minValue === 'string')
+        exceedMin = minValue && new Date(value) < new Date(minValue);
     }
 
     if (exceedMax || exceedMin) {
@@ -78,8 +80,14 @@ export default async <Data>(
   }
 
   if ((maxLength || minLength) && STRING_INPUTS.includes(type)) {
-    const { value: maxLengthValue, message: maxLengthMessage } = getValueAndMessage(maxLength);
-    const { value: minLengthValue, message: minLengthMessage } = getValueAndMessage(minLength);
+    const {
+      value: maxLengthValue,
+      message: maxLengthMessage,
+    } = getValueAndMessage(maxLength);
+    const {
+      value: minLengthValue,
+      message: minLengthMessage,
+    } = getValueAndMessage(minLength);
     const exceedMax = maxLength && value.toString().length > maxLengthValue;
     const exceedMin = minLength && value.toString().length < minLengthValue;
 
@@ -95,7 +103,9 @@ export default async <Data>(
   }
 
   if (pattern) {
-    const { value: patternValue, message: patternMessage } = getValueAndMessage(pattern);
+    const { value: patternValue, message: patternMessage } = getValueAndMessage(
+      pattern,
+    );
 
     if (patternValue instanceof RegExp && !patternValue.test(value)) {
       error[name] = {
@@ -114,20 +124,30 @@ export default async <Data>(
 
     if (typeof validate === 'function') {
       const result = await validate(fieldValue);
-      if (typeof result !== 'boolean' || !result) {
+      if (typeof result === 'string' && !!result) {
         error[name] = {
           ...error[name],
           type: 'validate',
-          message: isString(result) ? result : '',
+          message: result,
           ref: validateRef,
         };
-        return error;
+      } else if (typeof result === 'boolean' && !result) {
+        error[name] = {
+          ...error[name],
+          type: 'validate',
+          message: '',
+          ref: validateRef,
+        };
+      } else {
+        delete error[name];
       }
     } else if (typeof validate === 'object') {
       const validationResult = await new Promise(
         (resolve): ValidatePromiseResult => {
           const values = Object.entries(validate);
-          values.reduce(async (previous, [key, validate], index): Promise<ValidatePromiseResult> => {
+          values.reduce(async (previous, [key, validate], index): Promise<
+            ValidatePromiseResult
+          > => {
             const lastChild = values.length - 1 === index;
 
             if (typeof validate === 'function') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export type Validate = (data: string | number) => boolean | string | number | Date;
+export type Validate = (data: string | number) => string | boolean;
 
 export type NumberOrString = number | string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4620,7 +4620,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.4.3:
+typescript@3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
   integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==


### PR DESCRIPTION
Hi @bluebill1049 - please take a look at this if you have time (still in draft as I would like feedback).   This branch fixed some remaining issues I had with trying to make my custom component with custom validation work.    One notable change (you'll see in the unit tests) is that if a validation fails, I would like it to return an empty object, so that isEmptyObject handles it properly. 

Thoughts?