### PR TITLE
:beetle: fix Controller component props and event names

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -27,8 +27,8 @@ const Controller = ({
   as: InnerComponent,
   onChange,
   onBlur,
-  onChangeName,
-  onBlurName,
+  onChangeName = VALIDATION_MODE.onChange,
+  onBlurName = VALIDATION_MODE.onBlur,
   defaultValue,
   control: {
     defaultValues,
@@ -118,22 +118,12 @@ const Controller = ({
   const props = {
     ...rest,
     ...(onChange
-      ? {
-          [onChangeName || VALIDATION_MODE.onChange]: eventWrapper(
-            onChange,
-            VALIDATION_MODE.onChange,
-          ),
-        }
-      : { onChange: handleChange }),
+      ? { [onChangeName]: eventWrapper(onChange, EVENTS.CHANGE) }
+      : { [onChangeName]: handleChange }),
     ...(isOnBlur || isReValidateOnBlur
       ? onBlur
-        ? {
-            [onBlurName || VALIDATION_MODE.onBlur]: eventWrapper(
-              onBlur,
-              VALIDATION_MODE.onBlur,
-            ),
-          }
-        : { onBlur: handleBlur }
+        ? { [onBlurName]: eventWrapper(onBlur, EVENTS.BLUR) }
+        : { [onBlurName]: handleBlur }
       : {}),
     ...(isCheckboxInput ? { checked: value } : { value }),
   };


### PR DESCRIPTION
This adds two small fixes to the `<Controller />` component:

- `eventWrapper` expected an event name like `blur` but was being passed
  a method name like `onBlur`. Now the two will match.

- The component's `onBlurName` and `onChangeName` props weren't being
  used if a custom handler wasn't provided.