### PR TITLE
Fix min and max value validation when min/max is 0

### DIFF
--- a/src/logic/getValueAndMessage.test.ts
+++ b/src/logic/getValueAndMessage.test.ts
@@ -2,7 +2,9 @@ import getValueAndMessage from './getValueAndMessage';
 
 describe('getValueAndMessage', () => {
   it('should return message and value correctly', () => {
+    expect(getValueAndMessage(0).value).toEqual(0);
     expect(getValueAndMessage(3).value).toEqual(3);
+    expect(getValueAndMessage({ value: 0 }).value).toEqual(0);
     expect(getValueAndMessage({ value: 2 }).value).toEqual(2);
     expect(getValueAndMessage({ message: 'test' }).message).toEqual('test');
   });

--- a/src/logic/getValueAndMessage.ts
+++ b/src/logic/getValueAndMessage.ts
@@ -1,3 +1,4 @@
+import isNullOrUndefined from '../utils/isNullOrUndefined';
 import { DataType } from '../types';
 
 export default (
@@ -6,6 +7,9 @@ export default (
   value: number | string | RegExp;
   message: string;
 } => ({
-  value: typeof item === 'object' && item.value ? item.value : item,
+  value:
+    typeof item === 'object' && !isNullOrUndefined(item.value)
+      ? item.value
+      : item,
   message: typeof item === 'object' && item.message ? item.message : '',
 });

--- a/src/logic/validateField.test.ts
+++ b/src/logic/validateField.test.ts
@@ -121,6 +121,23 @@ describe('validateField', () => {
         {
           ref: { type: 'number', name: 'test', value: 10 },
           required: true,
+          max: 0,
+        },
+        {},
+      ),
+    ).toEqual({
+      test: {
+        type: 'max',
+        message: '',
+        ref: { type: 'number', name: 'test', value: 10 },
+      },
+    });
+
+    expect(
+      await validateField(
+        {
+          ref: { type: 'number', name: 'test', value: 10 },
+          required: true,
           max: 8,
         },
         {},
@@ -152,6 +169,23 @@ describe('validateField', () => {
   });
 
   it('should return min error', async () => {
+    expect(
+      await validateField(
+        {
+          ref: { type: 'number', name: 'test', value: -1 },
+          required: true,
+          min: 0,
+        },
+        {},
+      ),
+    ).toEqual({
+      test: {
+        type: 'min',
+        message: '',
+        ref: { type: 'number', name: 'test', value: -1 },
+      },
+    });
+
     expect(
       await validateField(
         {

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -1,4 +1,5 @@
 import getRadioValue from './getRadioValue';
+import isNullOrUndefined from '../utils/isNullOrUndefined';
 import isRadioInput from '../utils/isRadioInput';
 import getValueAndMessage from './getValueAndMessage';
 import isCheckBoxInput from '../utils/isCheckBoxInput';
@@ -56,17 +57,16 @@ export default async <Data>(
     return error;
   }
 
-  if ((min || max) && !isStringInput) {
+  if ((!isNullOrUndefined(min) || !isNullOrUndefined(max)) && !isStringInput) {
     let exceedMax;
     let exceedMin;
     const valueNumber = parseFloat(value);
     const { value: maxValue, message: maxMessage } = getValueAndMessage(max);
     const { value: minValue, message: minMessage } = getValueAndMessage(min);
-    const message = exceedMax ? maxMessage : minMessage;
 
     if (type === 'number') {
-      exceedMax = maxValue && valueNumber > maxValue;
-      exceedMin = minValue && valueNumber < minValue;
+      exceedMax = !isNullOrUndefined(maxValue) && valueNumber > maxValue;
+      exceedMin = !isNullOrUndefined(minValue) && valueNumber < minValue;
     } else if (DATE_INPUTS.includes(type)) {
       if (typeof maxValue === 'string')
         exceedMax = maxValue && new Date(value) > new Date(maxValue);
@@ -75,6 +75,7 @@ export default async <Data>(
     }
 
     if (exceedMax || exceedMin) {
+      const message = exceedMax ? maxMessage : minMessage;
       error[name] = {
         type: exceedMax ? 'max' : 'min',
         message,

--- a/src/utils/isNullOrUndefined.test.ts
+++ b/src/utils/isNullOrUndefined.test.ts
@@ -1,0 +1,17 @@
+import isNullOrUndefined from './isNullOrUndefined';
+
+describe('isNullOrUndefined', () => {
+  it('should return true when object is null or undefined', () => {
+    expect(isNullOrUndefined(null)).toBeTruthy();
+    expect(isNullOrUndefined(undefined)).toBeTruthy();
+  });
+
+  it('should return false when object is neither null nor undefined', () => {
+    expect(isNullOrUndefined(-1)).toBeFalsy();
+    expect(isNullOrUndefined(0)).toBeFalsy();
+    expect(isNullOrUndefined(1)).toBeFalsy();
+    expect(isNullOrUndefined('')).toBeFalsy();
+    expect(isNullOrUndefined({})).toBeFalsy();
+    expect(isNullOrUndefined([])).toBeFalsy();
+  });
+});

--- a/src/utils/isNullOrUndefined.ts
+++ b/src/utils/isNullOrUndefined.ts
@@ -1,0 +1,1 @@
+export default (value: any): boolean => value === null || value === undefined;


### PR DESCRIPTION
Hi, thanks for all of your effort putting together this awesome library!

This PR fixes an issue with min and max validation not working for `min: 0` or `max: 0`, due to `0` being treated as falsy and being ignored.

The same issue exists for `minLength` and `maxLength`, but a max length of 0 doesn't sound sensible and a min length of 0 should use `required: true` instead.

That said, I'm happy to add this same fix for the length validations if you think it's worthwhile?