### PR TITLE
improve triggerValidation type

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -88,10 +88,15 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
     namesWithValue: DeepPartial<Pick<FormValues, T>>[],
     shouldValidate?: boolean,
   ): void;
-  triggerValidation: (
-    payload?: FieldName<FormValues> | FieldName<FormValues>[] | string,
-    shouldRender?: boolean,
-  ) => Promise<boolean>;
+  triggerValidation(
+    payload?:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
+  ): Promise<boolean>;
   errors: FieldErrors<FormValues>;
   formState: FormStateProxy<FormValues>;
   reset: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,10 +263,15 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
     refOrValidationOptions: ValidationOptions | Element | null,
     validationOptions?: ValidationOptions,
   ): ((ref: Element | null) => void) | void;
-  triggerValidation: (
-    payload?: FieldName<FormValues> | FieldName<FormValues>[] | string,
-    shouldRender?: boolean,
-  ) => Promise<boolean>;
+  triggerValidation(
+    payload?:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
+  ): Promise<boolean>;
   reRender: () => void;
   removeFieldEventListener: (field: Field, forceDelete?: boolean) => void;
   unregister(name: FieldName<FormValues>): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,15 +263,6 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
     refOrValidationOptions: ValidationOptions | Element | null,
     validationOptions?: ValidationOptions,
   ): ((ref: Element | null) => void) | void;
-  triggerValidation(
-    payload?:
-      | (IsFlatObject<FormValues> extends true
-          ? Extract<keyof FormValues, string>
-          : string)
-      | (IsFlatObject<FormValues> extends true
-          ? Extract<keyof FormValues, string>
-          : string)[],
-  ): Promise<boolean>;
   reRender: () => void;
   removeFieldEventListener: (field: Field, forceDelete?: boolean) => void;
   unregister(name: FieldName<FormValues>): void;
@@ -302,6 +293,15 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
   getValues<T extends string, U extends unknown>(
     payload: T,
   ): T extends keyof FormValues ? FormValues[T] : U;
+  triggerValidation(
+    payload?:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
+  ): Promise<boolean>;
   formState: FormStateProxy<FormValues>;
   mode: {
     isOnBlur: boolean;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -356,9 +356,7 @@ export function useForm<
   );
 
   const executeSchemaOrResolverValidation = React.useCallback(
-    async (
-      payload: FieldName<FormValues> | FieldName<FormValues>[],
-    ): Promise<boolean> => {
+    async (payload: string | string[]): Promise<boolean> => {
       const { errors } = await validateWithSchema<
         FormValues,
         ValidationContext
@@ -405,7 +403,13 @@ export function useForm<
 
   const triggerValidation = React.useCallback(
     async (
-      payload?: FieldName<FormValues> | FieldName<FormValues>[] | string,
+      payload?:
+        | (IsFlatObject<FormValues> extends true
+            ? Extract<keyof FormValues, string>
+            : string)
+        | (IsFlatObject<FormValues> extends true
+            ? Extract<keyof FormValues, string>
+            : string)[],
     ): Promise<boolean> => {
       const fields = payload || Object.keys(fieldsRef.current);
 


### PR DESCRIPTION
Fixed to auto completion works on flat objects.

flat object (payload: `keyof FormValues`):

<img width="512" alt="スクリーンショット 2020-04-21 23 20 26" src="https://user-images.githubusercontent.com/12913947/79877050-bba50800-8426-11ea-9ee6-b153e422a6bd.png">

nested object (payload: `string`):

<img width="512" alt="スクリーンショット 2020-04-21 23 19 50" src="https://user-images.githubusercontent.com/12913947/79877042-b942ae00-8426-11ea-8c78-c1e04907c800.png">

My related tweets: https://twitter.com/kotarella1110/status/1251890099425439745