### PR TITLE
added example for parse and format input value, see #1297

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,3 +35,4 @@ you can view the source code within the folder or visit code sand box to see how
 | ValidationSchema                        | https://codesandbox.io/s/928po918qr                                           |
 | Validation On Blur                      | https://codesandbox.io/s/w7p3km6nyw                                           |
 | Validation On Change                    | https://codesandbox.io/s/74zw1oqozx                                           |
+| Parse and format input value            | https://codesandbox.io/s/react-hook-form-parse-and-format-textarea-52dvm

--- a/examples/parseFormatInputValues.tsx
+++ b/examples/parseFormatInputValues.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Controller, useForm } from 'react-hook-form';
+
+const ParseFormatTextarea = ({ value = [], onChange }) => {
+  const [text, setText] = React.useState<string>(value.join("\n"));
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+
+    setText(value);
+    onChange(value.split("\n"));
+  };
+
+  return <textarea onChange={handleChange} value={text} />;
+};
+
+export default function App() {
+  const { errors, control, handleSubmit } = useForm();
+  const onSubmit = data => {
+    alert(JSON.stringify(data));
+  };
+
+  return (
+    <div className="App">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        {errors.emails && (
+          <ul>
+            {errors.emails.filter(message => !!message).map(({ message }, index) => (
+              <li>Email #{index}: {message}</li>
+            ))}
+          </ul>
+        )}
+        <Controller name="emails" as={ParseFormatTextarea} control={control} />
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  );
+}

--- a/examples/parseFormatInputValues.tsx
+++ b/examples/parseFormatInputValues.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { Controller, useForm } from 'react-hook-form';
 
 const ParseFormatTextarea = ({ value = [], onChange }) => {
   const [text, setText] = React.useState<string>(value.join("\n"));
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = e.target.value;
+    const value = e.target.value.split("\n");
 
     setText(value);
-    onChange(value.split("\n"));
+    onChange(value);
   };
 
   return <textarea onChange={handleChange} value={text} />;
@@ -18,22 +17,20 @@ const ParseFormatTextarea = ({ value = [], onChange }) => {
 export default function App() {
   const { errors, control, handleSubmit } = useForm();
   const onSubmit = data => {
-    alert(JSON.stringify(data));
+    console.log(data);
   };
 
   return (
-    <div className="App">
-      <form onSubmit={handleSubmit(onSubmit)}>
-        {errors.emails && (
-          <ul>
-            {errors.emails.filter(message => !!message).map(({ message }, index) => (
-              <li>Email #{index}: {message}</li>
-            ))}
-          </ul>
-        )}
-        <Controller name="emails" as={ParseFormatTextarea} control={control} />
-        <button type="submit">Submit</button>
-      </form>
-    </div>
+    <form onSubmit={handleSubmit(onSubmit)}>
+      {errors.emails && (
+        <ul>
+          {errors.emails.filter(message => !!message).map(({ message }, index) => (
+            <li>Email #{index}: {message}</li>
+          ))}
+        </ul>
+      )}
+      <Controller name="emails" as={ParseFormatTextarea} control={control} />
+      <button type="submit">Submit</button>
+    </form>
   );
 }

--- a/examples/parseFormatInputValues.tsx
+++ b/examples/parseFormatInputValues.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import React from "react";
+import { Controller, useForm } from "react-hook-form";
 
 const ParseFormatTextarea = ({ value = [], onChange }) => {
-  const [text, setText] = React.useState<string>(value.join("\n"));
+  const [text, setText] = React.useState < string > value.join("\n");
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value.split("\n");
@@ -15,21 +15,22 @@ const ParseFormatTextarea = ({ value = [], onChange }) => {
 };
 
 export default function App() {
-  const { errors, control, handleSubmit } = useForm();
-  const onSubmit = data => {
+  const { control, handleSubmit } = useForm();
+  const onSubmit = (data) => {
     console.log(data);
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      {errors.emails && (
-        <ul>
-          {errors.emails.filter(message => !!message).map(({ message }, index) => (
-            <li>Email #{index}: {message}</li>
-          ))}
-        </ul>
-      )}
       <Controller name="emails" as={ParseFormatTextarea} control={control} />
+      
+      <Controller
+        name="emails"
+        as={<input type="number" />}
+        onChange={(e) => parseInt(e.target.value, 10)}
+        control={control}
+      />
+
       <button type="submit">Submit</button>
     </form>
   );


### PR DESCRIPTION
We added a `parseFormatInputValues.tsx` to `examples/` where we show how
one can implement custom parse and format value behavior to, for
example, parse a newline-separated list of emails to an array and format
them back to a newline-separated string.

Questions and suggestions:
* [ ] You probably want to fork [my codesandbox][1] to your account?
* [ ] Is the code style used in `examples/parseFormatInputValue.tsx` correct?
* [ ] Is there away to run `examples/parseFormatInputValue.tsx`?

[1]: https://codesandbox.io/s/react-hook-form-parse-and-format-textarea-52dvm