### PR TITLE
Allow OnSubmit event handler to return promises

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type DataType = Record<string, FieldValue>;
 export type OnSubmit<Data extends DataType> = (
   data: Data,
   e: React.SyntheticEvent,
-) => void;
+) => Promise<void>;
 
 export type Mode = keyof typeof VALIDATION_MODE;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type DataType = Record<string, FieldValue>;
 export type OnSubmit<Data extends DataType> = (
   data: Data,
   e: React.SyntheticEvent,
-) => Promise<void>;
+) => void | Promise<void>;
 
 export type Mode = keyof typeof VALIDATION_MODE;
 


### PR DESCRIPTION
Simple change to allow async event handlers in type definitions