### PR TITLE
New controller with types supports implementation suggestion

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -12,6 +12,7 @@ import {
   ManualFieldError,
   MultipleFieldErrors,
 } from './types';
+import { TypedController } from './typedController';
 
 export interface FormProps<FormValues extends FieldValues = FieldValues>
   extends FormContextValues<FormValues> {
@@ -21,6 +22,7 @@ export interface FormProps<FormValues extends FieldValues = FieldValues>
 export interface FormContextValues<
   FormValues extends FieldValues = FieldValues
 > {
+  Controller: typeof TypedController;
   register<Element extends ElementLike = ElementLike>(
     validationOptions: ValidationOptions,
   ): (ref: Element | null) => void;

--- a/src/typedController.tsx
+++ b/src/typedController.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { useFormContext } from './useFormContext';
+
+interface ControllerProps<FormValuesKeys, ValueType> {
+  /**
+   * The name that will be used for register.
+   *
+   * @type {FormValuesKeys}
+   * @memberof Props
+   */
+  name: FormValuesKeys;
+
+  /**
+   * The default value to provide to the internal state.
+   * Take priority over useForm default value argument.
+   */
+  defaultValue?: ValueType;
+
+  children(params: ControllerCommand<ValueType>): React.ReactElement;
+}
+
+interface ControllerCommand<ValueType> {
+  value?: ValueType;
+  onValueChange(data: ValueType): void;
+}
+
+/**
+ *
+ * @param props
+ */
+export function TypedController<FormValuesKeys extends string, InputValueType>(
+  props: ControllerProps<FormValuesKeys, InputValueType>,
+) {
+  // TODO add fallback to default values, or just remove defaultValue prop and let form handle it
+  const [internalValue, setInternalValue] = useState<
+    InputValueType | undefined
+  >(props.defaultValue);
+  const form = useFormContext();
+
+  const onValueChange = (data: InputValueType) => {
+    form.setValue(props.name, data);
+    setInternalValue(data);
+  };
+
+  useEffect(() => {
+    if (props.name) {
+      form.register({ name: props.name });
+      form.setValue(props.name, props.defaultValue);
+    }
+
+    return () => form.unregister(props.name);
+  }, [form, props.defaultValue, props.name]);
+
+  return props.children({ value: internalValue, onValueChange });
+}

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -49,6 +49,7 @@ import {
   HandleChange,
   Touched,
 } from './types';
+import { TypedController } from './typedController';
 
 const { useRef, useState, useCallback, useEffect } = React;
 
@@ -1044,6 +1045,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
   return {
     watch,
     control,
+    Controller: TypedController,
     handleSubmit,
     setValue,
     triggerValidation,


### PR DESCRIPTION
# Suggestion: Another controller implementation

Thanks for your great work again, I really enjoy my developping experience with that lib. I had a bit of time so I spent my day about thinking how to make that lib even greater as it is :) 

As mentioned in #777 here is my first draft of an implementation that should work for controlled components and typescript requirements in kind of props.

**This is a work in progress suggestion but I would like to get your feedback.**

Currently, despite the fact they works (I had to check deep in the code to understand their behavior) the controllers are subject to error because the API is not really easy to understand when you're new. You have props like `onChangeName` which are not currently typed, this can be confusing.

Also, there are some kinds of things that seems strange to me, I made an issue so we can discuss it, it's mostly related to documentation: https://github.com/react-hook-form/react-hook-form/issues/780

In my opinion, it's not really clear on what args are passed down to InnerComponent, or even the type of the even component (JSX element, ReactElement, string ?)

What's following is a proposition that might be totally irrelevant, but imagine we would implement that, would it be better for some cases?

# PROS
- Clarity, this doesn't magically inject props using `valueName` or `onChangeName` things, which make complicated to take in hand and are currently not typed enough. If we solve typings this argument is irrelevant and it can be just easy as moving Controller component to the useForm args as I did for this new controller.
- Effortless, at the moment only two props are given for the child function, everything else can be accessed outside of this scope, like errors and etc…
- There are no 3 ways to do, more choice, more bugs? :p (can also be solved in current implementation)

# LACK
- For now, we are forced to provide `<keyof FormValues, boolean>` or something else but I guess we could improve and generate values of typings directly from form typings as it's exposed from form hook.
- Currently, it only supports `useFormContext` but can be easily decoupled?

## Usage

```tsx
type FormValues = { a: boolean; b: string }

const Dummy: React.FC = () => {
  const { Controller } = useForm<FormValues>();

  return (
    <Controller<keyof FormValues, boolean> name="a" defaultValue={false}>
      {arg => (
        <EuiSwitch
          name="a" // It's just for the DOM and Accessibility, we could completly generate it if none is provided.
          label="Some label"
          checked={arg.value}
          onChange={(val: any) => {arg.onValueChange(Boolean(val.target.value ?? val))}}
        />
      )}
      </Controller>
  );
};
```