### PR TITLE
Enable Proxy check React Native

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -118,7 +118,6 @@ export function useForm<
     !isWindowUndefined &&
     !isUndefined(window.HTMLElement);
   const isProxyEnabled =
-    (isWeb && 'Proxy' in window) ||
     isWeb ? 'Proxy' in window : typeof Proxy !== UNDEFINED;
   const readFormStateRef = React.useRef<ReadFormState>({
     dirty: !isProxyEnabled,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -117,7 +117,9 @@ export function useForm<
     typeof document !== UNDEFINED &&
     !isWindowUndefined &&
     !isUndefined(window.HTMLElement);
-  const isProxyEnabled = isWeb && 'Proxy' in window;
+  const isProxyEnabled =
+    (isWeb && 'Proxy' in window) ||
+    (typeof navigator !== UNDEFINED && typeof Proxy !== UNDEFINED);
   const readFormStateRef = React.useRef<ReadFormState>({
     dirty: !isProxyEnabled,
     dirtyFields: !isProxyEnabled,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -119,7 +119,7 @@ export function useForm<
     !isUndefined(window.HTMLElement);
   const isProxyEnabled =
     (isWeb && 'Proxy' in window) ||
-    (typeof navigator !== UNDEFINED && typeof Proxy !== UNDEFINED);
+    isWeb ? 'Proxy' in window : typeof Proxy !== UNDEFINED;
   const readFormStateRef = React.useRef<ReadFormState>({
     dirty: !isProxyEnabled,
     dirtyFields: !isProxyEnabled,


### PR DESCRIPTION
Add proxy-polyfill in react-native to increase performance, because avoid re-render unneccesary.
fix: #1379 

Example with [proxy-polyfill](https://www.npmjs.com/package/proxy-polyfill) package, call this code in your App.js or index.js:

```typescript
import 'proxy-polyfill';
```