### PR TITLE
Fix typing error for reset in context types

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -41,7 +41,7 @@ export interface FormContextValues<
     fields: FieldName<FormValues>[],
     defaultValues?: Partial<FormValues>,
   ): Partial<FormValues>;
-  reset: (values?: FieldValues) => void;
+  reset: (values?: FormValues) => void;
   clearError(): void;
   clearError(name: FieldName<FormValues>): void;
   clearError(names: FieldName<FormValues>[]): void;


### PR DESCRIPTION
The type of `reset` is inconsistent between `useForm.ts` and `contextTypes.ts`:
https://github.com/react-hook-form/react-hook-form/blob/a4c3f02265828897412150cd04ae3b9f6337af2b/src/useForm.ts#L757
versus
https://github.com/react-hook-form/react-hook-form/blob/a4c3f02265828897412150cd04ae3b9f6337af2b/src/contextTypes.ts#L44

`FormValues` is the generic type which defaults to `FieldValues`, which is the default value if the type argument is not provided. We should use the generic type not the default.