### PR TITLE
Cleanup ts-ignore on useForm

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     '@typescript-eslint/indent': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ["error", { "varsIgnorePattern": /^_/ }],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-object-literal-type-assertion': 'off',
     'react/prop-types': 'off',

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,15 +59,15 @@ export type FieldsObject<Data extends DataType> = {
   [Key in keyof Data]?: Field;
 };
 
-export interface Error {
+export interface ReactHookFormError {
   ref: Ref;
+  type: string;
   message?: string;
-  type?: string;
   isManual?: boolean;
 }
 
 export type ObjectErrorMessages<Data extends DataType> = {
-  [Key in keyof Data]?: Error;
+  [Key in keyof Data]?: ReactHookFormError;
 };
 export type StringErrorMessages<Data extends DataType> = {
   [Key in keyof Data]?: string;

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -504,7 +504,7 @@ describe('useForm', () => {
 
     it('should remove error', () => {
       hookForm.setError('input', 'test');
-      hookForm.setError('input');
+      hookForm.clearError('input');
       expect(hookForm.errors).toEqual({});
     });
   });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -307,7 +307,6 @@ export default function useForm<
     message?: string,
     ref?: Ref,
   ): void => {
-    // since errors can be strings or objects, and we only wa
     const errorsFromRef = errorsRef.current;
     const error = errorsFromRef[name];
     const isSameError =
@@ -316,7 +315,7 @@ export default function useForm<
       (error.type === type && error.message === message);
 
     if (!isSameError) {
-      // we sorted out that it's not a string erorr, so cast it (can likely use a typeguard here)
+      // TODO: we sorted out that it's not a string error, so cast it (can likely use a typeguard here)
       const objectErrors = errorsFromRef as ObjectErrorMessages<Data>;
       objectErrors[name] = {
         type,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -304,7 +304,7 @@ export default function useForm<
   const setError = (
     name: Name,
     type: string,
-    message: string,
+    message?: string,
     ref?: Ref,
   ): void => {
     // since errors can be strings or objects, and we only wa


### PR DESCRIPTION
Did a bit of work around useForm's ts-ignore issues.  See my comments in the code. (@stramel  I realized late you were looking at this too, so sorry if I stepped on your toes)

BTW, A couple things I'm looking at to further improve, something I've done in my other hooks projects

- Get Eslint working properly in vscode for this project 
- Use the react-hooks ESLint plugin ( a big deal to help ensure safety)
- use UseCallback, useMemo etc to help ensure memoization of useForm's result functions and reduce redraws of the using components