### PR TITLE
Feature/support ie11

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "sourceMap": true,
     "module": "es2015",
-    "target": "es2015",
+    "target": "es5",
     "moduleResolution": "node",
     "outDir": "./dist",
     "strictNullChecks": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "sourceMap": true,
     "module": "es2015",
-    "target": "es2017",
+    "target": "es2015",
     "moduleResolution": "node",
     "outDir": "./dist",
     "strictNullChecks": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "sourceMap": true,
     "module": "es2015",
     "target": "es5",
+    "downlevelIteration": true,
     "moduleResolution": "node",
     "outDir": "./dist",
     "strictNullChecks": true,


### PR DESCRIPTION
With the following `compilerOptions` adjustments and the required polyfills everything is working fine with IE11. We didn't found any incompatibilities yet.

* Adjust the compilerOptios to add support for IE11, more details here: #56
* `"downlevelIteration": true` is needed so object spreading is transpiled correctly for ES5 (https://mariusschulz.com/blog/downlevel-iteration-for-es3-es5-in-typescript).