### PR TITLE
improve register type

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -23,10 +23,10 @@ export type FormProps<FormValues extends FieldValues = FieldValues> = {
 } & FormContextValues<FormValues>;
 
 export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
-  register<Element extends FieldElement = FieldElement>(): (
-    ref: Element | null,
-  ) => void;
-  register<Element extends FieldElement = FieldElement>(
+  register<
+    Element extends FieldElement<FormValues> = FieldElement<FormValues>
+  >(): (ref: Element | null) => void;
+  register<Element extends FieldElement<FormValues> = FieldElement<FormValues>>(
     validationOptions: ValidationOptions,
   ): (ref: Element | null) => void;
   register(
@@ -35,7 +35,7 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
       : string,
     validationOptions?: ValidationOptions,
   ): void;
-  register<Element extends FieldElement = FieldElement>(
+  register<Element extends FieldElement<FormValues> = FieldElement<FormValues>>(
     ref: Element,
     validationOptions?: ValidationOptions,
   ): void;

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -7,7 +7,6 @@ import {
   OnSubmit,
   FieldElement,
   ValidationOptions,
-  FieldName,
   ManualFieldError,
   MultipleFieldErrors,
   Control,

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -29,24 +29,16 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
   register<Element extends FieldElement = FieldElement>(
     validationOptions: ValidationOptions,
   ): (ref: Element | null) => void;
-  register<Element extends FieldElement = FieldElement>(
-    name: FieldName<FormValues>,
+  register(
+    name: IsFlatObject<FormValues> extends true
+      ? Extract<keyof FormValues, string>
+      : string,
     validationOptions?: ValidationOptions,
-  ): void;
-  register<Element extends FieldElement = FieldElement>(
-    namesWithValidationOptions: Record<
-      FieldName<FormValues>,
-      ValidationOptions
-    >,
   ): void;
   register<Element extends FieldElement = FieldElement>(
     ref: Element,
     validationOptions?: ValidationOptions,
   ): void;
-  register<Element extends FieldElement = FieldElement>(
-    refOrValidationOptions: ValidationOptions | Element | null,
-    validationOptions?: ValidationOptions,
-  ): ((ref: Element | null) => void) | void;
   unregister(
     name:
       | (IsFlatObject<FormValues> extends true

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,8 +218,10 @@ export type RadioOrCheckboxOption = {
   mutationWatcher?: MutationWatcher;
 };
 
-export type CustomElement = {
-  name: string;
+export type CustomElement<FormValues extends FieldValues> = {
+  name: IsFlatObject<FormValues> extends true
+    ? Extract<keyof FormValues, string>
+    : string;
   type?: string;
   value?: any;
   checked?: boolean;
@@ -228,11 +230,11 @@ export type CustomElement = {
   focus?: () => void;
 };
 
-export type FieldElement =
+export type FieldElement<FormValues extends FieldValues = FieldValues> =
   | HTMLInputElement
   | HTMLSelectElement
   | HTMLTextAreaElement
-  | CustomElement;
+  | CustomElement<FormValues>;
 
 export type HandleChange = (evt: Event) => Promise<void | boolean>;
 
@@ -283,10 +285,10 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
           ? Extract<keyof FormValues, string>
           : string)[],
   ): Promise<boolean>;
-  register<Element extends FieldElement = FieldElement>(): (
-    ref: Element | null,
-  ) => void;
-  register<Element extends FieldElement = FieldElement>(
+  register<
+    Element extends FieldElement<FormValues> = FieldElement<FormValues>
+  >(): (ref: Element | null) => void;
+  register<Element extends FieldElement<FormValues> = FieldElement<FormValues>>(
     validationOptions: ValidationOptions,
   ): (ref: Element | null) => void;
   register(
@@ -295,7 +297,7 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
       : string,
     validationOptions?: ValidationOptions,
   ): void;
-  register<Element extends FieldElement = FieldElement>(
+  register<Element extends FieldElement<FormValues> = FieldElement<FormValues>>(
     ref: Element,
     validationOptions?: ValidationOptions,
   ): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,30 +245,6 @@ export type FormValuesFromErrors<Errors> = Errors extends FieldErrors<
 export type EventFunction = (args: any[]) => any;
 
 export type Control<FormValues extends FieldValues = FieldValues> = {
-  register<Element extends FieldElement = FieldElement>(): (
-    ref: Element | null,
-  ) => void;
-  register<Element extends FieldElement = FieldElement>(
-    validationOptions: ValidationOptions,
-  ): (ref: Element | null) => void;
-  register<Element extends FieldElement = FieldElement>(
-    name: FieldName<FormValues>,
-    validationOptions?: ValidationOptions,
-  ): void;
-  register<Element extends FieldElement = FieldElement>(
-    namesWithValidationOptions: Record<
-      FieldName<FormValues>,
-      ValidationOptions
-    >,
-  ): void;
-  register<Element extends FieldElement = FieldElement>(
-    ref: Element,
-    validationOptions?: ValidationOptions,
-  ): void;
-  register<Element extends FieldElement = FieldElement>(
-    refOrValidationOptions: ValidationOptions | Element | null,
-    validationOptions?: ValidationOptions,
-  ): ((ref: Element | null) => void) | void;
   reRender: () => void;
   removeFieldEventListener: (field: Field, forceDelete?: boolean) => void;
   setValue<T extends keyof FormValues>(
@@ -307,6 +283,22 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
           ? Extract<keyof FormValues, string>
           : string)[],
   ): Promise<boolean>;
+  register<Element extends FieldElement = FieldElement>(): (
+    ref: Element | null,
+  ) => void;
+  register<Element extends FieldElement = FieldElement>(
+    validationOptions: ValidationOptions,
+  ): (ref: Element | null) => void;
+  register(
+    name: IsFlatObject<FormValues> extends true
+      ? Extract<keyof FormValues, string>
+      : string,
+    validationOptions?: ValidationOptions,
+  ): void;
+  register<Element extends FieldElement = FieldElement>(
+    ref: Element,
+    validationOptions?: ValidationOptions,
+  ): void;
   unregister(
     name:
       | (IsFlatObject<FormValues> extends true

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -736,7 +736,7 @@ describe('useForm', () => {
 
     it('should trigger multiple fields validation', async () => {
       const { result } = renderHook(() =>
-        useForm<{ test: string }>({
+        useForm<{ test: string; test1: string }>({
           mode: VALIDATION_MODE.onChange,
         }),
       );
@@ -1292,7 +1292,7 @@ describe('useForm', () => {
 
     it('should return true when no validation is registered', () => {
       const { result } = renderHook(() =>
-        useForm<{ input: string }>({
+        useForm<{ test: string }>({
           mode: VALIDATION_MODE.onBlur,
         }),
       );
@@ -1306,7 +1306,7 @@ describe('useForm', () => {
 
     it('should return false when default value is not valid value', async () => {
       const { result } = renderHook(() =>
-        useForm<{ input: string }>({
+        useForm<{ input: string; issue: string }>({
           mode: VALIDATION_MODE.onChange,
         }),
       );
@@ -1332,7 +1332,7 @@ describe('useForm', () => {
 
     it('should return true when default value meet the validation criteria', async () => {
       const { result } = renderHook(() =>
-        useForm<{ input: string }>({
+        useForm<{ input: string; issue: string }>({
           mode: VALIDATION_MODE.onChange,
         }),
       );

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -831,7 +831,7 @@ export function useForm<
     }
   }
 
-  function registerFieldsRef<Element extends FieldElement>(
+  function registerFieldsRef<Element extends FieldElement<FormValues>>(
     ref: Element,
     validateOptions: ValidationOptions | null = {},
   ): ((name: FieldName<FormValues>) => void) | void {
@@ -952,23 +952,24 @@ export function useForm<
     }
   }
 
-  function register<Element extends FieldElement = FieldElement>(): (
-    ref: Element | null,
-  ) => void;
-  function register<Element extends FieldElement = FieldElement>(
-    validationOptions: ValidationOptions,
-  ): (ref: Element | null) => void;
+  function register<
+    Element extends FieldElement<FormValues> = FieldElement<FormValues>
+  >(): (ref: Element | null) => void;
+  function register<
+    Element extends FieldElement<FormValues> = FieldElement<FormValues>
+  >(validationOptions: ValidationOptions): (ref: Element | null) => void;
   function register(
     name: IsFlatObject<FormValues> extends true
       ? Extract<keyof FormValues, string>
       : string,
     validationOptions?: ValidationOptions,
   ): void;
-  function register<Element extends FieldElement = FieldElement>(
-    ref: Element,
-    validationOptions?: ValidationOptions,
-  ): void;
-  function register<Element extends FieldElement = FieldElement>(
+  function register<
+    Element extends FieldElement<FormValues> = FieldElement<FormValues>
+  >(ref: Element, validationOptions?: ValidationOptions): void;
+  function register<
+    Element extends FieldElement<FormValues> = FieldElement<FormValues>
+  >(
     refOrValidationOptions?:
       | (IsFlatObject<FormValues> extends true
           ? Extract<keyof FormValues, string>

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -958,22 +958,24 @@ export function useForm<
   function register<Element extends FieldElement = FieldElement>(
     validationOptions: ValidationOptions,
   ): (ref: Element | null) => void;
-  function register<Element extends FieldElement = FieldElement>(
-    name: FieldName<FormValues>,
+  function register(
+    name: IsFlatObject<FormValues> extends true
+      ? Extract<keyof FormValues, string>
+      : string,
     validationOptions?: ValidationOptions,
-  ): void;
-  function register<Element extends FieldElement = FieldElement>(
-    namesWithValidationOptions: Record<
-      FieldName<FormValues>,
-      ValidationOptions
-    >,
   ): void;
   function register<Element extends FieldElement = FieldElement>(
     ref: Element,
     validationOptions?: ValidationOptions,
   ): void;
   function register<Element extends FieldElement = FieldElement>(
-    refOrValidationOptions?: ValidationOptions | Element | null,
+    refOrValidationOptions?:
+      | (IsFlatObject<FormValues> extends true
+          ? Extract<keyof FormValues, string>
+          : string)
+      | ValidationOptions
+      | Element
+      | null,
     validationOptions?: ValidationOptions,
   ): ((ref: Element | null) => void) | void {
     if (isWindowUndefined) {


### PR DESCRIPTION
Fixed to auto completion works on flat objects.

flat object (typesafe):

![スクリーンショット 2020-04-24 14 17 08](https://user-images.githubusercontent.com/12913947/80177350-748d6180-8636-11ea-808b-72c027e6b591.png)

nested object (no-typesafe):

![スクリーンショット 2020-04-24 14 17 26](https://user-images.githubusercontent.com/12913947/80177342-71927100-8636-11ea-9421-d7ceee05c478.png)

