### PR TITLE
add clearError to types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,7 @@ export interface FormProps<
   ) => FieldValue | Partial<Data> | void;
   unSubscribe: () => void;
   reset: () => void;
+  clearError: (name: Name) => void;
   setError: (name: Name, type?: string, message?: string, ref?: Ref) => void;
   setValue: (name: Name, value: Data[Name], shouldValidate?: boolean) => void;
   triggerValidation: (


### PR DESCRIPTION
Noticed `clearError` wasn't updated in types. Small update to stop typescript complaining.