### PR TITLE
Forward Controller ref to as component

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -15,20 +15,23 @@ const Controller = <
     | React.ComponentType<any>
     | keyof JSX.IntrinsicElements,
   ControlProp extends Control = Control
->({
-  name,
-  rules,
-  as: InnerComponent,
-  onBlur,
-  onChange,
-  onChangeName = VALIDATION_MODE.onChange,
-  onBlurName = VALIDATION_MODE.onBlur,
-  valueName,
-  defaultValue,
-  control,
-  onFocus,
-  ...rest
-}: ControllerProps<As, ControlProp>) => {
+>(
+  {
+    name,
+    rules,
+    as: InnerComponent,
+    onBlur,
+    onChange,
+    onChangeName = VALIDATION_MODE.onChange,
+    onBlurName = VALIDATION_MODE.onBlur,
+    valueName,
+    defaultValue,
+    control,
+    onFocus,
+    ...rest
+  }: ControllerProps<As, ControlProp>,
+  ref: React.Ref<As>,
+) => {
   const methods = useFormContext();
   const {
     defaultValuesRef,
@@ -144,6 +147,7 @@ const Controller = <
   });
 
   const props = {
+    ref,
     name,
     ...rest,
     ...(onChange
@@ -170,4 +174,6 @@ const Controller = <
     : React.createElement(InnerComponent as string, props);
 };
 
-export { Controller };
+const ControllerWithRef = React.forwardRef(Controller);
+
+export { ControllerWithRef as Controller };


### PR DESCRIPTION
I'm using ReactNative and I need TextInput's ref so I can set focus when I press enter on a previous input.

I tested locally and it worked, I don't know exactly how to write test for the ref prop.

I know I can write `<Controller as={<TextInput ref={ref} />} />` but I think this would be a more elegant way to do it.