### PR TITLE
Fix bug in controlledInput example.

### DIFF
--- a/examples/controlledInput.tsx
+++ b/examples/controlledInput.tsx
@@ -20,7 +20,6 @@ export default function App() {
         <div>
           <label htmlFor="firstName">First Name</label>
           <input
-            onChange={e => update(e.target.value)}
             name="firstName"
             placeholder="bill"
             ref={register}
@@ -31,6 +30,7 @@ export default function App() {
           <label htmlFor="lastName">Last Name</label>
           <input
             value={state}
+            onChange={e => update(e.target.value)}
             name="lastName"
             placeholder="luo"
             ref={register}


### PR DESCRIPTION
It seems to me like the `controlledInput.tsx` example has a bug in it. It looks like the intent of the code is to control the last name input, but the `onChange` handler is placed on the firstName field.

This PR moves full controls over to the lastName input.