### PR TITLE
chore(rollup): fix build warning messages

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ export function getConfig({
     {
       file: `dist/${pkg.name}.js`,
       format: 'cjs',
+      exports: 'named',
     },
     {
       file: `dist/${pkg.name}.es.js`,

--- a/rollup.ie11.config.js
+++ b/rollup.ie11.config.js
@@ -7,6 +7,7 @@ export default getConfig({
     {
       file: `dist/${pkg.name}.ie11.js`,
       format: 'cjs',
+      exports: 'named',
     },
   ],
 });


### PR DESCRIPTION
### Before
<img width="948" alt="螢幕快照 2019-12-05 上午10 57 39" src="https://user-images.githubusercontent.com/10325111/70200051-550c9f80-174e-11ea-9140-36c4d5c385c8.png">

### After
<img width="566" alt="螢幕快照 2019-12-05 上午10 58 39" src="https://user-images.githubusercontent.com/10325111/70200062-5b9b1700-174e-11ea-94f1-1488e17a3b53.png">

---

From docs:

**output.exports**
- `named` – suitable if you are exporting more than one thing