### PR TITLE
support register method with optional first argument for useFieldArray hook

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -22,6 +22,9 @@ export interface FormProps<FormValues extends FieldValues = FieldValues>
 export interface FormContextValues<
   FormValues extends FieldValues = FieldValues
 > {
+  register<Element extends ElementLike = ElementLike>(): (
+    ref: Element | null,
+  ) => void;
   register<Element extends ElementLike = ElementLike>(
     validationOptions: ValidationOptions,
   ): (ref: Element | null) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,9 @@ export type FormValuesFromErrors<Errors> = Errors extends FieldErrors<
 export type EventFunction = (args: any) => any;
 
 export type Control<FormValues extends FieldValues = FieldValues> = {
+  register<Element extends ElementLike = ElementLike>(): (
+    ref: Element | null,
+  ) => void;
   register<Element extends ElementLike = ElementLike>(
     validationOptions: ValidationOptions,
   ): (ref: Element | null) => void;

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -79,11 +79,11 @@ describe('useForm', () => {
   });
 
   describe('register', () => {
-    it('should return undefined when ref is undefined', () => {
+    it('should return undefined when ref is defined', () => {
       const { result } = renderHook(() => useForm());
 
       act(() => {
-        expect(result.current.register(undefined as any)).toBeUndefined();
+        expect(result.current.register(undefined as any)).toBeDefined();
       });
     });
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -700,7 +700,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
 
   function registerFieldsRef<Element extends ElementLike>(
     ref: Element,
-    validateOptions: ValidationOptions = {},
+    validateOptions: ValidationOptions | null = {},
   ): ((name: FieldName<FormValues>) => void) | void {
     if (!ref.name) {
       return console.warn('Missing name @', ref);
@@ -822,6 +822,9 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
     });
   }
 
+  function register<Element extends ElementLike = ElementLike>(): (
+    ref: Element | null,
+  ) => void;
   function register<Element extends ElementLike = ElementLike>(
     validationOptions: ValidationOptions,
   ): (ref: Element | null) => void;
@@ -840,10 +843,10 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
     validationOptions?: ValidationOptions,
   ): void;
   function register<Element extends ElementLike = ElementLike>(
-    refOrValidationOptions: ValidationOptions | Element | null,
+    refOrValidationOptions?: ValidationOptions | Element | null,
     validationOptions?: ValidationOptions,
   ): ((ref: Element | null) => void) | void {
-    if (isWindowUndefined || !refOrValidationOptions) {
+    if (isWindowUndefined) {
       return;
     }
 


### PR DESCRIPTION
Support not only `ref={register({})}` but also `ref={register()}`.

related: https://github.com/react-hook-form/react-hook-form/pull/896