### PR TITLE
fix #712 setValue path type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type Primitive = string | boolean | number | symbol | null | undefined;
 export type FieldValues = Record<string, any>;
 
 export type FieldName<FormValues extends FieldValues> =
-  | keyof FormValues
+  | (keyof FormValues & string)
   | string;
 
 export type FieldValue<FormValues extends FieldValues> = FormValues[FieldName<

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,9 @@ export type Primitive = string | boolean | number | symbol | null | undefined;
 
 export type FieldValues = Record<string, any>;
 
-export type FieldName<FormValues extends FieldValues> = keyof FormValues &
-  string;
+export type FieldName<FormValues extends FieldValues> =
+  | keyof FormValues
+  | string;
 
 export type FieldValue<FormValues extends FieldValues> = FormValues[FieldName<
   FormValues


### PR DESCRIPTION
fix setValue path type in typescript

issue: #712 

### before
```js
type Form = { name: string, person: { firstName: string, lastName: string } };

const {setValue} = useForm<Form>();

setValue('person.firstName', 'tanmen'); //<- error
```

### after
```js
type Form = { name: string, person: { firstName: string, lastName: string } };

const {setValue} = useForm<Form>();

setValue('person.firstName', 'tanmen'); //<- no error
```
