### PR TITLE
Fixing key

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {
   FieldValues,
+  FieldName,
+  FieldValue,
   ElementLike,
   FormState,
   FieldErrors,
@@ -8,21 +10,15 @@ import {
   Ref,
   ValidationOptions,
   ValidationPayload,
-  DefaultFieldValues,
 } from './types';
 
-export interface FormProps<
-  FormValues extends FieldValues = DefaultFieldValues,
-  FieldName extends keyof FormValues = keyof FormValues,
-  FieldValue = FormValues[FieldName]
-> extends FormContextValues<FormValues, FieldName, FieldValue> {
+export interface FormProps<FormValues extends FieldValues = FieldValues>
+  extends FormContextValues<FormValues> {
   children: JSX.Element[] | JSX.Element;
 }
 
 export interface FormContextValues<
-  FormValues extends FieldValues = DefaultFieldValues,
-  FieldName extends keyof FormValues = keyof FormValues,
-  FieldValue = FormValues[FieldName]
+  FormValues extends FieldValues = FieldValues
 > {
   register<Element extends ElementLike = ElementLike>(
     validateRule: ValidationOptions,
@@ -31,38 +27,41 @@ export interface FormContextValues<
     ref: Element | null,
     validationOptions?: ValidationOptions,
   ): void;
-  unregister(name: FieldName | string): void;
-  unregister(names: (FieldName | string)[]): void;
+  unregister(name: FieldName<FormValues>): void;
+  unregister(names: (FieldName<FormValues>)[]): void;
   handleSubmit: (
     callback: OnSubmit<FormValues>,
   ) => (e: React.SyntheticEvent) => Promise<void>;
   watch(): FormValues;
-  watch(field: FieldName | string, defaultValue?: string): FieldValue;
   watch(
-    fields: (FieldName | string)[],
+    field: FieldName<FormValues>,
+    defaultValue?: string,
+  ): FieldValue<FormValues>;
+  watch(
+    fields: FieldName<FormValues>[],
     defaultValues?: Partial<FormValues>,
   ): Partial<FormValues>;
   reset: (values?: FieldValues) => void;
   clearError(): void;
-  clearError(name: FieldName): void;
-  clearError(names: FieldName[]): void;
+  clearError(name: FieldName<FormValues>): void;
+  clearError(names: FieldName<FormValues>[]): void;
   setError: (
-    name: FieldName,
+    name: FieldName<FormValues>,
     type: string,
     message?: string,
     ref?: Ref,
   ) => void;
   setValue: (
-    name: FieldName,
-    value: FieldValue,
+    name: FieldName<FormValues>,
+    value: FieldValue<FormValues>,
     shouldValidate?: boolean,
   ) => void;
   triggerValidation: (
     payload:
-      | ValidationPayload<FieldName, FieldValue>
-      | ValidationPayload<FieldName, FieldValue>[],
+      | ValidationPayload<FieldName<FormValues>, FieldValue<FormValues>>
+      | ValidationPayload<FieldName<FormValues>, FieldValue<FormValues>>[],
   ) => Promise<boolean>;
   getValues: (payload?: { nest: boolean }) => FormValues;
   errors: FieldErrors<FormValues>;
-  formState: FormState<FormValues, FieldName>;
+  formState: FormState<FormValues>;
 }

--- a/src/logic/assignWatchFields.ts
+++ b/src/logic/assignWatchFields.ts
@@ -5,29 +5,29 @@ import isEmptyObject from '../utils/isEmptyObject';
 import isUndefined from '../utils/isUndefined';
 import isArray from '../utils/isArray';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
-import { FieldValue } from '../types';
+import { FieldValue, FieldValues, FieldName } from '../types';
 
-export default <FieldName, FormValues>(
+export default <FormValues extends FieldValues>(
   fieldValues: FormValues,
-  fieldName: FieldName | string | (FieldName | string)[],
-  watchFields: Partial<Record<keyof FormValues, boolean>>,
-): FieldValue | Partial<FormValues> => {
+  fieldName: FieldName<FormValues>,
+  watchFields: Partial<Record<FieldName<FormValues>, boolean>>,
+): FieldValue<FormValues> | Partial<FormValues> | undefined => {
   if (isNullOrUndefined(fieldValues) || isEmptyObject(fieldValues))
     return undefined;
 
-  if (!isUndefined(fieldValues[fieldName as keyof FormValues])) {
-    watchFields[fieldName as keyof FormValues] = true;
-    return fieldValues[fieldName as keyof FormValues];
+  if (!isUndefined(fieldValues[fieldName])) {
+    watchFields[fieldName] = true;
+    return fieldValues[fieldName];
   }
 
-  const values = get(combineFieldValues(fieldValues), fieldName as string);
+  const values = get(combineFieldValues(fieldValues), fieldName);
 
   if (!isUndefined(values)) {
-    const result = getPath<FieldName>(fieldName as string, values);
+    const result = getPath<FormValues>(fieldName, values);
 
     if (isArray(result)) {
       result.forEach(name => {
-        watchFields[name as keyof FormValues] = true;
+        watchFields[name] = true;
       });
     }
   }

--- a/src/logic/getDefaultValue.ts
+++ b/src/logic/getDefaultValue.ts
@@ -1,15 +1,12 @@
 import get from '../utils/get';
 import isUndefined from '../utils/isUndefined';
-import { FieldValue } from '../types';
+import { FieldValues, BaseFieldValue, FieldValue, FieldName } from '../types';
 
-export default <
-  Data extends FieldValue,
-  FieldName extends keyof Data = keyof Data
->(
-  defaultValues: Partial<Data>,
-  name: FieldName,
-  defaultValue?: FieldValue,
-): Data[FieldName] | undefined =>
+export default <FormValues extends FieldValues>(
+  defaultValues: Partial<FormValues>,
+  name: FieldName<FormValues>,
+  defaultValue?: BaseFieldValue,
+): FieldValue<FormValues> | undefined =>
   isUndefined(defaultValues[name])
     ? get(defaultValues, name as string, defaultValue)
     : defaultValues[name];

--- a/src/logic/getFieldValues.ts
+++ b/src/logic/getFieldValues.ts
@@ -1,11 +1,11 @@
 import getFieldValue from './getFieldValue';
 import { FieldValues, Ref } from '../types';
 
-export default (fields: FieldValues) =>
-  Object.values(fields).reduce(
-    (previous: FieldValues, { ref, ref: { name } }: Ref) => ({
+export default <FormValues extends FieldValues>(fields: FieldValues) =>
+  Object.values(fields).reduce<FormValues>(
+    (previous, { ref, ref: { name } }: Ref) => ({
       ...previous,
       ...{ [name]: getFieldValue(fields, ref) },
     }),
-    {},
+    {} as FormValues,
   );

--- a/src/logic/omitValidFields.ts
+++ b/src/logic/omitValidFields.ts
@@ -1,8 +1,8 @@
-import { FieldErrors } from '../types';
+import { FieldErrors, FieldName, FieldValues } from '../types';
 
-export default <Data, FieldName>(
-  errorFields: FieldErrors<Data>,
-  validFieldNames: FieldName[],
+export default <FormValues extends FieldValues>(
+  errorFields: FieldErrors<FormValues>,
+  validFieldNames: FieldName<FormValues>[],
 ) =>
   Object.entries(errorFields).reduce(
     (previous, [name, error]) =>

--- a/src/logic/pickErrors.ts
+++ b/src/logic/pickErrors.ts
@@ -1,13 +1,13 @@
-import { FieldErrors } from '../types';
+import { FieldErrors, FieldValues, FieldName } from '../types';
 
-export default <FormValues>(
+export default <FormValues extends FieldValues>(
   errors: FieldErrors<FormValues>,
-  pickList: (keyof FormValues)[],
+  pickList: FieldName<FormValues>[],
 ): FieldErrors<FormValues> =>
   Object.entries(errors).reduce(
     (previous, [key, error]) => ({
       ...previous,
-      ...(pickList.includes(key as keyof FormValues) ? { [key]: error } : null),
+      ...(pickList.includes(key) ? { [key]: error } : null),
     }),
     {},
   );

--- a/src/logic/shouldUpdateWithError.ts
+++ b/src/logic/shouldUpdateWithError.ts
@@ -1,8 +1,9 @@
 import isEmptyObject from '../utils/isEmptyObject';
 import isSameError from '../utils/isSameError';
+import { FieldValues, FieldName } from '../types';
 
-// Todo: improve the types in this file
-export default function shouldUpdateWithError<FieldName>({
+// TODO: improve the types in this file
+export default function shouldUpdateWithError<FormValues extends FieldValues>({
   errors,
   name,
   error,
@@ -11,9 +12,9 @@ export default function shouldUpdateWithError<FieldName>({
 }: {
   errors: any;
   error: any;
-  name: FieldName;
-  validFields: Set<FieldName>;
-  fieldsWithValidation: Set<FieldName>;
+  name: FieldName<FormValues>;
+  validFields: Set<FieldName<FormValues>>;
+  fieldsWithValidation: Set<FieldName<FormValues>>;
 }): boolean {
   if (
     (validFields.has(name) && isEmptyObject(error)) ||

--- a/src/logic/validateWithSchema.ts
+++ b/src/logic/validateWithSchema.ts
@@ -6,6 +6,7 @@ import {
   FieldErrors,
 } from '../types';
 
+// TODO: Fix these types
 export const parseErrorSchema = <FormValues>(
   error: FieldValues,
 ): FieldErrors<FormValues> =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,27 @@
 import * as React from 'react';
 import * as ReactNative from 'react-native';
 
-export type DefaultFieldValues = Record<string, unknown>;
+export type BaseFieldValue = any;
+export type FieldValues = Record<string, BaseFieldValue>;
 
-export type FieldValue = any;
+export type RawFieldName<FormValues extends FieldValues> = Extract<
+  keyof FormValues,
+  string
+>;
+export type FieldName<FormValues extends FieldValues> =
+  | RawFieldName<FormValues>
+  | string;
 
-export type FieldValues = Record<string, FieldValue>;
+export type FieldValue<FormValues extends FieldValues> = FormValues[FieldName<
+  FormValues
+>];
 
 export type Ref = any;
 
 type Mode = keyof ValidationMode;
 
-export type OnSubmit<Data extends FieldValues> = (
-  data: Data,
+export type OnSubmit<FormValues extends FieldValues> = (
+  data: FormValues,
   e: React.SyntheticEvent | ReactNative.GestureResponderEvent,
 ) => void | Promise<void>;
 
@@ -34,14 +43,11 @@ export interface Schema<Data> {
   validate(value: FieldValues, options?: SchemaValidateOptions): Promise<Data>;
 }
 
-export type Options<
-  FormValues extends FieldValues = DefaultFieldValues,
-  FieldName extends keyof FormValues = keyof FormValues
-> = Partial<{
+export type Options<FormValues extends FieldValues = FieldValues> = Partial<{
   mode: Mode;
   defaultValues: Partial<FormValues>;
   validationSchemaOption: SchemaValidateOptions;
-  validationFields: FieldName[];
+  validationFields: FieldName<FormValues>[];
   validationSchema: any;
   nativeValidation: boolean;
   submitFocusError: boolean;
@@ -58,7 +64,7 @@ export type ValidationTypes = number | string | RegExp;
 
 export type ValidateResult = string | boolean | void;
 
-export type Validate = (data: FieldValue) => ValidateResult;
+export type Validate = (data: BaseFieldValue) => ValidateResult;
 
 export type ValidationOptions = Partial<{
   required: boolean | string;
@@ -93,11 +99,11 @@ export interface Field extends ValidationOptions {
 }
 
 export type FieldsRefs<Data extends FieldValues> = Partial<
-  Record<keyof Data, Field>
+  Record<FieldName<Data>, Field>
 >;
 
 export type FieldErrors<Data extends FieldValues> = Partial<
-  Record<keyof Data, FieldError>
+  Record<FieldName<Data>, FieldError>
 >;
 
 export interface SubmitPromiseResult<Data extends FieldValues> {
@@ -115,14 +121,11 @@ export interface ValidationPayload<Name, Value> {
   value?: Value;
 }
 
-export interface FormState<
-  FormValues extends FieldValues = FieldValues,
-  FieldName extends keyof FormValues = keyof FormValues
-> {
+export interface FormState<FormValues extends FieldValues = FieldValues> {
   dirty: boolean;
   isSubmitted: boolean;
   submitCount: number;
-  touched: FieldName[];
+  touched: FieldName<FormValues>[];
   isSubmitting: boolean;
   isValid: boolean;
 }

--- a/src/utils/getPath.ts
+++ b/src/utils/getPath.ts
@@ -1,12 +1,12 @@
 import flatArray from './flatArray';
 import isString from './isString';
 import isObject from './isObject';
-import { FieldValues } from '../types';
+import { FieldValues, FieldName } from '../types';
 import isArray from './isArray';
 
-const getPath = <FieldName>(
-  path: FieldName | string,
-  values: FieldValues | string[] | string,
+const getPath = <FormValues extends FieldValues = FieldValues>(
+  path: FieldName<FormValues>,
+  values: FormValues | string[] | string,
 ): any =>
   isArray(values)
     ? values.map((item, index) => {
@@ -28,7 +28,7 @@ const getPath = <FieldName>(
         isString(objectValue) ? `${path}.${key}` : getPath(path, objectValue),
       );
 
-export default <FieldName>(
-  parentPath: FieldName | string,
-  value: FieldValues,
-) => flatArray(getPath<FieldName>(parentPath, value));
+export default <FormValues extends FieldValues = FieldValues>(
+  parentPath: FieldName<FormValues>,
+  value: FormValues,
+) => flatArray<FieldName<FormValues>>(getPath<FormValues>(parentPath, value));


### PR DESCRIPTION
Abstracts the `FieldName` and `FieldValue` out of generics into types.

This also utilizes the `Extract` helper that pulls out only the `string` keys.

There is still a bit of clean up left in here. Tried to tackle some things as I saw them.

Should resolve #351 