### PR TITLE
TS `any` cleanup

### DIFF
--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -85,7 +85,7 @@ export default async <FormValues extends FieldValues>(
       error[name] = {
         type: INPUT_VALIDATION_RULES.required,
         message: requiredMessage,
-        ref: isRadioOrCheckbox ? (fields[name] as any).options[0].ref : ref,
+        ref: isRadioOrCheckbox ? (fields[name] as Field).options?.[0].ref : ref,
         ...appendErrorsCurry(INPUT_VALIDATION_RULES.required, requiredMessage),
       };
       if (!validateAllFieldCriteria) {

--- a/src/utils/isHTMLElement.ts
+++ b/src/utils/isHTMLElement.ts
@@ -1,4 +1,4 @@
 import isObject from './isObject';
 
 export default (value: any): value is HTMLElement =>
-  isObject(value) && (value as any).nodeType === Node.ELEMENT_NODE;
+  isObject(value) && (value as HTMLElement).nodeType === Node.ELEMENT_NODE;

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -19,7 +19,7 @@ export default function set(object: FieldValues, path: string, value: any) {
       newValue =
         isObject(objValue) || isArray(objValue)
           ? objValue
-          : !isNaN(tempPath[index + 1] as any)
+          : !isNaN(+tempPath[index + 1])
           ? []
           : {};
     }


### PR DESCRIPTION
I was supposed to change below snippet:

```js
function getCheckboxValue(options) {
  // some code
  
  const { checked, value, attributes } = options[0].ref;

  return checked
    ? attributes && !isUndefined((attributes as any).value)
      ? isUndefined(value) || isEmptyString(value)
        ? validResult
        : { value: value, isValid: true }
      : validResult
  : defaultResult;
}
```

But to change it, I need to do below because `attributes` is of type [`NamedNodeMap`](https://developer.mozilla.org/en-US/docs/Web/API/NamedNodeMap) of which we need to use `getNamedItems`.

```js
attributes.getNamedItem("value")
```

However, a lot of breaking changes in the test are needed to update as well therefore decided not to because the simpler the better.