### PR TITLE
allow empty object in prepend, append and insert.

### DIFF
--- a/src/useFieldArray.test.ts
+++ b/src/useFieldArray.test.ts
@@ -53,6 +53,16 @@ describe('useFieldArray', () => {
       { id: '1', test: 'test' },
       { id: '1', test: 'test1' },
     ]);
+
+    act(() => {
+      result.current.append({});
+    });
+
+    expect(result.current.fields).toEqual([
+      { id: '1', test: 'test' },
+      { id: '1', test: 'test1' },
+      { id: '1' },
+    ]);
   });
 
   it('should pre-append data into the fields', () => {
@@ -81,6 +91,16 @@ describe('useFieldArray', () => {
     });
 
     expect(result.current.fields).toEqual([
+      { id: '1', test: 'test1' },
+      { id: '1', test: 'test' },
+    ]);
+
+    act(() => {
+      result.current.prepend({});
+    });
+
+    expect(result.current.fields).toEqual([
+      { id: '1' },
       { id: '1', test: 'test1' },
       { id: '1', test: 'test' },
     ]);
@@ -169,6 +189,17 @@ describe('useFieldArray', () => {
 
     expect(result.current.fields).toEqual([
       { id: '1', test: '1' },
+      { id: '1', test: '3' },
+      { id: '1', test: '2' },
+    ]);
+
+    act(() => {
+      result.current.insert(1, {});
+    });
+
+    expect(result.current.fields).toEqual([
+      { id: '1', test: '1' },
+      { id: '1' },
       { id: '1', test: '3' },
       { id: '1', test: '2' },
     ]);

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { useFormContext } from './useFormContext';
 import isMatchFieldArrayName from './logic/isMatchFieldArrayName';
 import { appendId, mapIds } from './logic/mapIds';
-import isUndefined from './utils/isUndefined';
 import { FieldValues, UseFieldArrayProps, WithFieldId } from './types';
+import { useFormContext } from './useFormContext';
+import isUndefined from './utils/isUndefined';
 
 export function useFieldArray<
   FormArrayValues extends FieldValues = FieldValues
@@ -29,12 +29,12 @@ export function useFieldArray<
     }
   };
 
-  const prepend = (value?: WithFieldId<FormArrayValues>) => {
+  const prepend = (value?: WithFieldId<FormArrayValues> | null) => {
     resetFields();
     setField([appendId(value ? value : {}), ...fields]);
   };
 
-  const append = (value?: WithFieldId<FormArrayValues>) =>
+  const append = (value?: WithFieldId<FormArrayValues> | null) =>
     setField([...fields, appendId(value ? value : {})]);
 
   const remove = (index?: number) => {
@@ -46,7 +46,10 @@ export function useFieldArray<
     );
   };
 
-  const insert = (index: number, value?: WithFieldId<FormArrayValues>) => {
+  const insert = (
+    index: number,
+    value?: WithFieldId<FormArrayValues> | null,
+  ) => {
     resetFields();
     setField([
       ...fields.slice(0, index),

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -29,13 +29,13 @@ export function useFieldArray<
     }
   };
 
-  const prepend = (value?: WithFieldId<FormArrayValues> | null) => {
+  const prepend = (value: WithFieldId<Partial<FormArrayValues>>) => {
     resetFields();
-    setField([appendId(value ? value : {}), ...fields]);
+    setField([appendId(value), ...fields]);
   };
 
-  const append = (value?: WithFieldId<FormArrayValues> | null) =>
-    setField([...fields, appendId(value ? value : {})]);
+  const append = (value: WithFieldId<Partial<FormArrayValues>>) =>
+    setField([...fields, appendId(value)]);
 
   const remove = (index?: number) => {
     resetFields();
@@ -48,12 +48,12 @@ export function useFieldArray<
 
   const insert = (
     index: number,
-    value?: WithFieldId<FormArrayValues> | null,
+    value: WithFieldId<Partial<FormArrayValues>>,
   ) => {
     resetFields();
     setField([
       ...fields.slice(0, index),
-      appendId(value ? value : {}),
+      appendId(value),
       ...fields.slice(index),
     ]);
   };

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
+import { useFormContext } from './useFormContext';
 import isMatchFieldArrayName from './logic/isMatchFieldArrayName';
 import { appendId, mapIds } from './logic/mapIds';
-import { FieldValues, UseFieldArrayProps, WithFieldId } from './types';
-import { useFormContext } from './useFormContext';
 import isUndefined from './utils/isUndefined';
+import { FieldValues, UseFieldArrayProps, WithFieldId } from './types';
 
 export function useFieldArray<
   FormArrayValues extends FieldValues = FieldValues

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -17,9 +17,9 @@ export function useFieldArray<
     unregister,
   } = control || methods.control;
 
-  const [fields, setField] = React.useState<WithFieldId<FormArrayValues>[]>(
-    mapIds(defaultValues[name]),
-  );
+  const [fields, setField] = React.useState<
+    WithFieldId<Partial<FormArrayValues>>[]
+  >(mapIds(defaultValues[name]));
 
   const resetFields = () => {
     for (const key in globalFields) {
@@ -29,13 +29,13 @@ export function useFieldArray<
     }
   };
 
-  const prepend = (value: WithFieldId<FormArrayValues>) => {
+  const prepend = (value?: WithFieldId<FormArrayValues>) => {
     resetFields();
-    setField([appendId(value), ...fields]);
+    setField([appendId(value ? value : {}), ...fields]);
   };
 
-  const append = (value: WithFieldId<FormArrayValues>) =>
-    setField([...fields, appendId(value)]);
+  const append = (value?: WithFieldId<FormArrayValues>) =>
+    setField([...fields, appendId(value ? value : {})]);
 
   const remove = (index?: number) => {
     resetFields();
@@ -46,11 +46,11 @@ export function useFieldArray<
     );
   };
 
-  const insert = (index: number, value: WithFieldId<FormArrayValues>) => {
+  const insert = (index: number, value?: WithFieldId<FormArrayValues>) => {
     resetFields();
     setField([
       ...fields.slice(0, index),
-      appendId(value),
+      appendId(value ? value : {}),
       ...fields.slice(index),
     ]);
   };


### PR DESCRIPTION
allow undefined form object.

issue: #827

before
```js
const { control } = useForm();
const { append } = useFieldArray({ control, name: "test" });
append() // <- error
```

after
```js
const { control } = useForm();
const { append } = useFieldArray({ control, name: "test" });
append() // <- arrow undfined or null
```