### PR TITLE
improve clearError type

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -74,10 +74,15 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
     type: string | MultipleFieldErrors,
     message?: Message,
   ): void;
-  clearError(): void;
-  clearError(name: FieldName<FormValues>): void;
-  clearError(names: FieldName<FormValues>[]): void;
-  clearError(name?: FieldName<FormValues> | FieldName<FormValues>[]): void;
+  clearError(
+    name?:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
+  ): void;
   setValue<T extends string, U extends unknown>(
     name: T,
     value: T extends keyof FormValues

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -650,11 +650,14 @@ export function useForm<
     ],
   );
 
-  function clearError(): void;
-  function clearError(name: FieldName<FormValues>): void;
-  function clearError(names: FieldName<FormValues>[]): void;
   function clearError(
-    name?: FieldName<FormValues> | FieldName<FormValues>[],
+    name?:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
   ): void {
     if (name) {
       unset(errorsRef.current, isArray(name) ? name : [name]);


### PR DESCRIPTION
Fixed to auto completion works on flat objects.

flat object (typesafe):

<img width="512" alt="スクリーンショット 2020-04-23 23 27 28" src="https://user-images.githubusercontent.com/12913947/80110920-30f51200-85ba-11ea-81a6-e906e7878f2d.png">

nested object (no-typesafe):

<img width="512" alt="スクリーンショット 2020-04-23 23 27 55" src="https://user-images.githubusercontent.com/12913947/80110931-35212f80-85ba-11ea-88b8-a11b1070f49b.png">

