### PR TITLE
Prevent DeepPartial from recursively deep partialing primitive values.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,9 @@ export type DeepPartial<T> = {
     ? Array<DeepPartial<U>>
     : T[P] extends ReadonlyArray<infer U>
     ? ReadonlyArray<DeepPartial<U>>
-    : DeepPartial<T[P]>;
+    : T[P] extends { [key: string]: unknown }
+    ? DeepPartial<T[P]>
+    : T[P];
 };
 
 export type ValidationMode = {

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1432,7 +1432,7 @@ describe('useForm', () => {
       });
     });
 
-    it('should infer from defaultValues without a type parameter', async () => {
+    it('should infer from defaultValues without a type parameter', () => {
       const { result } = renderHook(() =>
         useForm({
           mode: VALIDATION_MODE.onSubmit,

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1431,5 +1431,23 @@ describe('useForm', () => {
         } as React.SyntheticEvent);
       });
     });
+
+    it('should infer from defaultValues without a type parameter', async () => {
+      const { result } = renderHook(() =>
+        useForm({
+          mode: VALIDATION_MODE.onSubmit,
+          defaultValues: {
+            test: 'data',
+            deep: {
+              values: '5',
+            },
+          },
+        }),
+      );
+      const test: string = result.current.getValues().test;
+      expect(test).toEqual('data');
+      const deep: { values: string } = result.current.getValues().deep;
+      expect(deep).toEqual({ values: '5' });
+    });
   });
 });

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1444,10 +1444,19 @@ describe('useForm', () => {
           },
         }),
       );
-      const test: string = result.current.getValues().test;
-      expect(test).toEqual('data');
-      const deep: { values: string } = result.current.getValues().deep;
-      expect(deep).toEqual({ values: '5' });
+
+      (getFieldsValues as any).mockImplementation(async () => {
+        return {};
+      });
+
+      act(() => {
+        const test: string = result.current.getValues({ nest: true }).test;
+        expect(test).toEqual('data');
+        const deep: { values: string } = result.current.getValues({
+          nest: true,
+        }).deep;
+        expect(deep).toEqual({ values: '5' });
+      });
     });
   });
 });


### PR DESCRIPTION
DeepPartial currently handles arrays and readonly arrays, but ends up applying `DeepPartial` recursively to primitives until TS eventually detects the loop and forces the properties to `unknown`, which leads to some _very_ confusing types coming out of `getValues` when using `useForm` without a type parameter.

```typescript
const { getValues } = useForm({ defaultValues: { name: "" } })
getValues().name;
(property) test: {
    toString: unknown;
    charAt: unknown;
    charCodeAt: unknown;
    concat: unknown;
    indexOf: unknown;
    lastIndexOf: unknown;
    localeCompare: unknown;
    match: unknown;
    replace: unknown;
    search: unknown;
    slice: unknown;
    split: unknown;
    substring: unknown;
    toLowerCase: unknown;
    toLocaleLowerCase: unknown;
    toUpperCase: unknown;
    toLocaleUpperCase: unknown;
    ... 30 more ...;
    matchAll: unknown;
}
```

```
Type '{ toString: unknown; charAt: unknown; charCodeAt: unknown; concat: unknown; indexOf: unknown; lastIndexOf: unknown; localeCompare: unknown; match: unknown; replace: unknown; search: unknown; slice: unknown; split: unknown; substring: unknown; toLowerCase: unknown; toLocaleLowerCase: unknown; toUpperCase: unknown; to...' is not assignable to type 'string'.ts(2322)
```

This PR stops that by only applying `DeepPartial` to objects (anything that extends `{ [key: string]: unknown }`.