### PR TITLE
add runtime field name check and add unit test

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,5 @@
 import { ValidationMode } from './types';
 
-export const IS_DEV_ENV = process.env.NODE_ENV !== 'production';
-
 export const VALIDATION_MODE: ValidationMode = {
   onBlur: 'onBlur',
   onChange: 'onChange',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 import { ValidationMode } from './types';
 
+export const IS_DEV_ENV = process.env.NODE_ENV !== 'production';
+
 export const VALIDATION_MODE: ValidationMode = {
   onBlur: 'onBlur',
   onChange: 'onChange',

--- a/src/logic/assignWatchFields.test.ts
+++ b/src/logic/assignWatchFields.test.ts
@@ -1,5 +1,9 @@
 import assignWatchFields from './assignWatchFields';
 
+jest.mock('./reportFieldNotFound', () => ({
+  default: () => {},
+}));
+
 describe('assignWatchFields', () => {
   test('should return undefined when field values is empty object or undefined', () => {
     expect(assignWatchFields<any>({}, '', new Set(''), {})).toEqual(undefined);

--- a/src/logic/assignWatchFields.ts
+++ b/src/logic/assignWatchFields.ts
@@ -1,12 +1,12 @@
 import transformToNestObject from './transformToNestObject';
+import getDefaultValue from './getDefaultValue';
+import reportFieldNotFound from './reportFieldNotFound';
 import get from '../utils/get';
 import getPath from '../utils/getPath';
 import isEmptyObject from '../utils/isEmptyObject';
 import isUndefined from '../utils/isUndefined';
-import getDefaultValue from './getDefaultValue';
 import isObject from '../utils/isObject';
 import { FieldValue, FieldValues, FieldName } from '../types';
-import reportFieldNotFound from './reportFieldNotFound';
 
 export default <FormValues extends FieldValues>(
   fieldValues: FormValues,

--- a/src/logic/assignWatchFields.ts
+++ b/src/logic/assignWatchFields.ts
@@ -6,6 +6,7 @@ import isUndefined from '../utils/isUndefined';
 import getDefaultValue from './getDefaultValue';
 import isObject from '../utils/isObject';
 import { FieldValue, FieldValues, FieldName } from '../types';
+import reportFieldNotFound from './reportFieldNotFound';
 
 export default <FormValues extends FieldValues>(
   fieldValues: FormValues,
@@ -23,7 +24,9 @@ export default <FormValues extends FieldValues>(
   } else {
     value = get(transformToNestObject(fieldValues), fieldName);
 
-    if (!isUndefined(value)) {
+    if (isUndefined(value)) {
+      reportFieldNotFound(fieldName);
+    } else {
       getPath<FormValues>(fieldName, value).forEach(name =>
         watchFields.add(name),
       );

--- a/src/logic/reportFieldNotFound.test.ts
+++ b/src/logic/reportFieldNotFound.test.ts
@@ -5,6 +5,15 @@ jest.mock('../constants', () => ({
 }));
 
 describe('reportFieldNotFound', () => {
+  const env = process.env.NODE_ENV;
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = env;
+  });
+
   it('should report when field is not found', () => {
     expect(() => reportFieldNotFound('test')).toThrowError(
       'test field not found.',

--- a/src/logic/reportFieldNotFound.test.ts
+++ b/src/logic/reportFieldNotFound.test.ts
@@ -5,24 +5,15 @@ jest.mock('../constants', () => ({
 }));
 
 describe('reportFieldNotFound', () => {
-  const original = console.error;
-  const errorLog = jest.fn();
-
-  beforeEach(() => {
-    console.error = errorLog;
-  });
-
-  afterEach(() => {
-    console.error = original;
-  });
-
   it('should report when field is not found', () => {
-    reportFieldNotFound('test');
-    expect(errorLog).toBeCalledWith('test field not found.');
+    expect(() => reportFieldNotFound('test')).toThrowError(
+      'test field not found.',
+    );
   });
 
   it('should ', () => {
-    reportFieldNotFound('test', { last: 'test' });
-    expect(errorLog).toBeCalledWith('test field not found.');
+    expect(() => reportFieldNotFound('test', { last: 'test' })).toThrowError(
+      'test field not found.',
+    );
   });
 });

--- a/src/logic/reportFieldNotFound.test.ts
+++ b/src/logic/reportFieldNotFound.test.ts
@@ -1,9 +1,5 @@
 import reportFieldNotFound from './reportFieldNotFound';
 
-jest.mock('../constants', () => ({
-  IS_DEV_ENV: true,
-}));
-
 describe('reportFieldNotFound', () => {
   const env = process.env.NODE_ENV;
   beforeEach(() => {

--- a/src/logic/reportFieldNotFound.test.ts
+++ b/src/logic/reportFieldNotFound.test.ts
@@ -1,0 +1,28 @@
+import reportFieldNotFound from './reportFieldNotFound';
+
+jest.mock('../constants', () => ({
+  IS_DEV_ENV: true,
+}));
+
+describe('reportFieldNotFound', () => {
+  const original = console.error;
+  const errorLog = jest.fn();
+
+  beforeEach(() => {
+    console.error = errorLog;
+  });
+
+  afterEach(() => {
+    console.error = original;
+  });
+
+  it('should report when field is not found', () => {
+    reportFieldNotFound('test');
+    expect(errorLog).toBeCalledWith('test field not found.');
+  });
+
+  it('should ', () => {
+    reportFieldNotFound('test', { last: 'test' });
+    expect(errorLog).toBeCalledWith('test field not found.');
+  });
+});

--- a/src/logic/reportFieldNotFound.ts
+++ b/src/logic/reportFieldNotFound.ts
@@ -1,8 +1,10 @@
 import isUndefined from '../utils/isUndefined';
-import { IS_DEV_ENV } from '../constants';
 
 export default (name: any, fields?: any): void => {
-  if (IS_DEV_ENV && ((fields && isUndefined(fields[name])) || !fields)) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    ((fields && isUndefined(fields[name])) || !fields)
+  ) {
     throw new Error(`${name} field not found.`);
   }
 };

--- a/src/logic/reportFieldNotFound.ts
+++ b/src/logic/reportFieldNotFound.ts
@@ -1,0 +1,8 @@
+import isUndefined from '../utils/isUndefined';
+import { IS_DEV_ENV } from '../constants';
+
+export default (name: any, fields?: any): void => {
+  if (IS_DEV_ENV && ((fields && isUndefined(fields[name])) || !fields)) {
+    console.error(`${name} field not found.`);
+  }
+};

--- a/src/logic/reportFieldNotFound.ts
+++ b/src/logic/reportFieldNotFound.ts
@@ -3,6 +3,6 @@ import { IS_DEV_ENV } from '../constants';
 
 export default (name: any, fields?: any): void => {
   if (IS_DEV_ENV && ((fields && isUndefined(fields[name])) || !fields)) {
-    console.error(`${name} field not found.`);
+    throw new Error(`${name} field not found.`);
   }
 };

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -19,6 +19,9 @@ jest.mock('./logic/transformToNestObject', () => ({
   default: (data: any) => data,
   esmodule: true,
 }));
+jest.mock('./logic/reportFieldNotFound', () => ({
+  default: () => {},
+}));
 
 describe('useForm', () => {
   beforeEach(() => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -27,7 +27,7 @@ import unset from './utils/unset';
 import isMultipleSelect from './utils/isMultipleSelect';
 import modeChecker from './utils/validationModeChecker';
 import isNullOrUndefined from './utils/isNullOrUndefined';
-import { EVENTS, IS_DEV_ENV, UNDEFINED, VALIDATION_MODE } from './constants';
+import { EVENTS, UNDEFINED, VALIDATION_MODE } from './constants';
 import { FormContextValues } from './contextTypes';
 import {
   FieldValues,
@@ -680,7 +680,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
     ref: Element,
     validateOptions: ValidationOptions = {},
   ): ((name: FieldName<FormValues>) => void) | void {
-    if (!ref.name && IS_DEV_ENV) {
+    if (!ref.name && process.env.NODE_ENV !== 'production') {
       return console.warn('Missing name @', ref);
     }
 


### PR DESCRIPTION
This PR is related to an issue around TS runtime name check:

because you can `setValue('test.data[0]')` there is no way we can do check for type at build time. so this PR will address this issue during runtime and only fire during development mode.