### PR TITLE
#211 merge errors into return data from handleSubmit

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,12 @@ export type NumberOrString = number | string;
 
 export type DataType = Record<string, FieldValue>;
 
+export type FieldErrors = Record<string, string>;
+
 export type OnSubmit<Data extends DataType> = (
   data: Data,
   e: React.SyntheticEvent,
-) => void;
+) => void | FieldErrors;
 
 export type Mode = keyof typeof VALIDATION_MODE;
 
@@ -84,8 +86,6 @@ export interface RadioReturn {
   isValid: boolean;
   value: NumberOrString;
 }
-
-export type FieldErrors = Record<string, string>;
 
 export interface ValidationReturn {
   fieldErrors: FieldErrors;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -18,6 +18,7 @@ import modeChecker from './utils/validationModeChecker';
 import warnMessage from './utils/warnMessage';
 import get from './utils/get';
 import isString from './utils/isString';
+import isObject from "./utils/isObject";
 import isUndefined from './utils/isUndefined';
 import omitValidFields from './logic/omitValidFields';
 import { VALIDATION_MODE } from './constants';
@@ -580,7 +581,13 @@ export default function useForm<
 
     if (isEmptyObject(fieldErrors)) {
       errorsRef.current = {};
-      await callback(combineFieldValues(fieldValues), e);
+      const errors = await callback(combineFieldValues(fieldValues), e);
+      if (errors && isObject(errors)) {
+        errorsRef.current = {
+          ...errorsRef.current,
+          ...errors,
+        }
+      }
     } else {
       errorsRef.current = fieldErrors as any;
     }


### PR DESCRIPTION
right now `handleSubmit(callback)` `callback` return doesn't take any effects as it typed as `void`.

This PR will allow return data to merge into `errors` object, hence make DX better for async data submit with `errors`