### PR TITLE
allow Controller to be focus while there is an error

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -25,6 +25,7 @@ const Controller = <
   valueName,
   defaultValue,
   control,
+  onFocus,
   ...rest
 }: ControllerProps<As, ControlProp>) => {
   const methods = useFormContext();
@@ -85,7 +86,7 @@ const Controller = <
     }
 
     register(
-      Object.defineProperty({ name }, VALUE, {
+      Object.defineProperty({ name, focus: onFocus }, VALUE, {
         set(data) {
           setInputStateValue(data);
           valueRef.current = data;

--- a/src/logic/focusErrorField.ts
+++ b/src/logic/focusErrorField.ts
@@ -10,7 +10,7 @@ export default <FormValues>(
       const field = fields[key];
       if (field) {
         if ((field.ref as FieldElement).focus) {
-          (field.ref as FieldElement).focus();
+          (field.ref as any).focus();
           break;
         } else if (field.options) {
           field.options[0].ref.focus();

--- a/src/logic/focusErrorField.ts
+++ b/src/logic/focusErrorField.ts
@@ -1,6 +1,5 @@
-import isHTMLElement from '../utils/isHTMLElement';
 import get from '../utils/get';
-import { FieldErrors, FieldRefs } from '../types';
+import { FieldElement, FieldErrors, FieldRefs } from '../types';
 
 export default <FormValues>(
   fields: FieldRefs<FormValues>,
@@ -10,8 +9,8 @@ export default <FormValues>(
     if (get(fieldErrors, key)) {
       const field = fields[key];
       if (field) {
-        if (isHTMLElement(field.ref) && field.ref.focus) {
-          field.ref.focus();
+        if ((field.ref as FieldElement).focus) {
+          (field.ref as FieldElement).focus();
           break;
         } else if (field.options) {
           field.options[0].ref.focus();

--- a/src/logic/focusErrorField.ts
+++ b/src/logic/focusErrorField.ts
@@ -9,8 +9,8 @@ export default <FormValues>(
     if (get(fieldErrors, key)) {
       const field = fields[key];
       if (field) {
-        if ((field.ref as FieldElement).focus) {
-          (field.ref as any).focus();
+        if (field.ref.focus) {
+          field.ref.focus();
           break;
         } else if (field.options) {
           field.options[0].ref.focus();

--- a/src/logic/focusErrorField.ts
+++ b/src/logic/focusErrorField.ts
@@ -1,5 +1,5 @@
 import get from '../utils/get';
-import { FieldElement, FieldErrors, FieldRefs } from '../types';
+import { FieldErrors, FieldRefs } from '../types';
 
 export default <FormValues>(
   fields: FieldRefs<FormValues>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,7 +202,7 @@ export type CustomElement = {
   checked?: boolean;
   options?: HTMLOptionsCollection;
   files?: FileList | null;
-  focus: () => void;
+  focus?: () => void;
 };
 
 export type FieldElement =

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,12 +195,6 @@ export type RadioOrCheckboxOption = {
   mutationWatcher?: MutationWatcher;
 };
 
-export type FieldElement =
-  | HTMLInputElement
-  | HTMLSelectElement
-  | HTMLTextAreaElement
-  | CustomElement;
-
 export type CustomElement = {
   name: string;
   type?: string;
@@ -208,7 +202,14 @@ export type CustomElement = {
   checked?: boolean;
   options?: HTMLOptionsCollection;
   files?: FileList | null;
+  focus: () => void;
 };
+
+export type FieldElement =
+  | HTMLInputElement
+  | HTMLSelectElement
+  | HTMLTextAreaElement
+  | CustomElement;
 
 export type HandleChange = (evt: Event) => Promise<void | boolean>;
 
@@ -330,6 +331,7 @@ export type ControllerProps<
     as: As;
     rules?: ValidationOptions;
     onChange?: EventFunction;
+    onFocus?: () => void;
     onBlur?: EventFunction;
     mode?: Mode;
     onChangeName?: string;


### PR DESCRIPTION
This issue has bothered me for awhile: https://github.com/react-hook-form/react-hook-form/issues/1237 it makes Controller autoFocus terrible for DX, to a point when @JuanmaMenendez was suggested to disable that feature all together. here i would like to propose this solution and codesandbox below:

https://codesandbox.io/s/react-hook-form-controller-test-out-ref-5tru5

```
<Controller
  as={<TextField inputRef={inputRef} />}
  name="TextField"
  onFocus={() => inputRef.current.focus()}
  control={control}
  rules={{ required: true }}
/>
```