### PR TITLE
watch internal TS improvement

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -13,6 +13,7 @@ import {
   Control,
   OmitResetState,
   Message,
+  LiteralUnion,
   LiteralToPrimitive,
 } from './types';
 
@@ -50,14 +51,12 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
   unregister(names: FieldName<FormValues> | FieldName<FormValues>[]): void;
   watch(): FormValues;
   watch(option: { nest: boolean }): FormValues;
-  watch<T extends keyof FormValues>(
+  watch<T extends LiteralUnion<keyof FormValues, string>, U extends unknown>(
     field: T,
-    defaultValue?: FormValues[T],
-  ): FormValues[T];
-  watch<T extends unknown>(
-    field: string,
-    defaultValue?: T,
-  ): LiteralToPrimitive<T>;
+    defaultValue?: T extends keyof FormValues
+      ? FormValues[T]
+      : LiteralToPrimitive<U>,
+  ): T extends keyof FormValues ? FormValues[T] : LiteralToPrimitive<U>;
   watch<T extends keyof FormValues>(
     fields: T[],
     defaultValues?: DeepPartial<Pick<FormValues, T>>,

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -13,7 +13,6 @@ import {
   Control,
   OmitResetState,
   Message,
-  LiteralUnion,
   LiteralToPrimitive,
 } from './types';
 
@@ -51,7 +50,7 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
   unregister(names: FieldName<FormValues> | FieldName<FormValues>[]): void;
   watch(): FormValues;
   watch(option: { nest: boolean }): FormValues;
-  watch<T extends LiteralUnion<keyof FormValues, string>, U extends unknown>(
+  watch<T extends string, U extends unknown>(
     field: T,
     defaultValue?: T extends keyof FormValues
       ? FormValues[T]
@@ -65,10 +64,6 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
     fields: string[],
     defaultValues?: DeepPartial<FormValues>,
   ): DeepPartial<FormValues>;
-  watch(
-    fieldNames?: string | string[] | { nest: boolean },
-    defaultValue?: unknown,
-  ): unknown;
   setError(name: ManualFieldError<FormValues>[]): void;
   setError(name: FieldName<FormValues>, type: MultipleFieldErrors): void;
   setError(name: FieldName<FormValues>, type: string, message?: Message): void;

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -60,12 +60,12 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
   ): LiteralToPrimitive<T>;
   watch<T extends keyof FormValues>(
     fields: T[],
-    defaultValues?: FormValues[T],
-  ): Record<T, FormValues[T]>;
-  watch<T extends DeepPartial<FormValues>>(
+    defaultValues?: DeepPartial<Pick<FormValues, T>>,
+  ): Pick<FormValues, T>;
+  watch(
     fields: string[],
-    defaultValues?: T,
-  ): T;
+    defaultValues?: DeepPartial<FormValues>,
+  ): DeepPartial<FormValues>;
   watch(
     fieldNames?: string | string[] | { nest: boolean },
     defaultValue?: unknown,

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -8,12 +8,12 @@ import {
   FieldElement,
   ValidationOptions,
   FieldName,
-  FieldValue,
   ManualFieldError,
   MultipleFieldErrors,
   Control,
   OmitResetState,
   Message,
+  LiteralToPrimitive,
 } from './types';
 
 export type FormProps<FormValues extends FieldValues = FieldValues> = {
@@ -50,21 +50,26 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
   unregister(names: FieldName<FormValues> | FieldName<FormValues>[]): void;
   watch(): FormValues;
   watch(option: { nest: boolean }): FormValues;
-  watch<T extends FieldName<FormValues>>(
-    field: T & string,
-    defaultValue?: string,
+  watch<T extends keyof FormValues>(
+    field: T,
+    defaultValue?: FormValues[T],
   ): FormValues[T];
+  watch<T extends unknown>(
+    field: string,
+    defaultValue?: T,
+  ): LiteralToPrimitive<T>;
+  watch<T extends keyof FormValues>(
+    fields: T[],
+    defaultValues?: FormValues[T],
+  ): Record<T, FormValues[T]>;
+  watch<T extends DeepPartial<FormValues>>(
+    fields: string[],
+    defaultValues?: T,
+  ): T;
   watch(
-    fields: FieldName<FormValues>[] | string[],
-    defaultValues?: DeepPartial<FormValues>,
-  ): DeepPartial<FormValues>;
-  watch(
-    fieldNames?:
-      | FieldName<FormValues>
-      | FieldName<FormValues>[]
-      | { nest: boolean },
-    defaultValue?: string | DeepPartial<FormValues>,
-  ): FieldValue<FormValues> | DeepPartial<FormValues> | string | undefined;
+    fieldNames?: string | string[] | { nest: boolean },
+    defaultValue?: unknown,
+  ): unknown;
   setError(name: ManualFieldError<FormValues>[]): void;
   setError(name: FieldName<FormValues>, type: MultipleFieldErrors): void;
   setError(name: FieldName<FormValues>, type: string, message?: Message): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,10 +2,6 @@ import * as React from 'react';
 
 export type Primitive = string | boolean | number | symbol | null | undefined;
 
-export type LiteralUnion<T extends Primitive, U extends Primitive> =
-  | T
-  | (U & { _?: never });
-
 export type LiteralToPrimitive<T extends any> = T extends string
   ? string
   : T extends number

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,14 @@ import * as React from 'react';
 
 export type Primitive = string | boolean | number | symbol | null | undefined;
 
+export type LiteralToPrimitive<T extends any> = T extends string
+  ? string
+  : T extends number
+  ? number
+  : T extends boolean
+  ? boolean
+  : T;
+
 export type FieldValues = Record<string, any>;
 
 export type FieldName<FormValues extends FieldValues> =

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,10 @@ import * as React from 'react';
 
 export type Primitive = string | boolean | number | symbol | null | undefined;
 
+export type LiteralUnion<T extends Primitive, U extends Primitive> =
+  | T
+  | (U & { _?: never });
+
 export type LiteralToPrimitive<T extends any> = T extends string
   ? string
   : T extends number

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -39,6 +39,7 @@ import isHTMLElement from './utils/isHTMLElement';
 import { EVENTS, UNDEFINED, VALIDATION_MODE } from './constants';
 import { FormContextValues } from './contextTypes';
 import {
+  LiteralUnion,
   LiteralToPrimitive,
   DeepPartial,
   FieldValues,
@@ -732,14 +733,15 @@ export function useForm<
 
   function watch(): FormValues;
   function watch(option: { nest: boolean }): FormValues;
-  function watch<T extends keyof FormValues>(
+  function watch<
+    T extends LiteralUnion<keyof FormValues, string>,
+    U extends unknown
+  >(
     field: T,
-    defaultValue?: FormValues[T],
-  ): FormValues[T];
-  function watch<T extends unknown>(
-    field: string,
-    defaultValue?: T,
-  ): LiteralToPrimitive<T>;
+    defaultValue?: T extends keyof FormValues
+      ? FormValues[T]
+      : LiteralToPrimitive<U>,
+  ): T extends keyof FormValues ? FormValues[T] : LiteralToPrimitive<U>;
   function watch<T extends keyof FormValues>(
     fields: T[],
     defaultValues?: DeepPartial<Pick<FormValues, T>>,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -742,12 +742,12 @@ export function useForm<
   ): LiteralToPrimitive<T>;
   function watch<T extends keyof FormValues>(
     fields: T[],
-    defaultValues?: FormValues[T],
-  ): Record<T, FormValues[T]>;
-  function watch<T extends DeepPartial<FormValues>>(
+    defaultValues?: DeepPartial<Pick<FormValues, T>>,
+  ): Pick<FormValues, T>;
+  function watch(
     fields: string[],
-    defaultValues?: T,
-  ): T;
+    defaultValues?: DeepPartial<FormValues>,
+  ): DeepPartial<FormValues>;
   function watch(
     fieldNames?: string | string[] | { nest: boolean },
     defaultValue?: unknown,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -39,6 +39,7 @@ import isHTMLElement from './utils/isHTMLElement';
 import { EVENTS, UNDEFINED, VALIDATION_MODE } from './constants';
 import { FormContextValues } from './contextTypes';
 import {
+  LiteralToPrimitive,
   DeepPartial,
   FieldValues,
   FieldName,
@@ -731,21 +732,26 @@ export function useForm<
 
   function watch(): FormValues;
   function watch(option: { nest: boolean }): FormValues;
-  function watch<T extends FieldName<FormValues>>(
-    field: T & string,
-    defaultValue?: string,
+  function watch<T extends keyof FormValues>(
+    field: T,
+    defaultValue?: FormValues[T],
   ): FormValues[T];
+  function watch<T extends unknown>(
+    field: string,
+    defaultValue?: T,
+  ): LiteralToPrimitive<T>;
+  function watch<T extends keyof FormValues>(
+    fields: T[],
+    defaultValues?: FormValues[T],
+  ): Record<T, FormValues[T]>;
+  function watch<T extends DeepPartial<FormValues>>(
+    fields: string[],
+    defaultValues?: T,
+  ): T;
   function watch(
-    fields: FieldName<FormValues>[] | string[],
-    defaultValues?: DeepPartial<FormValues>,
-  ): DeepPartial<FormValues>;
-  function watch(
-    fieldNames?:
-      | FieldName<FormValues>
-      | FieldName<FormValues>[]
-      | { nest: boolean },
-    defaultValue?: string | DeepPartial<FormValues>,
-  ): FieldValue<FormValues> | DeepPartial<FormValues> | string | undefined {
+    fieldNames?: string | string[] | { nest: boolean },
+    defaultValue?: unknown,
+  ): unknown {
     const combinedDefaultValues = isUndefined(defaultValue)
       ? isUndefined(defaultValuesRef.current)
         ? {}
@@ -766,7 +772,7 @@ export function useForm<
         fieldValues,
         fieldNames,
         watchFields,
-        combinedDefaultValues,
+        combinedDefaultValues as DeepPartial<FormValues>,
       );
     }
 
@@ -778,7 +784,7 @@ export function useForm<
             fieldValues,
             name,
             watchFields,
-            combinedDefaultValues,
+            combinedDefaultValues as DeepPartial<FormValues>,
           ),
         }),
         {},

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -39,7 +39,6 @@ import isHTMLElement from './utils/isHTMLElement';
 import { EVENTS, UNDEFINED, VALIDATION_MODE } from './constants';
 import { FormContextValues } from './contextTypes';
 import {
-  LiteralUnion,
   LiteralToPrimitive,
   DeepPartial,
   FieldValues,
@@ -733,10 +732,7 @@ export function useForm<
 
   function watch(): FormValues;
   function watch(option: { nest: boolean }): FormValues;
-  function watch<
-    T extends LiteralUnion<keyof FormValues, string>,
-    U extends unknown
-  >(
+  function watch<T extends string, U extends unknown>(
     field: T,
     defaultValue?: T extends keyof FormValues
       ? FormValues[T]


### PR DESCRIPTION
```ts
type FormValues = {
  key1: string;
  key2: number;
  key3: {
    key1: number;
    key2: boolean;
  };
};

const { watch } = useForm<FormValues>;

watch();
// function watch(): FormValues
watch({ nest: true })
// function watch(option: { nest: boolean; }): FormValues
watch('key1')
// function watch<"key1">(field: "key1", defaultValue?: string | undefined): string
watch('key1', 'test')
// function watch<"key1">(field: "key1", defaultValue?: string | undefined): string
watch('key1', true)
// ❌: type error
watch('key3.key1')
// function watch<unknown>(field: string, defaultValue?: unknown): unknown
watch('key3.key1', 1);
// function watch<1>(field: string, defaultValue?: 1 | undefined): number
watch('key3.key1', 'test');
// function watch<"key3.key1", "test">(field: "key3.key1", defaultValue?: string | undefined): string
watch('key3.key2', true);
// function watch<true>(field: string, defaultValue?: true | undefined): boolean
watch(['key1', 'key2'])
// function watch<"key1" | "key2">(fields: ("key1" | "key2")[], defaultValues?: DeepPartial<Pick<FormValues, "key1" | "key2">> | undefined): Pick<FormValues, "key1" | "key2">
watch(['key1', 'key2'], { key1: 'test' })
// function watch<"key1" | "key2">(fields: ("key1" | "key2")[], defaultValues?: DeepPartial<Pick<FormValues, "key1" | "key2">> | undefined): Pick<FormValues, "key1" | "key2">
watch(['key1', 'key2'], { key1: 'test', key2: true })
// ❌: type error
watch(['key1', 'key3.key1'], { key1: 'string' })
// function watch(fields: string[], defaultValues?: DeepPartial<FormValues> | undefined): DeepPartial<FormValues>
watch(['key1', 'key3.key1'], { test: 'string' })
// ❌: type error
```

[TypeScript Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAYg9gJwLYDUCGAbArhAzlAXigG8AoKKAawhAEYAuKXYBASwDsBzAbnKpoBMjdliQAjCAl4VqIAMyMyFGTQZQR4ydOWyhUMXDgYIadtoC+vS6VIQAHmETAooSFAAKbJK2CsAbtBEzGxcUAA++obGpuHqohIIsbgg4kaxIhgYsVjsACYQAGYcELm8tg5OLuDQADI+kpgAquyscOwAPKQAkAAqUPbAEHn4nqzevgEANN2N-XaDwx5ePv4QpAB8hFB9EQAUswBkJAD6APzCEAEI5gCUZa619QiYPXCj46vtfQNDufimIE2RG+81++GCHE4fFOTBYkL4jBBCz+cU0CGhqISCO2c2R+AMRhM7AxBOixIoiPu1SgABEIBAwO40AhfJgvkCSHwANruKAcfggOAFbYAXXO2x5ItxYKgAEEEM8QO0OAVJFBGus+BQYfLFe06QymSzWGyNZrlFBEZLpYsAEomXJtDAgXVoJUqtUarVQGH2tCO9jO11Kg2M5msjDtM3eq3uKU-RbEKBc2SMCFcEWMHKUdhwADu7Cg5m9MNDRojX0l5uUsZFVjK+QAxhhmdACjlG742lA82hgI2ABa7G6MeDIdDYPC8JsthBtjtdwu9-tDuBgReKdR4YCMUlEosj2CIVCYHC4acQZutqDt9id1pLvuDr42lF1QbPDDNB-tWRCo-jqeeCTLCIScOsIGzAmKLZrmBbrLsfBFBAGC5Ii0wUPkBRoFgGDABOODikiMp-sKY4npO+AwuRBF4FyPRSow74NBgrzvCsARRpqh7EYspEARRZ4+gJtG4PRjFQMxn5scsEwQFxF5XnON4Lg+PZPgOL7Qfg-E0UBuAIUhrAoX8VoihhUBYTheGieKZbhiakbuKwjaUO0emUSBPTrBBpCHs5rnuceoleesimzvOd6LupK6IRQyGobgaZwlwXLmXwVm4fh+l2fSYbGmyHlnr5h72QVkZFXgYU2Mug7DrwAD0DUqVFam1UOh6VbgpDtbsSbsNujAsDgB6kE1LX3t2vVrhuJBbswu5RES3AHqOwX6T1Gm7AA5LItDbTcY3Nbek2Piu7QAER7RdCEJWhUBXaoF0gZlNlAeK6acNkeSFMUuSHp9m2xbtqjbSB22DMwB1HRN0XtZd123cZqGMI9dDPZZhTWdlk4fSlX0RDkWF-QD+NA3VIN0GDLgIDgh3jYAMuRDdSkgIIg5NDpTcgAHR7dD40nXDGntLB+bsEjJnJWBL1Y1ltHiqLBaHorxK9VzvOgyBtB3DDgttcLtASyjoGQjL2Fy+9jC0N9xMDf9wjxJIHM7bIPN8+DkPAAdjXHapU3C2jbtPSBF2ezdux3ajrsa+jZvY-LUuQjbv126TYHO+rujU8NEA6wLftnc+OdG-dn1xxbuNDbT0CEz9RSp4thKmM7XKU-t4NZyK9O+61-vnWjtAXbEaMCOHd1JVAuwD0PEQjxdNxpeXb2UblhoOWyAVuV1IfXcPug3Zste2yU-kuVv62eQ9u+z-vmq9a37tQJTAjbeZc17YwEPbtto3573heaWnnvQQY9kamUnkAm+ICF5v1ejjM8q98oVk3kFQCl9IFXxAT5ZO9cT6MBQdvTB6NgEgFHnfLaD9NZP07iBJMH8n6e2proKuI1bgwyZlUNwrN2b3zbtTTOoM350NUJ-T6P82F-1OjFOq49E6pVgbLZeCDGBlQrF1Q+UAiYpzwbSPK5ZHKoMElVFufCO40CDlTIRLhBpPzEb-ZqHCHj9AVIgIAA)

close #1371