### PR TITLE
Properly nest getValues for defaultValue

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -868,10 +868,8 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
 
   const getValues = (payload?: { nest: boolean }): FormValues => {
     const fieldValues = getFieldsValues(fieldsRef.current);
-    const output =
-      payload && payload.nest ? combineFieldValues(fieldValues) : fieldValues;
-
-    return isEmptyObject(output) ? defaultValues : output;
+    const outputValues = isEmptyObject(fieldValues) ? defaultValues : fieldValues;
+    return payload && payload.nest ? combineFieldValues(outputValues) : outputValues;
   };
 
   useEffect(


### PR DESCRIPTION
Now, we fallback to `defaultValue` _before_ applying our nesting logic.

Fixes https://github.com/react-hook-form/react-hook-form/issues/409