### PR TITLE
fixed useFormContext for register issue of useFieldArray

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -24,10 +24,16 @@ const Controller = <
   onBlurName = VALIDATION_MODE.onBlur,
   valueName,
   defaultValue,
-  control,
+  control: controlFromProps,
   ...rest
 }: ControllerProps<As, ControlProp>) => {
-  const methods = useFormContext();
+  let control;
+  try {
+    const methods = useFormContext();
+    control = methods.control;
+  } catch {
+    control = controlFromProps;
+  }
   const {
     defaultValuesRef,
     setValue,
@@ -41,7 +47,7 @@ const Controller = <
     formState: { isSubmitted },
     fieldsRef,
     fieldArrayNamesRef,
-  } = control || methods.control;
+  } = control as ControlProp;
   const [value, setInputStateValue] = React.useState(
     isUndefined(defaultValue)
       ? get(defaultValuesRef.current, name)

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -24,8 +24,13 @@ const ErrorMessage = <
   children,
   ...rest
 }: ErrorMessageProps<Errors, Name, As>) => {
-  const methods = useFormContext();
-  const error = get(errors || methods.errors, name);
+  let error;
+  try {
+    const methods = useFormContext();
+    error = get(methods.errors, name);
+  } catch {
+    error = get(errors, name);
+  }
 
   if (!error) {
     return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -272,6 +272,9 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
   defaultValuesRef: React.MutableRefObject<
     DeepPartial<FormValues> | FormValues[FieldName<FormValues>]
   >;
+  defaultRenderValuesRef: React.MutableRefObject<
+    DeepPartial<Record<FieldName<FormValues>, FieldValue<FormValues>>>
+  >;
 };
 
 export type Assign<T extends object, U extends object> = T & Omit<U, keyof T>;

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -28,11 +28,17 @@ export const useFieldArray = <
   KeyName extends string = 'id',
   ControlProp extends Control = Control
 >({
-  control,
+  control: controlFromProps,
   name,
   keyName = 'id' as KeyName,
 }: UseFieldArrayProps<KeyName, ControlProp>) => {
-  const methods = useFormContext();
+  let control;
+  try {
+    const methods = useFormContext();
+    control = methods.control;
+  } catch {
+    control = controlFromProps;
+  }
   const {
     resetFieldArrayFunctionRef,
     fieldArrayNamesRef,
@@ -50,7 +56,7 @@ export const useFieldArray = <
     validFieldsRef,
     fieldsWithValidationRef,
     validateSchemaIsValid,
-  } = control || methods.control;
+  } = control as ControlProp;
   const memoizedDefaultValues = useRef(get(defaultValuesRef.current, name, []));
   const [fields, setField] = useState<
     Partial<ArrayField<FormArrayValues, KeyName>>[]

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -75,6 +75,9 @@ export const reconfigureControl = (
       dirtyFields: false,
     },
   },
+  defaultRenderValuesRef: {
+    current: {},
+  },
   ...controlOverrides,
 });
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1235,6 +1235,7 @@ export function useForm<
     isDirtyRef,
     readFormStateRef,
     defaultValuesRef,
+    defaultRenderValuesRef,
   };
 
   return {

--- a/src/useFormContext.test.tsx
+++ b/src/useFormContext.test.tsx
@@ -8,12 +8,23 @@ describe('FormContext', () => {
   });
 
   it('should have access to all methods with useFormContext', () => {
-    const mockRegister = jest.fn();
+    const control = {
+      register: jest.fn(),
+      defaultValuesRef: {
+        current: {},
+      },
+      watchFieldArrayRef: {
+        current: {},
+      },
+      defaultRenderValuesRef: {
+        current: {},
+      },
+    };
     const { result } = renderHook(() => useFormContext(), {
       /* eslint-disable-next-line react/display-name */
       wrapper: (props: { children?: React.ReactNode }) => (
         // @ts-ignore
-        <FormContext register={mockRegister} {...props} />
+        <FormContext control={control} {...props} />
       ),
     });
     const { register } = result.current;
@@ -22,6 +33,6 @@ describe('FormContext', () => {
       register('test');
     });
 
-    expect(mockRegister).toHaveBeenCalled();
+    expect(control.register).toHaveBeenCalled();
   });
 });

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FieldValues } from './types';
 import { FormContextValues, FormProps } from './contextTypes';
-import isUndefined from './utils/isUndefined';
+import isNullOrUndefined from './utils/isNullOrUndefined';
 
 const FormGlobalContext = React.createContext<FormContextValues<
   FieldValues
@@ -9,7 +9,27 @@ const FormGlobalContext = React.createContext<FormContextValues<
 
 export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
   const context = React.useContext(FormGlobalContext) as FormContextValues<T>;
-  if (!isUndefined(context)) return context;
+  if (!isNullOrUndefined(context)) {
+    const {
+      register,
+      defaultValuesRef,
+      defaultRenderValuesRef,
+      watchFieldArrayRef,
+    } = context.control;
+    return {
+      ...context,
+      register: React.useCallback(
+        (refOrValidationOptions?: any, validationOptions?: any): any =>
+          register(refOrValidationOptions, validationOptions),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [
+          defaultValuesRef.current,
+          defaultRenderValuesRef.current,
+          watchFieldArrayRef.current,
+        ],
+      ),
+    };
+  }
   throw new Error('Missing FormContext');
 }
 


### PR DESCRIPTION
I fixed `useFieldContext` hook to recreate `register` method when updated to `fields` state in `useFieldArray`.

codesandbox: https://codesandbox.io/s/react-hook-form-usefieldarray-cifzp

**INPORTANT: This is not an essential solution. we should just stick with `register()` for `useFieldArray`. See [this comment](https://github.com/react-hook-form/react-hook-form/issues/1190#issuecomment-597971105) for details.**

related
* Issue: #1070
* PR: #1106

close #1190