### PR TITLE
fix typescript error type in array

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -126,9 +126,7 @@ export type NestDataObject<FormValues> = {
     : FieldError;
 };
 
-export declare type FieldErrors<FormValues> = FieldValues extends object
-  ? NestDataObject<FormValues>
-  : FieldError;
+export declare type FieldErrors<FormValues> = NestDataObject<FormValues>;
 
 export type Touched<FormValues> = NestDataObject<FormValues>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,8 @@ export type NestDataObject<FormValues> = {
   [Key in keyof FormValues]?: FormValues[Key] extends any[]
     ? FormValues[Key][number] extends object
       ? FieldErrors<FormValues[Key][number]>[]
+      : FormValues[Key][number] extends string | number
+      ? FieldError[]
       : FieldError
     : FormValues[Key] extends Date
     ? FieldError
@@ -124,7 +126,9 @@ export type NestDataObject<FormValues> = {
     : FieldError;
 };
 
-export type FieldErrors<FormValues> = NestDataObject<FormValues>;
+export declare type FieldErrors<FormValues> = FieldValues extends object
+  ? NestDataObject<FormValues>
+  : FieldError;
 
 export type Touched<FormValues> = NestDataObject<FormValues>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,7 @@ export type NestDataObject<FormValues> = {
     : FieldError;
 };
 
-export declare type FieldErrors<FormValues> = NestDataObject<FormValues>;
+export type FieldErrors<FormValues> = NestDataObject<FormValues>;
 
 export type Touched<FormValues> = NestDataObject<FormValues>;
 


### PR DESCRIPTION
fix erros type in array.

issue: #803 

### before
```js
type Form = { firstName: string[]; lastName: string[] };
const { register, handleSubmit, errors } = useForm<Form>();
errors.firstName && errors.firstName[index].message // <- error
```

### after
```js
type Form = { firstName: string[]; lastName: string[] };
const { register, handleSubmit, errors } = useForm<Form>();
errors.firstName && errors.firstName[index].message // <- no error
```