### PR TITLE
Allow to clean up files

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -192,7 +192,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
           ({ ref: radioRef }) => (radioRef.checked = radioRef.value === value),
         );
       } else if (isFileInput(type)) {
-        if (value instanceof FileList) {
+        if (value instanceof FileList || value === '') {
           ref.files = value;
         }
       } else if (isMultipleSelect(type)) {


### PR DESCRIPTION
Currently, I have a custom image uploader that contains a delete button when user attached image.
But, when I tried to clean up the value through `setValue` by clicking delete button, it still keeps his value.

https://codesandbox.io/s/distracted-wildflower-kgr6o?fontsize=14&hidenavigation=1&theme=dark
In the example, you can reproduce the error.

1. Choose an image file
2. Click delete button
3. Click submit button

I believe in here it should accept the value empty string.
https://github.com/react-hook-form/react-hook-form/blob/2a99ad2c5fc07b7b45e3d2934d8c1b105c760304/src/useForm.ts#L194-L197

Related PR #790

I create this PR, but I'm little suspicious it's right way to resolve the problem.
Please let me know if you have any solution.