### PR TITLE
improve type getValues

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -98,8 +98,9 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
     omitResetState?: OmitResetState,
   ) => void;
   getValues(payload?: { nest: boolean }): FormValues;
-  getValues<T extends keyof FormValues>(payload: T): FormValues[T];
-  getValues<T extends unknown>(payload: string): T;
+  getValues<T extends string, U extends unknown>(
+    payload: T,
+  ): T extends keyof FormValues ? FormValues[T] : U;
   handleSubmit: (
     callback: OnSubmit<FormValues>,
   ) => (e?: React.BaseSyntheticEvent) => Promise<void>;

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -14,6 +14,7 @@ import {
   OmitResetState,
   Message,
   LiteralToPrimitive,
+  IsFlatObject,
 } from './types';
 
 export type FormProps<FormValues extends FieldValues = FieldValues> = {
@@ -97,7 +98,16 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
     values?: DeepPartial<FormValues>,
     omitResetState?: OmitResetState,
   ) => void;
-  getValues(payload?: { nest: boolean }): FormValues;
+  getValues(): IsFlatObject<FormValues> extends true
+    ? FormValues
+    : Record<string, unknown>;
+  getValues<T extends boolean>(payload: {
+    nest: T;
+  }): T extends true
+    ? FormValues
+    : IsFlatObject<FormValues> extends true
+    ? FormValues
+    : Record<string, unknown>;
   getValues<T extends string, U extends unknown>(
     payload: T,
   ): T extends keyof FormValues ? FormValues[T] : U;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-export type IsFlatObject<T extends Record<string, any>> = Extract<
+export type IsFlatObject<T extends Record<string, unknown>> = Extract<
   T[keyof T],
-  any[] | Record<string, any>
+  unknown[] | Record<string, unknown>
 > extends never
   ? true
   : false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,12 @@
 import * as React from 'react';
 
+export type IsFlatObject<T extends Record<string, any>> = Extract<
+  T[keyof T],
+  any[] | Record<string, any>
+> extends never
+  ? true
+  : false;
+
 export type Primitive = string | boolean | number | symbol | null | undefined;
 
 export type LiteralToPrimitive<T extends any> = T extends string
@@ -276,6 +283,16 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
       : LiteralToPrimitive<U>,
     shouldValidate?: boolean,
   ): void;
+  getValues(): IsFlatObject<FormValues> extends true
+    ? FormValues
+    : Record<string, unknown>;
+  getValues<T extends boolean>(payload: {
+    nest: T;
+  }): T extends true
+    ? FormValues
+    : IsFlatObject<FormValues> extends true
+    ? FormValues
+    : Record<string, unknown>;
   getValues(payload?: { nest: boolean }): FormValues;
   getValues<T extends string, U extends unknown>(
     payload: T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,8 +277,9 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
     shouldValidate?: boolean,
   ): void;
   getValues(payload?: { nest: boolean }): FormValues;
-  getValues<T extends keyof FormValues>(payload: T): FormValues[T];
-  getValues<T extends unknown>(payload: string): T;
+  getValues<T extends string, U extends unknown>(
+    payload: T,
+  ): T extends keyof FormValues ? FormValues[T] : U;
   formState: FormStateProxy<FormValues>;
   mode: {
     isOnBlur: boolean;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1147,8 +1147,9 @@ export function useForm<
   };
 
   function getValues(payload?: { nest: boolean }): FormValues;
-  function getValues<T extends keyof FormValues>(payload: T): FormValues[T];
-  function getValues<T extends unknown>(payload: string): T;
+  function getValues<T extends string, U extends unknown>(
+    payload: T,
+  ): T extends keyof FormValues ? FormValues[T] : U;
   function getValues(payload?: { nest: boolean } | string): unknown {
     if (isString(payload)) {
       return fieldsRef.current[payload]

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -62,6 +62,7 @@ import {
   RadioOrCheckboxOption,
   OmitResetState,
   Message,
+  IsFlatObject,
 } from './types';
 
 export function useForm<
@@ -1150,7 +1151,16 @@ export function useForm<
     reRender();
   };
 
-  function getValues(payload?: { nest: boolean }): FormValues;
+  function getValues(): IsFlatObject<FormValues> extends true
+    ? FormValues
+    : Record<string, unknown>;
+  function getValues<T extends boolean>(payload: {
+    nest: T;
+  }): T extends true
+    ? FormValues
+    : IsFlatObject<FormValues> extends true
+    ? FormValues
+    : Record<string, unknown>;
   function getValues<T extends string, U extends unknown>(
     payload: T,
   ): T extends keyof FormValues ? FormValues[T] : U;


### PR DESCRIPTION
1. Fixed return type when argument is undefined or {nest: false}.

ref: https://github.com/react-hook-form/react-hook-form/pull/1436#issuecomment-615000416

Hack to solve this:

```ts
type IsFlatObject<T extends Record<string, unknown>> = Extract<
  T[keyof T],
  unknown[] | Record<string, unknown>
> extends never
  ? true
  : false;

type A = IsFlatObject<{
  key1: string;
  key2: number;
}>
// type A = true
type B = IsFlatObject<{
  key1: string;
  key2: Date;
}>
// type B = true
type C = IsFlatObject<{
  key1: string;
  key2: boolean[];
}>
// type C = false
type D = IsFlatObject<{
  key1: string;
  key2: {
    key1: number;
  };
}>
// type D = false
type E = IsFlatObject<{
  key1: string;
  key2: {
    key1: number;
  }[];
}>
// type E = false
```

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=36&ssc=18&pln=1&pc=1#code/C4TwDgpgBAkgzgMQDYENgHkBGArCBjYAHgBUoIAPYCAOwBM4oAlfAewCdbC5g2BLagOYAaKAFdqAa2osA7tQB88qAF4oAUUpsUBQgCgoUYgG0JEECwBmhgLpD9YydLlHrUAD5NWHLj37CHUrIKukoUVHQM1BAAbhBs9gD8UDyiEPYAXFAWKEhwEADcurqgkFAAgiqwiKgYOPhEAN72piAAjJncfIKFBi0ATJnUogC2mHGFAL7yugD0M8ng0BWqKWkl0ABClfDIaFi4Ok29Zu1QnX49UP2ZACJoBbpTs-PrUFsrbKnFi1AAwtvVPZ1Q7NE4dXzdUEgAZQTAsFhICAoaguSbTOYLUr-VTZXJrH43AG7WoHRpQ07nSHHaGZI4GK5gqBDUbjewTNHPTHQQk4nJ5b6lNREmr7eqEOktCkQgSXa5QOnU07MsZsS4TVGPdEvH5C3l4oA)

1.1. flat object

```ts
type FormValues = {
  key1: string;
  key2: number;
  key3: boolean;
  key4: Date;
};

getValues()
// function getValues(): FormValues
getValues({ nest: true })
// function getValues<true>(payload: {
//     nest: true;
// }): FormValuees
getValues({ nest: false })
// function getValues<false>(payload: {
//     nest: false;
// }): FormValuees
```

[TypeScript Playground](https://www.typescriptlang.org/play/#code/C4TwDgpgBAkgzgMQDYENgHkBGArCBjYAHgBUoIAPYCAOwBM4oAlfAewCdbC5g2BLagOYAaKAFdqAa2osA7tQB88qAF4oAUUpsUBQgCgoUYgG0JEECwBmhgLpD9YydLlHrUAD5NWHLj37CHUrIKukoUVHQM1BAAbhBs9gD8UDyiEPYAXFAWKEhwEADcurq0+Khs0BbiBLws1FACEMAAajmpcAAUAJSZ8MhoWLg6COwAti1IbaGUNPTJbKmJUMNsY60QcBmeeOyc3HyCIuKBcvKFJXhlFVXANXUNzWtwJGTTEVCYLCxIECgK7WAoEBIFgoWiZADe9ii3EyxEKAF9uoYXuFZik0gYkstVhN1pteqgMDh8ERseNJiiZgx0YsyY9Nsxtt49n5Do4gqdiqUUOUstdbvVGuT1s8wlSoCyDlAAKqUt5HJx-ewAoEgsGGOxI0hit6mcxWOm4hhY0bCuBGYiuTLSwq6UCQJamx4qKCQgx6gCMmUlAkK7rMACZMtRRCNMHE-VA9QBmTIfL4-aiRvUAFkyABE0AVdPDbfczV1dAB6It86jVWqCh5GrqZQ1tXT5x7tcFQaHATLoqCI4ulyrlm6VptGwjo+T-QHA0EQ3sGOftzvzbMl7tI+sQPHDtottvrDtZHJ5Vez-sVu5Cx6EbK5CDjlVT9WQldz3cwg83worxF1p249ZAA)

1.2. nested object

```ts
type FormValues = {
  key1: string;
  key2: number;
  key3: {
    key1: number;
    key2: boolean;
  };
  key4: string[];
};

getValues()
// function getValues(): Record<string, unknown>
getValues({ nest: true })
// function getValues<true>(payload: {
//     nest: true;
// }): FormValuees
getValues({ nest: false })
// function getValues<false>(payload: {
//     nest: false;
// }): Record<string, unknown>
```

[TypeScript Playground](https://www.typescriptlang.org/play/#code/C4TwDgpgBAkgzgMQDYENgHkBGArCBjYAHgBUoIAPYCAOwBM4oAlfAewCdbC5g2BLagOYAaKAFdqAa2osA7tQB88qAF4oAUUpsUBQgCgoUYgG0JEECwBmhgLpD9YydLlHrUAD5NWHLj37CHUrIKukoUVHQM1BAAbhBs9gD8UDyiEPYAXFAWKEhwEADcurq0+Khs0BbiBLws1FACEMAAajmpcAAUAJSZ8MhoWLg6COwAti1IbaGUNPTJbKmJUMNsY60QcBmeeOyc3HyCIuKBcvKFJXhlFVXANXUNzWtwJGTTEVCYLCxIECgK7WAoEBIFgoWiZADe9ii3EyxEKAF9uoYXuFZik0gYkstVhN1pteqgMDh8ERseNJiiZgx0YsyY9Nsxtt49n5Do4gqdiqUUOUstdbvVGuT1s8wlSoCyDlAAKqUt5HJx-ewAoEgsGGOxI0hit6mcxWOm4hhY0bCuBGYiuTLSwq6UCQJamx4qKCQgx6gCMmUlAkK7rMACZMtRRCNMHE-VA9QBmCH2f0gL1QENhiPxqOBzIfL4-aiR+GRvUAFm9vkELgRtvuZq6ugA9HW+dRqrVBQ8jV1Moydj59v4FRzdNXHu1wcn1sBMuioIj643Ks2bq3h0bCOj5P9AcDQXGGwZ99DJ3NUoU94jMobUniV21R+OYVkcnkZ50502W3chY9CNlchANyq27qpCe77veR6-nkp6NueWw9j6bLHAoQA)

2. Fixed to have two `getValues` ​​arguments same as `watch` and `setValue` for consistency.

ref: https://github.com/react-hook-form/react-hook-form/pull/1412#issuecomment-614926941

```ts
type FormValues = {
  key1: string;
  key2: number;
  key3: {
    key1: number;
    key2: boolean;
  };
  key4: string[];
};

getValues('key1')
// function getValues<"key1", unknown>(payload: "key1"): string
getValues('key2')
// function getValues<"key2", unknown>(payload: "key2"): number
getValues('key3.key1')
// function getValues<"key3.key1", unknown>(payload: "key3.key1"): unknown
getValues<string, number>('key3.key1')
// function getValues<string, number>(payload: string): number
getValues<string, boolean>('key3.key2')
// function getValues<string, boolean>(payload: string): boolean
getValues('key4')
// function getValues<"key4", unknown>(payload: "key4"): string[]
```

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=43&ssc=66&pln=22&pc=1#code/C4TwDgpgBAkgzgMQDYENgHkBGArCBjYAHgBUoIAPYCAOwBM4oAlfAewCdbC5g2BLagOYAaKAFdqAa2osA7tQB88qAF4oAUUpsUBQgCgoUYgG0JEECwBmhgLpD9YydLlHrUAD5NWHLj37CHUrIKukoUVHQM1BAAbhBs9gD8UDyiEPYAXFAWKEhwEADcurq0+Khs0BbiBLws1FACEMAAajmpcAAUAJSZ8MhoWLg6COwAti1IbaGUNPTJbKmJUMNsY60QcBmeeOyc3HyCIuKBcvKFJXhlFVXANXUNzWtwJGTTEVCYLCxIECgK7WAoEBIFgoWiZADe9ii3EyxEKAF9uoYXuFZik0gYkstVhN1pteqgMDh8ERseNJiiZgx0YsyY9Nsxtt49n5Do4gqdiqUUOUstdbvVGuT1s8wlSoCyDlAAKqUt5HJx-ewAoEgsGGOxI0hit6mcxWOm4hhY0bCuBGYiuTLSwq6UCQJamx4qKCQgx6gCMmUlAkK7rMACZMtRRCNMHE-VA9QBmCH2f0gL1QENhiPxqOBzIfL4-aiR+GRvUAFm9vkELgRtvuZvaAHJPbXOroAPTNvnUaq1QUPI2EABEnr7bOOfxVwNBmQHZg9faRPt01cedb1AcbLbblQ7Ny7i97U5AAaHAUV8n+gPH6v3h6RKfD8V3bWXZmjADoG03W+3O3chY9+zG32nI8FQ5M9VQnKB91fQckRAuQF1-XsfREW84lPetn0AxM10-Tdv27M0fH2fxULYU8xzVUtiJvUM7wQns2iI1l3k+b5fnQgCVxwjd+R3RDGOQlic3YsCLyovwkWzNjqHomsMJAItuK-bcfwYkV9yLYD2ROUTKMg4tZ3E8trCAA)

Related PR:

* https://github.com/react-hook-form/react-hook-form/pull/1412
* https://github.com/react-hook-form/react-hook-form/pull/1328