### PR TITLE
Bugfix: fix setValue to always re-render if shouldValidate is true

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -174,7 +174,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         ref[isCheckBoxInput(type) ? 'checked' : 'value'] = value;
       }
 
-      return true;
+      return type;
     },
     [isWindowDefined],
   );
@@ -333,7 +333,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         watchFieldsRef.current.has(name);
 
       if (shouldValidate) {
-        return triggerValidation({ name }, shouldRender);
+        return triggerValidation({ name }, true);
       }
 
       if (shouldRender) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -174,7 +174,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         ref[isCheckBoxInput(type) ? 'checked' : 'value'] = value;
       }
 
-      return type;
+      return true;
     },
     [isWindowDefined],
   );


### PR DESCRIPTION
Fixes #456 

Currently, `setValue` does not always re-render even when `shouldValidate` is set to true. This can be problematic for fields that were registered manually since the counterpart function `getValues` will not sync properly without a re-render.