### PR TITLE
clean up code for useFieldArray

### DIFF
--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -18,6 +18,9 @@ function reconfigureControl(changedControl = {}) {
       isReValidateOnSubmit: false,
     },
     formState: { isSubmitted: false },
+    fieldsRef: {
+      current: {},
+    },
     fieldArrayNamesRef: {
       current: new Set(),
     },

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -31,7 +31,7 @@ const Controller = ({
     mode: { isOnSubmit, isOnBlur },
     reValidateMode: { isReValidateOnBlur, isReValidateOnSubmit },
     formState: { isSubmitted },
-    fields,
+    fieldsRef,
     fieldArrayNamesRef,
   } = control || methods.control;
   const [value, setInputStateValue] = React.useState(
@@ -96,7 +96,7 @@ const Controller = ({
       { ...rules },
     );
 
-  if (!fields[name]) {
+  if (!fieldsRef.current[name]) {
     registerField();
   }
 

--- a/src/useFieldArray.test.ts
+++ b/src/useFieldArray.test.ts
@@ -11,6 +11,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           defaultValues: {},
           resetFieldArrayFunctionRef: {
@@ -28,6 +29,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           getValues: () => ({}),
           defaultValues: {},
@@ -69,6 +71,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           getValues: () => ({}),
           defaultValues: {},
@@ -110,6 +113,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           defaultValues: { test: [{ test: '1' }, { test: '2' }] },
           resetFieldArrayFunctionRef: {
@@ -130,6 +134,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           defaultValues: { test: [{ test: '1' }, { test: '2' }] },
           resetFieldArrayFunctionRef: {
@@ -151,6 +156,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           getValues: () => ({ test: [{ test: '1' }, { test: '2' }] }),
           defaultValues: {},
@@ -173,6 +179,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           defaultValues: { test: [{ test: '1' }, { test: '2' }] },
           resetFieldArrayFunctionRef: {
@@ -209,6 +216,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           defaultValues: { test: [{ test: '1' }, { test: '2' }] },
           resetFieldArrayFunctionRef: {
@@ -233,6 +241,7 @@ describe('useFieldArray', () => {
     const { result } = renderHook(() =>
       useFieldArray({
         control: {
+          fieldsRef: { crrent: {} },
           fieldArrayNamesRef: { current: new Set() },
           defaultValues: {
             test: [{ test: '1' }, { test: '2' }, { test: '3' }],

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -13,7 +13,7 @@ export function useFieldArray<
   const {
     resetFieldArrayFunctionRef,
     fieldArrayNamesRef,
-    fields: globalFields,
+    fieldsRef,
     defaultValues,
     unregister,
   } = control || methods.control;
@@ -23,7 +23,7 @@ export function useFieldArray<
   >(mapIds(get(defaultValues, name)));
 
   const resetFields = () => {
-    for (const key in globalFields) {
+    for (const key in fieldsRef.current) {
       if (isMatchFieldArrayName(key, name)) {
         unregister(key, true);
       }

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -25,7 +25,7 @@ export function useFieldArray<
   const resetFields = () => {
     for (const key in globalFields) {
       if (isMatchFieldArrayName(key, name)) {
-        unregister(key, true);
+        unregister(key);
       }
     }
   };

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -25,7 +25,7 @@ export function useFieldArray<
   const resetFields = () => {
     for (const key in globalFields) {
       if (isMatchFieldArrayName(key, name)) {
-        unregister(key);
+        unregister(key, true);
       }
     }
   };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1052,7 +1052,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
       isReValidateOnSubmit,
     },
     errors: errorsRef.current,
-    fields: fieldsRef.current,
+    fieldsRef,
     resetFieldArrayFunctionRef,
     fieldArrayNamesRef,
   };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -495,12 +495,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
 
   const removeEventListenerAndRef = useCallback(
     (field: Field | undefined, forceDelete?: boolean) => {
-      if (
-        !field ||
-        (field &&
-          isNameInFieldArray(fieldArrayNamesRef.current, field.ref.name) &&
-          !forceDelete)
-      ) {
+      if (!field) {
         return;
       }
 
@@ -989,8 +984,6 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
       }
     }
 
-    resetRefs();
-
     if (values) {
       defaultValuesRef.current = values;
     }
@@ -1000,6 +993,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
         isFunction(resetFieldArray) &&
         resetFieldArray(defaultValuesRef.current),
     );
+
+    resetRefs();
 
     reRender();
   };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -984,17 +984,15 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
       }
     }
 
-    if (values) {
-      defaultValuesRef.current = values;
-    }
-
     Object.values(resetFieldArrayFunctionRef.current).forEach(
-      resetFieldArray =>
-        isFunction(resetFieldArray) &&
-        resetFieldArray(defaultValuesRef.current),
+      resetFieldArray => isFunction(resetFieldArray) && resetFieldArray(values),
     );
 
     resetRefs();
+
+    if (values) {
+      defaultValuesRef.current = values;
+    }
 
     reRender();
   };


### PR DESCRIPTION
minor fix this PR: https://github.com/react-hook-form/react-hook-form/pull/842

* ~~removed the second argument passed by calling the `unregister` function.~~
* instead of fixing if statement in `removeEventListenerAndRef` function, fixed position of ` resetFieldArray ` function called in `reset` function. this one is more simple.