### PR TITLE
Feature/support custom schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 - [Tiny size](https://bundlephobia.com/result?p=react-hook-form@latest) without any dependency
 - Follows HTML standard for validation
 - Compatible with React Native
-- Support [Yup](https://github.com/jquense/yup) schema-based validation
+- Support [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or custom schema-based validation
 - Support browser native validation
 - Build forms quickly with the [form builder](https://react-hook-form.com/form-builder)
 

--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -18,6 +18,7 @@ import ConditionalField from './conditionalField';
 import FormStateWithSchema from './formStateWithSchema';
 import SetValueWithSchema from './setValueWithSchema';
 import SetValueWithTrigger from './setValueWithTrigger';
+import CustomSchemaValidation from './customSchemaValidation';
 
 const App: React.FC = () => {
   return (
@@ -44,6 +45,11 @@ const App: React.FC = () => {
         exact
         component={BasicSchemaValidation}
       />
+        <Route
+          path="/customSchemaValidation/:mode"
+          exact
+          component={CustomSchemaValidation}
+        />
       <Route path="/setError" exact component={SetError} />
       <Route
         path="/setValueWithTrigger"

--- a/app/src/customSchemaValidation.tsx
+++ b/app/src/customSchemaValidation.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import useForm from 'react-hook-form';
+import Joi from '@hapi/joi';
+
+let renderCounter = 0;
+
+const validationSchema = Joi.object({
+  firstName: Joi.string().required(),
+  lastName: Joi.string()
+    .max(5)
+    .required(),
+  min: Joi.number()
+    .min(10)
+    .required(),
+  max: Joi.number()
+    .max(20)
+    .required(),
+  minDate: Joi.date().min('2019-08-01'),
+  maxDate: Joi.date().max('2019-08-01'),
+  minLength: Joi.string().min(2),
+  minRequiredLength: Joi.string().required(),
+  selectNumber: Joi.string().required(),
+  pattern: Joi.string().required(),
+  radio: Joi.string().required(),
+  checkbox: Joi.required(),
+});
+
+const resolver = (data: any) => {
+  const { error, value: values } = validationSchema.validate(data, {
+    abortEarly: false,
+  });
+
+  return {
+    values: error ? {} : values,
+    errors: error
+      ? error.details.reduce((previous, currentError) => {
+          return {
+            ...previous,
+            [currentError.path[0]]: currentError,
+          };
+        }, {})
+      : {},
+  };
+};
+
+const BasicSchemaValidation: React.FC = (props: any) => {
+  const { register, handleSubmit, errors } = useForm<{
+    firstName: string;
+    lastName: string;
+    min: string;
+    max: string;
+    minDate: string;
+    maxDate: string;
+    minLength: string;
+    minRequiredLength: string;
+    selectNumber: string;
+    pattern: string;
+    radio: string;
+    checkbox: string;
+    multiple: string;
+    validate: string;
+  }>({
+    validationSchema: {
+      resolver,
+    },
+    mode: props.match.params.mode,
+  });
+  const onSubmit = () => {};
+
+  renderCounter++;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input name="firstName" ref={register} placeholder="firstName" />
+      {errors.firstName && <p>firstName error</p>}
+      <input name="lastName" ref={register} placeholder="lastName" />
+      {errors.lastName && <p>lastName error</p>}
+      <input type="number" name="min" ref={register} placeholder="min" />
+      {errors.min && <p>min error</p>}
+      <input type="number" name="max" ref={register} placeholder="max" />
+      {errors.max && <p>max error</p>}
+      <input type="date" name="minDate" ref={register} placeholder="minDate" />
+      {errors.minDate && <p>minDate error</p>}
+      <input type="date" name="maxDate" ref={register} placeholder="maxDate" />
+      {errors.maxDate && <p>maxDate error</p>}
+      <input name="minLength" ref={register} placeholder="minLength" />
+      {errors.minLength && <p>minLength error</p>}
+      <input
+        name="minRequiredLength"
+        ref={register}
+        placeholder="minRequiredLength"
+      />
+      {errors.minRequiredLength && <p>minRequiredLength error</p>}
+      <select name="selectNumber" ref={register}>
+        <option value="">Select</option>
+        <option value={1}>1</option>
+        <option value={2}>1</option>
+      </select>
+      {errors.selectNumber && <p>selectNumber error</p>}
+      <input name="pattern" ref={register} placeholder="pattern" />
+      {errors.pattern && <p>pattern error</p>}
+      Radio1
+      <input type="radio" name="radio" ref={register} value="1" />
+      Radio2
+      <input type="radio" name="radio" ref={register} value="2" />
+      Radio3
+      <input type="radio" name="radio" ref={register} value="3" />
+      {errors.radio && <p>radio error</p>}
+      <input type="checkbox" name="checkbox" ref={register} />
+      {errors.checkbox && <p>checkbox error</p>}
+      <button>Submit</button>
+      <div id="renderCount">{renderCounter}</div>
+    </form>
+  );
+};
+
+export default BasicSchemaValidation;

--- a/cypress/integration/customSchemaValidation.ts
+++ b/cypress/integration/customSchemaValidation.ts
@@ -1,0 +1,161 @@
+context('basicSchemaValidation form validation', () => {
+  it('should validate the form with onSubmit mode', () => {
+    cy.visit('http://localhost:3000/customSchemaValidation/onSubmit');
+    cy.get('button').click();
+
+    cy.focused().should('have.attr', 'name', 'firstName');
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('select[name="selectNumber"] + p').contains('selectNumber error');
+    cy.get('input[name="minRequiredLength"] + p').contains(
+      'minRequiredLength error',
+    );
+    cy.get('input[name="radio"] + p').contains('radio error');
+
+    cy.get('input[name="firstName"]').type('bill');
+    cy.get('input[name="lastName"]').type('luo123456');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('select[name="selectNumber"]').select('1');
+    cy.get('input[name="pattern"]').type('luo');
+    cy.get('input[name="min"]').type('1');
+    cy.get('input[name="max"]').type('21');
+    cy.get('input[name="minDate"]').type('2019-07-30');
+    cy.get('input[name="maxDate"]').type('2019-08-02');
+    cy.get('input[name="lastName"]')
+      .clear()
+      .type('luo');
+    cy.get('input[name="minLength"]').type('2');
+    cy.get('input[name="minLength"] + p').contains('minLength error');
+    cy.get('input[name="min"] + p').contains('min error');
+    cy.get('input[name="max"] + p').contains('max error');
+    cy.get('input[name="minDate"] + p').contains('minDate error');
+    cy.get('input[name="maxDate"] + p').contains('maxDate error');
+
+    cy.get('input[name="pattern"]').type('23');
+    cy.get('input[name="minLength"]').type('bi');
+    cy.get('input[name="minRequiredLength"]').type('bi');
+    cy.get('input[name="radio"]').check('1');
+    cy.get('input[name="min"]')
+      .clear()
+      .type('11');
+    cy.get('input[name="max"]')
+      .clear()
+      .type('19');
+    cy.get('input[name="minDate"]').type('2019-08-01');
+    cy.get('input[name="maxDate"]').type('2019-08-01');
+    cy.get('input[name="checkbox"]').check();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('24');
+  });
+
+  it('should validate the form with onBlur mode', () => {
+    cy.visit('http://localhost:3000/customSchemaValidation/onBlur');
+
+    cy.get('input[name="firstName"]').focus();
+    cy.get('input[name="firstName"]').blur();
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="firstName"]').type('bill');
+    cy.get('input[name="lastName"]').focus();
+    cy.get('input[name="lastName"]').blur();
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('input[name="lastName"]').type('luo123456');
+    cy.get('input[name="lastName"]').blur();
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('select[name="selectNumber"]').focus();
+    cy.get('select[name="selectNumber"]').blur();
+    cy.get('select[name="selectNumber"] + p').contains('selectNumber error');
+    cy.get('select[name="selectNumber"]').select('1');
+    cy.get('input[name="pattern"]').type('luo');
+    cy.get('input[name="min"]').type('1');
+    cy.get('input[name="max"]').type('21');
+    cy.get('input[name="minDate"]').type('2019-07-30');
+    cy.get('input[name="maxDate"]').type('2019-08-02');
+    cy.get('input[name="lastName"]')
+      .clear()
+      .type('luo');
+    cy.get('input[name="minLength"]').type('2');
+    cy.get('input[name="minLength"]').blur();
+
+    cy.get('input[name="minLength"] + p').contains('minLength error');
+    cy.get('input[name="min"] + p').contains('min error');
+    cy.get('input[name="max"] + p').contains('max error');
+    cy.get('input[name="minDate"] + p').contains('minDate error');
+    cy.get('input[name="maxDate"] + p').contains('maxDate error');
+
+    cy.get('input[name="pattern"]').type('23');
+    cy.get('input[name="minLength"]').type('bi');
+    cy.get('input[name="minRequiredLength"]').type('bi');
+    cy.get('input[name="radio"]')
+      .first()
+      .focus();
+    cy.get('input[name="radio"]')
+      .first()
+      .blur();
+    cy.get('input[name="radio"] + p').contains('radio error');
+    cy.get('input[name="radio"]').check('1');
+    cy.get('input[name="min"]')
+      .clear()
+      .type('11');
+    cy.get('input[name="max"]')
+      .clear()
+      .type('19');
+    cy.get('input[name="minDate"]').type('2019-08-01');
+    cy.get('input[name="maxDate"]').type('2019-08-01');
+    cy.get('input[name="checkbox"]').check();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('24');
+  });
+
+  it('should validate the form with onChange mode', () => {
+    cy.visit('http://localhost:3000/customSchemaValidation/onChange');
+
+    cy.get('input[name="firstName"]').type('bill');
+    cy.get('input[name="lastName"]').focus();
+    cy.get('input[name="lastName"]').type('luo123456');
+    cy.get('input[name="lastName"]').clear();
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('input[name="lastName"]').type('luo123456');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('select[name="selectNumber"]').select('');
+    cy.get('select[name="selectNumber"] + p').contains('selectNumber error');
+    cy.get('select[name="selectNumber"]').select('1');
+    cy.get('input[name="pattern"]').type('luo');
+    cy.get('input[name="min"]').type('1');
+    cy.get('input[name="max"]').type('21');
+    cy.get('input[name="minDate"]').type('2019-07-30');
+    cy.get('input[name="maxDate"]').type('2019-08-02');
+    cy.get('input[name="lastName"]')
+      .clear()
+      .type('luo');
+    cy.get('input[name="minLength"]').type('2');
+
+    cy.get('input[name="minLength"] + p').contains('minLength error');
+    cy.get('input[name="min"] + p').contains('min error');
+    cy.get('input[name="max"] + p').contains('max error');
+    cy.get('input[name="minDate"] + p').contains('minDate error');
+    cy.get('input[name="maxDate"] + p').contains('maxDate error');
+
+    cy.get('input[name="pattern"]').type('23');
+    cy.get('input[name="minLength"]').type('bi');
+    cy.get('input[name="minRequiredLength"]').type('bi');
+    cy.get('input[name="radio"]')
+      .first()
+      .focus();
+    cy.get('input[name="radio"]').check('1');
+    cy.get('input[name="min"]')
+      .clear()
+      .type('11');
+    cy.get('input[name="max"]')
+      .clear()
+      .type('19');
+    cy.get('input[name="minDate"]').type('2019-08-01');
+    cy.get('input[name="maxDate"]').type('2019-08-01');
+    cy.get('input[name="checkbox"]').check();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('26');
+  });
+});

--- a/cypress/integration/customSchemaValidation.ts
+++ b/cypress/integration/customSchemaValidation.ts
@@ -106,7 +106,7 @@ context('basicSchemaValidation form validation', () => {
     cy.get('input[name="checkbox"]').check();
 
     cy.get('p').should('have.length', 0);
-    cy.get('#renderCount').contains('24');
+    cy.get('#renderCount').contains('27');
   });
 
   it('should validate the form with onChange mode', () => {
@@ -156,6 +156,6 @@ context('basicSchemaValidation form validation', () => {
     cy.get('input[name="checkbox"]').check();
 
     cy.get('p').should('have.length', 0);
-    cy.get('#renderCount').contains('26');
+    cy.get('#renderCount').contains('29');
   });
 });

--- a/package.json
+++ b/package.json
@@ -90,5 +90,9 @@
       "npm run prettier",
       "git add"
     ]
+  },
+  "dependencies": {
+    "@hapi/joi": "^16.1.7",
+    "@types/hapi__joi": "^16.0.3"
   }
 }

--- a/src/logic/__snapshots__/validateWithSchema.test.ts.snap
+++ b/src/logic/__snapshots__/validateWithSchema.test.ts.snap
@@ -35,7 +35,7 @@ Object {
 
 exports[`validateWithSchema should return undefined when no error reported 1`] = `
 Object {
-  "fieldErrors": Object {
+  "errors": Object {
     "age": Object {
       "message": "age is a required field",
       "type": "required",
@@ -45,6 +45,6 @@ Object {
       "type": "min",
     },
   },
-  "result": Object {},
+  "values": Object {},
 }
 `;

--- a/src/logic/validateWithSchema.test.ts
+++ b/src/logic/validateWithSchema.test.ts
@@ -82,3 +82,18 @@ describe('validateWithSchema', () => {
     });
   });
 });
+
+test('should invoke resolver function for custom schema validation', async () => {
+  const resolver = jest.fn();
+
+  await validateWithSchema(
+    {
+      resolver,
+    },
+    { abortEarly: false },
+    false,
+    {},
+  );
+
+  expect(resolver).toBeCalledWith({});
+});

--- a/src/logic/validateWithSchema.test.ts
+++ b/src/logic/validateWithSchema.test.ts
@@ -77,8 +77,8 @@ describe('validateWithSchema', () => {
         {},
       ),
     ).toEqual({
-      fieldErrors: {},
-      result: undefined,
+      errors: {},
+      values: undefined,
     });
   });
 });

--- a/src/logic/validateWithSchema.ts
+++ b/src/logic/validateWithSchema.ts
@@ -75,7 +75,6 @@ export default async function validateWithSchema<FormValues>(
         errors: {},
       };
     } catch (e) {
-      console.log(e);
       return {
         values: {},
         errors: parseErrorSchema<FormValues>(e, validateAllFieldCriteria),

--- a/src/logic/validateWithSchema.ts
+++ b/src/logic/validateWithSchema.ts
@@ -65,22 +65,23 @@ export default async function validateWithSchema<FormValues>(
   validateAllFieldCriteria: boolean,
   data: FieldValues,
 ): Promise<SchemaValidationResult<FormValues>> {
-  const { validate } = validationSchema as Schema<FormValues>;
-  const { resolver } = validationSchema as SchemaResolver<FormValues>;
-
-  if (validate) {
+  if ((validationSchema as Schema<FormValues>).validate) {
     try {
       return {
-        values: await validate(data, validationSchemaOption),
+        values: await (validationSchema as Schema<FormValues>).validate(
+          data,
+          validationSchemaOption,
+        ),
         errors: {},
       };
     } catch (e) {
+      console.log(e);
       return {
         values: {},
         errors: parseErrorSchema<FormValues>(e, validateAllFieldCriteria),
       };
     }
   } else {
-    return resolver(data);
+    return (validationSchema as SchemaResolver<FormValues>).resolver(data);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,12 @@ export type SchemaValidateOptions = Partial<{
   context: object;
 }>;
 
+export type SchemaResolver<FormValues> = {
+  resolver: (
+    values: FieldValues,
+  ) => { values: FieldValues; errors: FieldErrors<FormValues> };
+};
+
 export type UseFormOptions<
   FormValues extends FieldValues = FieldValues
 > = Partial<{
@@ -49,7 +55,7 @@ export type UseFormOptions<
   reValidateMode: Mode;
   defaultValues: Partial<FormValues>;
   validationSchemaOption: SchemaValidateOptions;
-  validationSchema: any;
+  validationSchema: SchemaResolver<FormValues> | any;
   nativeValidation: boolean;
   submitFocusError: boolean;
   validateCriteriaMode: 'firstError' | 'all';

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -619,8 +619,8 @@ describe('useForm', () => {
 
       (validateWithSchema as any).mockImplementation(async (payload: any) => {
         return {
-          fieldErrors: payload,
-          result: {},
+          errors: payload,
+          values: {},
         };
       });
 
@@ -647,8 +647,8 @@ describe('useForm', () => {
 
       (validateWithSchema as any).mockImplementation(async (payload: any) => {
         return {
-          fieldErrors: payload,
-          result: {},
+          errors: payload,
+          values: {},
         };
       });
 
@@ -685,10 +685,10 @@ describe('useForm', () => {
 
       (validateWithSchema as any).mockImplementation(async () => {
         return {
-          fieldErrors: {
+          errors: {
             test1: 'test',
           },
-          result: {},
+          values: {},
         };
       });
 
@@ -716,11 +716,11 @@ describe('useForm', () => {
 
       (validateWithSchema as any).mockImplementation(async () => {
         return {
-          fieldErrors: {
+          errors: {
             test1: 'test1',
             test: 'test',
           },
-          result: {},
+          values: {},
         };
       });
 
@@ -754,8 +754,8 @@ describe('useForm', () => {
 
       (validateWithSchema as any).mockImplementation(async (payload: any) => {
         return {
-          fieldErrors: payload,
-          result: {},
+          errors: payload,
+          values: {},
         };
       });
 
@@ -803,11 +803,11 @@ describe('useForm', () => {
 
       (validateWithSchema as any).mockImplementation(async () => {
         return {
-          fieldErrors: {
+          errors: {
             test1: 'test1',
             test: 'test',
           },
-          result: {},
+          values: {},
         };
       });
 
@@ -893,8 +893,8 @@ describe('useForm', () => {
       });
       (validateWithSchema as any).mockImplementation(async () => {
         return {
-          fieldErrors: {},
-          result: {},
+          errors: {},
+          values: {},
         };
       });
 
@@ -1038,8 +1038,8 @@ describe('useForm', () => {
 
       (validateField as any).mockImplementation(async () => {
         return {
-          fieldErrors: { test: 'issue' },
-          result: {},
+          errors: { test: 'issue' },
+          values: {},
         };
       });
 
@@ -1057,8 +1057,8 @@ describe('useForm', () => {
 
       (validateField as any).mockImplementation(async () => {
         return {
-          fieldErrors: {},
-          result: {},
+          errors: {},
+          values: {},
         };
       });
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -294,7 +294,7 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         | ValidationPayload<FieldName<FormValues>, FieldValue<FormValues>>
         | ValidationPayload<FieldName<FormValues>, FieldValue<FormValues>>[],
     ): Promise<boolean> => {
-      const { fieldErrors } = await validateWithSchemaCurry(
+      const { errors } = await validateWithSchemaCurry(
         combineFieldValues(getFieldsValues(fieldsRef.current)),
       );
       const isMultipleFields = isArray(payload);
@@ -302,20 +302,20 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         ? payload.map(({ name }) => name)
         : [payload.name];
       const validFieldNames = names.filter(
-        name => !(fieldErrors as FieldErrors<FormValues>)[name],
+        name => !(errors as FieldErrors<FormValues>)[name],
       );
       const firstFieldName = names[0];
       schemaErrorsRef.current = isMultipleFields
-        ? fieldErrors
-        : fieldErrors[firstFieldName]
-        ? { [firstFieldName]: fieldErrors[firstFieldName] }
+        ? errors
+        : errors[firstFieldName]
+        ? { [firstFieldName]: errors[firstFieldName] }
         : {};
       isSchemaValidateTriggeredRef.current = true;
 
       if (isMultipleFields) {
         errorsRef.current = omitValidFields<FormValues>(
           combineErrorsRef(
-            Object.entries(fieldErrors)
+            Object.entries(errors)
               .filter(([key]) => names.includes(key))
               .reduce(
                 (previous, [name, error]) => ({ ...previous, [name]: error }),
@@ -426,15 +426,15 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
         }
 
         if (validationSchema) {
-          const { fieldErrors } = await validateWithSchemaCurry(
+          const { errors } = await validateWithSchemaCurry(
             combineFieldValues(getFieldsValues(fields)),
           );
-          Object.keys(fieldErrors).forEach(name =>
+          Object.keys(errors).forEach(name =>
             validFieldsRef.current.delete(name),
           );
-          schemaErrorsRef.current = fieldErrors;
+          schemaErrorsRef.current = errors;
           isSchemaValidateTriggeredRef.current = true;
-          error = fieldErrors[name] ? { [name]: fieldErrors[name] } : {};
+          error = errors[name] ? { [name]: errors[name] } : {};
         } else {
           error = await validateFieldCurry(field);
         }
@@ -703,8 +703,8 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
           isSchemaValidateTriggeredRef.current = true;
           validateWithSchemaCurry(
             combineFieldValues(getFieldsValues(fields)),
-          ).then(({ fieldErrors }) => {
-            schemaErrorsRef.current = fieldErrors;
+          ).then(({ errors }) => {
+            schemaErrorsRef.current = errors;
             if (isEmptyObject(schemaErrorsRef.current)) {
               render();
             }
@@ -828,12 +828,12 @@ export default function useForm<FormValues extends FieldValues = FieldValues>({
     try {
       if (validationSchema) {
         fieldValues = getFieldsValues(fields);
-        const output = await validateWithSchemaCurry(
+        const { errors, values } = await validateWithSchemaCurry(
           combineFieldValues(fieldValues),
         );
-        schemaErrorsRef.current = output.fieldErrors;
-        fieldErrors = output.fieldErrors;
-        fieldValues = output.result;
+        schemaErrorsRef.current = errors;
+        fieldErrors = errors;
+        fieldValues = values;
       } else {
         const {
           errors,

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,6 +164,44 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@hapi/address@^2.1.2":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
+  integrity sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==
+
+"@hapi/formula@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-1.2.0.tgz#994649c7fea1a90b91a0a1e6d983523f680e10cd"
+  integrity sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==
+
+"@hapi/hoek@^8.2.4", "@hapi/hoek@^8.3.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.0.tgz#2f9ce301c8898e1c3248b0a8564696b24d1a9a5a"
+  integrity sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==
+
+"@hapi/joi@^16.1.7":
+  version "16.1.7"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-16.1.7.tgz#360857223a87bb1f5f67691537964c1b4908ed93"
+  integrity sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==
+  dependencies:
+    "@hapi/address" "^2.1.2"
+    "@hapi/formula" "^1.2.0"
+    "@hapi/hoek" "^8.2.4"
+    "@hapi/pinpoint" "^1.0.2"
+    "@hapi/topo" "^3.1.3"
+
+"@hapi/pinpoint@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-1.0.2.tgz#025b7a36dbbf4d35bf1acd071c26b20ef41e0d13"
+  integrity sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==
+
+"@hapi/topo@^3.1.3":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
+  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
+  dependencies:
+    "@hapi/hoek" "^8.3.0"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -430,6 +468,11 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/hapi__joi@^16.0.3":
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-16.0.3.tgz#8ed6a0bd3a3fc40c0b5ff41b399004c5f9bb0b0b"
+  integrity sha512-gPxCfPcdZx9220GP4MFlhyBonQuyy8c/NZkGJkdtGipaExFzNLGYzkH2eG+yo0eEoVWdSC/JxhokSR/IHfap8Q==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"


### PR DESCRIPTION
This feature request is waiting for more upvote. 

related PR: https://github.com/react-hook-form/react-hook-form-website/pull/139

if you want such feature, you can thumb up this comment. 👍 

------

example for `@hapi/joi`, this will apply for any other schema/custom validation.

```
import React from "react";
import useForm from "react-hook-form";
import joi from "@hapi/joi";

const schema = Joi.object({
  username: Joi.string().alphanum().min(3).max(30).required()
});

// Build your resolver to display errors and pass valid values
const resolver = (data: any) => {
  const { error, value: values } = validationSchema.validate(data, {
    abortEarly: false,
  });
  return {
    values: error ? {} : values,
    errors: error
      ? error.details.reduce((previous, currentError) => {
          return {
            ...previous,
            [currentError.path[0]]: currentError,
          };
        }, {})
      : {},
  };
};

function App() {
  const { register, handleSubmit, errors } = useForm({
    schemaResolver: resolver
   });
  
  return (
    <form onSubmit={handleSubmit(d => console.log(d))}>
      <input type="text" name="username" ref={register} />
    </form>
  );
}
```
