### PR TITLE
Assign empty filelist

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -195,7 +195,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
         if (value instanceof FileList) {
           ref.files = value;
         } else {
-          ref.files = new DataTransfer().files;
+          ref.value = value;
         }
       } else if (isMultipleSelect(type)) {
         [...ref.options].forEach(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -194,6 +194,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
       } else if (isFileInput(type)) {
         if (value instanceof FileList) {
           ref.files = value;
+        } else {
+          ref.files = new DataTransfer().files;
         }
       } else if (isMultipleSelect(type)) {
         [...ref.options].forEach(


### PR DESCRIPTION
First of all, I'm really sorry about that I made a mistake about handling `<input type="file" />` in the previous PR (#835).

So, when you try to clean up files through `setValue`, you can see the following error because input's files only accept `FileList`.
```
Uncaught TypeError: Failed to set the 'files' property on 'HTMLInputElement': The provided value is not of type 'FileList'.
```

I just changed `input.files` assigned empty `FileList` when user pass `null` or `undefined`.

I'm sorry again for the previous mistake.

ps. I would like to add test case for sure, but it looks like there's no way to create `FileList` manually in node environment. If I find the way, I'll add test cases.
ps2. If you think user needs to pass empty `FileList` manually to `setValue` for removing files, I'm going to change the codes to accept only `FileList`.