### PR TITLE
Close #447 isValid compute incorrect for dynamic fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form",
   "description": "Performant, flexible and extensible forms library for React Hooks",
-  "version": "3.26.5-beta.2",
+  "version": "3.26.5-beta.7",
   "main": "dist/react-hook-form.js",
   "module": "dist/react-hook-form.es.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
     }
   ],
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0"
   },
   "husky": {
     "hooks": {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -116,9 +116,15 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
           reRender = true;
         }
       } else {
-        validFieldsRef.current.delete(name);
+        if (!errorsRef.current[name]) {
+          validFieldsRef.current.delete(name);
+        }
         reRender = true;
       }
+
+      errorsRef.current = validationSchema
+        ? schemaErrorsRef.current
+        : combineErrorsRef(error);
 
       if (reRender) {
         render({});
@@ -228,7 +234,6 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       }
 
       const error = await validateField(field, fieldsRef.current);
-      errorsRef.current = combineErrorsRef(error);
       renderBaseOnError(name, error, shouldRender);
 
       return isEmptyObject(error);
@@ -405,9 +410,6 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         });
 
         if (shouldUpdate) {
-          errorsRef.current = validationSchema
-            ? schemaErrorsRef.current
-            : combineErrorsRef(error as FieldErrors<FormValues>);
           renderBaseOnError(name, error as FieldErrors<FormValues>);
           return;
         }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -415,7 +415,11 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         });
 
         if (shouldUpdate) {
-          renderBaseOnError(name, error as FieldErrors<FormValues>);
+          renderBaseOnError(
+            name,
+            error as FieldErrors<FormValues>,
+            shouldUpdate,
+          );
           return;
         }
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -634,7 +634,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
             }
 
             if (
-              validFieldsRef.current.size ===
+              validFieldsRef.current.size <=
               fieldsWithValidationRef.current.size
             ) {
               render({});

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -416,6 +416,10 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       validFieldsRef,
       watchFieldsRef,
     ].forEach(data => data.current.delete(name));
+
+    if (readFormState.current.isValid || readFormState.current.touched) {
+      render({});
+    }
   };
 
   const removeEventListenerAndRef = useCallback(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -110,16 +110,21 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       let reRender = shouldRender;
 
       if (isEmptyObject(error)) {
-        delete errorsRef.current[name];
         if (fieldsWithValidationRef.current.has(name) || validationSchema) {
           validFieldsRef.current.add(name);
+
+          if (errorsRef.current[name]) {
+            reRender = true;
+          }
+        }
+
+        delete errorsRef.current[name];
+      } else {
+        validFieldsRef.current.delete(name);
+
+        if (!errorsRef.current[name]) {
           reRender = true;
         }
-      } else {
-        if (!errorsRef.current[name]) {
-          validFieldsRef.current.delete(name);
-        }
-        reRender = true;
       }
 
       errorsRef.current = validationSchema

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -222,6 +222,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       if (!field) {
         return false;
       }
+
       if (!isUndefined(value)) {
         setInternalValue(name, value);
       }


### PR DESCRIPTION
- solve the problem when new fields get registered and trigger validation to set isValid to false
- solve when inputs get removed and update `isValid`
- avoid re-render in react native with setValue with validation
- remove peer dep in package.json with react-dom