### PR TITLE
fix - examples/FieldArray

### DIFF
--- a/examples/FieldArray.tsx
+++ b/examples/FieldArray.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { useForm } from 'react-hook-form';
 
 function createArrayWithNumbers(length) {
-  return Array.from({ length }, (_, k) => +k + 1);
+  return Array.from({ length }, (_, k) => k);
 }
 
 export default function App() {


### PR DESCRIPTION
I removed k +1 because otherwise createArrayWithNumbers(size).map(number ... (line 22) starts with 1 instead of 0 leading to a non existing first field when data are submitted