### PR TITLE
Form context types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   "prettier.eslintIntegration": true,
   "eslint.enable": true,
   "editor.formatOnSave": true,
-  "eslint.autoFixOnSave": true
+  "eslint.autoFixOnSave": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export type FieldsObject<Data extends DataType> = {
 
 export interface ReactHookFormError {
   ref: Ref;
-  type: string;
+  type?: string;
   message?: string;
   isManual?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export interface FormProps<
   Data extends DataType = DataType,
   Name extends keyof Data = keyof Data,
   Value = Data[Name]
-> extends FormContextValues<Data,Name,Value> {
+> extends FormContextValues<Data, Name, Value> {
   children: JSX.Element[] | JSX.Element;
 }
 
@@ -125,11 +125,11 @@ export interface FormContextValues<
   ) => any;
   unregister: (name: string | string[]) => void;
   handleSubmit: (
-    callback: (data: any, e: React.SyntheticEvent) => void,
+    callback: OnSubmit<Data>,
   ) => (e: React.SyntheticEvent) => Promise<void>;
   watch: (
-    fieldNames?: string | string[] | undefined,
-    defaultValue?: string | Partial<Data> | undefined,
+    fieldNames?: string | string[],
+    defaultValue?: string | Partial<Data>,
   ) => FieldValue | Partial<Data> | void;
   unSubscribe: VoidFunction;
   reset: VoidFunction;

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,7 +131,6 @@ export interface FormContextValues<
     fieldNames?: string | string[],
     defaultValue?: string | Partial<Data>,
   ) => FieldValue | Partial<Data> | void;
-  unSubscribe: VoidFunction;
   reset: VoidFunction;
   clearError: (name?: Name | Name[]) => void;
   setError: (name: Name, type?: string, message?: string, ref?: Ref) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,15 @@ export interface ValidationPayload<Name, Value> {
   value?: Value;
 }
 
+export interface FormState {
+  dirty: boolean;
+  isSubmitted: boolean;
+  submitCount: number;
+  touched: string[] | object[];
+  isSubmitting: boolean;
+  isValid: boolean;
+}
+
 export interface FormProps<
   Data extends DataType = DataType,
   Name extends keyof Data = keyof Data,
@@ -125,14 +134,7 @@ export interface FormProps<
   ) => Promise<boolean>;
   getValues: (payload?: { nest: boolean }) => DataType;
   errors: DataType;
-  formState: {
-    dirty: boolean;
-    isSubmitted: boolean;
-    submitCount: number;
-    touched: string[] | object[];
-    isSubmitting: boolean;
-    isValid: boolean;
-  };
+  formState: FormState;
 }
 
 export type FormContextValues = Omit<FormProps, 'children'>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,7 @@ export interface FormContextValues<
   triggerValidation: (
     payload: ValidationPayload<Name, Value> | ValidationPayload<Name, Value>[],
   ) => Promise<boolean>;
-  getValues: (payload?: { nest: boolean }) => DataType;
-  errors: DataType;
+  getValues: (payload?: { nest: boolean }) => Data;
+  errors: ObjectErrorMessages<Data>;
   formState: FormState<Data, Name>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export type FieldsObject<Data extends DataType> = {
 
 export interface ReactHookFormError {
   ref: Ref;
-  type?: string;
+  type: string;
   message?: string;
   isManual?: boolean;
 }
@@ -136,7 +136,7 @@ export interface FormContextValues<
   ) => FieldValue | Partial<Data> | void;
   reset: VoidFunction;
   clearError: (name?: Name | Name[]) => void;
-  setError: (name: Name, type?: string, message?: string, ref?: Ref) => void;
+  setError: (name: Name, type: string, message?: string, ref?: Ref) => void;
   setValue: (name: Name, value: Value, shouldValidate?: boolean) => void;
   triggerValidation: (
     payload: ValidationPayload<Name, Value> | ValidationPayload<Name, Value>[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export type FieldErrors = Record<string, string>;
 export interface ValidationReturn {
   fieldErrors: FieldErrors;
   result: DataType;
-};
+}
 
 export interface ValidationPayload<Name, Value> {
   name: Name;
@@ -110,8 +110,15 @@ export interface FormProps<
   Data extends DataType = DataType,
   Name extends keyof Data = keyof Data,
   Value = Data[Name]
-> {
+> extends FormContextValues<Data,Name,Value> {
   children: JSX.Element[] | JSX.Element;
+}
+
+export interface FormContextValues<
+  Data extends DataType = DataType,
+  Name extends keyof Data = keyof Data,
+  Value = Data[Name]
+> {
   register: (
     refOrValidateRule: RegisterInput | Ref,
     validateRule?: RegisterInput,
@@ -136,5 +143,3 @@ export interface FormProps<
   errors: DataType;
   formState: FormState;
 }
-
-export type FormContextValues = Omit<FormProps, 'children'>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,11 +97,14 @@ export interface ValidationPayload<Name, Value> {
   value?: Value;
 }
 
-export interface FormState {
+export interface FormState<
+  Data extends DataType = DataType,
+  Name extends keyof Data = keyof Data
+> {
   dirty: boolean;
   isSubmitted: boolean;
   submitCount: number;
-  touched: string[] | object[];
+  touched: Name[];
   isSubmitting: boolean;
   isValid: boolean;
 }
@@ -140,5 +143,5 @@ export interface FormContextValues<
   ) => Promise<boolean>;
   getValues: (payload?: { nest: boolean }) => DataType;
   errors: DataType;
-  formState: FormState;
+  formState: FormState<Data, Name>;
 }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -324,7 +324,7 @@ export default function useForm<
 
   const setError = (
     name: Name,
-    type: string,
+    type?: string,
     message?: string,
     ref?: Ref,
   ): void => {
@@ -525,7 +525,10 @@ export default function useForm<
 
     if (validationSchema) {
       fieldValues = getFieldsValues(fields);
-      const output = await validateWithSchema(validationSchema, combineFieldValues(fieldValues));
+      const output = await validateWithSchema(
+        validationSchema,
+        combineFieldValues(fieldValues),
+      );
       schemaErrorsRef.current = output.fieldErrors;
       fieldErrors = output.fieldErrors;
       fieldValues = output.result;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -324,7 +324,7 @@ export default function useForm<
 
   const setError = (
     name: Name,
-    type?: string,
+    type: string,
     message?: string,
     ref?: Ref,
   ): void => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -51,7 +51,7 @@ export default function useForm<
   const errorsRef = useRef<ErrorMessages<Data>>({});
   const schemaErrorsRef = useRef<DataType>({});
   const submitCountRef = useRef(0);
-  const touchedFieldsRef = useRef(new Set());
+  const touchedFieldsRef = useRef(new Set<Name>());
   const watchFieldsRef = useRef<Partial<Record<keyof Data, boolean>>>({});
   const isUnMount = useRef(false);
   const isWatchAllRef = useRef(false);
@@ -602,7 +602,7 @@ export default function useForm<
     isWatchAllRef.current = false;
     isSubmittedRef.current = false;
     isDirtyRef.current = false;
-    touchedFieldsRef.current = new Set();
+    touchedFieldsRef.current = new Set<Name>();
     fieldsWithValidationRef.current = new Set();
     validFieldsRef.current = new Set();
     submitCountRef.current = 0;

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,23 +1,18 @@
 import * as React from 'react';
 import { FormContextValues, FormProps, DataType } from './types';
 
-type FormContextType<T extends DataType = DataType> = FormContextValues<T>;
-
-export const FormGlobalContext = React.createContext<FormContextType | null>(
-  null,
-);
+const FormGlobalContext = React.createContext<FormContextValues<
+  DataType
+> | null>(null);
 
 export function useFormContext() {
-  const context = React.useContext(FormGlobalContext);
-  // TODO: Warn?
-  return context!;
+  return React.useContext(FormGlobalContext);
 }
 
 export function FormContext<T extends DataType>(props: FormProps<T>) {
   const { children, ...rest } = props;
   return (
-    // @ts-ignore
-    <FormGlobalContext.Provider value={rest}>
+    <FormGlobalContext.Provider value={rest as FormContextValues}>
       {children}
     </FormGlobalContext.Provider>
   );

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -10,10 +10,10 @@ export function useFormContext<T extends DataType>(): FormContextValues<T> {
   return React.useContext(FormGlobalContext);
 }
 
-export function FormContext(props: FormProps<DataType>) {
+export function FormContext<T extends DataType>(props: FormProps<T>) {
   const { children, ...rest } = props;
   return (
-    <FormGlobalContext.Provider value={rest}>
+    <FormGlobalContext.Provider value={rest as FormContextValues}>
       {children}
     </FormGlobalContext.Provider>
   );

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -6,7 +6,7 @@ const FormGlobalContext = React.createContext<FormContextValues<
 > | null>(null);
 
 export function useFormContext() {
-  return React.useContext(FormGlobalContext);
+  return React.useContext(FormGlobalContext)!;
 }
 
 export function FormContext<T extends DataType>(props: FormProps<T>) {

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -5,14 +5,15 @@ const FormGlobalContext = React.createContext<FormContextValues<
   DataType
 > | null>(null);
 
-export function useFormContext() {
-  return React.useContext(FormGlobalContext)!;
+export function useFormContext<T extends DataType>(): FormContextValues<T> {
+  // @ts-ignore
+  return React.useContext(FormGlobalContext);
 }
 
-export function FormContext<T extends DataType>(props: FormProps<T>) {
+export function FormContext(props: FormProps<DataType>) {
   const { children, ...rest } = props;
   return (
-    <FormGlobalContext.Provider value={rest as FormContextValues}>
+    <FormGlobalContext.Provider value={rest}>
       {children}
     </FormGlobalContext.Provider>
   );

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,23 +1,23 @@
 import * as React from 'react';
-import { FormContextValues, DataType } from './types';
+import { FormContextValues, FormProps, DataType } from './types';
 
-export const FormGlobalContext = React.createContext<FormContextValues>(
-  {} as FormContextValues,
+type FormContextType<T extends DataType = DataType> = FormContextValues<T>;
+
+export const FormGlobalContext = React.createContext<FormContextType | null>(
+  null,
 );
 
-export const useFormContext = () =>
-  React.useContext<FormContextValues>(FormGlobalContext);
+export function useFormContext() {
+  const context = React.useContext(FormGlobalContext);
+  // TODO: Warn?
+  return context!;
+}
 
-export function FormContext<T extends DataType>(props: T) {
+export function FormContext<T extends DataType>(props: FormProps<T>) {
   const { children, ...rest } = props;
   return (
-    <FormGlobalContext.Provider
-      value={
-        {
-          ...rest,
-        } as any
-      }
-    >
+    // @ts-ignore
+    <FormGlobalContext.Provider value={rest}>
       {children}
     </FormGlobalContext.Provider>
   );


### PR DESCRIPTION
Fixes #212 

@barrymay @bluebill1049 Can you take a look at this? I couldn't find a good way to handle generics on context. It really bugs me that I have a `@ts-ignore`.

In this, I exposed `FormState` as a type and attempted to provide generics through the context API.