### PR TITLE
support multiple error messages

### DIFF
--- a/src/logic/getValidateFunctionErrorObject.ts
+++ b/src/logic/getValidateFunctionErrorObject.ts
@@ -1,10 +1,10 @@
 import isString from '../utils/isString';
 import isArray from '../utils/isArray';
 import isBoolean from '../utils/isBoolean';
-import { FieldError, Ref } from '../types';
+import { FieldError, ValidateResult, Ref } from '../types';
 
 export default function getValidateFunctionErrorObject(
-  result: string | boolean | string[] | void,
+  result: ValidateResult,
   ref: Ref,
   nativeError: Function,
   type = 'validate',

--- a/src/logic/getValidateFunctionErrorObject.ts
+++ b/src/logic/getValidateFunctionErrorObject.ts
@@ -1,0 +1,28 @@
+import isString from '../utils/isString';
+import isArray from '../utils/isArray';
+import isBoolean from '../utils/isBoolean';
+import { FieldError, Ref } from '../types';
+
+export default function getValidateFunctionErrorObject(
+  result: string | boolean | string[] | void,
+  ref: Ref,
+  nativeError: Function,
+  type = 'validate',
+): FieldError | undefined {
+  const isStringValue = isString(result);
+  const isArrayValue = isArray(result);
+
+  if (isArrayValue || isStringValue || (isBoolean(result) && !result)) {
+    const message = isStringValue ? result : '';
+    const error = {
+      type,
+      message,
+      ref,
+      ...(isArrayValue ? { messages: result } : {}),
+    };
+    nativeError(message);
+    return error as FieldError;
+  }
+
+  return;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,9 @@ type ValidationOptionObject<Value> = Value | { value: Value; message: string };
 
 export type ValidationTypes = number | string | RegExp;
 
-export type Validate = (data: FieldValue) => string | boolean | string[] | void;
+export type ValidateResult = string | boolean | string[] | void;
+
+export type Validate = (data: FieldValue) => ValidateResult;
 
 export type ValidationOptions = Partial<{
   required: boolean | string;
@@ -70,13 +72,15 @@ export type ValidationOptions = Partial<{
     | { value: Validate | Record<string, Validate>; message: string };
 }>;
 
-export type ValidatePromiseResult =
-  | {}
-  | void
-  | {
-      type: string;
-      message: string | number | boolean | Date;
-    };
+export interface FieldError {
+  ref: Ref;
+  type: string;
+  message?: string;
+  messages?: string[];
+  isManual?: boolean;
+}
+
+export type ValidatePromiseResult = {} | void | FieldError;
 
 export interface Field extends ValidationOptions {
   ref: Ref;
@@ -91,14 +95,6 @@ export interface Field extends ValidationOptions {
 export type FieldsRefs<Data extends FieldValues> = Partial<
   Record<keyof Data, Field>
 >;
-
-export interface FieldError {
-  ref: Ref;
-  type: string;
-  message?: string;
-  messages?: string[];
-  isManual?: boolean;
-}
 
 export type FieldErrors<Data extends FieldValues> = Partial<
   Record<keyof Data, FieldError>

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ type ValidationOptionObject<Value> = Value | { value: Value; message: string };
 
 export type ValidationTypes = number | string | RegExp;
 
-export type Validate = (data: FieldValue) => string | boolean | void;
+export type Validate = (data: FieldValue) => string | boolean | string[] | void;
 
 export type ValidationOptions = Partial<{
   required: boolean | string;
@@ -96,6 +96,7 @@ export interface FieldError {
   ref: Ref;
   type: string;
   message?: string;
+  messages?: string[];
   isManual?: boolean;
 }
 


### PR DESCRIPTION
- allow `validate` function to return multiple error messages

```
validate: (text) => text !== 'test' && ['message1', 'message2']
```