### PR TITLE
Failing tests 

### DIFF
--- a/src/useForm-integration.test.ts
+++ b/src/useForm-integration.test.ts
@@ -1,0 +1,52 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useForm } from './useForm';
+
+describe('getValues', () => {
+  describe('nest: false', () => {
+    it('should returned a flattened version of defaultValues', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          defaultValues: {
+            foo: 'bar',
+            complex: {
+              field: 'value',
+            },
+          },
+        }),
+      );
+      act(() => {
+        const values = result.current.getValues({ nest: false });
+
+        expect(values).toEqual({
+          foo: 'bar',
+          'complex.field': 'value',
+        });
+      });
+    });
+  });
+});
+
+describe('watch', () => {
+  describe('nest: false', () => {
+    it('should returned a flattened version of defaultValues', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          defaultValues: {
+            foo: 'bar',
+            complex: {
+              field: 'value',
+            },
+          },
+        }),
+      );
+      act(() => {
+        const values = result.current.watch({ nest: false });
+
+        expect(values).toEqual({
+          foo: 'bar',
+          'complex.field': 'value',
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Failing tests for #698

Unsure why `useForm.test.ts` is using so many mocks as it kinda puts a spanner in actually testing the real behaviour of the hook, so I created a new file called  "integration".

I can try to do a patch for this.