### PR TITLE
improve unregister type

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -47,9 +47,15 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
     refOrValidationOptions: ValidationOptions | Element | null,
     validationOptions?: ValidationOptions,
   ): ((ref: Element | null) => void) | void;
-  unregister(name: FieldName<FormValues>): void;
-  unregister(names: FieldName<FormValues>[]): void;
-  unregister(names: FieldName<FormValues> | FieldName<FormValues>[]): void;
+  unregister(
+    name:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
+  ): void;
   watch(): FormValues;
   watch(option: { nest: boolean }): FormValues;
   watch<T extends string, U extends unknown>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,15 +271,6 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
   ): ((ref: Element | null) => void) | void;
   reRender: () => void;
   removeFieldEventListener: (field: Field, forceDelete?: boolean) => void;
-  unregister(
-    name:
-      | (IsFlatObject<FormValues> extends true
-          ? Extract<keyof FormValues, string>
-          : string)
-      | (IsFlatObject<FormValues> extends true
-          ? Extract<keyof FormValues, string>
-          : string)[],
-  ): void;
   setValue<T extends keyof FormValues>(
     namesWithValue: DeepPartial<Pick<FormValues, T>>[],
     shouldValidate?: boolean,
@@ -316,6 +307,15 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
           ? Extract<keyof FormValues, string>
           : string)[],
   ): Promise<boolean>;
+  unregister(
+    name:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
+  ): void;
   formState: FormStateProxy<FormValues>;
   mode: {
     isOnBlur: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,9 +271,15 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
   ): ((ref: Element | null) => void) | void;
   reRender: () => void;
   removeFieldEventListener: (field: Field, forceDelete?: boolean) => void;
-  unregister(name: FieldName<FormValues>): void;
-  unregister(names: FieldName<FormValues>[]): void;
-  unregister(names: FieldName<FormValues> | FieldName<FormValues>[]): void;
+  unregister(
+    name:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
+  ): void;
   setValue<T extends keyof FormValues>(
     namesWithValue: DeepPartial<Pick<FormValues, T>>[],
     shouldValidate?: boolean,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -815,13 +815,17 @@ export function useForm<
       : result;
   }
 
-  function unregister(name: FieldName<FormValues>): void;
-  function unregister(names: FieldName<FormValues>[]): void;
   function unregister(
-    names: FieldName<FormValues> | FieldName<FormValues>[],
+    name:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)[],
   ): void {
     if (fieldsRef.current) {
-      (isArray(names) ? names : [names]).forEach((fieldName) =>
+      (isArray(name) ? name : [name]).forEach((fieldName) =>
         removeFieldEventListenerAndRef(fieldsRef.current[fieldName], true),
       );
     }


### PR DESCRIPTION
Fixed to auto completion works on flat objects.

flat object (typesafe):

![スクリーンショット 2020-04-24 10 38 45](https://user-images.githubusercontent.com/12913947/80166067-f91cb780-8617-11ea-83e4-9dae49b0cb1a.png)

nested object (no-typesafe):

![スクリーンショット 2020-04-24 10 38 27](https://user-images.githubusercontent.com/12913947/80166069-fae67b00-8617-11ea-8945-5542c8ecec4a.png)
