### PR TITLE
Consolidate types at the top of function/interface generic

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,10 @@ export interface SubmitPromiseResult<Data extends DataType> {
 
 export type VoidFunction = () => void;
 
-export interface FormProps<Data extends DataType = DataType> {
+export interface FormProps<
+  Data extends DataType = DataType,
+  Name extends keyof Data = keyof Data
+> {
   children: JSX.Element[] | JSX.Element;
   register: (
     refOrValidateRule: RegisterInput | Ref,
@@ -95,18 +98,9 @@ export interface FormProps<Data extends DataType = DataType> {
   ) => FieldValue | Partial<Data> | void;
   unSubscribe: () => void;
   reset: () => void;
-  setError: <Name extends keyof Data>(
-    name: Name,
-    type?: string,
-    message?: string,
-    ref?: Ref,
-  ) => void;
-  setValue: <Name extends keyof Data>(
-    name: Name,
-    value: Data[Name],
-    shouldValidate?: boolean,
-  ) => void;
-  triggerValidation: <Name extends keyof Data>(
+  setError: (name: Name, type?: string, message?: string, ref?: Ref) => void;
+  setValue: (name: Name, value: Data[Name], shouldValidate?: boolean) => void;
+  triggerValidation: (
     payload:
       | {
           name: Name;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -29,7 +29,10 @@ import onDomRemove from './utils/onDomRemove';
 import modeChecker from './utils/validationModeChecker';
 import warnMissingRef from './utils/warnMissingRef';
 
-export default function useForm<Data extends DataType>(
+export default function useForm<
+  Data extends DataType,
+  Name extends keyof Data = keyof Data
+>(
   {
     mode,
     validationSchema,
@@ -83,7 +86,7 @@ export default function useForm<Data extends DataType>(
     return false;
   };
 
-  const executeValidation = async <Name extends keyof Data>(
+  const executeValidation = async (
     {
       name,
       value,
@@ -108,7 +111,7 @@ export default function useForm<Data extends DataType>(
     return isEmptyObject(error);
   };
 
-  const triggerValidation = async <Name extends keyof Data>(
+  const triggerValidation = async (
     payload:
       | {
           name: Name;
@@ -129,10 +132,7 @@ export default function useForm<Data extends DataType>(
     return executeValidation(payload);
   };
 
-  const setFieldValue = <Name extends keyof Data>(
-    name: Name,
-    value: Data[Name],
-  ): void => {
+  const setFieldValue = (name: Name, value: Data[Name]): void => {
     const field = fieldsRef.current[name];
     if (!field) return;
     const ref = field.ref;
@@ -147,7 +147,7 @@ export default function useForm<Data extends DataType>(
     }
   };
 
-  const setValue = <Name extends keyof Data>(
+  const setValue = (
     name: Name,
     value: Data[Name],
     shouldValidate: boolean = false,
@@ -240,7 +240,7 @@ export default function useForm<Data extends DataType>(
     validateAndStateUpdateRef.current,
   );
 
-  const setError = <Name extends keyof Data>(
+  const setError = (
     name: Name,
     type?: string,
     message?: string,
@@ -533,7 +533,7 @@ export default function useForm<Data extends DataType>(
     watch,
     unSubscribe,
     reset,
-    clearError: <Name extends keyof Data>(name: Name): void => {
+    clearError: (name: Name): void => {
       setError(name);
     },
     setError,


### PR DESCRIPTION
This change seems to help quite a bit (I tested on my local, but please test on your UseFormContext case).  If you defined the generic once at the top of the type, the same keyof will be propagated to all of the functional children.  This makes sense, because if you make each individual function generic, it could be overridden, which you kinda don't want...