### PR TITLE
fixed rollup output for umd

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,10 +14,13 @@ export function getConfig({
       format: 'esm',
     },
     {
-      name: "ReactHookForm",
+      name: 'ReactHookForm',
       file: `dist/${pkg.name}.umd.js`,
       format: 'umd',
-    }
+      globals: {
+        react: 'React',
+      },
+    },
   ],
   plugins = [],
 } = {}) {
@@ -29,7 +32,7 @@ export function getConfig({
         tsconfig,
         clean: true,
       }),
-      ...plugins
+      ...plugins,
     ],
     output,
   };


### PR DESCRIPTION
sorry.  It looks like we need to use [`output.globals`](https://rollupjs.org/guide/en/#outputglobals).

![スクリーンショット 2020-03-06 10 02 18](https://user-images.githubusercontent.com/12913947/76040100-c51b0380-5f91-11ea-86ac-bd17b3a5bb35.png)

related PR: https://github.com/react-hook-form/react-hook-form/pull/1157