### PR TITLE
V6: remove nest option

### DIFF
--- a/cypress/integration/watch.ts
+++ b/cypress/integration/watch.ts
@@ -7,7 +7,7 @@ context('watch form validation', () => {
     cy.get('input[name="testSingle"]').type('testSingle');
     cy.get('#HideTestSingle').contains('Hide Content TestSingle');
     cy.get('#watchAll').contains(
-      '{"testSingle":"testSingle","test[0]":"","test[1]":"","testObject.firstName":"","testObject.lastName":"","toggle":false}',
+      '{"testSingle":"testSingle","test":["",""],"testObject":{"firstName":"","lastName":""},"toggle":false}',
     );
 
     cy.get('input[name="test[0]"]').type('bill');
@@ -15,7 +15,7 @@ context('watch form validation', () => {
     cy.get('#testData').contains('["bill","luo"]');
     cy.get('#testArray').contains('{"test[0]":"bill","test[1]":"luo"}');
     cy.get('#watchAll').contains(
-      '{"testSingle":"testSingle","test[0]":"bill","test[1]":"luo","testObject.firstName":"","testObject.lastName":"","toggle":false}',
+      '{"testSingle":"testSingle","test":["bill","luo"],"testObject":{"firstName":"","lastName":""},"toggle":false}',
     );
 
     cy.get('input[name="testObject.firstName"').type('bill');
@@ -23,7 +23,7 @@ context('watch form validation', () => {
     cy.get('#testObject').contains('{"firstName":"bill","lastName":"luo"}');
     cy.get('#testArray').contains('{"test[0]":"bill","test[1]":"luo"}');
     cy.get('#watchAll').contains(
-      '{"testSingle":"testSingle","test[0]":"bill","test[1]":"luo","testObject.firstName":"bill","testObject.lastName":"luo","toggle":false}',
+      '{"testSingle":"testSingle","test":["bill","luo"],"testObject":{"firstName":"bill","lastName":"luo"},"toggle":false}',
     );
 
     cy.get('#hideContent').should('not.exist');
@@ -31,7 +31,7 @@ context('watch form validation', () => {
     cy.get('#hideContent').contains('Hide Content');
 
     cy.get('#watchAll').contains(
-      '{"testSingle":"testSingle","test[0]":"bill","test[1]":"luo","testObject.firstName":"bill","testObject.lastName":"luo","toggle":true}',
+      '{"testSingle":"testSingle","test":["bill","luo"],"testObject":{"firstName":"bill","lastName":"luo"},"toggle":true}',
     );
   });
 });

--- a/cypress/integration/watchDefaultValues.ts
+++ b/cypress/integration/watchDefaultValues.ts
@@ -4,11 +4,17 @@ context('watchDefaultValues', () => {
 
     cy.get('#watchAll').should(
       'have.text',
-      '{"test":"test","test1":{"firstName":"firstName","lastName":["lastName0","lastName1"],"deep":{"nest":"nest"}},"flatName[1].whatever":"flat"}',
+      '{"test":"test","test1":{"firstName":"firstName","lastName":["lastName0","lastName1"],"deep":{"nest":"nest"}},"flatName":[null,{"whatever":"flat"}]}',
     );
-    cy.get('#array').should('have.text', '{"test":"test","flatName[1].whatever":"flat"}');
+    cy.get('#array').should(
+      'have.text',
+      '{"test":"test","flatName[1].whatever":"flat"}',
+    );
     cy.get('#getArray').should('have.text', '["lastName0","lastName1"]');
-    cy.get('#object').should('have.text', '{"test":"test","test1.firstName":"firstName"}');
+    cy.get('#object').should(
+      'have.text',
+      '{"test":"test","test1.firstName":"firstName"}',
+    );
     cy.get('#single').should('have.text', '"firstName"');
     cy.get('#singleDeepArray').should('have.text', '"lastName0"');
   });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -739,7 +739,6 @@ export function useForm<
   }
 
   function watch(): FormValues;
-  function watch(option: { nest: boolean }): FormValues;
   function watch<T extends string, U extends unknown>(
     field: T,
     defaultValue?: T extends keyof FormValues
@@ -798,12 +797,10 @@ export function useForm<
 
     isWatchAllRef.current = true;
 
-    const result =
-      (!isEmptyObject(fieldValues) && fieldValues) || combinedDefaultValues;
-
-    return fieldNames && fieldNames.nest
-      ? transformToNestObject(result as FieldValues)
-      : result;
+    return transformToNestObject(
+      (!isEmptyObject(fieldValues) && fieldValues) ||
+        (combinedDefaultValues as FieldValues),
+    );
   }
 
   function unregister(
@@ -1150,13 +1147,6 @@ export function useForm<
   function getValues(): IsFlatObject<FormValues> extends false
     ? Record<string, unknown>
     : FormValues;
-  function getValues<T extends boolean>(payload: {
-    nest: T;
-  }): T extends true
-    ? FormValues
-    : IsFlatObject<FormValues> extends true
-    ? FormValues
-    : Record<string, unknown>;
   function getValues<T extends string, U extends unknown>(
     payload: T,
   ): T extends keyof FormValues ? FormValues[T] : U;
@@ -1168,13 +1158,10 @@ export function useForm<
     }
 
     const fieldValues = getFieldsValues(fieldsRef.current);
-    const outputValues = isEmptyObject(fieldValues)
-      ? defaultValuesRef.current
-      : fieldValues;
 
-    return payload && payload.nest
-      ? transformToNestObject(outputValues)
-      : outputValues;
+    return transformToNestObject(
+      isEmptyObject(fieldValues) ? defaultValuesRef.current : fieldValues,
+    );
   }
 
   React.useEffect(


### PR DESCRIPTION
- [x] remove `nest` option for `watch`& `getValues`, so data return from both methods will be in `FormValues` shape.

```diff
- getValues({ nest: true }); // { test: { data: 'test' }}
- watch({ nest: true });  // { test: { data: 'test' }}
+ getValues(); // { test: { data: 'test' }}
+ watch();  // { test: { data: 'test' }}
````
