### PR TITLE
Lint test files and ignore `@ts-ignore` rule within them.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,15 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'error',
     'no-console': 'error',
   },
+  overrides: [
+    {
+      files: ['*.test.ts', '*.test.tsx'],
+      rules: {
+        // Allow testing runtime errors when not using TS
+        '@typescript-eslint/ban-ts-ignore': 'off',
+      },
+    },
+  ],
   settings: {
     react: {
       pragma: 'React',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
     {
       files: ['*.test.ts', '*.test.tsx'],
       rules: {
-        // Allow testing runtime errors when not using TS
+        // Allow testing runtime errors to suppress TS errors
         '@typescript-eslint/ban-ts-ignore': 'off',
       },
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:ie11": "rollup -c rollup.ie11.config.js",
     "prettier": "prettier --write './src/**/*.ts' './src/**/*.tsx' --config ./.prettierrc",
     "lint": "yarn lint:check --fix && yarn prettier",
-    "lint:check": "eslint ./src --ext .jsx,.ts --ignore-pattern *.test.ts --report-unused-disable-directives",
+    "lint:check": "eslint ./src --ext .jsx,.ts --report-unused-disable-directives",
     "coverage": "jest --coverage --coverageReporters=text-lcov | coveralls",
     "postrelease": "yarn publish && git push --follow-tags",
     "test": "jest --runInBand",

--- a/src/utils/onDomRemove.test.ts
+++ b/src/utils/onDomRemove.test.ts
@@ -4,7 +4,6 @@ describe('onDomRemove', () => {
   it('should call the observer', () => {
     // @ts-ignore
     window.MutationObserver = class {
-      // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
       observe = jest.fn();
     };
     // @ts-ignore


### PR DESCRIPTION
During the last PR, I noticed that lint errors showed up in-editor, but this wasn't reflected in CI. It took me a bit of time to figure out if this was going to cause the CI checks to fail.

This just overrides the lint rules to allow `ts-ignore` within tests (and allows for other rules to be suppressed over time, as well). That should prevent the disconnect between code and tests for new contributors.