### PR TITLE
Fix name of prettier config file in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "typescript",
     "typescriptreact"
   ],
-  "prettier.configPath": "./.pretterrc",
+  "prettier.configPath": "./.prettierrc",
   "eslint.enable": true,
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {


### PR DESCRIPTION
The prettier settings are correct in the package.json file, but in the vscode settings, the file referenced is wrong