### PR TITLE
Wrap setValue function with useCallback to provide stable identity

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,9 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
+  plugins: [
+    'react-hooks'
+  ],
   rules: {
     '@typescript-eslint/indent': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
@@ -12,6 +15,8 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-object-literal-type-assertion': 'off',
     'react/prop-types': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn'
   },
   settings: {
     react: {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "enzyme-adapter-react-16": "^1.12.1",
     "eslint": "^5.16.0",
     "eslint-plugin-react": "^7.13.0",
+    "eslint-plugin-react-hooks": "^1.6.1",
     "husky": ">=1",
     "jest": "^24.7.1",
     "lint-staged": ">=8",

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -200,18 +200,17 @@ export default function useForm<
     }
   };
 
-  const setValue = (
-    name: Name,
-    value: Data[Name],
-    shouldValidate: boolean = false,
-  ): void => {
-    setFieldValue(name, value);
-    touchedFieldsRef.current.add(name);
-    isDirtyRef.current = true;
+  const setValue = useCallback(
+    (name: Name, value: Data[Name], shouldValidate: boolean = false): void => {
+      setFieldValue(name, value);
+      touchedFieldsRef.current.add(name);
+      isDirtyRef.current = true;
 
-    reRenderForm({});
-    if (shouldValidate) triggerValidation({ name });
-  };
+      reRenderForm({});
+      if (shouldValidate) triggerValidation({ name });
+    },
+    [],
+  );
 
   validateAndStateUpdateRef.current = validateAndStateUpdateRef.current
     ? validateAndStateUpdateRef.current


### PR DESCRIPTION
Hi again Bill!

I found that calling `setValue` inside a `useEffect` hook causes an infinite loop. This occurs because `setValue` needs to appear in the `useEffect` dependency list, but the `setValue` function changes with each render, and that causes the `useEffect` to run in an endless loop. Reproduced in [this CodeSandbox](https://codesandbox.io/s/react-hook-form-basic-oq64n).

My proposed fix is to wrap `setValue` in a `useCallback` to give it a stable identity for the lifetime of the form.

All of the tests still pass with this change, but I don't know enough about React component testing to figure out how to reproduce the issue in a test sorry!

I'm still pretty new to hooks, so it's possible I'm breaking something here, but I _think_ what I'm doing is sensible?