### PR TITLE
`isSubmitted` and `submitCount` should only update on success

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -915,6 +915,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
         if (isEmptyObject(fieldErrors)) {
           errorsRef.current = {};
           await callback(transformToNestObject(fieldValues), e);
+          isSubmittedRef.current = true;
+          submitCountRef.current = submitCountRef.current + 1;
         } else {
           if (submitFocusError) {
             for (const key in fieldsRef.current) {
@@ -936,9 +938,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
           errorsRef.current = fieldErrors;
         }
       } finally {
-        isSubmittedRef.current = true;
         isSubmittingRef.current = false;
-        submitCountRef.current = submitCountRef.current + 1;
         reRender();
       }
     },


### PR DESCRIPTION


**Problem**
`isSubmitted` and `submitCount` update whenever the submit handler is triggered, regardless of whether or not the submit was successful. This should only update if the form is valid and there were no issues during the submit process.

**Solution**
Move these updates out of the `finally` block and into the `try` block, so that they only happen if there are no issues with submit.