### PR TITLE
Add package description for better npm tooling display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "react-hook-form",
+  "description": "Performant, flexible and extensible forms library for React Hooks",
   "version": "3.23.0",
   "main": "dist/react-hook-form.js",
   "module": "dist/react-hook-form.es.js",


### PR DESCRIPTION
Create this PR because when looking at react-hook-form via the npm extension in VSCode, it gives a poor tooltip response that is likely fixed via a proper package.json description