### PR TITLE
chore(eslintrc): change react version to `detect`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
   settings: {
     react: {
       pragma: 'React',
-      version: '16.9',
+      version: 'detect',
     },
   },
 };


### PR DESCRIPTION
The `package.json` react version is `16.12.0`, but in the eslintrc is `16.9`, so I think it can adjust to `detect` automatically picks the version you have installed.