### PR TITLE
improve setError type

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -66,14 +66,20 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
     fields: string[],
     defaultValues?: DeepPartial<FormValues>,
   ): DeepPartial<FormValues>;
-  setError(name: ManualFieldError<FormValues>[]): void;
-  setError(name: FieldName<FormValues>, type: MultipleFieldErrors): void;
-  setError(name: FieldName<FormValues>, type: string, message?: Message): void;
   setError(
-    name: FieldName<FormValues> | ManualFieldError<FormValues>[],
-    type: string | MultipleFieldErrors,
+    name: IsFlatObject<FormValues> extends true
+      ? Extract<keyof FormValues, string>
+      : string,
+    type: MultipleFieldErrors,
+  ): void;
+  setError(
+    name: IsFlatObject<FormValues> extends true
+      ? Extract<keyof FormValues, string>
+      : string,
+    type: string,
     message?: Message,
   ): void;
+  setError(name: ManualFieldError<FormValues>[]): void;
   clearError(): void;
   clearError(name: FieldName<FormValues>): void;
   clearError(names: FieldName<FormValues>[]): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,8 +152,10 @@ export type FieldError = {
   isManual?: boolean;
 };
 
-export type ManualFieldError<FormValues> = {
-  name: FieldName<FormValues>;
+export type ManualFieldError<FormValues extends FieldValues> = {
+  name: IsFlatObject<FormValues> extends true
+    ? Extract<keyof FormValues, string>
+    : string;
   type: string;
   types?: MultipleFieldErrors;
   message?: Message;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -701,18 +701,26 @@ export function useForm<
     }
   };
 
-  function setError(name: ManualFieldError<FormValues>[]): void;
   function setError(
-    name: FieldName<FormValues>,
+    name: IsFlatObject<FormValues> extends true
+      ? Extract<keyof FormValues, string>
+      : string,
     type: MultipleFieldErrors,
   ): void;
   function setError(
-    name: FieldName<FormValues>,
+    name: IsFlatObject<FormValues> extends true
+      ? Extract<keyof FormValues, string>
+      : string,
     type: string,
     message?: Message,
   ): void;
+  function setError(name: ManualFieldError<FormValues>[]): void;
   function setError(
-    name: FieldName<FormValues> | ManualFieldError<FormValues>[],
+    name:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | ManualFieldError<FormValues>[],
     type: string | MultipleFieldErrors = '',
     message?: Message,
   ): void {


### PR DESCRIPTION
Fixed to auto completion works on flat objects.

flat object (typesafe):

<img width="512" alt="スクリーンショット 2020-04-23 23 56 18" src="https://user-images.githubusercontent.com/12913947/80115665-fc845480-85bf-11ea-91a7-2f23bc9e2f96.png">

<img width="512" alt="スクリーンショット 2020-04-23 23 58 23" src="https://user-images.githubusercontent.com/12913947/80115660-fb532780-85bf-11ea-9425-6d551623bb7d.png">

nested object (no-typesafe):

<img width="512" alt="スクリーンショット 2020-04-23 23 56 33" src="https://user-images.githubusercontent.com/12913947/80115664-fc845480-85bf-11ea-97a3-83e994429fa1.png">

<img width="512" alt="スクリーンショット 2020-04-24 0 00 44" src="https://user-images.githubusercontent.com/12913947/80115649-f8f0cd80-85bf-11ea-89dc-afa6e8e87857.png">
