### PR TITLE
Add control to FormContextValues, return FormContextValues in useForm

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -89,4 +89,5 @@ export interface FormContextValues<
   handleSubmit: (
     callback: OnSubmit<FormValues>,
   ) => (e: React.BaseSyntheticEvent) => Promise<void>;
+  control: any;
 }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -27,6 +27,7 @@ import isMultipleSelect from './utils/isMultipleSelect';
 import modeChecker from './utils/validationModeChecker';
 import isNullOrUndefined from './utils/isNullOrUndefined';
 import { EVENTS, UNDEFINED, VALIDATION_MODE } from './constants';
+import { FormContextValues } from './contextTypes';
 import {
   FieldValues,
   FieldName,
@@ -56,7 +57,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
   defaultValues = {},
   submitFocusError = true,
   validateCriteriaMode,
-}: UseFormOptions<FormValues> = {}) {
+}: UseFormOptions<FormValues> = {}): FormContextValues<FormValues> {
   const fieldsRef = useRef<FieldRefs<FormValues>>({});
   const validateAllFieldCriteria = validateCriteriaMode === 'all';
   const errorsRef = useRef<FieldErrors<FormValues>>({});


### PR DESCRIPTION
Make `useForm` and `FormContextProvider` APIs consistent.