### PR TITLE
More verbose warning when name attribute is missing on referenced element

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -466,7 +466,8 @@ export default function useForm<
     ref: Element,
     validateOptions: ValidationOptions = {},
   ): void {
-    if (!ref.name) return console.warn('Miss ref', ref);
+    if (!ref.name)
+      return console.warn('Missing name attrribute on ref element', ref);
 
     const { name, type, value } = ref;
     const fieldAttributes = {


### PR DESCRIPTION
Found "Miss ref" not clear while debugging this.