### PR TITLE
enable declaration map closes #1250

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 example/
 .circleci/
-src/
 test/
 .babelrc
 .flowconfig

--- a/.npmignore
+++ b/.npmignore
@@ -37,3 +37,4 @@ rollup.ie11.config.js
 rollup.min.config.js
 tsconfig.ie11.json
 .codesandbox/
+*.tgz

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,7 @@ export function getConfig({
       typescript({
         tsconfig,
         clean: true,
+        useTsconfigDeclarationDir: true,
       }),
       ...plugins,
     ],

--- a/rollup.min.config.js
+++ b/rollup.min.config.js
@@ -3,7 +3,7 @@ import { terser } from 'rollup-plugin-terser';
 
 export default {
   input: 'src/index.ts',
-  plugins: [typescript(), terser()],
+  plugins: [typescript({ useTsconfigDeclarationDir: true }), terser()],
   external: ['react', 'react-dom'],
   output: [
     {

--- a/tsconfig.ie11.json
+++ b/tsconfig.ie11.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "target": "es5",
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "declaration": false,
+    "declarationMap": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "jsx": "react",
     "skipLibCheck": true,
     "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "./dist",
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
I checked this change following steps.

1. run `yarn run clean && yarn build && yarn pack`
2. run `yarn add react-hook-form/react-hook-form-v5.1.1.tgz` in my own repo
3. run go-to-definition