### PR TITLE
fix #555 support all primitive types for custom fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+export type Primitive = string | boolean | number | symbol | null | undefined;
+
 export type FieldValues = Record<string, any>;
 
 type BaseFieldName<FormValues extends FieldValues> = Extract<

--- a/src/utils/getPath.test.ts
+++ b/src/utils/getPath.test.ts
@@ -11,6 +11,11 @@ describe('getPath', () => {
           kidding: { test: 'data' },
           foo: { bar: {} },
           what: [{ bill: { haha: 'test' } }, [3, 4]],
+          one: 1,
+          empty: null,
+          absent: undefined,
+          isAwesome: true,
+          answer: Symbol(42),
         },
       ]),
     ).toEqual([
@@ -22,6 +27,11 @@ describe('getPath', () => {
       'test[2].what[0].bill.haha',
       'test[2].what[1][0]',
       'test[2].what[1][1]',
+      'test[2].one',
+      'test[2].empty',
+      'test[2].absent',
+      'test[2].isAwesome',
+      'test[2].answer',
     ]);
   });
 });

--- a/src/utils/getPath.ts
+++ b/src/utils/getPath.ts
@@ -1,32 +1,23 @@
 import flatArray from './flatArray';
-import isString from './isString';
-import isObject from './isObject';
+import isPrimitive from './isPrimitive';
 import { FieldValues, FieldName } from '../types';
 import isArray from './isArray';
 
 const getPath = <FormValues extends FieldValues = FieldValues>(
   path: FieldName<FormValues>,
-  values: FormValues | string[] | string,
+  values: FormValues | any[],
 ): any[] =>
   isArray(values)
     ? values.map((item, index) => {
         const pathWithIndex = `${path}[${index}]`;
-
-        if (isArray(item)) {
-          return getPath(pathWithIndex, item);
-        } else if (isObject(item)) {
-          return Object.entries(item).map(([key, objectValue]: [string, any]) =>
-            isString(objectValue)
-              ? `${pathWithIndex}.${key}`
-              : getPath(`${pathWithIndex}.${key}`, objectValue),
-          );
-        }
-
-        return pathWithIndex;
+        return isPrimitive(item) ? pathWithIndex : getPath(pathWithIndex, item);
       })
-    : Object.entries(values).map(([key, objectValue]) =>
-        isString(objectValue) ? `${path}.${key}` : getPath(path, objectValue),
-      );
+    : Object.entries(values).map(([key, objectValue]: [string, any]) => {
+        const pathWithKey = `${path}.${key}`;
+        return isPrimitive(objectValue)
+          ? pathWithKey
+          : getPath(pathWithKey, objectValue);
+      });
 
 export default <FormValues extends FieldValues = FieldValues>(
   parentPath: FieldName<FormValues>,

--- a/src/utils/isPrimitive.test.ts
+++ b/src/utils/isPrimitive.test.ts
@@ -1,0 +1,35 @@
+import isPrimitive from './isPrimitive';
+
+describe('isPrimitive', () => {
+  it('should return true when value is a string', () => {
+    expect(isPrimitive('foobar')).toBeTruthy();
+  });
+
+  it('should return true when value is a boolean', () => {
+    expect(isPrimitive(false)).toBeTruthy();
+  });
+
+  it('should return true when value is a number', () => {
+    expect(isPrimitive(123)).toBeTruthy();
+  });
+
+  it('should return true when value is a symbol', () => {
+    expect(isPrimitive(Symbol())).toBeTruthy();
+  });
+
+  it('should return true when value is null', () => {
+    expect(isPrimitive(null)).toBeTruthy();
+  });
+
+  it('should return true when value is undefined', () => {
+    expect(isPrimitive(undefined)).toBeTruthy();
+  });
+
+  it('should return false when value is an object', () => {
+    expect(isPrimitive({})).toBeFalsy();
+  });
+
+  it('should return false when value is an array', () => {
+    expect(isPrimitive([])).toBeFalsy();
+  });
+});

--- a/src/utils/isPrimitive.ts
+++ b/src/utils/isPrimitive.ts
@@ -1,0 +1,5 @@
+import isNullOrUndefined from './isNullOrUndefined';
+import { Primitive } from '../types';
+
+export default (value: unknown): value is Primitive =>
+  isNullOrUndefined(value) || typeof value !== 'object';


### PR DESCRIPTION
`getPath` method threw an error in certain cases when `values` contained some primitive types which are not strings. You can execute updated `getPath.test.ts` on the current `master` branch to see how it fails.

I created a new `isPrimitive` util and refactored `getPath` method