### PR TITLE
fix FieldErrors to allow any type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -113,12 +113,16 @@ export type FieldRefs<FormValues extends FieldValues> = Partial<
 >;
 
 export type NestDataObject<FormValues> = {
-  [Key in keyof FormValues]?: FormValues[Key] extends any[]
-    ? FormValues[Key][number] extends object
-      ? FieldErrors<FormValues[Key][number]>[]
-      : FormValues[Key][number] extends string | number
+  [Key in keyof FormValues]?: FormValues[Key] extends Array<infer U>
+    ? 0 extends 1 & U
+      ? any
+      : U extends object
+      ? FieldErrors<U>[]
+      : U extends string | number
       ? FieldError[]
       : FieldError
+    : 0 extends 1 & FormValues[Key]
+    ? any
     : FormValues[Key] extends Date
     ? FieldError
     : FormValues[Key] extends object

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,7 +117,9 @@ export type NestDataObject<FormValues> = {
     ? 0 extends 1 & U
       ? any
       : U extends object
-      ? FieldErrors<U>[]
+      ? keyof U extends never
+        ? any
+        : FieldErrors<U>[]
       : U extends string | number
       ? FieldError[]
       : FieldError
@@ -126,7 +128,9 @@ export type NestDataObject<FormValues> = {
     : FormValues[Key] extends Date
     ? FieldError
     : FormValues[Key] extends object
-    ? FieldErrors<FormValues[Key]>
+    ? keyof FormValues[Key] extends never
+      ? any
+      : FieldErrors<FormValues[Key]>
     : FieldError;
 };
 


### PR DESCRIPTION
fixed to check for the exact `any` and `object` type using TypeScript conditionals.

```ts
type IsAny<T> = 0 extends (1 & T) ? true : false;
type A = IsAny<any> // true
type B = IsAny<unknown> // false
type C = IsAny<string> // false
type D = IsAny<number> // false
type E = IsAny<bigint> // false
type F = IsAny<boolean> // false
type G = IsAny<symbol> // false
type H = IsAny<null> // false
type I = IsAny<undefined> // false
type J = IsAny<object> // false
type K = IsAny<never> // false
```

[TypeScript Playground](http://www.typescriptlang.org/play/#code/C4TwDgpgBAkgzgQQHYgDwBUB8UC8UAMUEAHsBEgCZxQAUAjFAGRToCUUA-FMAE4Cu0AFxQAZgEMANnAgBuAFChIUBLliIUqMSmwB6Hd34QF4aACFV8ZGj5IA1kgD2AdyS794qUcXQAwhfVocLwAlkgA5m6iktLGSgAi-laoSHwAtgBGEDyRHjHeUACiiRrpwWGhwDnRXiZQAGLFaOkODhIQWlWesdAA4o2ocCAZrZ15tQAS-SkSEqM1SjD9NhQQIqEQFHPdUABS-Q7pAFYQAMaVUHpRXfkA0lMQAG5Zc0A)

```ts
type IsObject<T extends object> = keyof T extends never ? true : false;
type A = IsObject<object> // true
type B = IsObject<{ a: string }> // false
```

[TypeScript Playground](http://www.typescriptlang.org/play/?ssl=3&ssc=42&pln=1&pc=1#code/C4TwDgpgBAkgzgeQEYCsIGNgB4AqUIAewEAdgCZxQD2qGwAfFALxQDWEIVAZlHoceUokIANwgAnKAH4owcQFdoALihcAhgBs4EANwAoUJCgBBZrES1MWGmkyMA9PdkKIB8NABCZ+MlvYA3lBqKnByAJYkAOZQAL4OTupaEEA)

fixed codesandbox
* https://codesandbox.io/s/immutable-leftpad-w2ix4
* https://codesandbox.io/s/black-snowflake-r22e6

related PR https://github.com/react-hook-form/react-hook-form/pull/1083
close #987 