### PR TITLE
Feature/reset omit state update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form",
   "description": "Performant, flexible and extensible forms library for React Hooks",
-  "version": "4.10.1",
+  "version": "4.10.2-beta.1",
   "main": "dist/react-hook-form.js",
   "module": "dist/react-hook-form.es.js",
   "types": "dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,12 +332,12 @@ export type ArrayField<
   KeyName extends string = 'id'
 > = FormArrayValues & Record<KeyName, string>;
 
-export type OmitResetState = {
-  errors?: boolean;
-  dirty?: boolean;
-  dirtyFields?: boolean;
-  isSubmitted?: boolean;
-  touched?: boolean;
-  isValid?: boolean;
-  submitCount?: boolean;
-};
+export type OmitResetState = Partial<{
+  errors: boolean;
+  dirty: boolean;
+  dirtyFields: boolean;
+  isSubmitted: boolean;
+  touched: boolean;
+  isValid: boolean;
+  submitCount: boolean;
+}>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,7 +332,7 @@ export type ArrayField<
   KeyName extends string = 'id'
 > = FormArrayValues & Record<KeyName, string>;
 
-export type OmitFormState = {
+export type OmitResetState = {
   errors?: boolean;
   dirty?: boolean;
   dirtyFields?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,3 +331,13 @@ export type ArrayField<
   FormArrayValues extends FieldValues = FieldValues,
   KeyName extends string = 'id'
 > = FormArrayValues & Record<KeyName, string>;
+
+export type OmitFormState = {
+  errors?: boolean;
+  dirty?: boolean;
+  dirtyFields?: boolean;
+  isSubmitted?: boolean;
+  touched?: boolean;
+  isValid?: boolean;
+  submitCount?: boolean;
+};

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -61,7 +61,7 @@ import {
   Touched,
   FieldError,
   RadioOrCheckboxOption,
-  OmitFormState,
+  OmitResetState,
 } from './types';
 
 const { useRef, useState, useCallback, useEffect } = React;
@@ -1093,7 +1093,7 @@ export function useForm<
     touched,
     isValid,
     submitCount,
-  }: OmitFormState) => {
+  }: OmitResetState) => {
     fieldsRef.current = {};
     if (!errors) {
       errorsRef.current = {};
@@ -1129,7 +1129,7 @@ export function useForm<
 
   const reset = (
     values?: DeepPartial<FormValues>,
-    omitFormState: OmitFormState = {},
+    omitResetState: OmitResetState = {},
   ): void => {
     if (isWeb) {
       for (const value of Object.values(fieldsRef.current)) {
@@ -1150,7 +1150,7 @@ export function useForm<
       resetFieldArray => isFunction(resetFieldArray) && resetFieldArray(),
     );
 
-    resetRefs(omitFormState);
+    resetRefs(omitResetState);
 
     reRender();
   };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -61,6 +61,7 @@ import {
   Touched,
   FieldError,
   RadioOrCheckboxOption,
+  OmitFormState,
 } from './types';
 
 const { useRef, useState, useCallback, useEffect } = React;
@@ -1085,23 +1086,51 @@ export function useForm<
     ],
   );
 
-  const resetRefs = () => {
-    errorsRef.current = {};
+  const resetRefs = ({
+    errors,
+    dirty,
+    isSubmitted,
+    touched,
+    isValid,
+    submitCount,
+  }: OmitFormState) => {
     fieldsRef.current = {};
-    touchedFieldsRef.current = {};
-    validFieldsRef.current = new Set();
-    fieldsWithValidationRef.current = new Set();
+    if (!errors) {
+      errorsRef.current = {};
+    }
+
+    if (!touched) {
+      touchedFieldsRef.current = {};
+    }
+
+    if (!isValid) {
+      validFieldsRef.current = new Set();
+      fieldsWithValidationRef.current = new Set();
+      isValidRef.current = true;
+    }
+
+    if (!dirty) {
+      dirtyFieldsRef.current = new Set();
+      isDirtyRef.current = false;
+    }
+
+    if (!isSubmitted) {
+      isSubmittedRef.current = false;
+    }
+
+    if (!submitCount) {
+      submitCountRef.current = 0;
+    }
+
     defaultRenderValuesRef.current = {};
     watchFieldsRef.current = new Set();
-    dirtyFieldsRef.current = new Set();
     isWatchAllRef.current = false;
-    isSubmittedRef.current = false;
-    isDirtyRef.current = false;
-    isValidRef.current = true;
-    submitCountRef.current = 0;
   };
 
-  const reset = (values?: DeepPartial<FormValues>): void => {
+  const reset = (
+    values?: DeepPartial<FormValues>,
+    omitFormState: OmitFormState = {},
+  ): void => {
     if (isWeb) {
       for (const value of Object.values(fieldsRef.current)) {
         if (value && isHTMLElement(value.ref) && value.ref.closest) {
@@ -1121,7 +1150,7 @@ export function useForm<
       resetFieldArray => isFunction(resetFieldArray) && resetFieldArray(),
     );
 
-    resetRefs();
+    resetRefs(omitFormState);
 
     reRender();
   };


### PR DESCRIPTION
This feature allow you to reset the form value without reset the `formState`

`reset({}, { dirty, touched })`