### PR TITLE
[Typo] fix a typo for 'React Native' in README.ko-KR.md

### DIFF
--- a/docs/README.ko-KR.md
+++ b/docs/README.ko-KR.md
@@ -37,7 +37,7 @@
 - 제어되지 않는 양식 검증
 - 의존성 없는 [작은 용량](https://bundlephobia.com/result?p=react-hook-form@latest)
 - HTML 표준을 따르는 검증
-- Reative Native 와 호환
+- React Native 와 호환
 - [Yup](https://github.com/jquense/yup) 스키마 기반의 검증 지원
 - 브라우저 네이티브 검증 지원
 - [Form Builder](https://react-hook-form.com/form-builder)로 폼 빠르게 생성


### PR DESCRIPTION
**Eng ver. of README.md**

<img width="666" alt="eng" src="https://user-images.githubusercontent.com/6101260/71301833-9906d200-23e7-11ea-9f62-c0908a68717f.png">

---
**Kor ver. of README.md**

<img width="666" alt="kor" src="https://user-images.githubusercontent.com/6101260/71301846-acb23880-23e7-11ea-93a4-1b4d24f15a81.png">

**so I fixed the "Reative Native" to "React Native", to match it up with the Eng ver.**

<img width="666" alt="kor-modified" src="https://user-images.githubusercontent.com/6101260/71301920-a53f5f00-23e8-11ea-9b73-b519c4365732.png">
