### PR TITLE
fix(Controller): Invoke `onBlur` method when `mode` is `onBlur`.

### DIFF
--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -137,9 +137,7 @@ describe('Controller', () => {
 
   it('should invoke custom onBlur method', () => {
     const onBlur = jest.fn();
-    const setValue = jest.fn();
     const control = reconfigureControl({
-      setValue,
       mode: { isOnSubmit: false, isOnBlur: true },
     });
 
@@ -159,7 +157,6 @@ describe('Controller', () => {
       },
     });
 
-    expect(setValue).not.toBeCalled();
     expect(onBlur).toBeCalled();
   });
 

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -135,6 +135,34 @@ describe('Controller', () => {
     expect(onChange).toBeCalled();
   });
 
+  it('should invoke custom onBlur method', () => {
+    const onBlur = jest.fn();
+    const setValue = jest.fn();
+    const control = reconfigureControl({
+      setValue,
+      mode: { isOnSubmit: false, isOnBlur: true },
+    });
+
+    const { getByPlaceholderText } = render(
+      <Controller
+        defaultValue=""
+        name="test"
+        as={<input placeholder="test" />}
+        onBlur={onBlur}
+        control={control}
+      />,
+    );
+
+    fireEvent.blur(getByPlaceholderText('test'), {
+      target: {
+        value: 'test',
+      },
+    });
+
+    expect(setValue).not.toBeCalled();
+    expect(onBlur).toBeCalled();
+  });
+
   it('should support default value from hook form', () => {
     const control = reconfigureControl({
       defaultValuesRef: {

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -13,6 +13,7 @@ const Controller = <ControlProp extends Control = Control>({
   name,
   rules,
   as: InnerComponent,
+  onBlur,
   onChange,
   onChangeName = VALIDATION_MODE.onChange,
   onBlurName = VALIDATION_MODE.onBlur,
@@ -105,15 +106,28 @@ const Controller = <ControlProp extends Control = Control>({
     [name],
   );
 
+  const shouldReValidateOnBlur = isOnBlur || isReValidateOnBlur;
+
   const props = {
     name,
     ...rest,
     ...(onChange
       ? { [onChangeName]: eventWrapper(onChange) }
       : { [onChangeName]: handleChange }),
-    ...(isOnBlur || isReValidateOnBlur
-      ? { [onBlurName]: () => triggerValidation(name) }
+    ...(onBlur || shouldReValidateOnBlur
+      ? {
+          [onBlurName]: (...args: any[]) => {
+            if (onBlur) {
+              onBlur(args);
+            }
+
+            if (shouldReValidateOnBlur) {
+              triggerValidation(name);
+            }
+          },
+        }
       : {}),
+
     ...{ [valueName || (isCheckboxInput ? 'checked' : VALUE)]: value },
   };
 

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -127,7 +127,6 @@ const Controller = <ControlProp extends Control = Control>({
           },
         }
       : {}),
-
     ...{ [valueName || (isCheckboxInput ? 'checked' : VALUE)]: value },
   };
 


### PR DESCRIPTION
After #862 behavior of `onBlur` passed to `Controller` become inconsistent, it get called when `mode` is `onSubmit` or `onChange`, but stop working when it's `onBlur`.

Here is the example with broken behavior https://codesandbox.io/s/react-hook-form-rhfinput-rice1