### PR TITLE
fix children prop type for ErrorMessage component

### DIFF
--- a/src/errorMessage.test.tsx
+++ b/src/errorMessage.test.tsx
@@ -91,6 +91,7 @@ describe('React Hook Form Error Message', () => {
         name="flat"
       >
         {({ messages }) =>
+          messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
@@ -119,6 +120,7 @@ describe('React Hook Form Error Message', () => {
         name="flat"
       >
         {({ messages }) =>
+          messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
@@ -197,6 +199,7 @@ describe('React Hook Form Error Message', () => {
         name="nested.object"
       >
         {({ messages }) =>
+          messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
@@ -227,6 +230,7 @@ describe('React Hook Form Error Message', () => {
         name="nested.object"
       >
         {({ messages }) =>
+          messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
@@ -313,6 +317,7 @@ describe('React Hook Form Error Message', () => {
         name="nested[0].array"
       >
         {({ messages }) =>
+          messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
@@ -345,6 +350,7 @@ describe('React Hook Form Error Message', () => {
         name="nested[0].array"
       >
         {({ messages }) =>
+          messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,7 +291,7 @@ export type ErrorMessageProps<
   message?: string;
   children?: (data: {
     message: string;
-    messages: MultipleFieldErrors;
+    messages?: MultipleFieldErrors;
   }) => React.ReactNode;
 } & AsProps<As>;
 


### PR DESCRIPTION
If we don't set validateCriteriaMode to 'all', `messages` will be `undefined`.