### PR TITLE
Make handleSubmit event optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export type Mode = keyof ValidationMode;
 
 export type OnSubmit<FormValues extends FieldValues> = (
   data: FormValues,
-  event: React.BaseSyntheticEvent,
+  event?: React.BaseSyntheticEvent,
 ) => void | Promise<void>;
 
 export type SchemaValidateOptions = Partial<{

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -867,7 +867,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
 
   const handleSubmit = useCallback(
     (callback: OnSubmit<FormValues>) => async (
-      e: React.BaseSyntheticEvent,
+      e?: React.BaseSyntheticEvent,
     ): Promise<void> => {
       if (e) {
         e.preventDefault();


### PR DESCRIPTION
This eliminates the typescript error we get if we try to remotely submit a form without an Event

Based on https://github.com/react-hook-form/react-hook-form/issues/884#issuecomment-576966751