### PR TITLE
support name of dot syntax for useFieldArray

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useFormContext } from './useFormContext';
 import { isMatchFieldArrayName } from './logic/isNameInFieldArray';
 import { appendId, mapIds } from './logic/mapIds';
+import get from './utils/get';
 import isUndefined from './utils/isUndefined';
 import { FieldValues, UseFieldArrayProps, WithFieldId } from './types';
 
@@ -19,7 +20,7 @@ export function useFieldArray<
 
   const [fields, setField] = React.useState<
     WithFieldId<Partial<FormArrayValues>>[]
-  >(mapIds(defaultValues[name]));
+  >(mapIds(get(defaultValues, name)));
 
   const resetFields = () => {
     for (const key in globalFields) {
@@ -72,7 +73,7 @@ export function useFieldArray<
 
   const reset = (values: any) => {
     resetFields();
-    setField(mapIds(values[name]));
+    setField(mapIds(get(values, name)));
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
related: https://spectrum.chat/react-hook-form/help/usefieldarray-does-not-work-with-dot-syntax~6eb0cd11-8bd6-491b-b9b2-502ceba53b9f

```ts
function Test() {
  const { control, register, handleSubmit } = useForm({
    defaultValues: {
      test: {
        nested: [{ name: "test1" }, { name: "test2" }, { name: "test3" }]
      }
    }
  });
  const { fields, append, prepend, remove } = useFieldArray({
    control,
    name: "test.nested"
  });

  return (
    <form onSubmit={handleSubmit(data => console.log("data", data))}>
      <ul>
        {fields.map((item, index) => (
          <li key={item.id}>
            <input
              name={`test.nested[${index}].name`}
              defaultValue={item.name}
              ref={register}
            />
            <button onClick={() => remove(index)}>Delete</button>
          </li>
        ))}
      </ul>
      <section>
        <button type="button" onClick={() => append({ name: "test" })}>
          append
        </button>
        <button type="button" onClick={() => prepend({ name: "test1" })}>
          prepend
        </button>
        <button type="submit">submit</button>
      </section>
    </form>
  );
}
```