### PR TITLE
Fix setValue for file type input

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,8 @@ export const VALIDATION_MODE: ValidationMode = {
 
 export const RADIO_INPUT = 'radio';
 
+export const FILE_INPUT = 'file';
+
 export const VALUE = 'value';
 
 export const UNDEFINED = 'undefined';

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -1,6 +1,7 @@
 import getRadioValue from './getRadioValue';
 import getMultipleSelectValue from './getMultipleSelectValue';
 import isRadioInput from '../utils/isRadioInput';
+import isFileInput from '../utils/isFileInput';
 import isCheckBox from '../utils/isCheckBoxInput';
 import isMultipleSelect from '../utils/isMultipleSelect';
 import getCheckboxValue from './getCheckboxValue';
@@ -13,7 +14,7 @@ export default function getFieldValue<FormValues extends FieldValues>(
   const { type, name, options, value, files } = ref;
   const field = fields[name];
 
-  if (type === 'file') {
+  if (isFileInput(type)) {
     return files;
   }
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -13,6 +13,7 @@ import skipValidation from './logic/skipValidation';
 import isCheckBoxInput from './utils/isCheckBoxInput';
 import isEmptyObject from './utils/isEmptyObject';
 import isRadioInput from './utils/isRadioInput';
+import isFileInput from './utils/isFileInput';
 import isObject from './utils/isObject';
 import isArray from './utils/isArray';
 import isString from './utils/isString';
@@ -186,6 +187,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
         options.forEach(
           ({ ref: radioRef }) => (radioRef.checked = radioRef.value === value),
         );
+      } else if (isFileInput(type)) {
+        ref.files = value;
       } else if (isMultipleSelect(type)) {
         [...ref.options].forEach(
           selectRef =>

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -188,7 +188,9 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
           ({ ref: radioRef }) => (radioRef.checked = radioRef.value === value),
         );
       } else if (isFileInput(type)) {
-        ref.files = value;
+        if (value instanceof FileList) {
+          ref.files = value;
+        }
       } else if (isMultipleSelect(type)) {
         [...ref.options].forEach(
           selectRef =>

--- a/src/utils/isFileInput.test.ts
+++ b/src/utils/isFileInput.test.ts
@@ -1,0 +1,7 @@
+import isFileInput from './isFileInput';
+
+describe('isFileInput', () => {
+  it('should return true when type is file', () => {
+    expect(isFileInput('file')).toBeTruthy();
+  });
+});

--- a/src/utils/isFileInput.ts
+++ b/src/utils/isFileInput.ts
@@ -1,0 +1,3 @@
+import { FILE_INPUT } from '../constants';
+
+export default (type?: string): boolean => type === FILE_INPUT;


### PR DESCRIPTION
**Description**

setValue would try to assign the FileList object to _value_ instead of _files_.

**Motivation**

Inputs type file would break after assigning the FileList object as defaultValue or setValue since _value_ only accepts strings. FileList object can be assigned to inputs type file though _files_, which automatically sets the _value_ of the DOM element.

MDN: [input file](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#files)

See [this spectrum chat for more detail](https://spectrum.chat/react-hook-form/help/defaultvalue-of-an-input-type-file~23c450c7-a0c3-46c8-ba8d-889c1bc45430)

