### PR TITLE
Improve typing of `setValue`

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -51,9 +51,9 @@ export interface FormContextValues<
     message?: string,
     ref?: Ref,
   ) => void;
-  setValue: (
-    name: FieldName<FormValues>,
-    value: FieldValue<FormValues>,
+  setValue: <Name extends FieldName<FormValues>>(
+    name: Name,
+    value: FormValues[Name],
     shouldValidate?: boolean,
   ) => void;
   triggerValidation: (

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -271,12 +271,14 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
     [executeSchemaValidation, executeValidation, validationSchema],
   );
 
-  const setValue = useCallback(
-    (
-      name: FieldName<FormValues>,
-      value: FieldValue<FormValues>,
-      shouldValidate: boolean = false,
-    ): void | Promise<boolean> => {
+  const setValue = useCallback<
+    <Name extends FieldName<FormValues>>(
+      name: Name,
+      value: FormValues[Name],
+      shouldValidate?: boolean,
+    ) => void | Promise<boolean>
+  >(
+    (name, value, shouldValidate = false) => {
       setValueInternal(name, value);
       const shouldRender =
         isWatchAllRef.current || watchFieldsRef.current[name];
@@ -284,6 +286,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         return triggerValidation({ name }, shouldRender);
       }
       if (shouldRender) render({});
+      return;
     },
     [setValueInternal, triggerValidation],
   );


### PR DESCRIPTION
With the latest versions of `react-hook-form` it seems that `setValue` (amongst others) doesn't do type checking properly anymore, as you can see on [this sandbox](https://codesandbox.io/s/react-hook-form-ts-playground-7v3gj?fontsize=14&module=%2Fsrc%2Fapp.tsx): 

This PR aims to fix the type checking for `setValue` so that it 
1. will only accept field names defined in form data type when provided
1. will only accept the correct type of value for a given field name.