### PR TITLE
onBlur mode, revalidateMode "onChange" revalidation fix for nested fields

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -42,10 +42,11 @@ const Controller = <ControlProp extends Control = Control>({
   );
   const valueRef = React.useRef(value);
   const isCheckboxInput = isBoolean(value);
+  const currentError = get(errors, name);
 
   const shouldValidate = (isBlurEvent?: boolean) =>
     !skipValidation({
-      hasError: !!errors[name],
+      hasError: !!currentError,
       isBlurEvent,
       isOnBlur,
       isOnSubmit,


### PR DESCRIPTION
Had the same issue with https://github.com/react-hook-form/react-hook-form/issues/836. I didn't have much time to debug but in my scenario I am hitting the one in `controller.tsx`, so just applied  the same solution (https://github.com/react-hook-form/react-hook-form/commit/f8699083a9ef478c67165d20405db349119abd6b) to the one in `controller.tsx` 

Search for `errors[name]` returns couple of other occurrences, not sure if they need the same thing though. 