### PR TITLE
re-regeister controlled component on validation rule change

### DIFF
--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -338,3 +338,49 @@ describe('Controller', () => {
     expect(removeFieldEventListener).toBeCalled();
   });
 });
+
+it('should re-register on new validation rules`', () => {
+  const control = reconfigureControl();
+  const fieldsRef = {
+    current: {},
+  };
+  const register = jest.fn().mockImplementation((payload: any) => {
+    // @ts-ignore
+    fieldsRef.current[payload.name] = 'test';
+  });
+
+  const { rerender } = render(
+    <Controller
+      defaultValue=""
+      name="test"
+      as={'input' as 'input'}
+      rules={{ required: false }}
+      control={{
+        ...control,
+        fieldsRef,
+        register: register,
+      }}
+    />,
+  );
+
+  expect(register).toHaveBeenCalledWith({ name: 'test' }, { required: false });
+
+  rerender(
+    <Controller
+      defaultValue=""
+      name="test"
+      as={'input' as 'input'}
+      rules={{ required: true }}
+      control={{
+        ...control,
+        fieldsRef,
+        register: register,
+      }}
+    />,
+  );
+
+  expect(register).toHaveBeenLastCalledWith(
+    { name: 'test' },
+    { required: true },
+  );
+});

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -120,9 +120,6 @@ const Controller = <
 
   React.useEffect(() => {
     registerField();
-    if (touchedFieldsRef.current[name] && shouldValidate()) {
-      triggerValidation(name);
-    }
   }, [rules]);
 
   const shouldReValidateOnBlur = isOnBlur || isReValidateOnBlur;

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -41,6 +41,7 @@ const Controller = <
     formState: { isSubmitted },
     fieldsRef,
     fieldArrayNamesRef,
+    touchedFieldsRef,
   } = control || methods.control;
   const [value, setInputStateValue] = React.useState(
     isUndefined(defaultValue)
@@ -116,6 +117,13 @@ const Controller = <
       }
     };
   }, [name]);
+
+  React.useEffect(() => {
+    registerField();
+    if (touchedFieldsRef.current[name] && shouldValidate()) {
+      triggerValidation(name);
+    }
+  }, [rules]);
 
   const shouldReValidateOnBlur = isOnBlur || isReValidateOnBlur;
 

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -41,7 +41,6 @@ const Controller = <
     formState: { isSubmitted },
     fieldsRef,
     fieldArrayNamesRef,
-    touchedFieldsRef,
   } = control || methods.control;
   const [value, setInputStateValue] = React.useState(
     isUndefined(defaultValue)


### PR DESCRIPTION
added useEffect with the validation rules as dependency to re-register field and trigger re-validation if needed

fixes bug: https://github.com/react-hook-form/react-hook-form/issues/1184