### PR TITLE
support multiple errors for ErrorMessage component

### DIFF
--- a/src/__snapshots__/errorMessage.test.tsx.snap
+++ b/src/__snapshots__/errorMessage.test.tsx.snap
@@ -8,7 +8,53 @@ exports[`React Hook Form Error Message should render correctly with flat errors 
 </DocumentFragment>
 `;
 
+exports[`React Hook Form Error Message should render correctly with flat errors and as with component and children 1`] = `
+<DocumentFragment>
+  <span>
+    flat
+  </span>
+</DocumentFragment>
+`;
+
 exports[`React Hook Form Error Message should render correctly with flat errors and as with string 1`] = `
+<DocumentFragment>
+  <span>
+    flat
+  </span>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with flat multiple errors and as with component and children 1`] = `
+<DocumentFragment>
+  <div>
+    <span>
+      flat1
+    </span>
+    <span>
+      flat2
+    </span>
+    <span>
+      flat3
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with flat multiple errors and children 1`] = `
+<DocumentFragment>
+  <span>
+    flat1
+  </span>
+  <span>
+    flat2
+  </span>
+  <span>
+    flat3
+  </span>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with nested errors and as with componet and children 1`] = `
 <DocumentFragment>
   <span>
     object
@@ -22,7 +68,15 @@ exports[`React Hook Form Error Message should render correctly with nested error
 </DocumentFragment>
 `;
 
-exports[`React Hook Form Error Message should render correctly with nested errors array and as with component 1`] = `
+exports[`React Hook Form Error Message should render correctly with nested errors array and as with component and children 1`] = `
+<DocumentFragment>
+  <span>
+    array
+  </span>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with nested errors array and as with string 1`] = `
 <DocumentFragment>
   <span>
     array
@@ -36,10 +90,70 @@ exports[`React Hook Form Error Message should render correctly with nested error
 </DocumentFragment>
 `;
 
-exports[`React Hook Form Error Message should render correctly with nested errors object and as with component 1`] = `
+exports[`React Hook Form Error Message should render correctly with nested errors object and as with string 1`] = `
 <DocumentFragment>
   <span>
     object
+  </span>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with nested multiple errors and as with component and children 1`] = `
+<DocumentFragment>
+  <div>
+    <span>
+      object1
+    </span>
+    <span>
+      object2
+    </span>
+    <span>
+      object3
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with nested multiple errors and children 1`] = `
+<DocumentFragment>
+  <span>
+    object1
+  </span>
+  <span>
+    object2
+  </span>
+  <span>
+    object3
+  </span>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with nested multiple errors array and as with component and children 1`] = `
+<DocumentFragment>
+  <div>
+    <span>
+      array1
+    </span>
+    <span>
+      array2
+    </span>
+    <span>
+      array3
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with nested multiple errors array and children 1`] = `
+<DocumentFragment>
+  <span>
+    array1
+  </span>
+  <span>
+    array2
+  </span>
+  <span>
+    array3
   </span>
 </DocumentFragment>
 `;

--- a/src/errorMessage.test.tsx
+++ b/src/errorMessage.test.tsx
@@ -24,13 +24,78 @@ describe('React Hook Form Error Message', () => {
     const { asFragment } = render(
       <ErrorMessage
         as="span"
+        errors={{ flat: { type: 'flat', message: 'flat' } }}
+        name="flat"
+      />,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with flat errors and as with component and children', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        as={<span />}
+        errors={{ flat: { type: 'flat', message: 'flat' } }}
+        name="flat"
+      >
+        {({ message }) => message}
+      </ErrorMessage>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with flat multiple errors and children', () => {
+    const { asFragment } = render(
+      <ErrorMessage
         errors={{
-          nested: {
-            object: { type: 'object', message: 'object' },
+          flat: {
+            type: 'flat',
+            message: 'flat',
+            types: {
+              flat1: 'flat1',
+              flat2: 'flat2',
+              flat3: 'flat3',
+            },
           },
         }}
-        name="nested.object"
-      />,
+        name="flat"
+      >
+        {({ messages }) =>
+          Object.entries(messages).map(([type, message]) => (
+            <span key={type}>{message}</span>
+          ))
+        }
+      </ErrorMessage>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with flat multiple errors and as with component and children', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        as={<div />}
+        errors={{
+          flat: {
+            type: 'flat',
+            message: 'flat',
+            types: {
+              flat1: 'flat1',
+              flat2: 'flat2',
+              flat3: 'flat3',
+            },
+          },
+        }}
+        name="flat"
+      >
+        {({ messages }) =>
+          Object.entries(messages).map(([type, message]) => (
+            <span key={type}>{message}</span>
+          ))
+        }
+      </ErrorMessage>,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -51,7 +116,23 @@ describe('React Hook Form Error Message', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render correctly with nested errors object and as with component', () => {
+  it('should render correctly with nested errors object and as with string', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        as="span"
+        errors={{
+          nested: {
+            object: { type: 'object', message: 'object' },
+          },
+        }}
+        name="nested.object"
+      />,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with nested errors and as with componet and children', () => {
     const { asFragment } = render(
       <ErrorMessage
         as={<span />}
@@ -61,7 +142,68 @@ describe('React Hook Form Error Message', () => {
           },
         }}
         name="nested.object"
-      />,
+      >
+        {({ message }) => message}
+      </ErrorMessage>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with nested multiple errors and children', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        errors={{
+          nested: {
+            object: {
+              type: 'object',
+              message: 'object',
+              types: {
+                object1: 'object1',
+                object2: 'object2',
+                object3: 'object3',
+              },
+            },
+          },
+        }}
+        name="nested.object"
+      >
+        {({ messages }) =>
+          Object.entries(messages).map(([type, message]) => (
+            <span key={type}>{message}</span>
+          ))
+        }
+      </ErrorMessage>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with nested multiple errors and as with component and children', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        as={<div />}
+        errors={{
+          nested: {
+            object: {
+              type: 'object',
+              message: 'object',
+              types: {
+                object1: 'object1',
+                object2: 'object2',
+                object3: 'object3',
+              },
+            },
+          },
+        }}
+        name="nested.object"
+      >
+        {({ messages }) =>
+          Object.entries(messages).map(([type, message]) => (
+            <span key={type}>{message}</span>
+          ))
+        }
+      </ErrorMessage>,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -84,7 +226,25 @@ describe('React Hook Form Error Message', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('should render correctly with nested errors array and as with component', () => {
+  it('should render correctly with nested errors array and as with string', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        as="span"
+        errors={{
+          nested: [
+            {
+              array: { type: 'array', message: 'array' },
+            },
+          ],
+        }}
+        name="nested[0].array"
+      />,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with nested errors array and as with component and children', () => {
     const { asFragment } = render(
       <ErrorMessage
         as={<span />}
@@ -96,7 +256,72 @@ describe('React Hook Form Error Message', () => {
           ],
         }}
         name="nested[0].array"
-      />,
+      >
+        {({ message }) => message}
+      </ErrorMessage>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with nested multiple errors array and children', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        errors={{
+          nested: [
+            {
+              array: {
+                type: 'array',
+                message: 'array',
+                types: {
+                  array1: 'array1',
+                  array2: 'array2',
+                  array3: 'array3',
+                },
+              },
+            },
+          ],
+        }}
+        name="nested[0].array"
+      >
+        {({ messages }) =>
+          Object.entries(messages).map(([type, message]) => (
+            <span key={type}>{message}</span>
+          ))
+        }
+      </ErrorMessage>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with nested multiple errors array and as with component and children', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        as={<div />}
+        errors={{
+          nested: [
+            {
+              array: {
+                type: 'array',
+                message: 'array',
+                types: {
+                  array1: 'array1',
+                  array2: 'array2',
+                  array3: 'array3',
+                },
+              },
+            },
+          ],
+        }}
+        name="nested[0].array"
+      >
+        {({ messages }) =>
+          Object.entries(messages).map(([type, message]) => (
+            <span key={type}>{message}</span>
+          ))
+        }
+      </ErrorMessage>,
     );
 
     expect(asFragment()).toMatchSnapshot();

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -40,7 +40,7 @@ const ErrorMessage = <
 
   const props = {
     children: children
-      ? children({ message: message, messages: types })
+      ? children({ message, messages: types })
       : message,
   };
 

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -1,12 +1,21 @@
 import * as React from 'react';
 import { useFormContext } from './useFormContext';
 import get from './utils/get';
-import { FieldErrors, FieldName, FormValuesFromErrors } from './types';
+import {
+  FieldErrors,
+  FieldName,
+  MultipleFieldErrors,
+  FormValuesFromErrors,
+} from './types';
 
 type Props<Errors, Name> = {
   as?: React.ElementType<any> | React.FunctionComponent<any> | string | any;
   errors?: Errors;
   name: Name;
+  children?: (data: {
+    message: string;
+    messages: MultipleFieldErrors;
+  }) => React.ReactNode;
 };
 
 const ErrorMessage = <
@@ -14,17 +23,26 @@ const ErrorMessage = <
   Name extends FieldName<FormValuesFromErrors<Errors>>
 >({
   as: InnerComponent,
-  errors: errorsFromProps,
+  errors,
   name,
+  children,
 }: Props<Errors, Name>) => {
   const methods = useFormContext() || {};
-  const { message } = get(errorsFromProps || methods.errors, name, {});
+  const { message, types } = get(
+    errors || (methods.errors as Errors),
+    name,
+    {},
+  );
 
   if (!message) {
     return null;
   }
 
-  const props = { children: message };
+  const props = {
+    children: children
+      ? children({ message: message, messages: types })
+      : message,
+  };
 
   return InnerComponent ? (
     React.isValidElement(InnerComponent) ? (
@@ -33,7 +51,7 @@ const ErrorMessage = <
       <InnerComponent {...props} />
     )
   ) : (
-    <>{message}</>
+    <React.Fragment {...props} />
   );
 };
 


### PR DESCRIPTION
Add render prop (`children` prop) with `message` and `messages` as arguments!

Related PR: https://github.com/react-hook-form/react-hook-form/pull/715

```ts
export default function App() {
  const { register, errors, handleSubmit } = useForm<{
    password: string;
  }>({
    validateCriteriaMode: "all"
  });
  const onSubmit = data => console.log(data);

  return (
    <form onSubmit={handleSubmit(onSubmit)}>
      <input
        type="password"
        name="password"
        ref={register({
          required: "password required",
          minLength: {
            value: 10,
            message: "password minLength 10"
          },
          pattern: {
            value: /\d+/,
            message: "password number only"
          }
        })}
      />
      <ErrorMessage name="password" errors={errors}>
        {({ message, messages }) => {
          console.log("single", message);
          console.log("multiple", messages);
          return Object.entries(messages).map(([type, message]) => (
            <span key={type}>{message}</span>
          ));
        }}
      </ErrorMessage>

      <input type="submit" />
    </form>
  );
}
```