### PR TITLE
Update useFormContext.tsx

### DIFF
--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -8,7 +8,7 @@ const FormGlobalContext = React.createContext<FormContextValues<
 
 export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
   const context = React.useContext(FormGlobalContext) as FormContextValues<T>;
-  if (context) return context;
+  if (context !== undefined) return context;
   throw new Error('Missing FormContext');
 }
 

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -11,7 +11,7 @@ export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
   if (context === undefined) {
     throw new Error('useFormContext must be used within a FormContext');
   }
-  return context;
+  return context || throw new Error('Missing FormContext');
 }
 
 export function FormContext<T extends FieldValues>({

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FieldValues } from './types';
 import { FormContextValues, FormProps } from './contextTypes';
+import isUndefined from './utils/isUndefined';
 
 const FormGlobalContext = React.createContext<FormContextValues<
   FieldValues
@@ -8,7 +9,7 @@ const FormGlobalContext = React.createContext<FormContextValues<
 
 export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
   const context = React.useContext(FormGlobalContext) as FormContextValues<T>;
-  if (context !== undefined) return context;
+  if (!isUndefined(context)) return context;
   throw new Error('Missing FormContext');
 }
 

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -7,7 +7,11 @@ const FormGlobalContext = React.createContext<FormContextValues<
 > | null>(null);
 
 export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
-  return React.useContext(FormGlobalContext) as FormContextValues<T>;
+  const context = React.useContext(FormGlobalContext) as FormContextValues<T>;
+  if (context === undefined) {
+    throw new Error('useFormContext must be used within a FormContext');
+  }
+  return context;
 }
 
 export function FormContext<T extends FieldValues>({

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -8,10 +8,8 @@ const FormGlobalContext = React.createContext<FormContextValues<
 
 export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
   const context = React.useContext(FormGlobalContext) as FormContextValues<T>;
-  if (context === undefined) {
-    throw new Error('useFormContext must be used within a FormContext');
-  }
-  return context || throw new Error('Missing FormContext');
+  if (context) return context;
+  throw new Error('Missing FormContext');
 }
 
 export function FormContext<T extends FieldValues>({


### PR DESCRIPTION
Fail fast if `useFormContext` is used outside of a FormContext. This would have helped me earlier today when I was learning this library. Thanks! 