### PR TITLE
Fix triggerValidation when using schema

### DIFF
--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -1,5 +1,6 @@
 import removeAllEventListeners from './removeAllEventListeners';
 import isRadioInput from '../utils/isRadioInput';
+import isDetached from '../utils/isDetached';
 import { Field, FieldsObject, DataType } from '../types';
 
 export default function findRemovedFieldAndRemoveListener<
@@ -15,13 +16,13 @@ export default function findRemovedFieldAndRemoveListener<
   if (!ref || !ref.type) return;
 
   const { name, type } = ref;
-  const isRefDeleted = !document.body.contains(ref);
+  const isRefDetached = isDetached(ref);
   touchedFieldsRef.current.delete(name);
   fieldsWithValidationRef.current.delete(name);
 
   if (isRadioInput(type) && options) {
     options.forEach(({ ref }, index): void => {
-      if (ref instanceof HTMLElement && isRefDeleted && options[index]) {
+      if (ref instanceof HTMLElement && isRefDetached && options[index]) {
         removeAllEventListeners(options[index], validateWithStateUpdate);
         (
           options[index].mutationWatcher || { disconnect: (): void => {} }
@@ -31,7 +32,7 @@ export default function findRemovedFieldAndRemoveListener<
     });
 
     if (!options.length) delete fields[name];
-  } else if ((ref instanceof HTMLElement && isRefDeleted) || forceDelete) {
+  } else if ((ref instanceof HTMLElement && isRefDetached) || forceDelete) {
     removeAllEventListeners(ref, validateWithStateUpdate);
     if (mutationWatcher) mutationWatcher.disconnect();
     delete fields[name];

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -285,7 +285,33 @@ describe('useForm', () => {
         return payload;
       });
       await hookForm.triggerValidation({ name: 'test' });
-      expect(hookForm.errors).toEqual({ 'test': 'test' });
+      expect(hookForm.errors).toEqual({ test: 'test' });
+    });
+
+    it('should return the status of the requested field with single field validation', async () => {
+      testComponent(() => {
+        hookForm = useForm({
+          mode: VALIDATION_MODE.onChange,
+          validationSchema: {
+            test2: 'test2',
+          },
+        });
+        return hookForm;
+      });
+
+      hookForm.register({ type: 'input', name: 'test1' }, { required: false });
+      hookForm.register({ type: 'input', name: 'test2' }, { required: true });
+      // @ts-ignore
+      validateWithSchema.mockImplementation(async payload => {
+        return payload;
+      });
+      const resultTrue = await hookForm.triggerValidation({ name: 'test1' });
+      expect(resultTrue).toEqual(true);
+      const resultFalse = await hookForm.triggerValidation({ name: 'test2' });
+      expect(resultFalse).toEqual(false);
+      expect(hookForm.errors).toEqual({
+        test2: 'test2',
+      });
     });
 
     it('should not trigger any error when schema validation result not found', async () => {
@@ -329,6 +355,39 @@ describe('useForm', () => {
       expect(hookForm.errors).toEqual({
         test: 'test',
         test1: 'test1',
+      });
+    });
+
+    it('should return the status of the requested fields with array of fields for validation', async () => {
+      testComponent(() => {
+        hookForm = useForm({
+          mode: VALIDATION_MODE.onChange,
+          validationSchema: {
+            test3: 'test3',
+          },
+        });
+        return hookForm;
+      });
+
+      hookForm.register({ type: 'input', name: 'test1' }, { required: false });
+      hookForm.register({ type: 'input', name: 'test2' }, { required: false });
+      hookForm.register({ type: 'input', name: 'test3' }, { required: true });
+      // @ts-ignore
+      validateWithSchema.mockImplementation(async payload => {
+        return payload;
+      });
+      const resultTrue = await hookForm.triggerValidation([
+        { name: 'test1' },
+        { name: 'test2' },
+      ]);
+      expect(resultTrue).toEqual(true);
+      const resultFalse = await hookForm.triggerValidation([
+        { name: 'test2' },
+        { name: 'test3' },
+      ]);
+      expect(resultFalse).toEqual(false);
+      expect(hookForm.errors).toEqual({
+        test3: 'test3',
       });
     });
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -185,7 +185,7 @@ export default function useForm<
       isSchemaValidateTriggeredRef.current = true;
 
       reRenderForm({});
-      return isEmptyObject(fieldErrors);
+      return isEmptyObject(errorsRef.current);
     },
     [validationSchema],
   );
@@ -298,16 +298,21 @@ export default function useForm<
     [],
   );
 
-  const removeInputEventListener: Function = useCallback(field => {
-    if (!field) return;
-    const {
-      ref: { type },
-      options,
-    } = field;
-    isRadioInput(type) && Array.isArray(options)
-      ? options.forEach((fieldRef): void => removeEventListener(fieldRef, true))
-      : removeEventListener(field, true);
-  }, [removeEventListener]);
+  const removeInputEventListener: Function = useCallback(
+    field => {
+      if (!field) return;
+      const {
+        ref: { type },
+        options,
+      } = field;
+      isRadioInput(type) && Array.isArray(options)
+        ? options.forEach((fieldRef): void =>
+            removeEventListener(fieldRef, true),
+          )
+        : removeEventListener(field, true);
+    },
+    [removeEventListener],
+  );
 
   const clearError = (name?: Name | Name[]): void => {
     if (name === undefined) {

--- a/src/utils/isDetached.test.ts
+++ b/src/utils/isDetached.test.ts
@@ -1,0 +1,112 @@
+import isDetached from './isDetached';
+
+describe('isDetached', () => {
+  it('should return false when the node is still in the main document', () => {
+    document.body.innerHTML = ''; // Make sure the body is empty
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+
+    expect(isDetached(node)).toBeFalsy();
+  });
+
+  it('should return true when the node was never attached to the main document', () => {
+    document.body.innerHTML = ''; // Make sure the body is empty
+    const node = document.createElement('div');
+
+    expect(isDetached(node)).toBeTruthy();
+  });
+
+  it('should return true when the node is no longer in the main document', () => {
+    document.body.innerHTML = ''; // Make sure the body is empty
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+    expect(isDetached(node)).toBeFalsy();
+    document.body.removeChild(node);
+    expect(isDetached(node)).toBeTruthy();
+  });
+
+  it('should return false when the node is nested deep in the main document', () => {
+    document.body.innerHTML = ''; // Make sure the body is empty
+
+    let lastNode = document.body;
+    for (var i = 0; i < 10; ++i) {
+      const newNode = document.createElement('div');
+      lastNode.appendChild(newNode);
+      lastNode = newNode;
+    }
+
+    expect(isDetached(lastNode)).toBeFalsy();
+  });
+
+  it('should return false when the node is an attached iframe', () => {
+    document.body.innerHTML = ''; // Make sure the body is empty
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    expect(isDetached(iframe)).toBeFalsy();
+  });
+
+  it('should return true when the node is a detached iframe', () => {
+    document.body.innerHTML = ''; // Make sure the body is empty
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    expect(isDetached(iframe)).toBeFalsy();
+    document.body.removeChild(iframe);
+    expect(isDetached(iframe)).toBeTruthy();
+  });
+
+  it('should return false when the node is nested inside an iframe', () => {
+    return new Promise((resolve, reject) => {
+      document.body.innerHTML = ''; // Make sure the body is empty
+
+      const iframe = document.createElement('iframe');
+      iframe.src = 'about:blank';
+      iframe.addEventListener(
+        'load',
+        function() {
+          var node = document.createElement('div');
+          if (iframe.contentDocument) {
+            iframe.contentDocument.body.appendChild(node);
+
+            resolve(isDetached(node));
+          } else {
+            reject('Could not find iframe contentDocument');
+          }
+        },
+        false,
+      );
+
+      document.body.appendChild(iframe);
+    }).then(detached => expect(detached).toBeFalsy());
+  });
+
+  it('should return true when the node is nested inside an iframe and the iframe is detached', () => {
+    return new Promise((resolve, reject) => {
+      document.body.innerHTML = ''; // Make sure the body is empty
+
+      const iframe = document.createElement('iframe');
+      iframe.src = 'about:blank';
+      iframe.addEventListener(
+        'load',
+        function() {
+          var node = document.createElement('div');
+          if (iframe.contentDocument) {
+            iframe.contentDocument.body.appendChild(node);
+
+            expect(isDetached(node)).toBeFalsy();
+
+            // Now detach the iframe
+            document.body.removeChild(iframe);
+
+            resolve(isDetached(node));
+          } else {
+            reject('Could not find iframe contentDocument');
+          }
+        },
+        false,
+      );
+
+      document.body.appendChild(iframe);
+    }).then(detached => expect(detached).toBeTruthy());
+  });
+});

--- a/src/utils/isDetached.ts
+++ b/src/utils/isDetached.ts
@@ -1,0 +1,10 @@
+import { Ref } from '../types';
+
+export default function isDetached(element: Ref): boolean {
+  // null elements are detached (probably a null parent)
+  if (!element) return true;
+  // If we can find our way up to a document node, we assume we are still attached!
+  if (element.nodeType === Node.DOCUMENT_NODE) return false;
+
+  return isDetached(element.parentNode);
+}

--- a/src/utils/onDomRemove.ts
+++ b/src/utils/onDomRemove.ts
@@ -1,19 +1,11 @@
 import { Ref, MutationWatcher } from '../types';
+import isDetached from './isDetached';
 
-export default function onDomRemove(element: Ref, onDetachCallback: () => void): MutationWatcher {
+export default function onDomRemove(
+  element: Ref,
+  onDetachCallback: () => void,
+): MutationWatcher {
   const observer = new MutationObserver((): void => {
-    function isDetached(element: any): boolean {
-      if (!element || !element.parentNode) return true;
-
-      if (element.parentNode === window.document) {
-        return false;
-      } else if (element.parentNode === null) {
-        return true;
-      }
-
-      return isDetached(element.parentNode);
-    }
-
     if (isDetached(element)) {
       observer.disconnect();
       onDetachCallback();


### PR DESCRIPTION
The method `triggerValidation` returns a boolean indicating wether the requested fields were valid or not. However, when using a schema, it returns a boolean based on all the fields, even the ones that were not requested. As far as I can tell, it works fine when using basic validation, as this only loops over the requested fields to create a response.

I added two test cases for this and made a slight modification to `executeSchemaValidation` to correct this.