### PR TITLE
improve controlled component onchange with setValue

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,9 @@ export const INPUT_VALIDATION_RULES = {
   required: 'required',
   validate: 'validate',
 };
+
+export const VALUE_ATTRIBUTE = {
+  value: 'value',
+  checked: 'checked',
+  selected: 'selected',
+};

--- a/src/logic/setNativeValue.ts
+++ b/src/logic/setNativeValue.ts
@@ -1,12 +1,12 @@
 export default function setNativeValue(element: HTMLInputElement, value: any) {
-  const getOwnProperty = (element: HTMLInputElement) => {
-    const valueAttribute = 'value';
-    return Object.getOwnPropertyDescriptor(element, valueAttribute) || {};
-  };
-  const { set: valueSetter } = getOwnProperty(element);
-  const { set: prototypeValueSetter } = getOwnProperty(
-    Object.getPrototypeOf(element),
-  );
+  const valueAttribute = 'value';
+  const { set: valueSetter } =
+    Object.getOwnPropertyDescriptor(element, valueAttribute) || {};
+  const { set: prototypeValueSetter } =
+    Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(element),
+      valueAttribute,
+    ) || {};
 
   if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
     prototypeValueSetter.call(element, value);

--- a/src/logic/setNativeValue.ts
+++ b/src/logic/setNativeValue.ts
@@ -1,12 +1,12 @@
-export default function setNativeValue(element: any, value: any) {
-  const valueAttribute = 'value';
-  const { set: valueSetter } =
-    Object.getOwnPropertyDescriptor(element, valueAttribute) || {};
-  const { set: prototypeValueSetter } =
-    Object.getOwnPropertyDescriptor(
-      Object.getPrototypeOf(element),
-      valueAttribute,
-    ) || {};
+export default function setNativeValue(element: HTMLInputElement, value: any) {
+  const getOwnProperty = (element: HTMLInputElement) => {
+    const valueAttribute = 'value';
+    return Object.getOwnPropertyDescriptor(element, valueAttribute) || {};
+  };
+  const { set: valueSetter } = getOwnProperty(element);
+  const { set: prototypeValueSetter } = getOwnProperty(
+    Object.getPrototypeOf(element),
+  );
 
   if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
     prototypeValueSetter.call(element, value);

--- a/src/logic/setNativeValue.ts
+++ b/src/logic/setNativeValue.ts
@@ -1,0 +1,16 @@
+export default function setNativeValue(element: any, value: any) {
+  const valueAttribute = 'value';
+  const { set: valueSetter } =
+    Object.getOwnPropertyDescriptor(element, valueAttribute) || {};
+  const { set: prototypeValueSetter } =
+    Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(element),
+      valueAttribute,
+    ) || {};
+
+  if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+    prototypeValueSetter.call(element, value);
+  } else if (valueSetter) {
+    valueSetter.call(element, value);
+  }
+}

--- a/src/logic/setNativeValue.ts
+++ b/src/logic/setNativeValue.ts
@@ -1,10 +1,17 @@
-// reference https://github.com/facebook/react/issues/10135#issuecomment-401496776
-export default function setNativeValue(element: HTMLInputElement, value: any) {
+import { VALUE_ATTRIBUTE } from '../constants';
+
+export default function setNativeValue(
+  element: HTMLInputElement,
+  value: any,
+  valueAttribute: string = VALUE_ATTRIBUTE.value,
+) {
   const { set: valueSetter } =
-    Object.getOwnPropertyDescriptor(element, 'value') || {};
-  const prototype = Object.getPrototypeOf(element);
+    Object.getOwnPropertyDescriptor(element, valueAttribute) || {};
   const { set: prototypeValueSetter } =
-    Object.getOwnPropertyDescriptor(prototype, 'value') || {};
+    Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(element),
+      valueAttribute,
+    ) || {};
 
   if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
     prototypeValueSetter.call(element, value);

--- a/src/logic/setNativeValue.ts
+++ b/src/logic/setNativeValue.ts
@@ -1,3 +1,4 @@
+// reference https://github.com/facebook/react/issues/10135#issuecomment-401496776
 export default function setNativeValue(element: HTMLInputElement, value: any) {
   const valueAttribute = 'value';
   const { set: valueSetter } =

--- a/src/logic/setNativeValue.ts
+++ b/src/logic/setNativeValue.ts
@@ -1,13 +1,10 @@
 // reference https://github.com/facebook/react/issues/10135#issuecomment-401496776
 export default function setNativeValue(element: HTMLInputElement, value: any) {
-  const valueAttribute = 'value';
   const { set: valueSetter } =
-    Object.getOwnPropertyDescriptor(element, valueAttribute) || {};
+    Object.getOwnPropertyDescriptor(element, 'value') || {};
+  const prototype = Object.getPrototypeOf(element);
   const { set: prototypeValueSetter } =
-    Object.getOwnPropertyDescriptor(
-      Object.getPrototypeOf(element),
-      valueAttribute,
-    ) || {};
+    Object.getOwnPropertyDescriptor(prototype, 'value') || {};
 
   if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
     prototypeValueSetter.call(element, value);

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -8,6 +8,7 @@ import validateWithSchema from './logic/validateWithSchema';
 import validateField from './logic/validateField';
 import onDomRemove from './utils/onDomRemove';
 import { VALIDATION_MODE } from './constants';
+import setNativeValue from './logic/setNativeValue';
 
 jest.mock('./utils/onDomRemove');
 jest.mock('./logic/findRemovedFieldAndRemoveListener');
@@ -19,6 +20,7 @@ jest.mock('./logic/combineFieldValues', () => ({
   default: (data: any) => data,
   esmodule: true,
 }));
+jest.mock('./logic/setNativeValue');
 
 describe('useForm', () => {
   beforeEach(() => {
@@ -372,9 +374,19 @@ describe('useForm', () => {
       });
 
       await act(async () => {
+        expect(setNativeValue).toBeCalledWith(
+          { name: 'test', type: 'radio', value: '1' },
+          '1',
+          'checked',
+        );
+        expect(setNativeValue).toBeCalledWith(
+          { name: 'test', type: 'radio', value: '2' },
+          '2',
+          'checked',
+        );
         await result.current.handleSubmit(data => {
           expect(data).toEqual({
-            test: '1',
+            test: '',
           });
         })({
           preventDefault: () => {},
@@ -411,9 +423,30 @@ describe('useForm', () => {
       });
 
       await act(async () => {
+        expect(setNativeValue).toBeCalledWith(
+          {
+            attributes: { value: '1' },
+            name: 'test',
+            type: 'checkbox',
+            value: '1',
+          },
+          true,
+          'checked',
+        );
+        expect(setNativeValue).toBeCalledWith(
+          {
+            attributes: { value: '2' },
+            name: 'test',
+            type: 'checkbox',
+            value: '2',
+          },
+          false,
+          'checked',
+        );
+
         await result.current.handleSubmit(data => {
           expect(data).toEqual({
-            test: ['1'],
+            test: [],
           });
         })({
           preventDefault: () => {},
@@ -444,9 +477,19 @@ describe('useForm', () => {
       });
 
       await act(async () => {
+        expect(setNativeValue).toBeCalledWith(
+          {
+            attributes: { value: '1' },
+            name: 'test',
+            type: 'checkbox',
+            value: '1',
+          },
+          true,
+          'checked',
+        );
         await result.current.handleSubmit(data => {
           expect(data).toEqual({
-            test: '1',
+            test: false,
           });
         })({
           preventDefault: () => {},

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -11,6 +11,7 @@ import attachNativeValidation from './logic/attachNativeValidation';
 import getDefaultValue from './logic/getDefaultValue';
 import assignWatchFields from './logic/assignWatchFields';
 import omitValidFields from './logic/omitValidFields';
+import setNativeValue from './logic/setNativeValue';
 import isCheckBoxInput from './utils/isCheckBoxInput';
 import isEmptyObject from './utils/isEmptyObject';
 import isRadioInput from './utils/isRadioInput';
@@ -249,7 +250,12 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       name: FieldName<FormValues>,
       value: FieldValue<FormValues>,
     ): boolean | void => {
-      setFieldValue(name, value);
+      const inputRef = fieldsRef.current[name]!.ref;
+
+      if (inputRef) {
+        setNativeValue(inputRef, value);
+        inputRef.dispatchEvent(new Event(EVENTS.INPUT, { bubbles: true }));
+      }
 
       if (
         setDirty(name) ||
@@ -258,7 +264,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         return !!touchedFieldsRef.current.add(name);
       }
     },
-    [setFieldValue],
+    [],
   );
 
   const executeValidation = useCallback(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -252,7 +252,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
     ): boolean | void => {
       setFieldValue(name, value);
 
-      if (fieldsRef.current[name]) {
+      if (fieldsRef.current[name] && isWeb) {
         const inputRef = fieldsRef.current[name]!.ref;
 
         if (!isEmptyObject(inputRef) && inputRef.dispatchEvent) {
@@ -276,7 +276,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         return !!touchedFieldsRef.current.add(name);
       }
     },
-    [setFieldValue],
+    [isWeb, setFieldValue],
   );
 
   const executeValidation = useCallback(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -252,7 +252,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
     ): boolean | void => {
       setFieldValue(name, value);
 
-      if (fieldsRef.current[name] && isWeb) {
+      if (isWeb && fieldsRef.current[name]) {
         const inputRef = fieldsRef.current[name]!.ref;
 
         if (!isEmptyObject(inputRef) && inputRef.dispatchEvent) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -223,7 +223,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         setNativeValue(ref, value);
       }
 
-      if (isWeb) {
+      if (isWeb && ref.dispatchEvent) {
         ref.dispatchEvent(new Event(EVENTS.INPUT, { bubbles: true }));
       }
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -250,11 +250,15 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       name: FieldName<FormValues>,
       value: FieldValue<FormValues>,
     ): boolean | void => {
-      const inputRef = fieldsRef.current[name]!.ref;
+      setFieldValue(name, value);
 
-      if (inputRef) {
-        setNativeValue(inputRef, value);
-        inputRef.dispatchEvent(new Event(EVENTS.INPUT, { bubbles: true }));
+      if (fieldsRef.current[name]) {
+        const inputRef = fieldsRef.current[name]!.ref;
+
+        if (inputRef && inputRef.dispatchEvent) {
+          setNativeValue(inputRef, value);
+          inputRef.dispatchEvent(new Event(EVENTS.INPUT, { bubbles: true }));
+        }
       }
 
       if (
@@ -264,7 +268,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         return !!touchedFieldsRef.current.add(name);
       }
     },
-    [],
+    [setFieldValue],
   );
 
   const executeValidation = useCallback(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -256,7 +256,15 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         const inputRef = fieldsRef.current[name]!.ref;
 
         if (inputRef && inputRef.dispatchEvent) {
-          setNativeValue(inputRef, value);
+          if (isMultipleSelect(inputRef.type)) {
+            [...inputRef.options].forEach(selectRef => {
+              if ((value as string[]).includes(selectRef.value)) {
+                setNativeValue(selectRef, selectRef.value);
+              }
+            });
+          } else {
+            setNativeValue(inputRef, value);
+          }
           inputRef.dispatchEvent(new Event(EVENTS.INPUT, { bubbles: true }));
         }
       }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -255,7 +255,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
       if (fieldsRef.current[name]) {
         const inputRef = fieldsRef.current[name]!.ref;
 
-        if (inputRef && inputRef.dispatchEvent) {
+        if (!isEmptyObject(inputRef) && inputRef.dispatchEvent) {
           if (isMultipleSelect(inputRef.type)) {
             [...inputRef.options].forEach(selectRef => {
               if ((value as string[]).includes(selectRef.value)) {

--- a/src/utils/isDetached.ts
+++ b/src/utils/isDetached.ts
@@ -1,14 +1,12 @@
 import { Ref } from '../types';
+import isHtmlElement from './isHtmlElement';
 
 export default function isDetached(element: Ref): boolean {
   if (!element) {
     return true;
   }
 
-  if (
-    !(element instanceof HTMLElement) ||
-    element.nodeType === Node.DOCUMENT_NODE
-  ) {
+  if (!isHtmlElement(element) || element.nodeType === Node.DOCUMENT_NODE) {
     return false;
   }
 

--- a/src/utils/isHtmlElement.ts
+++ b/src/utils/isHtmlElement.ts
@@ -1,0 +1,1 @@
+export default (element: any) => element instanceof HTMLElement;


### PR DESCRIPTION
Original issue: https://github.com/react-hook-form/react-hook-form/issues/477

This fix was inspired by MUI's author & related to the following GitHub issue. 
It was originally written by Kent ❤️ : 
https://github.com/facebook/react/issues/10135#issuecomment-401496776

@JeromeDeLeon I will keep the reference in this PR instead of the code. 

This PR will improve the following API

`reset()`
`setValue()`

with controlled components.
