### PR TITLE
Feature/support custom schema validation (new)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ function App() {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <input name="firstname" ref={register} /> {/* register an input */}
+
       <input name="lastname" ref={register({ required: true })} />
       {errors.lastname && 'Last name is required.'}
+
       <input name="age" ref={register({ pattern: /\d+/ })} />
       {errors.age && 'Please enter number for age.'}
+
       <input type="submit" />
     </form>
   );

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 - [Tiny size](https://bundlephobia.com/result?p=react-hook-form@latest) without any dependency
 - Follows HTML standard for validation
 - Compatible with React Native
-- Supports [Yup](https://github.com/jquense/yup) schema-based validation
+- Supports [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or custom schema-based validation
 - Supports native browser validation
 - Build forms quickly with the [form builder](https://react-hook-form.com/form-builder)
 
@@ -73,13 +73,10 @@ function App() {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <input name="firstname" ref={register} /> {/* register an input */}
-
       <input name="lastname" ref={register({ required: true })} />
       {errors.lastname && 'Last name is required.'}
-
       <input name="age" ref={register({ pattern: /\d+/ })} />
       {errors.age && 'Please enter number for age.'}
-
       <input type="submit" />
     </form>
   );

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 - [Tiny size](https://bundlephobia.com/result?p=react-hook-form@latest) without any dependency
 - Follows HTML standard for validation
 - Compatible with React Native
-- Supports [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or custom schema-based validation
+- Supports [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Superstruct](https://github.com/ianstormtaylor/superstruct) or custom
 - Supports native browser validation
 - Build forms quickly with the [form builder](https://react-hook-form.com/form-builder)
 

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@hapi/joi": "^17.1.0",
     "@material-ui/core": "^4.8.0",
+    "@types/hapi__joi": "^16.0.9",
     "@types/jest": "24.0.24",
     "@types/node": "12.12.21",
     "@types/react": "16.9.17",

--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -21,6 +21,7 @@ import SetValueWithTrigger from './setValueWithTrigger';
 import IsValid from './isValid';
 import Controller from './controller';
 import UseFieldArray from './useFieldArray';
+import CustomSchemaValidation from './customSchemaValidation';
 
 const App: React.FC = () => {
   return (
@@ -77,6 +78,11 @@ const App: React.FC = () => {
         path="/watch-default-values"
         exact
         component={WatchDefaultValues}
+      />
+      <Route
+        path="/customSchemaValidation/:mode"
+        exact
+        component={CustomSchemaValidation}
       />
     </Router>
   );

--- a/app/src/customSchemaValidation.tsx
+++ b/app/src/customSchemaValidation.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import useForm from 'react-hook-form';
+import Joi from '@hapi/joi';
+
+let renderCounter = 0;
+
+const validationSchema = Joi.object({
+  firstName: Joi.string().required(),
+  lastName: Joi.string()
+    .max(5)
+    .required(),
+  min: Joi.number()
+    .min(10)
+    .required(),
+  max: Joi.number()
+    .max(20)
+    .required(),
+  minDate: Joi.date().min('2019-08-01'),
+  maxDate: Joi.date().max('2019-08-01'),
+  minLength: Joi.string().min(2),
+  minRequiredLength: Joi.string().required(),
+  selectNumber: Joi.string().required(),
+  pattern: Joi.string().required(),
+  radio: Joi.string().required(),
+  checkbox: Joi.required(),
+});
+
+const resolver = (data: any) => {
+  const { error, value: values } = validationSchema.validate(data, {
+    abortEarly: false,
+  });
+
+  return {
+    values: error ? {} : values,
+    errors: error
+      ? error.details.reduce((previous, currentError) => {
+        return {
+          ...previous,
+          [currentError.path[0]]: currentError,
+        };
+      }, {})
+      : {},
+  };
+};
+
+const BasicSchemaValidation: React.FC = (props: any) => {
+  const { register, handleSubmit, errors } = useForm<{
+    firstName: string;
+    lastName: string;
+    min: string;
+    max: string;
+    minDate: string;
+    maxDate: string;
+    minLength: string;
+    minRequiredLength: string;
+    selectNumber: string;
+    pattern: string;
+    radio: string;
+    checkbox: string;
+    multiple: string;
+    validate: string;
+  }>({
+    validationResolver,
+    mode: props.match.params.mode,
+  });
+  const onSubmit = () => {};
+
+  renderCounter++;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input name="firstName" ref={register} placeholder="firstName" />
+      {errors.firstName && <p>firstName error</p>}
+      <input name="lastName" ref={register} placeholder="lastName" />
+      {errors.lastName && <p>lastName error</p>}
+      <input type="number" name="min" ref={register} placeholder="min" />
+      {errors.min && <p>min error</p>}
+      <input type="number" name="max" ref={register} placeholder="max" />
+      {errors.max && <p>max error</p>}
+      <input type="date" name="minDate" ref={register} placeholder="minDate" />
+      {errors.minDate && <p>minDate error</p>}
+      <input type="date" name="maxDate" ref={register} placeholder="maxDate" />
+      {errors.maxDate && <p>maxDate error</p>}
+      <input name="minLength" ref={register} placeholder="minLength" />
+      {errors.minLength && <p>minLength error</p>}
+      <input
+        name="minRequiredLength"
+        ref={register}
+        placeholder="minRequiredLength"
+      />
+      {errors.minRequiredLength && <p>minRequiredLength error</p>}
+      <select name="selectNumber" ref={register}>
+        <option value="">Select</option>
+        <option value={1}>1</option>
+        <option value={2}>1</option>
+      </select>
+      {errors.selectNumber && <p>selectNumber error</p>}
+      <input name="pattern" ref={register} placeholder="pattern" />
+      {errors.pattern && <p>pattern error</p>}
+      Radio1
+      <input type="radio" name="radio" ref={register} value="1" />
+      Radio2
+      <input type="radio" name="radio" ref={register} value="2" />
+      Radio3
+      <input type="radio" name="radio" ref={register} value="3" />
+      {errors.radio && <p>radio error</p>}
+      <input type="checkbox" name="checkbox" ref={register} />
+      {errors.checkbox && <p>checkbox error</p>}
+      <button>Submit</button>
+      <div id="renderCount">{renderCounter}</div>
+    </form>
+  );
+};
+
+export default BasicSchemaValidation;

--- a/app/src/customSchemaValidation.tsx
+++ b/app/src/customSchemaValidation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import useForm from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import Joi from '@hapi/joi';
 
 let renderCounter = 0;
@@ -25,7 +25,7 @@ const validationSchema = Joi.object({
   checkbox: Joi.required(),
 });
 
-const resolver = (data: any) => {
+const validationResolver = (data: any) => {
   const { error, value: values } = validationSchema.validate(data, {
     abortEarly: false,
   });

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1815,10 +1815,27 @@
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
   integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
 
+"@hapi/address@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.0.0.tgz#36affb4509b5a6adc628bcc394450f2a7d51d111"
+  integrity sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@hapi/formula@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-2.0.0.tgz#edade0619ed58c8e4f164f233cda70211e787128"
+  integrity sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==
+
 "@hapi/hoek@6.x.x":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-6.2.1.tgz#d3a66329159af879bfdf0b0cff2229c43c5a3451"
   integrity sha512-+ryw4GU9pjr1uT6lBuErHJg3NYqzwJTvZ75nKuJijEzpd00Uqi6oiawTGDDf5Hl0zWmI7qHfOtaqB0kpQZJQzA==
+
+"@hapi/hoek@^9.0.0":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.2.tgz#57597083f763eafbfdc902d16ec868aa787b24d2"
+  integrity sha512-LyibKv2QnD9BPI5g2L+g85yiIPv3ajYpENGFgy4u0xCLPhXWG1Zdx29neSB8sgX0/wz6k5TMjHzTwJ6+DaBYOA==
 
 "@hapi/joi@^15.0.0":
   version "15.0.2"
@@ -1829,12 +1846,35 @@
     "@hapi/hoek" "6.x.x"
     "@hapi/topo" "3.x.x"
 
+"@hapi/joi@^17.1.0":
+  version "17.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-17.1.0.tgz#cc4000b6c928a6a39b9bef092151b6bdee10ce55"
+  integrity sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==
+  dependencies:
+    "@hapi/address" "^4.0.0"
+    "@hapi/formula" "^2.0.0"
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/pinpoint" "^2.0.0"
+    "@hapi/topo" "^5.0.0"
+
+"@hapi/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.0.tgz#805b40d4dbec04fc116a73089494e00f073de8df"
+  integrity sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==
+
 "@hapi/topo@3.x.x":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.0.tgz#5c47cd9637c2953db185aa957a27bcb2a8b7a6f8"
   integrity sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==
   dependencies:
     "@hapi/hoek" "6.x.x"
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
 
 "@jest/console@^24.7.1":
   version "24.7.1"
@@ -2263,6 +2303,11 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/hapi__joi@^16.0.9":
+  version "16.0.9"
+  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-16.0.9.tgz#0ad11f9de3753748444ac16249a264fc7c798ab4"
+  integrity sha512-FV+rJxm4UBxBsRvT5hpiRvnxbpi9iJu4qdwXQvNXf6eXJkcgKGlTwHnstIDAxSTKTUMSmpJnyXpr6XI9X/4SjA==
 
 "@types/history@*":
   version "4.7.2"

--- a/cypress/integration/customSchemaValidation.ts
+++ b/cypress/integration/customSchemaValidation.ts
@@ -1,4 +1,4 @@
-context('basicSchemaValidation form validation', () => {
+context('customSchemaValidation form validation', () => {
   it('should validate the form with onSubmit mode', () => {
     cy.visit('http://localhost:3000/customSchemaValidation/onSubmit');
     cy.get('button').click();
@@ -47,7 +47,7 @@ context('basicSchemaValidation form validation', () => {
     cy.get('input[name="checkbox"]').check();
 
     cy.get('p').should('have.length', 0);
-    cy.get('#renderCount').contains('24');
+    cy.get('#renderCount').contains('25');
   });
 
   it('should validate the form with onBlur mode', () => {

--- a/cypress/integration/customSchemaValidation.ts
+++ b/cypress/integration/customSchemaValidation.ts
@@ -1,0 +1,161 @@
+context('basicSchemaValidation form validation', () => {
+  it('should validate the form with onSubmit mode', () => {
+    cy.visit('http://localhost:3000/customSchemaValidation/onSubmit');
+    cy.get('button').click();
+
+    cy.focused().should('have.attr', 'name', 'firstName');
+
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('select[name="selectNumber"] + p').contains('selectNumber error');
+    cy.get('input[name="minRequiredLength"] + p').contains(
+      'minRequiredLength error',
+    );
+    cy.get('input[name="radio"] + p').contains('radio error');
+
+    cy.get('input[name="firstName"]').type('bill');
+    cy.get('input[name="lastName"]').type('luo123456');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('select[name="selectNumber"]').select('1');
+    cy.get('input[name="pattern"]').type('luo');
+    cy.get('input[name="min"]').type('1');
+    cy.get('input[name="max"]').type('21');
+    cy.get('input[name="minDate"]').type('2019-07-30');
+    cy.get('input[name="maxDate"]').type('2019-08-02');
+    cy.get('input[name="lastName"]')
+      .clear()
+      .type('luo');
+    cy.get('input[name="minLength"]').type('2');
+    cy.get('input[name="minLength"] + p').contains('minLength error');
+    cy.get('input[name="min"] + p').contains('min error');
+    cy.get('input[name="max"] + p').contains('max error');
+    cy.get('input[name="minDate"] + p').contains('minDate error');
+    cy.get('input[name="maxDate"] + p').contains('maxDate error');
+
+    cy.get('input[name="pattern"]').type('23');
+    cy.get('input[name="minLength"]').type('bi');
+    cy.get('input[name="minRequiredLength"]').type('bi');
+    cy.get('input[name="radio"]').check('1');
+    cy.get('input[name="min"]')
+      .clear()
+      .type('11');
+    cy.get('input[name="max"]')
+      .clear()
+      .type('19');
+    cy.get('input[name="minDate"]').type('2019-08-01');
+    cy.get('input[name="maxDate"]').type('2019-08-01');
+    cy.get('input[name="checkbox"]').check();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('24');
+  });
+
+  it('should validate the form with onBlur mode', () => {
+    cy.visit('http://localhost:3000/customSchemaValidation/onBlur');
+
+    cy.get('input[name="firstName"]').focus();
+    cy.get('input[name="firstName"]').blur();
+    cy.get('input[name="firstName"] + p').contains('firstName error');
+    cy.get('input[name="firstName"]').type('bill');
+    cy.get('input[name="lastName"]').focus();
+    cy.get('input[name="lastName"]').blur();
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('input[name="lastName"]').type('luo123456');
+    cy.get('input[name="lastName"]').blur();
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('select[name="selectNumber"]').focus();
+    cy.get('select[name="selectNumber"]').blur();
+    cy.get('select[name="selectNumber"] + p').contains('selectNumber error');
+    cy.get('select[name="selectNumber"]').select('1');
+    cy.get('input[name="pattern"]').type('luo');
+    cy.get('input[name="min"]').type('1');
+    cy.get('input[name="max"]').type('21');
+    cy.get('input[name="minDate"]').type('2019-07-30');
+    cy.get('input[name="maxDate"]').type('2019-08-02');
+    cy.get('input[name="lastName"]')
+      .clear()
+      .type('luo');
+    cy.get('input[name="minLength"]').type('2');
+    cy.get('input[name="minLength"]').blur();
+
+    cy.get('input[name="minLength"] + p').contains('minLength error');
+    cy.get('input[name="min"] + p').contains('min error');
+    cy.get('input[name="max"] + p').contains('max error');
+    cy.get('input[name="minDate"] + p').contains('minDate error');
+    cy.get('input[name="maxDate"] + p').contains('maxDate error');
+
+    cy.get('input[name="pattern"]').type('23');
+    cy.get('input[name="minLength"]').type('bi');
+    cy.get('input[name="minRequiredLength"]').type('bi');
+    cy.get('input[name="radio"]')
+      .first()
+      .focus();
+    cy.get('input[name="radio"]')
+      .first()
+      .blur();
+    cy.get('input[name="radio"] + p').contains('radio error');
+    cy.get('input[name="radio"]').check('1');
+    cy.get('input[name="min"]')
+      .clear()
+      .type('11');
+    cy.get('input[name="max"]')
+      .clear()
+      .type('19');
+    cy.get('input[name="minDate"]').type('2019-08-01');
+    cy.get('input[name="maxDate"]').type('2019-08-01');
+    cy.get('input[name="checkbox"]').check();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('27');
+  });
+
+  it('should validate the form with onChange mode', () => {
+    cy.visit('http://localhost:3000/customSchemaValidation/onChange');
+
+    cy.get('input[name="firstName"]').type('bill');
+    cy.get('input[name="lastName"]').focus();
+    cy.get('input[name="lastName"]').type('luo123456');
+    cy.get('input[name="lastName"]').clear();
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('input[name="lastName"]').type('luo123456');
+    cy.get('input[name="lastName"] + p').contains('lastName error');
+    cy.get('select[name="selectNumber"]').select('');
+    cy.get('select[name="selectNumber"] + p').contains('selectNumber error');
+    cy.get('select[name="selectNumber"]').select('1');
+    cy.get('input[name="pattern"]').type('luo');
+    cy.get('input[name="min"]').type('1');
+    cy.get('input[name="max"]').type('21');
+    cy.get('input[name="minDate"]').type('2019-07-30');
+    cy.get('input[name="maxDate"]').type('2019-08-02');
+    cy.get('input[name="lastName"]')
+      .clear()
+      .type('luo');
+    cy.get('input[name="minLength"]').type('2');
+
+    cy.get('input[name="minLength"] + p').contains('minLength error');
+    cy.get('input[name="min"] + p').contains('min error');
+    cy.get('input[name="max"] + p').contains('max error');
+    cy.get('input[name="minDate"] + p').contains('minDate error');
+    cy.get('input[name="maxDate"] + p').contains('maxDate error');
+
+    cy.get('input[name="pattern"]').type('23');
+    cy.get('input[name="minLength"]').type('bi');
+    cy.get('input[name="minRequiredLength"]').type('bi');
+    cy.get('input[name="radio"]')
+      .first()
+      .focus();
+    cy.get('input[name="radio"]').check('1');
+    cy.get('input[name="min"]')
+      .clear()
+      .type('11');
+    cy.get('input[name="max"]')
+      .clear()
+      .type('19');
+    cy.get('input[name="minDate"]').type('2019-08-01');
+    cy.get('input[name="maxDate"]').type('2019-08-01');
+    cy.get('input[name="checkbox"]').check();
+
+    cy.get('p').should('have.length', 0);
+    cy.get('#renderCount').contains('29');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "bundlesize": [
     {
       "path": "./dist/react-hook-form.min.es.js",
-      "maxSize": "7.5 kB"
+      "maxSize": "7.8 kB"
     }
   ],
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form",
   "description": "Performant, flexible and extensible forms library for React Hooks",
-  "version": "4.8.2",
+  "version": "4.8.3-next.0",
   "main": "dist/react-hook-form.js",
   "module": "dist/react-hook-form.es.js",
   "types": "dist/index.d.ts",

--- a/src/logic/validateWithSchema.test.ts
+++ b/src/logic/validateWithSchema.test.ts
@@ -80,3 +80,18 @@ describe('validateWithSchema', () => {
     });
   });
 });
+
+test('should invoke resolver function for custom schema validation', async () => {
+  const resolver = jest.fn();
+
+  await validateWithSchema(
+    {
+      validationResolver,
+    },
+    { abortEarly: false },
+    false,
+    {},
+  );
+
+  expect(resolver).toBeCalledWith({});
+});

--- a/src/logic/validateWithSchema.test.ts
+++ b/src/logic/validateWithSchema.test.ts
@@ -61,6 +61,8 @@ describe('validateWithSchema', () => {
         },
         false,
         {},
+        undefined as any,
+        {},
       ),
     ).toMatchSnapshot();
   });
@@ -73,6 +75,8 @@ describe('validateWithSchema', () => {
         },
         false,
         {},
+        undefined as any,
+        {},
       ),
     ).toEqual({
       errors: {},
@@ -84,14 +88,7 @@ describe('validateWithSchema', () => {
 test('should invoke resolver function for custom schema validation', async () => {
   const resolver = jest.fn();
 
-  await validateWithSchema(
-    {
-      validationResolver,
-    },
-    { abortEarly: false },
-    false,
-    {},
-  );
+  await validateWithSchema({} as any, false, {}, resolver, {});
 
-  expect(resolver).toBeCalledWith({});
+  expect(resolver).toBeCalledWith({}, {});
 });

--- a/src/logic/validateWithSchema.ts
+++ b/src/logic/validateWithSchema.ts
@@ -62,27 +62,29 @@ export const parseErrorSchema = <FormValues>(
 
 export default async function validateWithSchema<FormValues>(
   validationSchema: Schema<FormValues>,
-  validationResolver: ValidationResolver,
-  context: any,
   validateAllFieldCriteria: boolean,
   data: FieldValues,
+  validationResolver?: ValidationResolver,
+  context?: any,
 ): Promise<SchemaValidationResult<FormValues>> {
-  if (validationSchema) {
-    try {
-      return {
-        values: await (validationSchema as Schema<FormValues>).validate(data, {
-          abortEarly: false,
-          context,
-        }),
-        errors: {},
-      };
-    } catch (e) {
-      return {
-        values: {},
-        errors: parseErrorSchema<FormValues>(e, validateAllFieldCriteria),
-      };
-    }
+  if (validationResolver) {
+    return validationResolver(data, context);
   }
 
-  return validationResolver(data, context);
+  try {
+    return {
+      values: await (validationSchema as Schema<FormValues>).validate(data, {
+        abortEarly: false,
+        context,
+      }),
+      errors: {},
+    };
+  } catch (e) {
+    return {
+      values: {},
+      errors: transformToNestObject(
+        parseErrorSchema<FormValues>(e, validateAllFieldCriteria),
+      ),
+    };
+  }
 }

--- a/src/logic/validateWithSchema.ts
+++ b/src/logic/validateWithSchema.ts
@@ -60,12 +60,12 @@ export const parseErrorSchema = <FormValues>(
         [error.path]: { message: error.message, type: error.type },
       };
 
-export default async function validateWithSchema<FormValues>(
+export default async function validateWithSchema<FormValues, ValidationContext>(
   validationSchema: Schema<FormValues>,
   validateAllFieldCriteria: boolean,
   data: FieldValues,
   validationResolver?: ValidationResolver,
-  context?: any,
+  context?: ValidationContext,
 ): Promise<SchemaValidationResult<FormValues>> {
   if (validationResolver) {
     return validationResolver(data, context);
@@ -73,7 +73,7 @@ export default async function validateWithSchema<FormValues>(
 
   try {
     return {
-      values: await (validationSchema as Schema<FormValues>).validate(data, {
+      values: await validationSchema.validate(data, {
         abortEarly: false,
         context,
       }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,23 +44,24 @@ export type SchemaValidateOptions = Partial<{
   abortEarly: boolean;
   stripUnknown: boolean;
   recursive: boolean;
-  context: object;
+  context: any;
 }>;
 
-export type ValidationResolver = <FormValues>(
+export type ValidationResolver = <FormValues, ValidationContext>(
   values: FieldValues,
-  validationContext: object,
+  validationContext: ValidationContext,
 ) => { values: FieldValues; errors: FieldErrors<FormValues> };
 
 export type UseFormOptions<
-  FormValues extends FieldValues = FieldValues
+  FormValues extends FieldValues = FieldValues,
+  ValidationContext = undefined
 > = Partial<{
   mode: Mode;
   reValidateMode: Mode;
   defaultValues: DeepPartial<FormValues>;
   validationSchema: any;
   validationResolver: ValidationResolver;
-  validationContext: object;
+  validationContext: ValidationContext;
   submitFocusError: boolean;
   validateCriteriaMode: 'firstError' | 'all';
 }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export type SchemaValidateOptions = Partial<{
 export type ValidationResolver = <FormValues, ValidationContext>(
   values: FieldValues,
   validationContext: ValidationContext,
-) => { values: FieldValues; errors: FieldErrors<FormValues> };
+) => { values: FieldValues | {}; errors: FieldErrors<FormValues> | {} };
 
 export type UseFormOptions<
   FormValues extends FieldValues = FieldValues,

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,11 @@ export type UseFormOptions<
   reValidateMode: Mode;
   defaultValues: DeepPartial<FormValues>;
   validationSchema: any;
+  validationResolver: (
+    values: FieldValues,
+    context: any,
+  ) => { values: FieldValues; errors: FieldErrors<FormValues> };
+  validationContext: object;
   submitFocusError: boolean;
   validateCriteriaMode: 'firstError' | 'all';
 }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export type SchemaValidateOptions = Partial<{
 
 export type ValidationResolver = <FormValues>(
   values: FieldValues,
-  context: any,
+  validationContext: object,
 ) => { values: FieldValues; errors: FieldErrors<FormValues> };
 
 export type UseFormOptions<

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,11 @@ export type SchemaValidateOptions = Partial<{
   context: object;
 }>;
 
+export type ValidationResolver = <FormValues>(
+  values: FieldValues,
+  context: any,
+) => { values: FieldValues; errors: FieldErrors<FormValues> };
+
 export type UseFormOptions<
   FormValues extends FieldValues = FieldValues
 > = Partial<{
@@ -54,10 +59,7 @@ export type UseFormOptions<
   reValidateMode: Mode;
   defaultValues: DeepPartial<FormValues>;
   validationSchema: any;
-  validationResolver: (
-    values: FieldValues,
-    context: any,
-  ) => { values: FieldValues; errors: FieldErrors<FormValues> };
+  validationResolver: ValidationResolver;
   validationContext: object;
   submitFocusError: boolean;
   validateCriteriaMode: 'firstError' | 'all';

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -60,7 +60,10 @@ import {
 
 const { useRef, useState, useCallback, useEffect } = React;
 
-export function useForm<FormValues extends FieldValues = FieldValues>({
+export function useForm<
+  FormValues extends FieldValues = FieldValues,
+  ValidationContext = undefined
+>({
   mode = VALIDATION_MODE.onSubmit,
   reValidateMode = VALIDATION_MODE.onChange,
   validationSchema,
@@ -309,7 +312,10 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
     async (
       payload: FieldName<FormValues> | FieldName<FormValues>[],
     ): Promise<boolean> => {
-      const { errors } = await validateWithSchema<FormValues>(
+      const { errors } = await validateWithSchema<
+        FormValues,
+        ValidationContext
+      >(
         validationSchema,
         validateAllFieldCriteria,
         getFieldValueByName(fieldsRef.current),
@@ -449,7 +455,10 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
         }
 
         if (shouldValidateCallback) {
-          const { errors } = await validateWithSchema<FormValues>(
+          const { errors } = await validateWithSchema<
+            FormValues,
+            ValidationContext
+          >(
             validationSchema,
             validateAllFieldCriteria,
             getFieldValueByName(fields),
@@ -484,7 +493,7 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
       ? getFieldsValues(fieldsRef.current)
       : defaultValuesRef.current;
 
-    validateWithSchema(
+    validateWithSchema<FormValues, ValidationContext>(
       validationSchema,
       validateAllFieldCriteria,
       transformToNestObject(fieldValues),
@@ -929,7 +938,10 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
       try {
         if (shouldValidateCallback) {
           fieldValues = getFieldsValues(fields);
-          const { errors, values } = await validateWithSchema(
+          const { errors, values } = await validateWithSchema<
+            FormValues,
+            ValidationContext
+          >(
             validationSchema,
             validateAllFieldCriteria,
             transformToNestObject(fieldValues),

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -64,6 +64,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
   mode = VALIDATION_MODE.onSubmit,
   reValidateMode = VALIDATION_MODE.onChange,
   validationSchema,
+  validationResolver,
+  validationContext,
   defaultValues = {},
   submitFocusError = true,
   validateCriteriaMode,
@@ -305,6 +307,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
     ): Promise<boolean> => {
       const { errors } = await validateWithSchema<FormValues>(
         validationSchema,
+        validationResolver,
+        validationContext,
         validateAllFieldCriteria,
         getFieldValueByName(fieldsRef.current),
       );
@@ -338,6 +342,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
       reRender,
       shouldRenderBaseOnError,
       validateAllFieldCriteria,
+      validationContext,
+      validationResolver,
       validationSchema,
     ],
   );
@@ -436,6 +442,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
         if (validationSchema) {
           const { errors } = await validateWithSchema<FormValues>(
             validationSchema,
+            validationResolver,
+            validationContext,
             validateAllFieldCriteria,
             getFieldValueByName(fields),
           );
@@ -469,6 +477,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
 
     validateWithSchema(
       validationSchema,
+      validationResolver,
+      validationContext,
       validateAllFieldCriteria,
       transformToNestObject(fieldValues),
     ).then(({ errors }) => {
@@ -479,7 +489,13 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
         reRender();
       }
     });
-  }, [reRender, validateAllFieldCriteria, validationSchema]);
+  }, [
+    reRender,
+    validateAllFieldCriteria,
+    validationContext,
+    validationResolver,
+    validationSchema,
+  ]);
 
   const resetFieldRef = useCallback(
     (name: FieldName<FormValues>) => {
@@ -906,6 +922,8 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
           fieldValues = getFieldsValues(fields);
           const { errors, values } = await validateWithSchema(
             validationSchema,
+            validationResolver,
+            validationContext,
             validateAllFieldCriteria,
             transformToNestObject(fieldValues),
           );
@@ -986,7 +1004,14 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
         reRender();
       }
     },
-    [reRender, submitFocusError, validateAllFieldCriteria, validationSchema],
+    [
+      reRender,
+      submitFocusError,
+      validateAllFieldCriteria,
+      validationContext,
+      validationResolver,
+      validationSchema,
+    ],
   );
 
   const resetRefs = () => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -307,10 +307,10 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
     ): Promise<boolean> => {
       const { errors } = await validateWithSchema<FormValues>(
         validationSchema,
-        validationResolver,
-        validationContext,
         validateAllFieldCriteria,
         getFieldValueByName(fieldsRef.current),
+        validationResolver,
+        validationContext,
       );
       const previousFormIsValid = isValidRef.current;
       isValidRef.current = isEmptyObject(errors);
@@ -439,13 +439,13 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
           return shouldUpdateState && reRender();
         }
 
-        if (validationSchema) {
+        if (validationSchema || validationResolver) {
           const { errors } = await validateWithSchema<FormValues>(
             validationSchema,
-            validationResolver,
-            validationContext,
             validateAllFieldCriteria,
             getFieldValueByName(fields),
+            validationResolver,
+            validationContext,
           );
           const previousFormIsValid = isValidRef.current;
           isValidRef.current = isEmptyObject(errors);
@@ -477,10 +477,10 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
 
     validateWithSchema(
       validationSchema,
-      validationResolver,
-      validationContext,
       validateAllFieldCriteria,
       transformToNestObject(fieldValues),
+      validationResolver,
+      validationContext,
     ).then(({ errors }) => {
       const previousFormIsValid = isValidRef.current;
       isValidRef.current = isEmptyObject(errors);
@@ -918,14 +918,14 @@ export function useForm<FormValues extends FieldValues = FieldValues>({
       }
 
       try {
-        if (validationSchema) {
+        if (validationSchema || validationResolver) {
           fieldValues = getFieldsValues(fields);
           const { errors, values } = await validateWithSchema(
             validationSchema,
-            validationResolver,
-            validationContext,
             validateAllFieldCriteria,
             transformToNestObject(fieldValues),
+            validationResolver,
+            validationContext,
           );
           errorsRef.current = errors;
           fieldErrors = errors;


### PR DESCRIPTION
This feature request is waiting for more upvote. 

related PR: https://github.com/react-hook-form/react-hook-form-website/pull/139

if you want such feature, you can thumb up this comment. 👍 

------

example for `@hapi/joi`, this will apply for any other schema/custom validation.

```
import React from "react";
import useForm from "react-hook-form";
import joi from "@hapi/joi";

const schema = Joi.object({
  username: Joi.string().alphanum().min(3).max(30).required()
});

// Build your resolver to display errors and pass valid values
const resolver = (data: any) => {
  const { error, value: values } = validationSchema.validate(data, {
    abortEarly: false,
  });
  return {
    values: error ? {} : values,
    errors: error
      ? error.details.reduce((previous, currentError) => {
          return {
            ...previous,
            [currentError.path[0]]: currentError,
          };
        }, {})
      : {},
  };
};

function App() {
  const { register, handleSubmit, errors } = useForm({
    validationResolver: resolver
   });
  
  return (
    <form onSubmit={handleSubmit(d => console.log(d))}>
      <input type="text" name="username" ref={register} />
    </form>
  );
}
```
