### PR TITLE
Update controller type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,7 @@ export type ControllerProps = {
   valueName?: string;
   defaultValue?: any;
   control?: any;
+  [key: string]: any;
 };
 
 export type ErrorMessageProps<Errors, Name> = {


### PR DESCRIPTION
I just started migrating my project to typescript and I was having type errors whenever I did below snippet:

```js
<Controller
  as={CustomField}
  control={control}
  name="sample"
  customProps="sampleProps"
/>
```

The errors are
```js
Type '{ as: Element; control: any; name: string; customProps: string; }' is not assignable to type 'IntrinsicAttributes & ControllerProps'.
Property 'customProps' does not exist on type 'IntrinsicAttributes & ControllerProps'.
```

The problem was handling `rest` props, Feel free to change my solution :+1: 