### PR TITLE
Remove Instance HTMLElement Value

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -111,8 +111,7 @@ export default function useForm<
     const ref = field.ref;
     const { type } = ref;
     const options = field.options;
-    const value =
-      ref instanceof HTMLElement && isNullOrUndefined(rawValue) ? '' : rawValue;
+    const value = ref && isNullOrUndefined(rawValue) ? '' : rawValue;
 
     if (isRadioInput(type) && options) {
       options.forEach(


### PR DESCRIPTION
I found this error when using this amazing library on React Native
<img width="390" alt="Image HTMLElement Error" src="https://user-images.githubusercontent.com/25479773/65888594-2cdf7980-e376-11e9-8561-397ba40bf28a.png">

And I realized that on line 115 the UseForm try to like cast the ref forcing to be a HTML Element, and when I have a TextInput this is a React Native Element

When I start typing in the input this error appears when the UseForm try to change the value

So i remove the instanceof HTMLElement and this library back to work on React Native

And I also run the tests and they are running normal

Cheers