### PR TITLE
Allow react-native projects that use a document polyfill to use library

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -111,9 +111,11 @@ export default function useForm<
     const ref = field.ref;
     const { type } = ref;
     const options = field.options;
-    const value =
+    const value = 
       typeof document !== UNDEFINED &&
-      ref instanceof HTMLElement &&
+      typeof window !== UNDEFINED && 
+      window.HTMLElement !== undefined &&
+      ref instanceof window.HTMLElement &&
       isNullOrUndefined(rawValue)
         ? ''
         : rawValue;


### PR DESCRIPTION
Fixed up the check on value to allow projects that use a document polyfill to use the library by checking for `window` and referencing `HTMLElement` from there; tested working on react-native.