### PR TITLE
improve type keyName for useFieldArray

### DIFF
--- a/app/src/useFieldArray.tsx
+++ b/app/src/useFieldArray.tsx
@@ -35,7 +35,7 @@ const UseFieldArray: React.FC = (props: any) => {
     move,
     insert,
     remove,
-  } = useFieldArray<{ name: string, id: string }>({
+  } = useFieldArray<{ name: string }>({
     control,
     name: 'data',
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,8 +283,16 @@ export type ErrorMessageProps<
   }) => React.ReactNode;
 } & AsProps<As>;
 
-export type UseFieldArrayProps<ControlProp extends Control = Control> = {
-  control?: ControlProp;
-  keyName?: string;
+export type UseFieldArrayProps<
+  KeyName extends string = 'id',
+  ControlProp extends Control = Control
+> = {
   name: string;
+  keyName?: KeyName;
+  control?: ControlProp;
 };
+
+export type ArrayField<
+  FormArrayValues extends FieldValues = FieldValues,
+  KeyName extends string = 'id'
+> = FormArrayValues & Record<KeyName, string>;

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -13,14 +13,25 @@ import prependAt from './utils/prepend';
 import isArray from './utils/isArray';
 import insertAt from './utils/insert';
 import fillEmptyArray from './utils/fillEmptyArray';
-import { FieldValues, Control, UseFieldArrayProps, Field } from './types';
+import {
+  Field,
+  FieldValues,
+  UseFieldArrayProps,
+  Control,
+  ArrayField,
+} from './types';
 
 const { useEffect, useRef, useState } = React;
 
-export function useFieldArray<
+export const useFieldArray = <
   FormArrayValues extends FieldValues = FieldValues,
+  KeyName extends string = 'id',
   ControlProp extends Control = Control
->({ control, name, keyName = 'id' }: UseFieldArrayProps<ControlProp>) {
+>({
+  control,
+  name,
+  keyName = 'id' as KeyName,
+}: UseFieldArrayProps<KeyName, ControlProp>) => {
   const methods = useFormContext();
   const {
     resetFieldArrayFunctionRef,
@@ -36,9 +47,9 @@ export function useFieldArray<
     watchFieldArrayRef,
   } = control || methods.control;
   const memoizedDefaultValues = useRef(get(defaultValuesRef.current, name, []));
-  const [fields, setField] = useState<Partial<FormArrayValues>[]>(
-    mapIds(memoizedDefaultValues.current, keyName),
-  );
+  const [fields, setField] = useState<
+    Partial<ArrayField<FormArrayValues, KeyName>>[]
+  >(mapIds(memoizedDefaultValues.current, keyName));
   const appendValueWithKey = (value: Partial<FormArrayValues>[]) =>
     value.map((v: Partial<FormArrayValues>) => appendId(v, keyName));
 
@@ -231,4 +242,4 @@ export function useFieldArray<
     insert,
     fields,
   };
-}
+};


### PR DESCRIPTION
```ts
useFieldArray<{ name: string }>()({
  control,
  name: "data"
});
// const fields: Partial<{
//     name: string;
//     id: string
// }>[]
```

```ts
const { fields } = useFieldArray<{ name: string }, "customId">()({
  keyName: "customId",
  control,
  name: "data"
});
// const fields: Partial<{
//     name: string;
//     customId: string
// }>[]
```

related: https://github.com/react-hook-form/react-hook-form/pull/957