### PR TITLE
fixing checkbox dynamic rendering

### DIFF
--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -24,9 +24,10 @@ export default function findRemovedFieldAndRemoveListener<
   }
 
   const { name, type } = ref;
-  const options = fields[name];
 
-  if (isRadioInput(type) || isCheckBoxInput(type)) {
+  const fieldValue: Field | undefined = fields[name];
+  if ((isRadioInput(type) || isCheckBoxInput(type)) && fieldValue) {
+    const { options } = fieldValue;
     if (isArray(options) && options.length) {
       options.forEach(({ ref }, index): void => {
         const option = options[index];
@@ -41,6 +42,10 @@ export default function findRemovedFieldAndRemoveListener<
           options.splice(index, 1);
         }
       });
+      // Unless all the options are removed from dom, do not delete the field
+      if (options && options.length === 0) {
+        delete fields[name];
+      }
     } else {
       delete fields[name];
     }


### PR DESCRIPTION
**Describe the bug**
When a different set of check boxes are rendered after the initial render. 
The checkboxes renderd after the initial render do not have their event handlers registered with react-hook-form

**To Reproduce**
Steps to reproduce the behavior:
1. Go to the dropdown
2. Select an option
3. Select the checkbox values and see the values getting rendered by the watch
4. Select a different option 
5. Select the checkboxes, notice that the values are not getting rendered

**Codesandbox link**
https://codesandbox.io/s/react-hook-form-custom-input-ymxx7

**Expected behavior**
Selected checkboxes should render values after the initial render

**Screenshots**
First render: 

![image](https://user-images.githubusercontent.com/55671870/69772029-a9b29680-11f3-11ea-91ea-ad8f7e0d9f16.png)

Select Strawberry from the dropdown and select all the strawberry checkboxes
Notice that the values are not getting updated for the checkBoxValues
![image](https://user-images.githubusercontent.com/55671870/69772049-b9ca7600-11f3-11ea-958b-838e176cc452.png)


**Additional context**

The fix for this would be inside findRemovedFieldAndRemoveListener.ts

`
 const { name, type } = ref;

 const fieldValue: Field | undefined = fields[name];

 if ((isRadioInput(type) || isCheckBoxInput(type)) && fieldValue) {

    const { options } = fieldValue;

    if (isArray(options) && options.length) {

      options.forEach(({ ref }, index): void => {

        const option = options[index];
        if ((option && isDetached(ref)) || forceDelete) {

          const mutationWatcher = option.mutationWatcher;

          removeAllEventListeners(option, handleChange);

          if (mutationWatcher) {
            mutationWatcher.disconnect();
          }
          options.splice(index, 1);
        }
      });
      // Unless all the options are removed from dom, do not delete the field
      if (options && options.length === 0) {
        delete fields[name];
      }
    } else {
      delete fields[name];
    }
 
`
![image](https://user-images.githubusercontent.com/55671870/70675580-6b869e00-1cee-11ea-9699-dd303f701f26.png)
