### PR TITLE
feature on revalidate mode

### DIFF
--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -11,11 +11,17 @@ import DefaultValues from './defaultValues';
 import WatchDefaultValues from './watchDefaultValues';
 import Reset from './reset';
 import TriggerValidation from './triggerValidation';
+import ReValidateMode from './reValidateMode';
 
 const App: React.FC = () => {
   return (
     <Router>
       <Route path="/basic/:mode" exact component={Basic} />
+      <Route
+        path="/re-validate-mode/:mode/:reValidateMode"
+        exact
+        component={ReValidateMode}
+      />
       <Route
         path="/manual-register-form"
         exact

--- a/app/src/basic.tsx
+++ b/app/src/basic.tsx
@@ -125,7 +125,7 @@ const Basic: React.FC = (props: any) => {
       />
       {errors.validate && <p>validate error</p>}
       <button id="submit">Submit</button>
-      <button type="button" id="resetForm" onClick={reset}>
+      <button type="button" id="resetForm" onClick={() => reset()}>
         Reset
       </button>
       <div id="renderCount">{renderCounter}</div>

--- a/app/src/reValidateMode.tsx
+++ b/app/src/reValidateMode.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import useForm from 'react-hook-form';
+
+let renderCounter = 0;
+
+const Basic: React.FC = (props: any) => {
+  const { register, handleSubmit, errors } = useForm({
+    mode: props.match.params.mode,
+    reValidateMode: props.match.params.reValidateMode,
+  });
+  const onSubmit = () => {};
+
+  renderCounter++;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input
+        name="firstName"
+        ref={register({ required: true })}
+        placeholder="firstName"
+      />
+      {errors.firstName && <p>firstName error</p>}
+      <input
+        name="lastName"
+        ref={register({ required: true, maxLength: 5 })}
+        placeholder="lastName"
+      />
+      {errors.lastName && <p>lastName error</p>}
+      <button id="submit">Submit</button>
+      <div id="renderCount">{renderCounter}</div>
+    </form>
+  );
+};
+
+export default Basic;

--- a/cypress/integration/reValidateMode.ts
+++ b/cypress/integration/reValidateMode.ts
@@ -21,6 +21,12 @@ context('re-validate mode', () => {
 
   it('should re-validate the form only onBlur with mode onSubmit and reValidateMode onBlur', () => {
     cy.visit('http://localhost:3000/re-validate-mode/onSubmit/onBlur');
+    cy.get('input[name="firstName"]').focus();
+    cy.get('input[name="firstName"]').blur();
+
+    cy.get('input[name="lastName"]').focus();
+    cy.get('input[name="lastName"]').blur();
+    cy.get('p').should('have.length', 0);
 
     cy.get('button#submit').click();
 
@@ -35,7 +41,7 @@ context('re-validate mode', () => {
     cy.get('input[name="lastName"]').blur();
 
     cy.get('p').should('have.length', 0);
-    cy.get('#renderCount').contains('7');
+    cy.get('#renderCount').contains('9');
   });
 
   it('should re-validate the form only onSubmit with mode onBlur and reValidateMode onSubmit', () => {

--- a/cypress/integration/reValidateMode.ts
+++ b/cypress/integration/reValidateMode.ts
@@ -1,0 +1,40 @@
+context('re validate mode', () => {
+  it('should re validate the form only onSubmit with mode onSubmit and reValidateMode onSubmit', () => {
+    cy.visit('http://localhost:3000/re-validate-mode/onSubmit/onSubmit');
+
+    cy.get('button#submit').click();
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('input[name="firstName"]').type('luo123456');
+    cy.get('input[name="lastName"]').type('luo12');
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('button#submit').click();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('5');
+  });
+
+  it('should re validate the form only onBlur with mode onSubmit and reValidateMode onBlur', () => {
+    cy.visit('http://localhost:3000/re-validate-mode/onSubmit/onBlur');
+
+    cy.get('button#submit').click();
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('input[name="firstName"]').type('luo123456');
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="firstName"]').blur();
+    cy.get('input[name="lastName"]').type('luo12');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('input[name="lastName"]').blur();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('7');
+  });
+});

--- a/cypress/integration/reValidateMode.ts
+++ b/cypress/integration/reValidateMode.ts
@@ -1,5 +1,5 @@
-context('re validate mode', () => {
-  it('should re validate the form only onSubmit with mode onSubmit and reValidateMode onSubmit', () => {
+context('re-validate mode', () => {
+  it('should re-validate the form only onSubmit with mode onSubmit and reValidateMode onSubmit', () => {
     cy.visit('http://localhost:3000/re-validate-mode/onSubmit/onSubmit');
 
     cy.get('button#submit').click();
@@ -19,7 +19,7 @@ context('re validate mode', () => {
     cy.get('#renderCount').contains('5');
   });
 
-  it('should re validate the form only onBlur with mode onSubmit and reValidateMode onBlur', () => {
+  it('should re-validate the form only onBlur with mode onSubmit and reValidateMode onBlur', () => {
     cy.visit('http://localhost:3000/re-validate-mode/onSubmit/onBlur');
 
     cy.get('button#submit').click();
@@ -36,5 +36,47 @@ context('re validate mode', () => {
 
     cy.get('p').should('have.length', 0);
     cy.get('#renderCount').contains('7');
+  });
+
+  it("should re-validate the form onBlur only with mode onBlur and reValidateMode onBlur", () => {
+    cy.visit('http://localhost:3000/re-validate-mode/onBlur/onBlur');
+
+    cy.get('p').should('have.length', 0);
+
+    cy.get('input[name="firstName"]').focus();
+    cy.get('input[name="firstName"]').blur();
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"]').focus();
+    cy.get('input[name="lastName"]').blur();
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('input[name="firstName"]').type('luo123456');
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="firstName"]').blur();
+    cy.get('input[name="lastName"]').type('luo12');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('input[name="lastName"]').blur();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('7');
+  });
+
+  it("should re-validate the form onChange with mode onBlur and reValidateMode onChange", () => {
+    cy.visit('http://localhost:3000/re-validate-mode/onBlur/onChange');
+
+    cy.get('p').should('have.length', 0);
+
+    cy.get('input[name="firstName"]').focus();
+    cy.get('input[name="firstName"]').blur();
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"]').focus();
+    cy.get('input[name="lastName"]').blur();
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('input[name="firstName"]').type('luo123456');
+    cy.get('input[name="lastName"]').type('luo12');
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('5');
   });
 });

--- a/cypress/integration/reValidateMode.ts
+++ b/cypress/integration/reValidateMode.ts
@@ -38,7 +38,53 @@ context('re-validate mode', () => {
     cy.get('#renderCount').contains('7');
   });
 
-  it("should re-validate the form onBlur only with mode onBlur and reValidateMode onBlur", () => {
+  it('should re-validate the form only onSubmit with mode onBlur and reValidateMode onSubmit', () => {
+    cy.visit('http://localhost:3000/re-validate-mode/onBlur/onSubmit');
+
+    cy.get('button#submit').click();
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('input[name="firstName"]').type('luo123456');
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="firstName"]').blur();
+    cy.get('input[name="lastName"]').type('luo12');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('input[name="lastName"]').blur();
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('button#submit').click();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('7');
+  });
+
+  it('should re-validate the form only onSubmit with mode onChange and reValidateMode onSubmit', () => {
+    cy.visit('http://localhost:3000/re-validate-mode/onChange/onSubmit');
+
+    cy.get('button#submit').click();
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('input[name="firstName"]').type('luo123456');
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"]').type('luo12');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+
+    cy.get('button#submit').click();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('7');
+  });
+
+  it('should re-validate the form onBlur only with mode onBlur and reValidateMode onBlur', () => {
     cy.visit('http://localhost:3000/re-validate-mode/onBlur/onBlur');
 
     cy.get('p').should('have.length', 0);
@@ -61,7 +107,7 @@ context('re-validate mode', () => {
     cy.get('#renderCount').contains('7');
   });
 
-  it("should re-validate the form onChange with mode onBlur and reValidateMode onChange", () => {
+  it('should re-validate the form onChange with mode onBlur and reValidateMode onChange', () => {
     cy.visit('http://localhost:3000/re-validate-mode/onBlur/onChange');
 
     cy.get('p').should('have.length', 0);

--- a/cypress/integration/reValidateMode.ts
+++ b/cypress/integration/reValidateMode.ts
@@ -93,8 +93,6 @@ context('re-validate mode', () => {
   it('should re-validate the form onBlur only with mode onBlur and reValidateMode onBlur', () => {
     cy.visit('http://localhost:3000/re-validate-mode/onBlur/onBlur');
 
-    cy.get('p').should('have.length', 0);
-
     cy.get('input[name="firstName"]').focus();
     cy.get('input[name="firstName"]').blur();
     cy.get('input[name="firstName"] + p').contains('firstName error');
@@ -115,8 +113,6 @@ context('re-validate mode', () => {
 
   it('should re-validate the form onChange with mode onBlur and reValidateMode onChange', () => {
     cy.visit('http://localhost:3000/re-validate-mode/onBlur/onChange');
-
-    cy.get('p').should('have.length', 0);
 
     cy.get('input[name="firstName"]').focus();
     cy.get('input[name="firstName"]').blur();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,9 @@ export const REQUIRED_ATTRIBUTE = 'required';
 export const PATTERN_ATTRIBUTE = 'pattern';
 
 export const UNDEFINED = 'undefined';
+
+export const BLUR = 'blur';
+
+export const CHANGE = 'change';
+
+export const INPUT = 'input';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,8 +14,8 @@ export const PATTERN_ATTRIBUTE = 'pattern';
 
 export const UNDEFINED = 'undefined';
 
-export const BLUR = 'blur';
-
-export const CHANGE = 'change';
-
-export const INPUT = 'input';
+export const EVENTS = {
+  BLUR: 'blur',
+  CHANGE: 'change',
+  INPUT: 'input',
+};

--- a/src/logic/attachEventListeners.test.ts
+++ b/src/logic/attachEventListeners.test.ts
@@ -20,6 +20,7 @@ describe('attachEventListeners', () => {
         field: fields.test,
         validateAndStateUpdate,
         isOnBlur: false,
+        isReValidateOnBlur: false,
       }),
     ).toBeUndefined();
 
@@ -46,6 +47,7 @@ describe('attachEventListeners', () => {
         isRadio: true,
         validateAndStateUpdate,
         isOnBlur: false,
+        isReValidateOnBlur: false,
       }),
     ).toBeUndefined();
 
@@ -53,7 +55,7 @@ describe('attachEventListeners', () => {
     expect(fields.test.eventAttached).toBeTruthy();
   });
 
-  it('should only attach blur event when it is under blur mode', () => {
+  it('should attach blur event when it is under blur mode', () => {
     const validateAndStateUpdate = jest.fn();
     const addEventListener = jest.fn();
     const fields = {
@@ -72,6 +74,33 @@ describe('attachEventListeners', () => {
         isRadio: true,
         validateAndStateUpdate,
         isOnBlur: true,
+        isReValidateOnBlur: false,
+      }),
+    ).toBeUndefined();
+
+    expect(addEventListener).toBeCalledWith('blur', validateAndStateUpdate);
+  });
+
+  it('should attach blur event when re validate mode is under blur', () => {
+    const validateAndStateUpdate = jest.fn();
+    const addEventListener = jest.fn();
+    const fields = {
+      test: {
+        ref: {
+          addEventListener,
+        },
+        eventAttached: [],
+        watch: true,
+      },
+    };
+
+    expect(
+      attachEventListeners({
+        field: fields.test,
+        isRadio: true,
+        validateAndStateUpdate,
+        isOnBlur: false,
+        isReValidateOnBlur: true,
       }),
     ).toBeUndefined();
 
@@ -97,6 +126,7 @@ describe('attachEventListeners', () => {
         isRadio: false,
         validateAndStateUpdate,
         isOnBlur: false,
+        isReValidateOnBlur: false,
       }),
     ).toBeUndefined();
 
@@ -124,6 +154,7 @@ describe('attachEventListeners', () => {
         isRadio: false,
         validateAndStateUpdate,
         isOnBlur: false,
+        isReValidateOnBlur: false,
       }),
     ).toBeUndefined();
 
@@ -149,6 +180,7 @@ describe('attachEventListeners', () => {
         isRadio: true,
         validateAndStateUpdate,
         isOnBlur: false,
+        isReValidateOnBlur: false,
       }),
     ).toBeUndefined();
 
@@ -175,6 +207,7 @@ describe('attachEventListeners', () => {
         isRadio: false,
         validateAndStateUpdate,
         isOnBlur: false,
+        isReValidateOnBlur: false,
       }),
     ).toBeUndefined();
 
@@ -189,6 +222,7 @@ describe('attachEventListeners', () => {
         isRadio: false,
         validateAndStateUpdate: () => {},
         isOnBlur: false,
+        isReValidateOnBlur: false,
       }),
     ).toBeUndefined();
   });

--- a/src/logic/attachEventListeners.ts
+++ b/src/logic/attachEventListeners.ts
@@ -7,11 +7,13 @@ export default function attachEventListeners({
   validateAndStateUpdate,
   isRadio,
   isOnBlur,
+  isReValidateOnBlur,
 }: {
   field: Field;
   isRadio: boolean;
   validateAndStateUpdate?: Function;
   isOnBlur: boolean;
+  isReValidateOnBlur: boolean;
 }): void {
   const { ref } = field;
 
@@ -21,5 +23,6 @@ export default function attachEventListeners({
     isCheckBoxInput(ref.type) || isRadio ? CHANGE : INPUT,
     validateAndStateUpdate,
   );
-  if (isOnBlur) ref.addEventListener(BLUR, validateAndStateUpdate);
+  if (isOnBlur || isReValidateOnBlur)
+    ref.addEventListener(BLUR, validateAndStateUpdate);
 }

--- a/src/logic/attachEventListeners.ts
+++ b/src/logic/attachEventListeners.ts
@@ -1,5 +1,5 @@
 import isCheckBoxInput from '../utils/isCheckBoxInput';
-import { BLUR, CHANGE, INPUT } from '../constants';
+import { EVENTS } from '../constants';
 import { Field } from '../types';
 
 export default function attachEventListeners({
@@ -20,9 +20,9 @@ export default function attachEventListeners({
   if (!ref.addEventListener) return;
 
   ref.addEventListener(
-    isCheckBoxInput(ref.type) || isRadio ? CHANGE : INPUT,
+    isCheckBoxInput(ref.type) || isRadio ? EVENTS.CHANGE : EVENTS.INPUT,
     validateAndStateUpdate,
   );
   if (isOnBlur || isReValidateOnBlur)
-    ref.addEventListener(BLUR, validateAndStateUpdate);
+    ref.addEventListener(EVENTS.BLUR, validateAndStateUpdate);
 }

--- a/src/logic/attachEventListeners.ts
+++ b/src/logic/attachEventListeners.ts
@@ -1,4 +1,5 @@
 import isCheckBoxInput from '../utils/isCheckBoxInput';
+import { BLUR, CHANGE, INPUT } from '../constants';
 import { Field } from '../types';
 
 export default function attachEventListeners({
@@ -17,8 +18,8 @@ export default function attachEventListeners({
   if (!ref.addEventListener) return;
 
   ref.addEventListener(
-    isCheckBoxInput(ref.type) || isRadio ? 'change' : 'input',
+    isCheckBoxInput(ref.type) || isRadio ? CHANGE : INPUT,
     validateAndStateUpdate,
   );
-  if (isOnBlur) ref.addEventListener('blur', validateAndStateUpdate);
+  if (isOnBlur) ref.addEventListener(BLUR, validateAndStateUpdate);
 }

--- a/src/logic/getDefaultValue.ts
+++ b/src/logic/getDefaultValue.ts
@@ -6,7 +6,7 @@ export default <FormValues extends FieldValues>(
   defaultValues: Partial<FormValues>,
   name: FieldName<FormValues>,
   defaultValue?: BaseFieldValue,
-): FieldValue<FormValues> | undefined =>
+): FieldValue<FormValues> | Partial<FormValues> | undefined =>
   isUndefined(defaultValues[name])
     ? get(defaultValues, name as string, defaultValue)
     : defaultValues[name];

--- a/src/logic/removeAllEventListeners.ts
+++ b/src/logic/removeAllEventListeners.ts
@@ -1,8 +1,9 @@
+import { BLUR, CHANGE, INPUT } from '../constants';
 import { Ref } from '../types';
 
 export default (ref: Ref, validateWithStateUpdate: Function): void => {
   if (!ref.removeEventListener) return;
-  ref.removeEventListener('input', validateWithStateUpdate);
-  ref.removeEventListener('change', validateWithStateUpdate);
-  ref.removeEventListener('blur', validateWithStateUpdate);
+  ref.removeEventListener(INPUT, validateWithStateUpdate);
+  ref.removeEventListener(CHANGE, validateWithStateUpdate);
+  ref.removeEventListener(BLUR, validateWithStateUpdate);
 };

--- a/src/logic/removeAllEventListeners.ts
+++ b/src/logic/removeAllEventListeners.ts
@@ -1,9 +1,9 @@
-import { BLUR, CHANGE, INPUT } from '../constants';
+import { EVENTS } from '../constants';
 import { Ref } from '../types';
 
 export default (ref: Ref, validateWithStateUpdate: Function): void => {
   if (!ref.removeEventListener) return;
-  ref.removeEventListener(INPUT, validateWithStateUpdate);
-  ref.removeEventListener(CHANGE, validateWithStateUpdate);
-  ref.removeEventListener(BLUR, validateWithStateUpdate);
+  ref.removeEventListener(EVENTS.INPUT, validateWithStateUpdate);
+  ref.removeEventListener(EVENTS.CHANGE, validateWithStateUpdate);
+  ref.removeEventListener(EVENTS.BLUR, validateWithStateUpdate);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,14 @@ import * as React from 'react';
 import * as ReactNative from 'react-native';
 
 export type BaseFieldValue = any;
+
 export type FieldValues = Record<string, BaseFieldValue>;
 
 export type RawFieldName<FormValues extends FieldValues> = Extract<
   keyof FormValues,
   string
 >;
+
 export type FieldName<FormValues extends FieldValues> =
   | RawFieldName<FormValues>
   | string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export interface Schema<Data> {
 
 export type Options<FormValues extends FieldValues = FieldValues> = Partial<{
   mode: Mode;
+  reValidateMode: Mode;
   defaultValues: Partial<FormValues>;
   validationSchemaOption: SchemaValidateOptions;
   validationFields: FieldName<FormValues>[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,8 +94,7 @@ export interface FieldError {
 export type ValidatePromiseResult = {} | void | FieldError;
 
 export interface Field extends ValidationOptions {
-  ref: Ref;
-  watch?: boolean;
+  ref?: Ref;
   mutationWatcher?: MutationWatcher;
   options?: {
     ref: Ref;

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export interface FieldError {
 export type ValidatePromiseResult = {} | void | FieldError;
 
 export interface Field extends ValidationOptions {
-  ref?: Ref;
+  ref: Ref;
   mutationWatcher?: MutationWatcher;
   options?: {
     ref: Ref;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,9 @@ export type FieldValue<FormValues extends FieldValues> = FormValues[FieldName<
   FormValues
 >];
 
-export type Ref = any;
+export type Inputs = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+
+export type Ref = Inputs | any;
 
 type Mode = keyof ValidationMode;
 

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -62,6 +62,7 @@ describe('useForm', () => {
         isRadio: false,
         validateAndStateUpdate: expect.any(Function),
         isOnBlur: false,
+        isReValidateOnBlur: false,
       });
       expect(onDomRemove).toHaveBeenCalled();
     });
@@ -84,6 +85,7 @@ describe('useForm', () => {
         isRadio: true,
         isOnBlur: false,
         validateAndStateUpdate: expect.any(Function),
+        isReValidateOnBlur: false,
       });
       expect(onDomRemove).toBeCalled();
     });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -24,7 +24,7 @@ import onDomRemove from './utils/onDomRemove';
 import isMultipleSelect from './utils/isMultipleSelect';
 import modeChecker from './utils/validationModeChecker';
 import pickErrors from './logic/pickErrors';
-import { BLUR, RADIO_INPUT, UNDEFINED, VALIDATION_MODE } from './constants';
+import { EVENTS, RADIO_INPUT, UNDEFINED, VALIDATION_MODE } from './constants';
 import isNullOrUndefined from './utils/isNullOrUndefined';
 import {
   FieldValues,
@@ -303,7 +303,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
 
         if (!ref) return;
 
-        const isBlurEvent = type === BLUR;
+        const isBlurEvent = type === EVENTS.BLUR;
         const isValidateDisabled =
           (isOnSubmit && !isSubmittedRef.current) ||
           (isOnBlur && !isBlurEvent && !errors[name]) ||

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -554,7 +554,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
     }
 
     if (validateOptions && !isEmptyObject(validateOptions)) {
-      fieldsWithValidationRef.current.add(name as FieldName<FormValues>);
+      fieldsWithValidationRef.current.add(name);
 
       if (!isOnSubmit) {
         if (validationSchema) {
@@ -567,8 +567,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
           });
         } else {
           validateField(currentField, fields).then(error => {
-            if (isEmptyObject(error))
-              validFieldsRef.current.add(name as FieldName<FormValues>);
+            if (isEmptyObject(error)) validFieldsRef.current.add(name);
 
             if (
               validFieldsRef.current.size ===
@@ -588,7 +587,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
 
     if (!type) return;
 
-    const field =
+    const fieldToRegister =
       isRadio && currentField.options
         ? currentField.options[currentField.options.length - 1]
         : currentField;
@@ -599,7 +598,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       attachNativeValidation(ref, validateOptions);
     } else {
       attachEventListeners({
-        field,
+        field: fieldToRegister,
         isRadio,
         validateAndStateUpdate: validateAndUpdateStateRef.current,
         isOnBlur,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -520,10 +520,12 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       );
 
       if (isRadio) {
+        let currentField: Field | undefined = fields[typedName];
         fields[typedName] = {
           options: [
-            // @ts-ignore
-            ...(fields[typedName] ? fields[typedName].options : []),
+            ...(currentField && currentField.options
+              ? currentField.options
+              : []),
             {
               ref,
               mutationWatcher,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -40,6 +40,7 @@ import {
   OnSubmit,
   ValidationPayload,
   ElementLike,
+  Inputs,
 } from './types';
 
 export default function useForm<FormValues extends FieldValues = FieldValues>({
@@ -289,7 +290,9 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
 
   validateAndUpdateStateRef.current = validateAndUpdateStateRef.current
     ? validateAndUpdateStateRef.current
-    : async ({ target: { name }, type }: Ref): Promise<void> => {
+    : async (event: MouseEvent): Promise<void> => {
+        const { type, target } = event;
+        const name = target ? (target as Inputs).name : '';
         if (
           isArray(validationFieldsRef.current) &&
           !validationFieldsRef.current.includes(name)

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -520,25 +520,18 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       );
 
       if (isRadio) {
-        if (!currentField)
-          fields[typedName] = {
-            options: [],
-            ref: { type: RADIO_INPUT, name },
-          };
-
-        // TODO: Fix ref
-        // @ts-ignore
         fields[typedName] = {
-          ...fields[name],
+          options: [
+            // @ts-ignore
+            ...(fields[typedName] ? fields[typedName].options : []),
+            {
+              ref,
+              mutationWatcher,
+            },
+          ],
+          ref: { type: RADIO_INPUT, name },
           ...validateOptions,
         };
-
-        // TODO: Fix undefined
-        // @ts-ignore
-        fields[typedName].options.push({
-          ref,
-          mutationWatcher,
-        });
       } else {
         fields[typedName] = {
           ...fieldAttributes,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -609,6 +609,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         isRadio,
         validateAndStateUpdate: validateAndUpdateStateRef.current,
         isOnBlur,
+        isReValidateOnBlur,
       });
     }
   }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -307,10 +307,11 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         if (!ref) return;
 
         const isBlurEvent = type === EVENTS.BLUR;
-        const isValidateDisabled =
+        const shouldSkipValidation =
           (isOnSubmit && !isSubmittedRef.current) ||
           (isOnBlur && !isBlurEvent && !errors[name]) ||
-          (isReValidateOnBlur && !isBlurEvent && errors[name]);
+          (isReValidateOnBlur && !isBlurEvent && errors[name]) ||
+          (isReValidateOnSubmit && errors[name]);
         const shouldUpdateDirty = setDirty(name);
         let shouldUpdateState =
           isWatchAllRef.current ||
@@ -322,7 +323,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
           shouldUpdateState = true;
         }
 
-        if (isValidateDisabled)
+        if (shouldSkipValidation)
           return shouldUpdateState ? render({}) : undefined;
 
         if (validationSchema) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -108,7 +108,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
 
   const setFieldValue = (
     name: FieldName<FormValues>,
-    rawValue: FieldValue<FormValues>,
+    rawValue: FieldValue<FormValues> | Partial<FormValues>,
   ): boolean => {
     const field = fieldsRef.current[name];
 
@@ -434,7 +434,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
   function watch(
     fieldNames?: FieldName<FormValues> | FieldName<FormValues>[],
     defaultValue?: string | Partial<FormValues>,
-  ): FieldValue<FormValues> | Partial<FormValues> {
+  ): FieldValue<FormValues> | Partial<FormValues> | string | undefined {
     const fieldValues = getFieldsValues<FormValues>(fieldsRef.current);
     const watchFields = watchFieldsRef.current;
 
@@ -445,8 +445,6 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         watchFields,
       );
 
-      // TODO: Fix
-      // @ts-ignore
       return isUndefined(value)
         ? isUndefined(defaultValue)
           ? getDefaultValue(defaultValues, fieldNames)
@@ -467,8 +465,6 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
             watchFields,
           );
 
-          // TODO: Fix
-          // @ts-ignore
           if (!isUndefined(tempValue)) value = tempValue;
         }
 
@@ -481,8 +477,6 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
 
     isWatchAllRef.current = true;
 
-    // TODO: Fix
-    // @ts-ignore
     return (
       (!isEmptyObject(fieldValues) && fieldValues) ||
       defaultValue ||
@@ -547,11 +541,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
     if (!isEmptyObject(defaultValues)) {
       const defaultValue = getDefaultValue(defaultValues, name);
 
-      if (!isUndefined(defaultValue))
-        setFieldValue(
-          name as FieldName<FormValues>,
-          defaultValue as FieldValue<FormValues>,
-        );
+      if (!isUndefined(defaultValue)) setFieldValue(name, defaultValue);
     }
 
     if (validateOptions && !isEmptyObject(validateOptions)) {


### PR DESCRIPTION
New Feature: `reValidateMode`

**Reason for the API:**

There are few users who request having validation onBlur instead of onChagne, while this library is restricted to the onChagne, to work on this feature which requires some users' effect. I think it makes sense to make it as optional as the library should not dictate how re-validate works on their behalf.

**reValidateMode**
- `onChange` defualt
- `onBlur`
- `onSubmit`

allow the user to config how re-validation works in react-hook-form, right now the default behavior is reValidate `onChange`. This new option will allow the user to set re-validate to be `blur` or `submit`

eg:
```
useForm({
  mode: 'onBlur',
  reValidateMode: 'onBlur',
})
```