### PR TITLE
Fix triggerValidation when using schema

### DIFF
--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -285,7 +285,33 @@ describe('useForm', () => {
         return payload;
       });
       await hookForm.triggerValidation({ name: 'test' });
-      expect(hookForm.errors).toEqual({ 'test': 'test' });
+      expect(hookForm.errors).toEqual({ test: 'test' });
+    });
+
+    it('should return the status of the requested field with single field validation', async () => {
+      testComponent(() => {
+        hookForm = useForm({
+          mode: VALIDATION_MODE.onChange,
+          validationSchema: {
+            test2: 'test2',
+          },
+        });
+        return hookForm;
+      });
+
+      hookForm.register({ type: 'input', name: 'test1' }, { required: false });
+      hookForm.register({ type: 'input', name: 'test2' }, { required: true });
+      // @ts-ignore
+      validateWithSchema.mockImplementation(async payload => {
+        return payload;
+      });
+      const resultTrue = await hookForm.triggerValidation({ name: 'test1' });
+      expect(resultTrue).toEqual(true);
+      const resultFalse = await hookForm.triggerValidation({ name: 'test2' });
+      expect(resultFalse).toEqual(false);
+      expect(hookForm.errors).toEqual({
+        test2: 'test2',
+      });
     });
 
     it('should not trigger any error when schema validation result not found', async () => {
@@ -329,6 +355,39 @@ describe('useForm', () => {
       expect(hookForm.errors).toEqual({
         test: 'test',
         test1: 'test1',
+      });
+    });
+
+    it('should return the status of the requested fields with array of fields for validation', async () => {
+      testComponent(() => {
+        hookForm = useForm({
+          mode: VALIDATION_MODE.onChange,
+          validationSchema: {
+            test3: 'test3',
+          },
+        });
+        return hookForm;
+      });
+
+      hookForm.register({ type: 'input', name: 'test1' }, { required: false });
+      hookForm.register({ type: 'input', name: 'test2' }, { required: false });
+      hookForm.register({ type: 'input', name: 'test3' }, { required: true });
+      // @ts-ignore
+      validateWithSchema.mockImplementation(async payload => {
+        return payload;
+      });
+      const resultTrue = await hookForm.triggerValidation([
+        { name: 'test1' },
+        { name: 'test2' },
+      ]);
+      expect(resultTrue).toEqual(true);
+      const resultFalse = await hookForm.triggerValidation([
+        { name: 'test2' },
+        { name: 'test3' },
+      ]);
+      expect(resultFalse).toEqual(false);
+      expect(hookForm.errors).toEqual({
+        test3: 'test3',
       });
     });
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -185,7 +185,7 @@ export default function useForm<
       isSchemaValidateTriggeredRef.current = true;
 
       reRenderForm({});
-      return isEmptyObject(fieldErrors);
+      return isEmptyObject(errorsRef.current);
     },
     [validationSchema],
   );
@@ -298,16 +298,21 @@ export default function useForm<
     [],
   );
 
-  const removeInputEventListener: Function = useCallback(field => {
-    if (!field) return;
-    const {
-      ref: { type },
-      options,
-    } = field;
-    isRadioInput(type) && Array.isArray(options)
-      ? options.forEach((fieldRef): void => removeEventListener(fieldRef, true))
-      : removeEventListener(field, true);
-  }, [removeEventListener]);
+  const removeInputEventListener: Function = useCallback(
+    field => {
+      if (!field) return;
+      const {
+        ref: { type },
+        options,
+      } = field;
+      isRadioInput(type) && Array.isArray(options)
+        ? options.forEach((fieldRef): void =>
+            removeEventListener(fieldRef, true),
+          )
+        : removeEventListener(field, true);
+    },
+    [removeEventListener],
+  );
 
   const clearError = (name?: Name | Name[]): void => {
     if (name === undefined) {


### PR DESCRIPTION
The method `triggerValidation` returns a boolean indicating wether the requested fields were valid or not. However, when using a schema, it returns a boolean based on all the fields, even the ones that were not requested. As far as I can tell, it works fine when using basic validation, as this only loops over the requested fields to create a response.

I added two test cases for this and made a slight modification to `executeSchemaValidation` to correct this.