### PR TITLE
improve types of Controller's onChange and onBlur

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -67,7 +67,7 @@ const Controller = <
     return data;
   };
 
-  const eventWrapper = (event: EventFunction) => (...arg: any) =>
+  const eventWrapper = (event: EventFunction) => (...arg: any[]) =>
     setValue(name, commonTask(event(arg)), shouldValidate());
 
   const handleChange = (event: any) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,7 +175,7 @@ export type FormValuesFromErrors<Errors> = Errors extends FieldErrors<
   ? FormValues
   : never;
 
-export type EventFunction = (args: any) => any;
+export type EventFunction = (args: any[]) => any;
 
 export type Control<FormValues extends FieldValues = FieldValues> = {
   register<Element extends FieldElement = FieldElement>(): (


### PR DESCRIPTION
Hi, thank you for creating this amazing library! It improved our DX incredibly.

We found that `Controller`'s `onChange` callback takes an array as its argument, but its type does not reflect it.
In this PR I changed `EventFunction` to prevent mistakes on its argument (like #1119, may not cover all cases though).
`EventFunction` is exported by the library and this change may affect users' code, but I guess it is OK in most cases...



