### PR TITLE
Reduce typing overhead

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,39 @@
-import { useRef, useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import attachEventListeners from './logic/attachEventListeners';
+import combineFieldValues from './logic/combineFieldValues';
+import findRemovedFieldAndRemoveListener from './logic/findRemovedFieldAndRemoveListener';
 import getFieldsValues from './logic/getFieldsValues';
 import getFieldValue from './logic/getFieldValue';
-import validateField from './logic/validateField';
-import findRemovedFieldAndRemoveListener from './logic/findRemovedFieldAndRemoveListener';
-import attachEventListeners from './logic/attachEventListeners';
-import validateWithSchema from './logic/validateWithSchema';
-import combineFieldValues from './logic/combineFieldValues';
 import shouldUpdateWithError from './logic/shouldUpdateWithError';
-import warnMissingRef from './utils/warnMissingRef';
-import modeChecker from './utils/validationModeChecker';
-import onDomRemove from './utils/onDomRemove';
-import isRadioInput from './utils/isRadioInput';
-import isEmptyObject from './utils/isEmptyObject';
-import filterUndefinedErrors from './utils/filterUndefinedErrors';
+import validateField from './logic/validateField';
+import validateWithSchema from './logic/validateWithSchema';
 import {
-  Props,
-  Field,
-  ErrorMessages,
-  Ref,
-  SubmitPromiseResult,
-  FieldsObject,
-  VoidFunction,
-  UseFormFunctions,
-  FieldValue,
-  RegisterInput,
   DataType,
-  WatchFunction,
-  SetValueFunction,
-  SetErrorFunction,
-  ValidateFunction,
+  ErrorMessages,
+  Field,
+  FieldsObject,
+  FieldValue,
+  Props,
+  Ref,
+  RegisterInput,
+  SubmitPromiseResult,
+  VoidFunction,
+  OnSubmit,
 } from './types';
+import filterUndefinedErrors from './utils/filterUndefinedErrors';
 import isCheckBoxInput from './utils/isCheckBoxInput';
+import isEmptyObject from './utils/isEmptyObject';
+import isRadioInput from './utils/isRadioInput';
+import onDomRemove from './utils/onDomRemove';
+import modeChecker from './utils/validationModeChecker';
+import warnMissingRef from './utils/warnMissingRef';
 
 export default function useForm<Data extends DataType>(
   { mode, validationSchema, defaultValues, validationFields }: Props<Data> = {
     mode: 'onSubmit',
     defaultValues: {},
   },
-): UseFormFunctions<Data> {
+) {
   const fieldsRef = useRef<FieldsObject<Data>>({});
   const errorsRef = useRef<ErrorMessages<Data>>({});
   const submitCountRef = useRef<number>(0);
@@ -50,7 +46,11 @@ export default function useForm<Data extends DataType>(
   const reRenderForm = useState({})[1];
   const validateAndStateUpdateRef = useRef<Function>();
 
-  const renderBaseOnError = (name: keyof Data, errors: ErrorMessages<Data>, error: ErrorMessages<Data>): void => {
+  const renderBaseOnError = (
+    name: keyof Data,
+    errors: ErrorMessages<Data>,
+    error: ErrorMessages<Data>,
+  ): void => {
     if (errors[name] && !error[name]) {
       delete errorsRef.current[name];
       reRenderForm({});
@@ -59,7 +59,10 @@ export default function useForm<Data extends DataType>(
     }
   };
 
-  const setValue = <Name extends keyof Data>(name: Extract<keyof Data, string>, value: Data[Name]): void => {
+  const setValue = <Name extends keyof Data>(
+    name: Extract<Name, string>,
+    value: Data[Name],
+  ): void => {
     const field = fieldsRef.current[name];
     if (!field) return;
     if (!touchedFieldsRef.current.includes(name)) {
@@ -89,7 +92,7 @@ export default function useForm<Data extends DataType>(
     forceValidation,
   }: {
     name: Extract<keyof Data, string>;
-    value?: FieldValue;
+    value?: Data[Name];
     forceValidation?: boolean;
   }): Promise<boolean> => {
     const field = fieldsRef.current[name]!;
@@ -100,7 +103,10 @@ export default function useForm<Data extends DataType>(
     if (value !== undefined) setValue(name, value);
 
     const error = await validateField(field, fieldsRef.current);
-    errorsRef.current = { ...filterUndefinedErrors(errorsRef.current), ...error };
+    errorsRef.current = {
+      ...filterUndefinedErrors(errorsRef.current),
+      ...error,
+    };
     renderBaseOnError(name, errors, error);
     return isEmptyObject(error);
   };
@@ -108,7 +114,8 @@ export default function useForm<Data extends DataType>(
   validateAndStateUpdateRef.current = validateAndStateUpdateRef.current
     ? validateAndStateUpdateRef.current
     : async ({ target: { name }, type }: Ref): Promise<void> => {
-        if (Array.isArray(validationFields) && !validationFields.includes(name)) return;
+        if (Array.isArray(validationFields) && !validationFields.includes(name))
+          return;
         const fields = fieldsRef.current;
         const errors = errorsRef.current;
         const ref = fields[name];
@@ -117,7 +124,8 @@ export default function useForm<Data extends DataType>(
         const { isOnChange, isOnBlur } = modeChecker(mode);
         const validateDisabled = isValidateDisabled();
         const isWatchAll = isWatchAllRef.current;
-        const shouldUpdateWatchMode = isWatchAll || watchFieldsRef.current[name];
+        const shouldUpdateWatchMode =
+          isWatchAll || watchFieldsRef.current[name];
         const shouldUpdateValidateMode = isOnChange || (isOnBlur && isBlurType);
         let shouldUpdateState = isWatchAll;
 
@@ -135,9 +143,11 @@ export default function useForm<Data extends DataType>(
 
         if (validationSchema) {
           const result = getFieldsValues(fields);
-          const schemaValidateErrors = (await validateWithSchema(validationSchema, result)) || {};
+          const schemaValidateErrors =
+            (await validateWithSchema(validationSchema, result)) || {};
           const error = schemaValidateErrors[name];
-          const shouldUpdate = ((!error && errors[name]) || error) && shouldUpdateValidateMode;
+          const shouldUpdate =
+            ((!error && errors[name]) || error) && shouldUpdateValidateMode;
 
           if (shouldUpdate || shouldUpdateWatchMode) {
             errorsRef.current = { ...errors, ...{ [name]: error } };
@@ -156,7 +166,11 @@ export default function useForm<Data extends DataType>(
             name,
           });
 
-          if (shouldUpdate || shouldUpdateValidateMode || shouldUpdateWatchMode) {
+          if (
+            shouldUpdate ||
+            shouldUpdateValidateMode ||
+            shouldUpdateWatchMode
+          ) {
             errorsRef.current = { ...filterUndefinedErrors(errors), ...error };
             renderBaseOnError(name, errorsRef.current, error);
           }
@@ -172,7 +186,7 @@ export default function useForm<Data extends DataType>(
   );
 
   const setError = <Name extends keyof Data>(
-    name: Extract<keyof Data, string>,
+    name: Extract<Name, string>,
     type: string,
     message?: string,
     ref?: Ref,
@@ -193,7 +207,10 @@ export default function useForm<Data extends DataType>(
     }
   };
 
-  function registerIntoFieldsRef(elementRef, data: RegisterInput | undefined): void {
+  function registerIntoFieldsRef(
+    elementRef,
+    data: RegisterInput | undefined,
+  ): void {
     if (elementRef && !elementRef.name) return warnMissingRef(elementRef);
 
     const { name, type, value } = elementRef;
@@ -217,17 +234,29 @@ export default function useForm<Data extends DataType>(
     }
 
     if (isRadio) {
-      if (!field) fields[name] = { options: [], required, validate, ref: { type: 'radio', name } };
+      if (!field)
+        fields[name] = {
+          options: [],
+          required,
+          validate,
+          ref: { type: 'radio', name },
+        };
       if (validate) fields[name]!.validate = validate;
 
       (fields[name]!.options || []).push({
         ...inputData,
-        mutationWatcher: onDomRemove(elementRef, (): Function => removeEventListener(inputData, true)),
+        mutationWatcher: onDomRemove(
+          elementRef,
+          (): Function => removeEventListener(inputData, true),
+        ),
       });
     } else {
       fields[name] = {
         ...inputData,
-        mutationWatcher: onDomRemove(elementRef, (): Function => removeEventListener(inputData, true)),
+        mutationWatcher: onDomRemove(
+          elementRef,
+          (): Function => removeEventListener(inputData, true),
+        ),
       };
     }
 
@@ -235,7 +264,9 @@ export default function useForm<Data extends DataType>(
       setValue(name, defaultValues[name]);
     }
 
-    const fieldData = isRadio ? (fields[name]!.options || [])[(fields[name]!.options || []).length - 1] : fields[name];
+    const fieldData = isRadio
+      ? (fields[name]!.options || [])[(fields[name]!.options || []).length - 1]
+      : fields[name];
 
     if (!fieldData) return;
 
@@ -266,26 +297,33 @@ export default function useForm<Data extends DataType>(
     }
 
     const values = getFieldsValues(fieldsRef.current, fieldNames);
-    const result = values === undefined || isEmptyObject(values) ? undefined : values;
+    const result =
+      values === undefined || isEmptyObject(values) ? undefined : values;
     return result === undefined ? defaultValue : result;
   }
 
-  function register(data: Ref | RegisterInput, rules?: RegisterInput): any {
-    if (!data || typeof window === 'undefined') return;
+  function register(
+    refOrValidateRule: RegisterInput | Ref,
+    validateRule?: RegisterInput,
+  ): undefined | Function {
+    if (!refOrValidateRule || typeof window === 'undefined') return;
 
-    if (rules && !data.name) {
-      warnMissingRef(data);
+    if (validateRule && !refOrValidateRule.name) {
+      warnMissingRef(refOrValidateRule);
       return;
     }
 
-    if (data.name) {
-      registerIntoFieldsRef(data, rules);
+    if (refOrValidateRule.name) {
+      registerIntoFieldsRef(refOrValidateRule, validateRule);
     }
 
-    return (ref): void => ref && registerIntoFieldsRef(ref, data);
+    return (ref: Ref): void =>
+      ref && registerIntoFieldsRef(ref, refOrValidateRule);
   }
 
-  const handleSubmit = (callback: (Object, e) => void): Function => async (e): Promise<void> => {
+  const handleSubmit = (callback: OnSubmit<Data>) => async (
+    e: React.SyntheticEvent,
+  ): Promise<void> => {
     if (e) {
       e.preventDefault();
       e.persist();
@@ -303,8 +341,14 @@ export default function useForm<Data extends DataType>(
       fieldValues = getFieldsValues(fields);
       fieldErrors = await validateWithSchema(validationSchema, fieldValues);
     } else {
-      const { errors, values }: SubmitPromiseResult<Data> = await currentFieldValues.reduce(
-        async (previous: Promise<SubmitPromiseResult<Data>>, field: Field): Promise<SubmitPromiseResult<Data>> => {
+      const {
+        errors,
+        values,
+      }: SubmitPromiseResult<Data> = await currentFieldValues.reduce(
+        async (
+          previous: Promise<SubmitPromiseResult<Data>>,
+          field: Field,
+        ): Promise<SubmitPromiseResult<Data>> => {
           const resolvedPrevious = await previous;
           const {
             ref,
@@ -316,7 +360,10 @@ export default function useForm<Data extends DataType>(
           const fieldError = await validateField(field, fields);
 
           if (fieldError[name]) {
-            resolvedPrevious.errors = { ...(resolvedPrevious.errors || {}), ...fieldError };
+            resolvedPrevious.errors = {
+              ...(resolvedPrevious.errors || {}),
+              ...fieldError,
+            };
             return Promise.resolve(resolvedPrevious);
           }
 
@@ -354,7 +401,9 @@ export default function useForm<Data extends DataType>(
         (field: Field): void => {
           const { ref, options } = field;
           isRadioInput(ref.type) && Array.isArray(options)
-            ? options.forEach((fieldRef): void => removeEventListener(fieldRef, true))
+            ? options.forEach(
+                (fieldRef): void => removeEventListener(fieldRef, true),
+              )
             : removeEventListener(field, true);
         },
       );
@@ -380,19 +429,20 @@ export default function useForm<Data extends DataType>(
     reRenderForm({});
   };
 
-  const getValues = (): { [key: string]: FieldValue } | {} => getFieldsValues(fieldsRef.current);
+  const getValues = (): { [key: string]: FieldValue } =>
+    getFieldsValues(fieldsRef.current);
 
   useEffect((): VoidFunction => unSubscribe, [mode]);
 
   return {
     register,
     handleSubmit,
-    watch: watch as WatchFunction<Data>,
+    watch,
     unSubscribe,
     reset,
-    setError: setError as SetErrorFunction<Data>,
-    setValue: setValue as SetValueFunction<Data>,
-    triggerValidation: triggerValidation as ValidateFunction<Data>,
+    setError,
+    setValue,
+    triggerValidation,
     getValues,
     errors: errorsRef.current,
     formState: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,10 +302,11 @@ export default function useForm<Data extends DataType>(
     return result === undefined ? defaultValue : result;
   }
 
+  // TODO - can this be typed toward the React.Ref type?
   function register(
     refOrValidateRule: RegisterInput | Ref,
     validateRule?: RegisterInput,
-  ): undefined | Function {
+  ): any {
     if (!refOrValidateRule || typeof window === 'undefined') return;
 
     if (validateRule && !refOrValidateRule.name) {

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -2,7 +2,7 @@ import getFieldValue from './getFieldValue';
 import isString from '../utils/isString';
 import { FieldValue, Ref } from '../types';
 
-export default function getFieldsValues(fields, filedName?: string | string[]): { [key: string]: FieldValue } | {} {
+export default function getFieldsValues(fields, fieldName?: string | string[]): { [key: string]: FieldValue } {
   return Object.values(fields).reduce((previous: {}, data: Ref): FieldValue => {
     const {
       ref,
@@ -10,12 +10,12 @@ export default function getFieldsValues(fields, filedName?: string | string[]): 
     } = data;
     const value = getFieldValue(fields, ref);
 
-    if (isString(filedName)) {
-      return name === filedName ? value : previous;
+    if (isString(fieldName)) {
+      return name === fieldName ? value : previous;
     }
 
-    if (Array.isArray(filedName)) {
-      if (filedName.includes(name)) {
+    if (Array.isArray(fieldName)) {
+      if (fieldName.includes(name)) {
         previous[name] = value;
       }
     } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface DataType {
   [key: string]: FieldValue;
 }
 
-type OnSubmit<Data extends DataType> = (data: Data, e: React.SyntheticEvent) => void;
+export type OnSubmit<Data extends DataType> = (data: Data, e: React.SyntheticEvent) => void;
 
 export interface Props<Data> {
   mode: 'onSubmit' | 'onBlur' | 'onChange';
@@ -67,48 +67,3 @@ export interface SubmitPromiseResult<Data extends DataType> {
 }
 
 export type VoidFunction = () => void;
-
-export type RegisterFunction = (refOrValidateRule: RegisterInput | Ref, validateRule?: RegisterInput) => any;
-
-export type WatchFunction<Data extends DataType> = ((name?: undefined) => DataType) &
-  (<Name extends keyof Data>(fieldName: Name, defaultValue?: Data[Name]) => Data[Name]) &
-  (<Names extends keyof Data>(fieldNames: Names[], defaultValue?: Pick<Data, Names>) => Pick<Data, Names>);
-
-export type SetValueFunction<Data extends DataType> = <Name extends keyof Data>(name: Name, value: Data[Name]) => void;
-
-export type SetErrorFunction<Data extends DataType> = <Name extends keyof Data>(
-  name: Name,
-  type: string,
-  message?: string,
-  ref?: Ref,
-) => void;
-
-export type ValidateFunction<Data extends DataType> = <Name extends keyof Data>({
-  name,
-  value,
-  forceValidation,
-}: {
-  name: Extract<keyof Data, string>;
-  value?: FieldValue;
-  forceValidation?: boolean;
-}) => Promise<boolean>;
-
-export interface UseFormFunctions<Data extends DataType> {
-  register: RegisterFunction;
-  handleSubmit: (func: OnSubmit<Data>) => any;
-  errors: ErrorMessages<Data>;
-  watch: WatchFunction<Data>;
-  unSubscribe: VoidFunction;
-  reset: VoidFunction;
-  setValue: SetValueFunction<Data>;
-  setError: SetErrorFunction<Data>;
-  getValues: () => { [key: string]: FieldValue };
-  triggerValidation: ValidateFunction<Data>;
-  formState: {
-    dirty: boolean;
-    isSubmitted: boolean;
-    isSubmitting: boolean;
-    submitCount: number;
-    touched: string[];
-  };
-}


### PR DESCRIPTION
First, apologies for the diff noise on this - majority of the diff is prettier since I added the formatonsave function for vscode so it auto-prettier's the update (hope you're using vscode! ;)) Definitely can be taken out if you like.  If you keep it in, the diffs definitely reduce over time as you keep using this flag!

The major change is related to types.ts - it's to avoid going forward the double typing you ran into with types.ts - it also makes the types in index a lot more consistent with what you want.

No functionality change here - just typing improvement.

BTW, VSCode's Organize Imports method is also a great IDE feature to remove unused imports. (used here with index.ts)

Check it out and ask any questions :)
