### PR TITLE
Pass the name prop to the rendered component

### DIFF
--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`React Hook Form Input should render correctly with as with component 1`] = `
 <DocumentFragment>
   <input
+    name="test"
     value=""
   />
 </DocumentFragment>
@@ -11,6 +12,7 @@ exports[`React Hook Form Input should render correctly with as with component 1`
 exports[`React Hook Form Input should render correctly with as with string 1`] = `
 <DocumentFragment>
   <input
+    name="test"
     value=""
   />
 </DocumentFragment>
@@ -19,6 +21,7 @@ exports[`React Hook Form Input should render correctly with as with string 1`] =
 exports[`React Hook Form Input should support custom value name 1`] = `
 <DocumentFragment>
   <input
+    name="test"
     selectedkey=""
   />
 </DocumentFragment>
@@ -27,6 +30,7 @@ exports[`React Hook Form Input should support custom value name 1`] = `
 exports[`React Hook Form Input should support default value from hook form 1`] = `
 <DocumentFragment>
   <input
+    name="test"
     value="data"
   />
 </DocumentFragment>

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -106,6 +106,7 @@ const Controller = ({
   React.useEffect(() => () => unregister(name), []);
 
   const props = {
+    name,
     ...rest,
     ...(onChange
       ? { [onChangeName]: eventWrapper(onChange, EVENTS.CHANGE) }


### PR DESCRIPTION
**Description**

Pass the `name` prop from `Controller` to the rendered component.

**Motivation**

While it is unlikely the `name` will be use directly on a rendered input, it may be useful - to namespace multiple inputs for instance. 

There is no benefit to _not_ passing the `name` to the rendered child, and this existing behaviour is unexpected and can lead to some confusion.

See [this spectrum chat for more detail](https://spectrum.chat/react-hook-form/help/v4-controller-is-name-intentionally-excluded-from-the-props~17b67326-5912-4d17-b0c6-067afd11ebf5)
