### PR TITLE
support rest props for ErrorMessage component

### DIFF
--- a/src/__snapshots__/errorMessage.test.tsx.snap
+++ b/src/__snapshots__/errorMessage.test.tsx.snap
@@ -16,9 +16,29 @@ exports[`React Hook Form Error Message should render correctly with flat errors 
 </DocumentFragment>
 `;
 
+exports[`React Hook Form Error Message should render correctly with flat errors and as with component and className and children 1`] = `
+<DocumentFragment>
+  <span
+    class="test"
+  >
+    flat
+  </span>
+</DocumentFragment>
+`;
+
 exports[`React Hook Form Error Message should render correctly with flat errors and as with string 1`] = `
 <DocumentFragment>
   <span>
+    flat
+  </span>
+</DocumentFragment>
+`;
+
+exports[`React Hook Form Error Message should render correctly with flat errors and as with string and className 1`] = `
+<DocumentFragment>
+  <span
+    class="test"
+  >
     flat
   </span>
 </DocumentFragment>

--- a/src/errorMessage.test.tsx
+++ b/src/errorMessage.test.tsx
@@ -32,12 +32,40 @@ describe('React Hook Form Error Message', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  it('should render correctly with flat errors and as with string and className', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        as="span"
+        errors={{ flat: { type: 'flat', message: 'flat' } }}
+        name="flat"
+        className="test"
+      />,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('should render correctly with flat errors and as with component and children', () => {
     const { asFragment } = render(
       <ErrorMessage
         as={<span />}
         errors={{ flat: { type: 'flat', message: 'flat' } }}
         name="flat"
+      >
+        {({ message }) => message}
+      </ErrorMessage>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with flat errors and as with component and className and children', () => {
+    const { asFragment } = render(
+      <ErrorMessage
+        as={<span />}
+        errors={{ flat: { type: 'flat', message: 'flat' } }}
+        name="flat"
+        className="test"
       >
         {({ message }) => message}
       </ErrorMessage>,

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -8,16 +8,21 @@ import {
   ErrorMessageProps,
 } from './types';
 
-const ErrorMessage = <
+function ErrorMessage<
   Errors extends FieldErrors<any>,
-  Name extends FieldName<FormValuesFromErrors<Errors>>
+  Name extends FieldName<FormValuesFromErrors<Errors>>,
+  As extends
+    | undefined
+    | React.ReactElement
+    | keyof JSX.IntrinsicElements = undefined
 >({
   as: InnerComponent,
   errors,
   name,
   message,
   children,
-}: ErrorMessageProps<Errors, Name>) => {
+  ...rest
+}: ErrorMessageProps<Errors, Name, As>) {
   const methods = useFormContext();
   const error = get(errors || methods.errors, name);
 
@@ -27,6 +32,7 @@ const ErrorMessage = <
 
   const { message: messageFromRegister, types } = error;
   const props = {
+    ...(InnerComponent ? rest : {}),
     children: children
       ? children({ message: messageFromRegister || message, messages: types })
       : messageFromRegister || message,
@@ -36,11 +42,11 @@ const ErrorMessage = <
     React.isValidElement(InnerComponent) ? (
       React.cloneElement(InnerComponent, props)
     ) : (
-      <InnerComponent {...props} />
+      React.createElement(InnerComponent as string, props)
     )
   ) : (
     <React.Fragment {...props} />
   );
-};
+}
 
 export { ErrorMessage };

--- a/src/types.ts
+++ b/src/types.ts
@@ -242,6 +242,19 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
   >;
 };
 
+export type AsProps<
+  As extends
+    | undefined
+    | React.ReactElement
+    | keyof JSX.IntrinsicElements = undefined
+> = As extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[As]
+  : As extends React.ReactElement
+  ? { [key: string]: any }
+  : As extends undefined
+  ? {}
+  : never;
+
 export type ControllerProps<ControlProp extends Control = Control> = {
   name: string;
   as: React.ReactElement | React.ElementType | string;
@@ -259,9 +272,13 @@ export type ControllerProps<ControlProp extends Control = Control> = {
 
 export type ErrorMessageProps<
   Errors extends FieldErrors<any>,
-  Name extends FieldName<FormValuesFromErrors<Errors>>
+  Name extends FieldName<FormValuesFromErrors<Errors>>,
+  As extends
+    | undefined
+    | React.ReactElement
+    | keyof JSX.IntrinsicElements = undefined
 > = {
-  as?: React.ReactElement | React.ElementType | string;
+  as?: As;
   errors?: Errors;
   name: Name;
   message?: string;
@@ -269,7 +286,7 @@ export type ErrorMessageProps<
     message: string;
     messages: MultipleFieldErrors;
   }) => React.ReactNode;
-};
+} & AsProps<As>;
 
 export type UseFieldArrayProps<ControlProp extends Control = Control> = {
   control?: ControlProp;


### PR DESCRIPTION
1. no pass `as` prop

![スクリーンショット 2020-01-31 12 14 52](https://user-images.githubusercontent.com/12913947/73509817-d10c2680-4423-11ea-977a-f36f24dcd822.png)

2. pass `as` prop with string

![スクリーンショット 2020-01-31 12 15 40](https://user-images.githubusercontent.com/12913947/73509881-fd27a780-4423-11ea-8822-72f002cc7be5.png)
![スクリーンショット 2020-01-31 12 16 02](https://user-images.githubusercontent.com/12913947/73509819-d10c2680-4423-11ea-960b-63c309fc4317.png)

3. pass `as` prop with ReactElement

![スクリーンショット 2020-01-31 12 17 28](https://user-images.githubusercontent.com/12913947/73509820-d10c2680-4423-11ea-9785-daaecbdbbc1a.png)
![スクリーンショット 2020-01-31 12 17 48](https://user-images.githubusercontent.com/12913947/73509821-d1a4bd00-4423-11ea-834d-3f31772c9404.png)

related: https://github.com/react-hook-form/react-hook-form/issues/937