### PR TITLE
Feature: Value transformation for string fields (type="text"/type="pa…

### DIFF
--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -21,6 +21,7 @@ import SetValueWithTrigger from './setValueWithTrigger';
 import IsValid from './isValid';
 import Controller from './controller';
 import UseFieldArray from './useFieldArray';
+import Transform from './transform';
 
 const App: React.FC = () => {
   return (
@@ -78,6 +79,7 @@ const App: React.FC = () => {
         exact
         component={WatchDefaultValues}
       />
+      <Route path="/transform" exact component={Transform} />
     </Router>
   );
 };

--- a/app/src/transform.tsx
+++ b/app/src/transform.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
+const Transform: React.FC = () => {
+  const { register, handleSubmit, watch, errors, reset } = useForm<{
+    firstName: string;
+    lastName: string;
+  }>();
+  const watchAll = watch();
+  return (
+    <form onSubmit={handleSubmit(() => {})}>
+      <input
+        name="firstName"
+        ref={register({
+          required: true,
+          transform: value => value.charAt(0).toUpperCase() + value.slice(1),
+          trim: true,
+        })}
+        placeholder="firstName"
+      />
+      {errors.firstName && <p>firstName error</p>}
+      <input
+        name="lastName"
+        ref={register({
+          required: true,
+          transform: value => (value ?? '').toUpperCase(),
+          trim: true,
+        })}
+        placeholder="lastName"
+      />
+      {errors.lastName && <p>lastName error</p>}
+      <button id="submit">Submit</button>
+      <button type="button" id="resetForm" onClick={() => reset()}>
+        Reset
+      </button>
+      <div id="watchAll">{JSON.stringify(watchAll)}</div>
+    </form>
+  );
+};
+
+export default Transform;

--- a/cypress/integration/transform.ts
+++ b/cypress/integration/transform.ts
@@ -1,0 +1,19 @@
+context.only('transform & trim', () => {
+  it('trim and transform should be applied', () => {
+    cy.visit('http://localhost:3000/transform');
+    cy.get('input[name="firstName"]').type('  foo ');
+    cy.get('input[name="lastName"]').type(' bar  ');
+    cy.get('#watchAll').should(
+      'contain',
+      '{"firstName":"Foo","lastName":"BAR"}',
+    );
+  });
+  it('trim and transform should be called before validation', () => {
+    cy.visit('http://localhost:3000/transform');
+    cy.get('input[name="firstName"]').type('   ');
+    cy.get('input[name="lastName"]').type('   ');
+    cy.get('button#submit').click();
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+  });
+});

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -6,7 +6,7 @@ import {
   FieldErrors,
   OnSubmit,
   ElementLike,
-  ValidationOptions,
+  FieldOptions,
   FieldName,
   FieldValue,
   ManualFieldError,
@@ -22,25 +22,22 @@ export interface FormContextValues<
   FormValues extends FieldValues = FieldValues
 > {
   register<Element extends ElementLike = ElementLike>(
-    validationOptions: ValidationOptions,
+    fieldOptions: FieldOptions,
   ): (ref: Element | null) => void;
   register<Element extends ElementLike = ElementLike>(
     name: FieldName<FormValues>,
-    validationOptions?: ValidationOptions,
+    fieldOptions?: FieldOptions,
   ): void;
   register<Element extends ElementLike = ElementLike>(
-    namesWithValidationOptions: Record<
-      FieldName<FormValues>,
-      ValidationOptions
-    >,
+    namesWithFieldOptions: Record<FieldName<FormValues>, FieldOptions>,
   ): void;
   register<Element extends ElementLike = ElementLike>(
     ref: Element,
-    validationOptions?: ValidationOptions,
+    fieldOptions?: FieldOptions,
   ): void;
   register<Element extends ElementLike = ElementLike>(
-    refOrValidationOptions: ValidationOptions | Element | null,
-    validationOptions?: ValidationOptions,
+    refOrOptions: FieldOptions | Element | null,
+    fieldOptions?: FieldOptions,
   ): ((ref: Element | null) => void) | void;
   unregister(name: FieldName<FormValues>): void;
   unregister(names: FieldName<FormValues>[]): void;

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -6,28 +6,33 @@ import isCheckBox from '../utils/isCheckBoxInput';
 import isMultipleSelect from '../utils/isMultipleSelect';
 import getCheckboxValue from './getCheckboxValue';
 import { FieldRefs, Ref, FieldValues } from '../types';
+import isString from '../utils/isString';
 
 export default function getFieldValue<FormValues extends FieldValues>(
   fields: FieldRefs<FormValues>,
   ref: Ref,
 ) {
-  const { type, name, options, value, files } = ref;
+  const { type, name, options, files } = ref;
   const field = fields[name];
+  let value = ref.value;
+
+  if (isString(value) && field) {
+    if (field.trim) {
+      value = value.trim();
+    }
+    if (field.transform) {
+      value = field.transform(value);
+    }
+  }
 
   if (isFileInput(type)) {
-    return files;
-  }
-
-  if (isRadioInput(type)) {
-    return field ? getRadioValue(field.options).value : '';
-  }
-
-  if (isMultipleSelect(type)) {
-    return getMultipleSelectValue(options);
-  }
-
-  if (isCheckBox(type)) {
-    return field ? getCheckboxValue(field.options).value : false;
+    value = files;
+  } else if (isRadioInput(type)) {
+    value = field ? getRadioValue(field.options).value : '';
+  } else if (isMultipleSelect(type)) {
+    value = getMultipleSelectValue(options);
+  } else if (isCheckBox(type)) {
+    value = field ? getCheckboxValue(field.options).value : false;
   }
 
   return value;

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -40,8 +40,18 @@ export default async <FormValues extends FieldValues>(
     max,
     pattern,
     validate,
+    transform,
+    trim,
   }: Field,
 ): Promise<FieldErrors<FormValues>> => {
+  if (isString(value)) {
+    if (transform) {
+      value = transform(value);
+    }
+    if (trim) {
+      value = value.trim();
+    }
+  }
   const fields = fieldsRef.current;
   const error: any = {};
   const isRadio = isRadioInput(type);

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,15 @@ export type ValidationOptions = Partial<{
   validate: Validate | Record<string, Validate>;
 }>;
 
+export type Transform = (value: string) => string;
+
+export type TransformationOptions = Partial<{
+  transform: Transform;
+  trim: boolean;
+}>;
+
+export type FieldOptions = ValidationOptions & TransformationOptions;
+
 export type MultipleFieldErrors = Record<string, ValidateResult>;
 
 export interface FieldError {
@@ -99,7 +108,7 @@ export interface ManualFieldError<FormValues> {
   message?: string;
 }
 
-export interface Field extends ValidationOptions {
+export interface Field extends FieldOptions {
   ref: Ref;
   mutationWatcher?: MutationWatcher;
   options?: {


### PR DESCRIPTION
**Issue:**
- If you trim an input value using `onChange`, it's not possible to let the user type spaces (eg: between words).
- If you trim once the form is submitted, it's too late because you can't use the form validation (eg: a required field filled with spaces will be valid).

**Feature:** The `register` function can take 2 new optional parameters:
- `trim?: boolean`
- `transform?: (value: string) => string`
Both options change the value returned with `getValues`/`watch`/`handleSubmit`... but won't affect the input value directly.