### PR TITLE
fix useFormContext to throw an error

### DIFF
--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -4,6 +4,8 @@ import { Controller } from './controller';
 import { reconfigureControl } from './useForm.test';
 import { Field } from './types';
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('Controller', () => {
   it('should render correctly with as with string', () => {
     const control = reconfigureControl();

--- a/src/errorMessage.test.tsx
+++ b/src/errorMessage.test.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ErrorMessage } from './index';
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('React Hook Form Error Message', () => {
   it('should render correctly', () => {
     const { asFragment } = render(<ErrorMessage name="test" errors={{}} />);

--- a/src/useFieldArray.test.ts
+++ b/src/useFieldArray.test.ts
@@ -3,6 +3,7 @@ import { useFieldArray } from './useFieldArray';
 import { appendId } from './logic/mapIds';
 import { reconfigureControl } from './useForm.test';
 
+jest.spyOn(console, 'warn').mockImplementation(() => {});
 jest.mock('./logic/generateId', () => ({
   default: () => '1',
 }));

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FieldValues } from './types';
 import { FormContextValues, FormProps } from './contextTypes';
-import isUndefined from './utils/isUndefined';
+import isNullOrUndefined from './utils/isNullOrUndefined';
 
 const FormGlobalContext = React.createContext<FormContextValues<
   FieldValues
@@ -9,8 +9,11 @@ const FormGlobalContext = React.createContext<FormContextValues<
 
 export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
   const context = React.useContext(FormGlobalContext) as FormContextValues<T>;
-  if (!isUndefined(context)) return context;
-  throw new Error('Missing FormContext');
+  if (isNullOrUndefined(context)) {
+    // eslint-disable-next-line no-console
+    console.warn('Missing FormContext');
+  }
+  return context;
 }
 
 export function FormContext<T extends FieldValues>({


### PR DESCRIPTION
fix `useFormContext` to throw an error if it is used outside of a `FormContext`.
This PR (https://github.com/react-hook-form/react-hook-form/pull/1054) is wrong.
As below, no throw an error even if we do not use `FormContext`.

https://codesandbox.io/s/react-hook-form-usefieldarray-c1wk4

We should use `isNullOrUndefined` instead of `isUndefined`.
Also,  I changed from throw an error to output console warn because `useFormContext` is used in `ErrorMessage` and `Controller` component and `useFieldArray` hook.