### PR TITLE
Allow the field value to be transformed before passing it to the controlled component

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -17,6 +17,7 @@ const Controller = <ControlProp extends Control = Control>({
   onChange,
   onChangeName = VALIDATION_MODE.onChange,
   onBlurName = VALIDATION_MODE.onBlur,
+  valueTransformer,
   valueName,
   defaultValue,
   control,
@@ -132,7 +133,11 @@ const Controller = <ControlProp extends Control = Control>({
           },
         }
       : {}),
-    ...{ [valueName || (isCheckboxInput ? 'checked' : VALUE)]: value },
+    ...{
+      [valueName || (isCheckboxInput ? 'checked' : VALUE)]: valueTransformer
+        ? valueTransformer(value)
+        : value,
+    },
   };
 
   return React.isValidElement(InnerComponent) ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,6 +260,7 @@ export type ControllerProps<ControlProp extends Control = Control> = {
   onChangeName?: string;
   onBlurName?: string;
   valueName?: string;
+  valueTransformer?: (value: any) => any;
   defaultValue?: any;
   control?: ControlProp;
   [key: string]: any;


### PR DESCRIPTION
I was trying to integrate a react-select component when I ran across the problem with the different `value` format (`{ value: "foo", label: "bar" }`) for react-select.

I thought it would make sense to allow the selected value to be transformed before passing it to the controlled component instead of forcing the structure of the `form values` to be changed to accommodate react-select.

That way, one can continue using the form values / fields however one wants to structure them and not have it dictated by react-select.