### PR TITLE
Allow undefined result from validate function

### DIFF
--- a/src/logic/validateField.test.ts
+++ b/src/logic/validateField.test.ts
@@ -593,6 +593,26 @@ describe('validateField', () => {
     });
   });
 
+  it('if undefined returned from validate, no error is reported', async () => {
+    expect(
+      await validateField(
+        {
+          ref: {
+            type: 'text',
+            name: 'test',
+            value: 'This is a long text input',
+          },
+          validate: () => undefined,
+        },
+        {
+          test: {
+            ref: {},
+          },
+        },
+      ),
+    ).toEqual({});
+  });
+
   it('should call setCustomValidity with empty string when native validation is on', async () => {
     const setCustomValidity = jest.fn();
     expect(

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,10 @@ export type FieldValue = any;
 
 export type FieldValues = Record<string, FieldValue>;
 
-export type Validate = (data: FieldValue) => string | boolean;
+/** Validation errors are triggered by returning a non-empty string or boolean true
+ *  - An undefined result signals a passed validation.
+ **/
+export type Validate = (data: FieldValue) => string | boolean | undefined;
 
 export type OnSubmit<Data extends FieldValues> = (
   data: Data,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type FieldValues = Record<string, FieldValue>;
 /** Validation errors are triggered by returning a non-empty string or boolean true
  *  - An undefined result signals a passed validation.
  **/
-export type Validate = (data: FieldValue) => string | boolean | undefined;
+export type Validate = (data: FieldValue) => string | boolean | void;
 
 export type OnSubmit<Data extends FieldValues> = (
   data: Data,


### PR DESCRIPTION
@bluebill1049 @stramel feel free to cancel this one if you don't feel it's ok, but the recent release caused a problem for me, as my old validation function return an undefined (for no error).  

I suggest allowing the undefined case for a fallout scenario for validation, like this

```
                validate: (name: string) => {
                  if (existingNames.includes(name)) {
                    return `name '${name}' is already in use`;
                  }
                },
```