### PR TITLE
Change parameter naming

### DIFF
--- a/src/logic/validateWithSchema.ts
+++ b/src/logic/validateWithSchema.ts
@@ -17,12 +17,12 @@ export function parseErrorSchema(error: FieldValues): FieldErrors {
 
 export default async function validateWithSchema(
   validationSchema: any,
-  validateWithSchema: SchemaValidateOptions,
+  validationSchemaOption: SchemaValidateOptions,
   data: FieldValues,
 ): Promise<ValidationReturn> {
   try {
     return {
-      result: await validationSchema.validate(data, validateWithSchema),
+      result: await validationSchema.validate(data, validationSchemaOption),
       fieldErrors: {},
     };
   } catch (e) {


### PR DESCRIPTION
To avoid conflicting parameter name with function name and for consistency, since you use `validationSchemaOption` in the `useForm`.