### PR TITLE
Fix Simplified Chinese characters to Shinjitai in README links for Japanese README

### DIFF
--- a/README.fr-FR.md
+++ b/README.fr-FR.md
@@ -29,7 +29,7 @@
     </p>
 </div>
 
-<a href="https://github.com/react-hook-form/react-hook-form">🇦🇺English</a> | <a href="./README.zh-CN.md">🇨🇳简体中文</a> | <a href="./README.ja-JP.md">🇯🇵日本语</a> | 🇫🇷 Français | <a href="./README.ko-KR.md">🇰🇷한국어</a>
+<a href="https://github.com/react-hook-form/react-hook-form">🇦🇺English</a> | <a href="./README.zh-CN.md">🇨🇳简体中文</a> | <a href="./README.ja-JP.md">🇯🇵日本語</a> | 🇫🇷 Français | <a href="./README.ko-KR.md">🇰🇷한국어</a>
 
 ## Fonctionnalités
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -29,7 +29,7 @@
     </p>
 </div>
 
-<a href="https://github.com/react-hook-form/react-hook-form">🇦🇺English</a> | <a href="./README.zh-CN.md">🇨🇳简体中文</a> | 🇯🇵日本语 | <a href="./README.fr-FR.md">🇫🇷Français</a> | <a href="./README.ko-KR.md">🇰🇷한국어</a>
+<a href="https://github.com/react-hook-form/react-hook-form">🇦🇺English</a> | <a href="./README.zh-CN.md">🇨🇳简体中文</a> | 🇯🇵日本語 | <a href="./README.fr-FR.md">🇫🇷Français</a> | <a href="./README.ko-KR.md">🇰🇷한국어</a>
 
 ## 特徴
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -6,7 +6,7 @@
     </p>
 </div>
 
-<p align="center">유연하고 확장 가능한 사용하기 쉬운 고성능 폼 검증 라이브러리</p> 
+<p align="center">유연하고 확장 가능한 사용하기 쉬운 고성능 폼 검증 라이브러리</p>
 
 <div align="center">
 
@@ -29,18 +29,18 @@
     </p>
 </div>
 
-<a href="https://github.com/react-hook-form/react-hook-form">🇦🇺English</a> | <a href="./README.zh-CN.md">🇨🇳简体中文</a> | <a href="./README.ja-JP.md">🇯🇵日本语</a> | 🇫🇷 <a href="./README.fr-FR.md">Français</a> | 🇰🇷한국어
+<a href="https://github.com/react-hook-form/react-hook-form">🇦🇺English</a> | <a href="./README.zh-CN.md">🇨🇳简体中文</a> | <a href="./README.ja-JP.md">🇯🇵日本語</a> | 🇫🇷 <a href="./README.fr-FR.md">Français</a> | 🇰🇷한국어
 
 ## 특징
 
 - 성능과 DX를 기반으로 구축
 - 제어되지 않는 양식 검증
-- 의존성 없는 [작은 용량](https://bundlephobia.com/result?p=react-hook-form@latest) 
-- HTML 표준을 따르는 검증  
+- 의존성 없는 [작은 용량](https://bundlephobia.com/result?p=react-hook-form@latest)
+- HTML 표준을 따르는 검증
 - Reative Native 와 호환
 - [Yup](https://github.com/jquense/yup) 스키마 기반의 검증 지원
 - 브라우저 네이티브 검증 지원
-- [Form Builder](https://react-hook-form.com/form-builder)로 폼 빠르게 생성 
+- [Form Builder](https://react-hook-form.com/form-builder)로 폼 빠르게 생성
 
 ## 설치
 
@@ -57,7 +57,7 @@
 - [Form Builder](https://react-hook-form.com/form-builder)
 - [FAQs](https://react-hook-form.com/faq)
 
-## 시작하기 
+## 시작하기
 
 ```jsx
 import React from 'react';
@@ -87,13 +87,13 @@ function App() {
 
 ## 기여자
 
-모든 기여자 분들께 감사합니다. [[기여 하기](CONTRIBUTING.md)] 
+모든 기여자 분들께 감사합니다. [[기여 하기](CONTRIBUTING.md)]
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />
 </a>
 
-## 후원자 
+## 후원자
 
 모둔 후원자 분들께 감사합니다 [[후원 하기](https://opencollective.com/react-hook-form#backer)]
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
     </p>
 </div>
 
-🇦🇺English | <a href="./README.zh-CN.md">🇨🇳简体中文</a> | <a href="./README.ja-JP.md">🇯🇵日本语</a> | <a href="./README.fr-FR.md">🇫🇷Français</a> | <a href="./README.ko-KR.md">🇰🇷한국어</a>
+🇦🇺English | <a href="./README.zh-CN.md">🇨🇳简体中文</a> | <a href="./README.ja-JP.md">日本語</a> | <a href="./README.fr-FR.md">🇫🇷Français</a> | <a href="./README.ko-KR.md">🇰🇷한국어</a>
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,7 +21,7 @@
 
 <div align="center"><p align="center"><a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form Logo - React hook form validation" width="750px" /></a></p></div>
 
-<a href="https://github.com/react-hook-form/react-hook-form">🇦🇺English</a> | 🇨🇳简体中文 | <a href="./README.ja-JP.md">🇯🇵日本语</a> | <a href="./README.fr-FR.md">🇫🇷Français</a> | <a href="./README.ko-KR.md">🇰🇷한국어</a>
+<a href="https://github.com/react-hook-form/react-hook-form">🇦🇺English</a> | 🇨🇳简体中文 | <a href="./README.ja-JP.md">🇯🇵日本語</a> | <a href="./README.fr-FR.md">🇫🇷Français</a> | <a href="./README.ko-KR.md">🇰🇷한국어</a>
 
 ## 特性
 


### PR DESCRIPTION
README links for Japanese README are written in Simplified Chinese characters, even though Simplified Chinese characters are not used in Japanese language.

I changed them to [Shinjitai](https://en.wikipedia.org/wiki/Shinjitai)(modern Japanese Chinese character) which is used in Japanese language.