### PR TITLE
Clean up config rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,6 @@ export function getConfig({
   return {
     input: 'src/index.ts',
     external: ['react', 'react-dom'],
-    // export: 'named',
     plugins: [
       typescript({
         tsconfig,
@@ -36,7 +35,6 @@ export function getConfig({
         },
       }),
     ],
-
     output: output(packageJson),
   };
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,29 +1,44 @@
 import typescript from 'rollup-plugin-typescript2';
 import { terser } from 'rollup-plugin-terser';
+import packageJson from './package.json';
 
-export default {
-  input: 'src/index.ts',
-  external: ['react', 'react-dom'],
-  plugins: [
-    typescript(),
-    terser({
-      warnings: true,
-      mangle: {
-        properties: {
-          regex: /^__/,
+const outputConfig = pkg => [
+  {
+    file: `dist/${pkg.name}.js`,
+    exports: 'named',
+    format: 'cjs',
+  },
+  {
+    file: `dist/${pkg.name}.es.js`,
+    exports: 'named',
+    format: 'es',
+  },
+];
+
+export function getConfig({
+  tsconfig = './tsconfig.json',
+  output = outputConfig,
+} = {}) {
+  return {
+    input: 'src/index.ts',
+    external: ['react', 'react-dom'],
+    // export: 'named',
+    plugins: [
+      typescript({
+        tsconfig,
+      }),
+      terser({
+        warnings: true,
+        mangle: {
+          properties: {
+            regex: /^__/,
+          },
         },
-      },
-    }),
-  ],
+      }),
+    ],
 
-  output: [
-    {
-      file: 'dist/react-hook-form.js',
-      format: 'cjs',
-    },
-    {
-      file: 'dist/react-hook-form.es.js',
-      format: 'esm',
-    },
-  ],
-};
+    output: output(packageJson),
+  };
+}
+
+export default getConfig();

--- a/rollup.ie11.config.js
+++ b/rollup.ie11.config.js
@@ -1,27 +1,12 @@
-import typescript from 'rollup-plugin-typescript2';
-import { terser } from 'rollup-plugin-terser';
+import { getConfig } from './rollup.config';
 
-export default {
-  input: 'src/index.ts',
-  external: ['react', 'react-dom'],
-  plugins: [
-    typescript({
-      tsconfig: 'tsconfig.ie11.json',
-    }),
-    terser({
-      warnings: true,
-      mangle: {
-        properties: {
-          regex: /^__/,
-        },
-      },
-    }),
-  ],
-
-  output: [
+export default getConfig({
+  tsconfig: './tsconfig.ie11.json',
+  output: pkg => [
     {
-      file: 'dist/react-hook-form.ie11.js',
+      file: `dist/${pkg.name}.ie11.js`,
+      exports: 'named',
       format: 'cjs',
     },
   ],
-};
+});


### PR DESCRIPTION
Keep a single copy of the config and utilize the package name for the files.