### PR TITLE
fix deep property names in useFieldArray

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -105,7 +105,7 @@ export const useFieldArray = <
   };
 
   const mapCurrentFieldsValueWithState = () => {
-    const currentFieldsValue = getValues({ nest: true })[name];
+    const currentFieldsValue = get(getValues({ nest: true }), name);
 
     if (isArray(currentFieldsValue)) {
       for (let i = 0; i < currentFieldsValue.length; i++) {


### PR DESCRIPTION
Since the `name` in `useFieldArray` can be a deep property (eg: `'field.subfield'`) there was a mismatch between the nested object returned by `getValues({ nest: true })` and shallow property access. 

This PR uses the `get` utility to support deep property access of the nested values object. 

As discussed in this spectrum chat:

https://spectrum.chat/react-hook-form/general/recursive-form-fields-problems-with-usefieldarray~08c2da1b-4dae-4966-ba45-40cd130b163f