### PR TITLE
change the type of FieldName

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,8 @@ export type Primitive = string | boolean | number | symbol | null | undefined;
 
 export type FieldValues = Record<string, any>;
 
-export type FieldName<FormValues extends FieldValues> =
-  | (keyof FormValues & string)
-  | string;
+export type FieldName<FormValues extends FieldValues> = keyof FormValues &
+  string;
 
 export type FieldValue<FormValues extends FieldValues> = FormValues[FieldName<
   FormValues


### PR DESCRIPTION
I'm not sure whether my understanding of the following code is correct.

```ts
export type FieldValues = Record<string, any>; // any object type with string keys

export type FieldName<FormValues extends FieldValues> =
  | (keyof FormValues & string) // doing interesection with string
  | string; // and everything goes to string because of this line
```

If we want to get any specific type, the last line `| string` ruins everything. As its just eats the former line.