### PR TITLE
only update submitting references after callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -387,15 +387,14 @@ export default function useForm<Data extends DataType>(
       fieldValues = values;
     }
 
-    isSubmittedRef.current = true;
-    submitCountRef.current += 1;
-    isSubmittingRef.current = false;
-
     if (isEmptyObject(fieldErrors)) {
       await callback(combineFieldValues(fieldValues), e);
     } else {
       errorsRef.current = fieldErrors;
     }
+    isSubmittedRef.current = true;
+    submitCountRef.current += 1;
+    isSubmittingRef.current = false;
     reRenderForm({});
   };
 


### PR DESCRIPTION
if you are using an async submit handler and you do something that updates the form, it will report as already submitted. This fixes that issue by delaying when those references are updated till after the submit handler has finished (or errors have been assigned)
