### PR TITLE
fix type for validationResolver

### DIFF
--- a/src/logic/validateWithSchema.ts
+++ b/src/logic/validateWithSchema.ts
@@ -63,8 +63,8 @@ export const parseErrorSchema = <FormValues>(
 export default async function validateWithSchema<FormValues, ValidationContext>(
   validationSchema: Schema<FormValues>,
   validateAllFieldCriteria: boolean,
-  data: FieldValues,
-  validationResolver?: ValidationResolver,
+  data: FormValues,
+  validationResolver?: ValidationResolver<FormValues, ValidationContext>,
   context?: ValidationContext,
 ): Promise<SchemaValidationResult<FormValues>> {
   if (validationResolver) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,20 +43,20 @@ export type SchemaValidateOptions = Partial<{
   context: any;
 }>;
 
-export type ValidationResolver = <FormValues, ValidationContext>(
-  values: FieldValues,
-  validationContext: ValidationContext,
-) => { values: FieldValues | {}; errors: FieldErrors<FormValues> | {} };
+export type ValidationResolver<FormValues, ValidationContext> = (
+  values: FormValues,
+  validationContext?: ValidationContext,
+) => { values: FormValues | {}; errors: FieldErrors<FormValues> | {} };
 
 export type UseFormOptions<
   FormValues extends FieldValues = FieldValues,
-  ValidationContext = undefined
+  ValidationContext = any
 > = Partial<{
   mode: Mode;
   reValidateMode: Mode;
   defaultValues: DeepPartial<FormValues>;
   validationSchema: any;
-  validationResolver: ValidationResolver;
+  validationResolver: ValidationResolver<FormValues, ValidationContext>;
   validationContext: ValidationContext;
   submitFocusError: boolean;
   validateCriteriaMode: 'firstError' | 'all';

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -64,7 +64,7 @@ const { useRef, useState, useCallback, useEffect } = React;
 
 export function useForm<
   FormValues extends FieldValues = FieldValues,
-  ValidationContext = undefined
+  ValidationContext = any
 >({
   mode = VALIDATION_MODE.onSubmit,
   reValidateMode = VALIDATION_MODE.onChange,
@@ -74,7 +74,9 @@ export function useForm<
   defaultValues = {},
   submitFocusError = true,
   validateCriteriaMode,
-}: UseFormOptions<FormValues> = {}): FormContextValues<FormValues> {
+}: UseFormOptions<FormValues, ValidationContext> = {}): FormContextValues<
+  FormValues
+> {
   const fieldsRef = useRef<FieldRefs<FormValues>>({});
   const validateAllFieldCriteria = validateCriteriaMode === 'all';
   const errorsRef = useRef<FieldErrors<FormValues>>({});
@@ -953,10 +955,7 @@ export function useForm<
       try {
         if (shouldValidateCallback) {
           fieldValues = getFieldsValues(fields);
-          const { errors, values } = await validateWithSchema<
-            FormValues,
-            ValidationContext
-          >(
+          const { errors, values } = await validateWithSchema(
             validationSchema,
             validateAllFieldCriteria,
             transformToNestObject(fieldValues),


### PR DESCRIPTION
1. improved type of first argument (`data`) of `validationResolver`.

type of `data` would be better type `FormValues` (`{ username: string }`) rather than `Record<string, any>`.

<img width="400" alt="スクリーンショット 2020-02-12 21 51 11" src="https://user-images.githubusercontent.com/12913947/74336962-ba31e080-4de2-11ea-9dd2-5873688d730f.png">

2. fixed type error when `validationContext` was specified as option of `useForm`.

csb: https://codesandbox.io/s/rhf-validationcontext-type-error-pr-1017-ns5mn

<img width="400" alt="スクリーンショット 2020-02-12 21 52 41" src="https://user-images.githubusercontent.com/12913947/74336972-bc943a80-4de2-11ea-8efb-f8ea74595bcb.png">
