### PR TITLE
V6 useForm: global nest config for errors & values

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,8 @@ export type UseFormOptions<
   validationContext: ValidationContext;
   submitFocusError: boolean;
   validateCriteriaMode: 'firstError' | 'all';
+  nestedError: boolean;
+  nestedValue: boolean;
 }>;
 
 export type MutationWatcher = {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -75,6 +75,8 @@ export function useForm<
   defaultValues = {},
   submitFocusError = true,
   validateCriteriaMode,
+  nestedError = true,
+  nestedValue = true,
 }: UseFormOptions<FormValues, ValidationContext> = {}): FormContextValues<
   FormValues
 > {
@@ -789,7 +791,9 @@ export function useForm<
     const result =
       (!isEmptyObject(fieldValues) && fieldValues) || combinedDefaultValues;
 
-    return fieldNames && fieldNames.nest
+    return fieldNames
+      ? fieldNames.nest
+      : nestedValue
       ? transformToNestObject(result as FieldValues)
       : result;
   }
@@ -1160,7 +1164,9 @@ export function useForm<
       ? defaultValuesRef.current
       : fieldValues;
 
-    return payload && payload.nest
+    return payload
+      ? payload.nest
+      : nestedValue
       ? transformToNestObject(outputValues)
       : outputValues;
   }


### PR DESCRIPTION
I think the issue is between `values` and `errors` are not always in sync with each other, purpose to have two separate `config`. Let me know what do you think @kotarella1110 

By default `errors` and `values` will be all nested object, and yet still allow users to config to be flat. We can then probably have a separate type for Values and Errors (if errors are different from values).