### PR TITLE
Don't clobber the keyName when already present in data for useFieldArray.

### DIFF
--- a/src/logic/mapIds.test.ts
+++ b/src/logic/mapIds.test.ts
@@ -1,0 +1,14 @@
+import { appendId } from './mapIds';
+
+describe('appendId', () => {
+  it('should add an auto-generated ID', () => {
+    expect(appendId({ value: 42 }, 'id')).toEqual({
+      value: 42,
+      id: expect.any(String),
+    });
+  });
+
+  it('should not override the keyName if already present', () => {
+    expect(appendId({ value: 42, id: 1 }, 'id')).toEqual({ value: 42, id: 1 });
+  });
+});

--- a/src/logic/mapIds.ts
+++ b/src/logic/mapIds.ts
@@ -7,8 +7,8 @@ export const appendId = <FormArrayValues extends FieldValues = FieldValues>(
   value: FormArrayValues,
   keyName: string,
 ) => ({
-  ...(isObject(value) ? value : { value }),
   [keyName]: generateId(),
+  ...(isObject(value) ? value : { value }),
 });
 
 export const mapIds = (data: any, keyName: string) =>


### PR DESCRIPTION
This PR addresses the suggestion raised in #1245. 

**Background**

The default `keyName` for `useFieldArray` is `id`. There was an issue raised where legitimate `id` values for objects were then being clobbered. A fix was introduced to customize the name of the key with `keyName`.

**The Problem**

It is highly likely that `id` values on an object would be unique. It is natural for a developer to think to use `id` as the `key` for their objects. The current behavior of `useFieldArray` requires knowledge that `id` would get clobbered without customization via `keyName`, when the existing `id` would actually suffice.

**Proposed solution**

Do not clobber the `keyName` value when it's already present. Augment the documentation to note that a unique `id` will be provided if absent, or will use an `id` if already present on the fields; and that the key must be unique. The docs will continue to explain how `keyName` can be used to customize the name of an auto-generated key.