### PR TITLE
improve type for validationResolver and validationSchema

### DIFF
--- a/src/logic/validateWithSchema.test.ts
+++ b/src/logic/validateWithSchema.test.ts
@@ -71,7 +71,7 @@ describe('validateWithSchema', () => {
     expect(
       await validateWithSchema(
         {
-          validate: () => new Promise(resolve => resolve()),
+          validate: () => new Promise(resolve => resolve()) as any,
         },
         false,
         {},

--- a/src/logic/validateWithSchema.ts
+++ b/src/logic/validateWithSchema.ts
@@ -6,12 +6,8 @@ import {
   SchemaValidateOptions,
   FieldErrors,
   ValidationResolver,
+  SchemaValidationResult,
 } from '../types';
-
-type SchemaValidationResult<FormValues> = {
-  errors: FieldErrors<FormValues>;
-  values: FieldValues;
-};
 
 type YupValidationError = {
   inner: { path: string; message: string; type: string }[];
@@ -60,7 +56,10 @@ export const parseErrorSchema = <FormValues>(
         [error.path]: { message: error.message, type: error.type },
       };
 
-export default async function validateWithSchema<FormValues, ValidationContext>(
+export default async function validateWithSchema<
+  FormValues extends FieldValues,
+  ValidationContext extends object
+>(
   validationSchema: Schema<FormValues>,
   validateAllFieldCriteria: boolean,
   data: FormValues,

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,17 +43,19 @@ export type SchemaValidateOptions = Partial<{
   context: any;
 }>;
 
+type EmptyObject = { [key: string]: never };
+
 export type SchemaValidationSuccess<
   FormValues extends FieldValues = FieldValues
 > = {
   values: FormValues;
-  errors: {};
+  errors: EmptyObject;
 };
 
 export type SchemaValidationError<
   FormValues extends FieldValues = FieldValues
 > = {
-  values: {};
+  values: EmptyObject;
   errors: FieldErrors<FormValues>;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type SchemaValidateOptions = Partial<{
   context: any;
 }>;
 
-type EmptyObject = { [key: string]: never };
+export type EmptyObject = { [key: string]: never };
 
 export type SchemaValidationSuccess<
   FormValues extends FieldValues = FieldValues

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type SchemaValidateOptions = Partial<{
   context: any;
 }>;
 
-export type EmptyObject = { [key: string]: never };
+export type EmptyObject = { [key in string | number]: never };
 
 export type SchemaValidationSuccess<
   FormValues extends FieldValues = FieldValues

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,21 +43,37 @@ export type SchemaValidateOptions = Partial<{
   context: any;
 }>;
 
-export type ValidationResolverResponse<FormValues> = {
-  values: FormValues | {};
-  errors: FieldErrors<FormValues> | {};
+export type SchemaValidationSuccess<
+  FormValues extends FieldValues = FieldValues
+> = {
+  values: FormValues;
+  errors: {};
 };
 
-export type ValidationResolver<FormValues, ValidationContext> = (
+export type SchemaValidationError<
+  FormValues extends FieldValues = FieldValues
+> = {
+  values: {};
+  errors: FieldErrors<FormValues>;
+};
+
+export type SchemaValidationResult<
+  FormValues extends FieldValues = FieldValues
+> = SchemaValidationSuccess<FormValues> | SchemaValidationError<FormValues>;
+
+export type ValidationResolver<
+  FormValues extends FieldValues = FieldValues,
+  ValidationContext extends object = object
+> = (
   values: FormValues,
   validationContext?: ValidationContext,
 ) =>
-  | ValidationResolverResponse<FormValues>
-  | Promise<ValidationResolverResponse<FormValues>>;
+  | SchemaValidationResult<FormValues>
+  | Promise<SchemaValidationResult<FormValues>>;
 
 export type UseFormOptions<
   FormValues extends FieldValues = FieldValues,
-  ValidationContext = any
+  ValidationContext extends object = object
 > = Partial<{
   mode: Mode;
   reValidateMode: Mode;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -995,7 +995,10 @@ export function useForm<
       try {
         if (shouldValidateCallback) {
           fieldValues = getFieldsValues(fields);
-          const { errors, values } = await validateWithSchema(
+          const { errors, values } = await validateWithSchema<
+            FormValues,
+            ValidationContext
+          >(
             validationSchema,
             validateAllFieldCriteria,
             transformToNestObject(fieldValues),

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -67,7 +67,7 @@ const { useRef, useState, useCallback, useEffect } = React;
 
 export function useForm<
   FormValues extends FieldValues = FieldValues,
-  ValidationContext = any
+  ValidationContext extends object = object
 >({
   mode = VALIDATION_MODE.onSubmit,
   reValidateMode = VALIDATION_MODE.onChange,

--- a/src/utils/isEmptyObject.ts
+++ b/src/utils/isEmptyObject.ts
@@ -1,4 +1,5 @@
 import isObject from './isObject';
+import { EmptyObject } from './../types';
 
-export default (value: unknown): boolean =>
+export default (value: unknown): value is EmptyObject =>
   isObject(value) && !Object.keys(value).length;


### PR DESCRIPTION
I fixed return type of `validationResolver` and `validateWithSchema`.

![スクリーンショット 2020-03-19 14 21 25](https://user-images.githubusercontent.com/12913947/77034367-2066e000-69ed-11ea-907d-878e3135b61d.png)
![スクリーンショット 2020-03-19 14 21 41](https://user-images.githubusercontent.com/12913947/77034370-2230a380-69ed-11ea-8fae-6b999080e616.png)
![スクリーンショット 2020-03-19 14 21 58](https://user-images.githubusercontent.com/12913947/77034373-22c93a00-69ed-11ea-81aa-8930b4cc1b8d.png)

I added `EmptyObect` type to indicate that it is an empty object. For more information, see "[Typescript empty object and any difference - Stack Overflow](https://stackoverflow.com/questions/47339869/typescript-empty-object-and-any-difference)".

```ts
type EmptyObject = { [key in string | number]: never };

let a: EmptyObject;
a = {}; // ok
a = 'foo'; // error
a = 123; // error
a = { foo:'bar' }; // error
```

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=7&ssc=28&pln=1&pc=1#code/C4TwDgpgBAogtmUB5ARgKwgY2FAvFAbygG0BrCEKASwDsoBnYAJ1oHMoAfKGgVzhQhMAugC5uEAG6CoAXwDcAWABQygDYQcAQzHxEIVBmyKlmvIXlQA9JagB7UstP4A5ADNbt53Ks3BTW0yOZgCMAEwAzN7WUH4BQfhE7rYiziiaTM6yUb5M-oEqSuo4KGIE8sooZmXGlS5JXhUhETVVUEkpaRlZQA)

related: https://github.com/react-hook-form/react-hook-form/issues/1226