### PR TITLE
Better type hints for .watch and .unregister of useForm instance

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -436,7 +436,7 @@ export default function useForm<
   );
 
   function watch(
-    fieldNames?: string | string[] | undefined,
+    fieldNames?: Name | string | (Name | string)[] | undefined,
     defaultValue?: string | Partial<Data> | undefined,
   ): FieldValue | Partial<Data> | void {
     if (isEmptyObject(fieldsRef.current)) {
@@ -446,7 +446,9 @@ export default function useForm<
       if (Array.isArray(fieldNames)) {
         return (
           defaultValue ||
-          fieldNames.map(fieldName => getDefaultValue(defaultValues, fieldName))
+          fieldNames.map(fieldName =>
+            getDefaultValue(defaultValues, fieldName as string),
+          )
         );
       }
       return defaultValue || defaultValues;
@@ -460,7 +462,7 @@ export default function useForm<
     }
     if (Array.isArray(fieldNames)) {
       return fieldNames.map(name =>
-        assignWatchFields(fieldValues, name, watchFields),
+        assignWatchFields(fieldValues, name as string, watchFields),
       );
     }
     return fieldValues;
@@ -485,8 +487,8 @@ export default function useForm<
     [registerIntoFieldsRef],
   );
 
-  const resetField = (name: string) => {
-    const field = fieldsRef.current[name];
+  const resetField = (name: Name | string) => {
+    const field = fieldsRef.current[name as string];
     if (!field) return;
     const { ref, options } = field;
     isRadioInput(ref.type) && Array.isArray(options)
@@ -501,7 +503,7 @@ export default function useForm<
     validFieldsRef.current.delete(name);
   };
 
-  const unregister = (name: string | string[]): void => {
+  const unregister = (name: Name | string | (Name | string)[]): void => {
     Array.isArray(name) ? name.forEach(resetField) : resetField(name);
   };
 


### PR DESCRIPTION
Fixes #159 

## Proposed Changes

  - Enhance field `name` arguments type of `.watch` and `.unregister` (in `useForm`) from `string | string[]` to `Name | string | (Name | string)[]`. This provides better auto-complete hints in IDEs for most field names (with the exception of individual array and nested field names).
