### PR TITLE
Fixed defaultValue check

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -386,7 +386,7 @@ export default function useForm<
 
     if (defaultValues) {
       const defaultValue = defaultValues[name] || get(defaultValues, name);
-      if (defaultValue) setFieldValue(name, defaultValue);
+      if (defaultValue !== undefined) setFieldValue(name, defaultValue);
     }
 
     if (!type) return;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -386,7 +386,7 @@ export default function useForm<
 
     if (defaultValues) {
       const defaultValue = defaultValues[name] || get(defaultValues, name);
-      if (isNullOrUndefined(defaultValue)) setFieldValue(name, defaultValue);
+      if (!isNullOrUndefined(defaultValue)) setFieldValue(name, defaultValue);
     }
 
     if (!type) return;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -386,7 +386,7 @@ export default function useForm<
 
     if (defaultValues) {
       const defaultValue = defaultValues[name] || get(defaultValues, name);
-      if (defaultValue !== undefined) setFieldValue(name, defaultValue);
+      if (isNullOrUndefined(defaultValue)) setFieldValue(name, defaultValue);
     }
 
     if (!type) return;


### PR DESCRIPTION
Previously `defaultValue` was checked for truthy, but a default value of `0` would return false and not set the value in the form. changed to a `defined` check so we can handle any value, including 0.