### PR TITLE
Support custom value name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,12 +2,14 @@
   "eslint.validate": [
     "javascript",
     "javascriptreact",
-    { "language": "typescript", "autoFix": true },
-    { "language": "typescriptreact", "autoFix": true }
+    "typescript",
+    "typescriptreact"
   ],
   "prettier.configPath": "./.pretterrc",
   "eslint.enable": true,
   "editor.formatOnSave": true,
-  "eslint.autoFixOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -16,6 +16,14 @@ exports[`React Hook Form Input should render correctly with as with string 1`] =
 </DocumentFragment>
 `;
 
+exports[`React Hook Form Input should support custom value name 1`] = `
+<DocumentFragment>
+  <input
+    value=""
+  />
+</DocumentFragment>
+`;
+
 exports[`React Hook Form Input should support default value from hook form 1`] = `
 <DocumentFragment>
   <input

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`React Hook Form Input should render correctly with as with string 1`] =
 exports[`React Hook Form Input should support custom value name 1`] = `
 <DocumentFragment>
   <input
-    value=""
+    selectedkey=""
   />
 </DocumentFragment>
 `;

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -2,52 +2,41 @@ import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { Controller } from './index';
 
+function reconfigureControl(changedControl = {}) {
+  const defaultControl = {
+    defaultValues: {},
+    fields: {},
+    setValue: jest.fn(),
+    register: jest.fn(),
+    unregister: jest.fn(),
+    errors: {},
+    mode: { isOnSubmit: false, isOnBlur: false },
+    reValidateMode: {
+      isReValidateOnBlur: false,
+      isReValidateOnSubmit: false,
+    },
+    formState: { isSubmitted: false },
+  };
+
+  return Object.assign({}, defaultControl, changedControl);
+}
+
 describe('React Hook Form Input', () => {
   it('should render correctly with as with string', () => {
+    const control = reconfigureControl();
+
     const { asFragment } = render(
-      <Controller
-        name="test"
-        as="input"
-        control={{
-          defaultValues: {},
-          fields: {},
-          setValue: jest.fn(),
-          register: jest.fn(),
-          unregister: jest.fn(),
-          errors: {},
-          mode: { isOnSubmit: false, isOnBlur: false },
-          reValidateMode: {
-            isReValidateOnBlur: false,
-            isReValidateOnSubmit: false,
-          },
-          formState: { isSubmitted: false },
-        }}
-      />,
+      <Controller name="test" as="input" control={control} />,
     );
 
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render correctly with as with component', () => {
+    const control = reconfigureControl();
+
     const { asFragment } = render(
-      <Controller
-        name="test"
-        as={<input />}
-        control={{
-          defaultValues: {},
-          fields: {},
-          setValue: jest.fn(),
-          register: jest.fn(),
-          unregister: jest.fn(),
-          errors: {},
-          mode: { isOnSubmit: false, isOnBlur: false },
-          reValidateMode: {
-            isReValidateOnBlur: false,
-            isReValidateOnSubmit: false,
-          },
-          formState: { isSubmitted: false },
-        }}
-      />,
+      <Controller name="test" as={<input />} control={control} />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -55,25 +44,16 @@ describe('React Hook Form Input', () => {
 
   it("should trigger component's onChange method and invoke setValue method", () => {
     const setValue = jest.fn();
+    const control = reconfigureControl({
+      setValue,
+      mode: { isOnSubmit: true, isOnBlur: false },
+    });
 
     const { getByPlaceholderText } = render(
       <Controller
         name="test"
         as={<input placeholder="test" />}
-        control={{
-          defaultValues: {},
-          fields: {},
-          setValue,
-          register: jest.fn(),
-          unregister: jest.fn(),
-          errors: {},
-          mode: { isOnSubmit: true, isOnBlur: false },
-          reValidateMode: {
-            isReValidateOnBlur: false,
-            isReValidateOnSubmit: false,
-          },
-          formState: { isSubmitted: false },
-        }}
+        control={control}
       />,
     );
 
@@ -88,25 +68,16 @@ describe('React Hook Form Input', () => {
 
   it("should trigger component's onBlur method and invoke setValue method", () => {
     const setValue = jest.fn();
+    const control = reconfigureControl({
+      setValue,
+      mode: { isOnSubmit: true, isOnBlur: true },
+    });
 
     const { getByPlaceholderText } = render(
       <Controller
         name="test"
         as={<input placeholder="test" />}
-        control={{
-          defaultValues: {},
-          fields: {},
-          setValue,
-          register: jest.fn(),
-          unregister: jest.fn(),
-          errors: {},
-          mode: { isOnSubmit: true, isOnBlur: true },
-          reValidateMode: {
-            isReValidateOnBlur: false,
-            isReValidateOnSubmit: false,
-          },
-          formState: { isSubmitted: false },
-        }}
+        control={control}
       />,
     );
 
@@ -121,26 +92,17 @@ describe('React Hook Form Input', () => {
 
   it('should invoke custom event named method', () => {
     const setValue = jest.fn();
+    const control = reconfigureControl({
+      setValue,
+      mode: { isOnSubmit: true, isOnBlur: true },
+    });
 
     const { getByPlaceholderText } = render(
       <Controller
         name="test"
         as={<input placeholder="test" />}
         onChangeName="onChange"
-        control={{
-          defaultValues: {},
-          setValue,
-          fields: {},
-          register: jest.fn(),
-          unregister: jest.fn(),
-          errors: {},
-          mode: { isOnSubmit: true, isOnBlur: true },
-          reValidateMode: {
-            isReValidateOnBlur: false,
-            isReValidateOnSubmit: false,
-          },
-          formState: { isSubmitted: false },
-        }}
+        control={control}
       />,
     );
 
@@ -156,6 +118,10 @@ describe('React Hook Form Input', () => {
   it('should invoke custom onChange method', () => {
     const onChange = jest.fn();
     const setValue = jest.fn();
+    const control = reconfigureControl({
+      setValue,
+      mode: { isOnSubmit: false, isOnBlur: true },
+    });
 
     onChange.mockImplementation(() => 'test');
 
@@ -164,20 +130,7 @@ describe('React Hook Form Input', () => {
         name="test"
         as={<input placeholder="test" />}
         onChange={onChange}
-        control={{
-          defaultValues: {},
-          fields: {},
-          setValue,
-          register: jest.fn(),
-          unregister: jest.fn(),
-          errors: {},
-          mode: { isOnSubmit: false, isOnBlur: true },
-          reValidateMode: {
-            isReValidateOnBlur: false,
-            isReValidateOnSubmit: false,
-          },
-          formState: { isSubmitted: false },
-        }}
+        control={control}
       />,
     );
 
@@ -192,27 +145,24 @@ describe('React Hook Form Input', () => {
   });
 
   it('should support default value from hook form', () => {
+    const control = reconfigureControl({
+      defaultValues: {
+        test: 'data',
+      },
+    });
+
     const { asFragment } = render(
-      <Controller
-        name="test"
-        as="input"
-        control={{
-          defaultValues: {
-            test: 'data',
-          },
-          fields: {},
-          setValue: jest.fn(),
-          register: jest.fn(),
-          unregister: jest.fn(),
-          errors: {},
-          mode: { isOnSubmit: false, isOnBlur: false },
-          reValidateMode: {
-            isReValidateOnBlur: false,
-            isReValidateOnSubmit: false,
-          },
-          formState: { isSubmitted: false },
-        }}
-      />,
+      <Controller name="test" as="input" control={control} />,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should support custom value name', () => {
+    const control = reconfigureControl();
+
+    const { asFragment } = render(
+      <Controller name="test" as="input" valueName="value" control={control} />,
     );
 
     expect(asFragment()).toMatchSnapshot();

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -162,7 +162,7 @@ describe('React Hook Form Input', () => {
     const control = reconfigureControl();
 
     const { asFragment } = render(
-      <Controller name="test" as="input" valueName="value" control={control} />,
+      <Controller name="test" as="input" valueName="selectedkey" control={control} />,
     );
 
     expect(asFragment()).toMatchSnapshot();

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -115,8 +115,7 @@ const Controller = ({
     registerField();
   }
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  React.useEffect(() => () => unregister(name), []);
+  React.useEffect(() => () => unregister(name), [unregister, name]);
 
   const props = {
     ...rest,

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -17,6 +17,7 @@ export type Props = {
   mode?: Mode;
   onChangeName?: string;
   onBlurName?: string;
+  valueName?: string;
   defaultValue?: any;
   control: any;
 };
@@ -29,6 +30,7 @@ const Controller = ({
   onBlur,
   onChangeName = VALIDATION_MODE.onChange,
   onBlurName = VALIDATION_MODE.onBlur,
+  valueName,
   defaultValue,
   control: {
     defaultValues,
@@ -113,6 +115,7 @@ const Controller = ({
     registerField();
   }
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(() => () => unregister(name), []);
 
   const props = {
@@ -125,7 +128,7 @@ const Controller = ({
         ? { [onBlurName]: eventWrapper(onBlur, EVENTS.BLUR) }
         : { [onBlurName]: handleBlur }
       : {}),
-    ...(isCheckboxInput ? { checked: value } : { value }),
+    ...{ [valueName || (isCheckboxInput ? 'checked' : 'value')]: value },
   };
 
   return React.isValidElement(InnerComponent) ? (

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -115,7 +115,8 @@ const Controller = ({
     registerField();
   }
 
-  React.useEffect(() => () => unregister(name), [unregister, name]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => () => unregister(name), []);
 
   const props = {
     ...rest,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -995,10 +995,9 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
     () => () => {
       isUnMount.current = true;
       fieldsRef.current &&
-        Object.values(
-          fieldsRef.current,
-        ).forEach((field: Field | undefined): void =>
-          removeEventListenerAndRef(field, true),
+        Object.values(fieldsRef.current).forEach(
+          (field: Field | undefined): void =>
+            removeEventListenerAndRef(field, true),
         );
     },
     [removeEventListenerAndRef],

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -995,9 +995,10 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
     () => () => {
       isUnMount.current = true;
       fieldsRef.current &&
-        Object.values(fieldsRef.current).forEach(
-          (field: Field | undefined): void =>
-            removeEventListenerAndRef(field, true),
+        Object.values(
+          fieldsRef.current,
+        ).forEach((field: Field | undefined): void =>
+          removeEventListenerAndRef(field, true),
         );
     },
     [removeEventListenerAndRef],

--- a/src/utils/omitObject.ts
+++ b/src/utils/omitObject.ts
@@ -3,6 +3,7 @@ interface OmitObject {
 }
 
 const omitObject: OmitObject = (obj, key) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { [key]: omitted, ...rest } = obj;
   return rest;
 };


### PR DESCRIPTION
Basically, it allows to override the `value | checked` prop to support other UI lib like `office-ui-fabric-react` that doesn't make use of `value`.

I only tried `ChoiceGroup` therefore, I assumed that some form components works the same.