### PR TITLE
improve DX of register function for useFieldArray hook

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -57,7 +57,10 @@ export const useFieldArray = <
     value.map((v: Partial<FormArrayValues>) => appendId(v, keyName));
 
   const commonTasks = (fieldsValues: any) => {
-    watchFieldArrayRef.current[name] = fieldsValues;
+    watchFieldArrayRef.current = {
+      ...watchFieldArrayRef.current,
+      [name]: fieldsValues,
+    };
     setField(fieldsValues);
 
     if (readFormStateRef.current.isValid && validateSchemaIsValid) {
@@ -250,7 +253,10 @@ export const useFieldArray = <
     const fieldArrayNames = fieldArrayNamesRef.current;
     fieldArrayNames.add(name);
     resetFunctions[name] = reset;
-    watchFieldArrayRef.current[name] = {};
+    watchFieldArrayRef.current = {
+      ...watchFieldArrayRef.current,
+      [name]: fields,
+    };
 
     return () => {
       resetFields();

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1211,6 +1211,7 @@ export function useForm<
     register: useCallback(register, [
       defaultValuesRef.current,
       defaultRenderValuesRef.current,
+      watchFieldArrayRef.current,
     ]),
     unregister: useCallback(unregister, []),
     clearError: useCallback(clearError, []),


### PR DESCRIPTION
Fixed to work without passing `register` function as empty arg when using `useFieldArray`.
This improves DX.

old:

```ts
ref={register()}
```

new:

```ts
ref={register}
```

codesandbox: https://codesandbox.io/s/react-hook-form-pr-1106-l3o3b

close #1070