### PR TITLE
Wrap handleSubmit with try-finally

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -807,6 +807,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       isSubmittingRef.current = true;
       render({});
     }
+
     try {
       if (validationSchema) {
         fieldValues = getFieldsValues(fields);
@@ -889,12 +890,11 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
 
         errorsRef.current = fieldErrors;
       }
-
+    } finally {
       if (isUnMount.current) {
         return;
       }
 
-    } finally {
       isSubmittedRef.current = true;
       isSubmittingRef.current = false;
       submitCountRef.current = submitCountRef.current + 1;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -807,97 +807,99 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       isSubmittingRef.current = true;
       render({});
     }
+    try {
+      if (validationSchema) {
+        fieldValues = getFieldsValues(fields);
+        const output = await validateWithSchemaCurry(
+          combineFieldValues(fieldValues),
+        );
+        schemaErrorsRef.current = output.fieldErrors;
+        fieldErrors = output.fieldErrors;
+        fieldValues = output.result;
+      } else {
+        const {
+          errors,
+          values,
+        }: SubmitPromiseResult<FormValues> = await fieldsToValidate.reduce(
+          async (
+            previous: Promise<SubmitPromiseResult<FormValues>>,
+            field: Field | undefined,
+          ): Promise<SubmitPromiseResult<FormValues>> => {
+            if (!field) {
+              return previous;
+            }
 
-    if (validationSchema) {
-      fieldValues = getFieldsValues(fields);
-      const output = await validateWithSchemaCurry(
-        combineFieldValues(fieldValues),
-      );
-      schemaErrorsRef.current = output.fieldErrors;
-      fieldErrors = output.fieldErrors;
-      fieldValues = output.result;
-    } else {
-      const {
-        errors,
-        values,
-      }: SubmitPromiseResult<FormValues> = await fieldsToValidate.reduce(
-        async (
-          previous: Promise<SubmitPromiseResult<FormValues>>,
-          field: Field | undefined,
-        ): Promise<SubmitPromiseResult<FormValues>> => {
-          if (!field) {
-            return previous;
-          }
+            const resolvedPrevious: any = await previous;
+            const {
+              ref,
+              ref: { name },
+            } = field;
 
-          const resolvedPrevious: any = await previous;
-          const {
-            ref,
-            ref: { name },
-          } = field;
+            if (!fields[name]) {
+              return Promise.resolve(resolvedPrevious);
+            }
 
-          if (!fields[name]) {
+            const fieldError = await validateField(
+              field,
+              fields,
+              nativeValidation,
+            );
+
+            if (fieldError[name]) {
+              resolvedPrevious.errors = {
+                ...resolvedPrevious.errors,
+                ...fieldError,
+              };
+
+              validFieldsRef.current.delete(name);
+
+              return Promise.resolve(resolvedPrevious);
+            }
+
+            if (fieldsWithValidationRef.current.has(name)) {
+              validFieldsRef.current.add(name);
+            }
+            resolvedPrevious.values[name] = getFieldValue(fields, ref);
             return Promise.resolve(resolvedPrevious);
-          }
+          },
+          Promise.resolve<SubmitPromiseResult<FormValues>>({
+            errors: {},
+            values: {} as FormValues,
+          }),
+        );
 
-          const fieldError = await validateField(
-            field,
-            fields,
-            nativeValidation,
-          );
-
-          if (fieldError[name]) {
-            resolvedPrevious.errors = {
-              ...resolvedPrevious.errors,
-              ...fieldError,
-            };
-
-            validFieldsRef.current.delete(name);
-
-            return Promise.resolve(resolvedPrevious);
-          }
-
-          if (fieldsWithValidationRef.current.has(name)) {
-            validFieldsRef.current.add(name);
-          }
-          resolvedPrevious.values[name] = getFieldValue(fields, ref);
-          return Promise.resolve(resolvedPrevious);
-        },
-        Promise.resolve<SubmitPromiseResult<FormValues>>({
-          errors: {},
-          values: {} as FormValues,
-        }),
-      );
-
-      fieldErrors = errors;
-      fieldValues = values;
-    }
-
-    if (isEmptyObject(fieldErrors)) {
-      errorsRef.current = {};
-      await callback(combineFieldValues(fieldValues), e);
-    } else {
-      if (submitFocusError) {
-        Object.keys(fieldErrors).reduce((previous, current) => {
-          const field = fields[current];
-          if (field && field.ref.focus && previous) {
-            field.ref.focus();
-            return false;
-          }
-          return previous;
-        }, true);
+        fieldErrors = errors;
+        fieldValues = values;
       }
 
-      errorsRef.current = fieldErrors;
-    }
+      if (isEmptyObject(fieldErrors)) {
+        errorsRef.current = {};
+        await callback(combineFieldValues(fieldValues), e);
+      } else {
+        if (submitFocusError) {
+          Object.keys(fieldErrors).reduce((previous, current) => {
+            const field = fields[current];
+            if (field && field.ref.focus && previous) {
+              field.ref.focus();
+              return false;
+            }
+            return previous;
+          }, true);
+        }
 
-    if (isUnMount.current) {
-      return;
-    }
+        errorsRef.current = fieldErrors;
+      }
 
-    isSubmittedRef.current = true;
-    isSubmittingRef.current = false;
-    submitCountRef.current = submitCountRef.current + 1;
-    render({});
+      if (isUnMount.current) {
+        return;
+      }
+
+    } finally {
+      isSubmittedRef.current = true;
+      isSubmittingRef.current = false;
+      submitCountRef.current = submitCountRef.current + 1;
+      render({});
+    }
   };
 
   const resetRefs = () => {


### PR DESCRIPTION
Since an failing API call will destroy the form right now (e.g. `isSubmitting` is not being reset to `false`), I wrapped the `callback(...)` in a try-finally statement to ensure the variables are set in any case.