### PR TITLE
test/clearError on nested structure error

### DIFF
--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -960,8 +960,20 @@ describe('useForm', () => {
     it('should remove error', () => {
       const { result } = renderHook(() => useForm<{ input: string }>());
       act(() => {
-        result.current.setError('input', 'test');
+        result.current.setError('input', 'test', 'message');
         result.current.clearError('input');
+      });
+      expect(result.current.errors).toEqual({});
+    });
+
+    it('should remove nested error', () => {
+      const { result } = renderHook(() => useForm<{ input: string }>());
+      act(() => {
+        result.current.setError('input.nested', 'test');
+      });
+      expect(result.current.errors).not.toEqual({});
+      act(() => {
+        result.current.clearError('input.nested');
       });
       expect(result.current.errors).toEqual({});
     });

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -967,15 +967,17 @@ describe('useForm', () => {
     });
 
     it('should remove nested error', () => {
-      const { result } = renderHook(() => useForm<{ input: string }>());
+      const { result } = renderHook(() =>
+        useForm<{ input: { nested: string } }>(),
+      );
       act(() => {
         result.current.setError('input.nested', 'test');
       });
-      expect(result.current.errors).not.toEqual({});
+      expect(result.current.errors.input?.nested).toBeDefined();
       act(() => {
         result.current.clearError('input.nested');
       });
-      expect(result.current.errors).toEqual({});
+      expect(result.current.errors.input?.nested).not.toBeDefined();
     });
   });
 


### PR DESCRIPTION
Add test for #878 (fix issue on clearError), as suggested in #880 (Error management: clear nested field error)
