### PR TITLE
[WIP] Trying different context approach

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { default } from './useForm';
-export { FormContext, useFormContext } from './useFormContext';
+export { FormContext } from './useFormContext';

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -38,8 +38,9 @@ import {
   ValidationPayload,
   ElementLike,
 } from './types';
+import { useFormContext } from './useFormContext';
 
-export default function useForm<
+export default function useCreateForm<
   FormValues extends FieldValues,
   FieldName extends keyof FormValues = keyof FormValues
 >({
@@ -783,4 +784,13 @@ export default function useForm<
           }),
     },
   };
+}
+
+export function useForm<FormValues extends FieldValues>(
+  options: Options<FormValues>,
+) {
+  const formContext = useFormContext();
+  const form = useCreateForm<FormValues>(options);
+
+  return formContext || form;
 }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -40,7 +40,7 @@ import {
 } from './types';
 import { useFormContext } from './useFormContext';
 
-export default function useCreateForm<
+export function useCreateForm<
   FormValues extends FieldValues,
   FieldName extends keyof FormValues = keyof FormValues
 >({
@@ -786,7 +786,7 @@ export default function useCreateForm<
   };
 }
 
-export function useForm<FormValues extends FieldValues>(
+export default function useForm<FormValues extends FieldValues>(
   options: Options<FormValues>,
 ) {
   const formContext = useFormContext();

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -787,7 +787,7 @@ export function useCreateForm<
 }
 
 export default function useForm<FormValues extends FieldValues>(
-  options: Options<FormValues>,
+  options?: Options<FormValues>,
 ) {
   const formContext = useFormContext();
   const form = useCreateForm<FormValues>(options);

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FieldValues, Options } from './types';
 import { FormContextValues } from './contextTypes';
-import useCreateForm from './useForm';
+import { useCreateForm } from './useForm';
 
 const FormGlobalContext = React.createContext<FormContextValues<
   FieldValues

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { FieldValues } from './types';
-import { FormContextValues, FormProps } from './contextTypes';
+import { FieldValues, Options } from './types';
+import { FormContextValues } from './contextTypes';
+import useCreateForm from './useForm';
 
 const FormGlobalContext = React.createContext<FormContextValues<
   FieldValues
@@ -10,11 +11,13 @@ export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
   return React.useContext(FormGlobalContext as any);
 }
 
-export function FormContext<T extends FieldValues>(props: FormProps<T>) {
-  const { children, ...rest } = props;
-
+export function FormContext<FormValues extends FieldValues>({
+  children,
+  ...options
+}: { children: React.ReactNode } & Options<FormValues>) {
+  const form = useCreateForm(options);
   return (
-    <FormGlobalContext.Provider value={rest as FormContextValues}>
+    <FormGlobalContext.Provider value={form as FormContextValues}>
       {children}
     </FormGlobalContext.Provider>
   );


### PR DESCRIPTION
**Do not merge**

Ideally, this would result in a more minimal API change when using the `FormContext`.

**Before:**
```jsx
import React from "react"
import useForm, { FormContext, useFormContext } from "react-hook-form"

function YourForm() {
  const methods = useForm()
  const onSubmit = data => { console.log(data) }

  return (
    <FormContext {...methods} > // pass all methods into the context
      <form onSubmit={methods.handleSubmit(onSubmit)}>
        <NestedInput />
        <input type="submit" />
      </form>
    </FormContext>
  )
}

function NestedInput() {
  const { register } = useFormContext() // retrieve all hook methods
  return <input name="test" ref={register} />
}
```

**After:**
```jsx
import React from "react"
import useForm, { FormContext } from "react-hook-form"

function YourForm() {
  const { handleSubmit } = useForm()  // retrieve all hook methods
  const onSubmit = data => { console.log(data) }

  return (
    <form onSubmit={handleSubmit(onSubmit)}>
      <NestedInput />
      <input type="submit" />
    </form>
  )
}

function NestedInput() {
  const { register } = useForm() // retrieve all hook methods
  return <input name="test" ref={register} />
}

function MyPage() {
	return (
		<FormContext mode="onSubmit" defaultValues={{ test: 'foobar' }} >
			<YourForm />
		</FormContext>
	)
}
```

This means the change necessary to start using the `FormContext` is to add the options to the `FormContext` instead of the `useForm` and wrap your form with the `FormContext`. This drops the need for `useFormContext` hook.

Looking for input.



