### PR TITLE
Add an example of forwardRef usage to the Examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ you can view the source code within the folder or visit code sand box to see how
 | Custom Validation                       | https://codesandbox.io/s/8n937m64o9                                           |
 | Conditional Fields                      | https://codesandbox.io/s/13ykqx4wx7                                           |
 | Custom Input                            | https://codesandbox.io/s/72j69vnk1x                                           |
+| Custom Input with ForwardRef         | https://codesandbox.io/s/rhfex-en254                                          |
 | Custom Masked Input                     | https://codesandbox.io/s/trusting-agnesi-rdi5m                                |
 | Custom Masked Input with Controller     | https://codesandbox.io/s/morning-sunset-8n3sx                                 |
 | Controlled Input                        | https://codesandbox.io/s/j36w7xkk7w                                           |
@@ -37,4 +38,3 @@ you can view the source code within the folder or visit code sand box to see how
 | ValidationSchema                        | https://codesandbox.io/s/928po918qr                                           |
 | Validation On Blur                      | https://codesandbox.io/s/w7p3km6nyw                                           |
 | Validation On Change                    | https://codesandbox.io/s/74zw1oqozx                                           |
-| ForwardRef To Pass Ref Prop Down        | https://codesandbox.io/s/rhfex-en254                                          |

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,3 +37,4 @@ you can view the source code within the folder or visit code sand box to see how
 | ValidationSchema                        | https://codesandbox.io/s/928po918qr                                           |
 | Validation On Blur                      | https://codesandbox.io/s/w7p3km6nyw                                           |
 | Validation On Change                    | https://codesandbox.io/s/74zw1oqozx                                           |
+| ForwardRef To Pass Ref Prop Down        | https://codesandbox.io/s/rhfex-en254                                          |

--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 
 export default function App() {
   const { register, handleSubmit } = useForm();
-  const onSubmit = (data) => {
+  const onSubmit = data => {
     alert(JSON.stringify(data));
   };
 

--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 
 export default function App() {
   const { register, handleSubmit } = useForm();
-  const onSubmit = data => {
+  const onSubmit = (data) => {
     alert(JSON.stringify(data));
   };
 

--- a/examples/forwardRefToPassRefProp.tsx
+++ b/examples/forwardRefToPassRefProp.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { useForm } from 'react-hook-form';
+
+const MyInput = React.forwardRef(
+  ({ placeholder, id, type, name, className, children }, ref) => {
+    return (
+      <label htmlFor={id}>
+        <input
+          placeholder={placeholder}
+          type={type}
+          id={id}
+          aria-label={placeholder}
+          ref={ref}
+          name={name}
+          className={className}
+        />
+        {children}
+      </label>
+    );
+  },
+);
+
+const MyButton = ({ type, id, value, form, children }) => {
+  return (
+    <label className={id} htmlFor={id}>
+      <button value={value} type={type} form={form} id={id}>
+        {children}
+      </button>
+    </label>
+  );
+};
+
+const MyForm = () => {
+  const { register, handleSubmit, errors } = useForm({ mode: 'onBlur' });
+  const onSubmit = (data, event) => {
+    event.target.reset(); // reset the form after submission
+    console.log(data); // handle the data here
+  };
+  return (
+    <>
+      <form id="email-submit" onSubmit={handleSubmit(onSubmit)}>
+        <MyInput
+          placeholder="First Name"
+          type="text"
+          id="firstName"
+          aria-invalid={errors.firstName ? 'true' : 'false'}
+          aria-describedby="error-firstName-required error-firstName-maxLength"
+          className={errors.firstName ? 'inputError' : ''}
+          ref={register({
+            required: (
+              <p role="alert" id="error-firstName-required">
+                First Name cannot be empty
+              </p>
+            ),
+            minLength: {
+              value: 2,
+              message: (
+                <p role="alert" id="error-firstName-maxLength">
+                  First Name must be at least 2 characters
+                </p>
+              ),
+            },
+          })}
+          name="firstName"
+        >
+          {errors.firstName && errors.firstName.message}
+        </MyInput>
+
+        <MyInput
+          id="email"
+          type="email"
+          placeholder="Email Address"
+          name="email"
+          aria-invalid={errors.email ? 'true' : 'false'}
+          aria-describedby="error-email-required error-email-pattern"
+          className={errors.email ? 'inputError' : ''}
+          ref={register({
+            required: (
+              <p role="alert" id="error-email-required">
+                Email cannot be empty
+              </p>
+            ),
+            pattern: {
+              value: /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,
+              message: (
+                <p role="alert" id="error-email-pattern">
+                  Email must be a valid email address
+                </p>
+              ),
+            },
+          })}
+        >
+          {errors.email && errors.email.message}
+        </MyInput>
+
+        <MyButton value="submit" type="submit" form="email-submit" id="my-form">
+          Subscribe your email
+        </MyButton>
+      </form>
+    </>
+  );
+};
+export default function App() {
+  return <MyForm />;
+}

--- a/examples/forwardRefToPassRefProp.tsx
+++ b/examples/forwardRefToPassRefProp.tsx
@@ -3,104 +3,24 @@ import ReactDOM from 'react-dom';
 import { useForm } from 'react-hook-form';
 
 const MyInput = React.forwardRef(
-  ({ placeholder, id, type, name, className, children }, ref) => {
+  ({ name, children }, ref) => {
     return (
-      <label htmlFor={id}>
-        <input
-          placeholder={placeholder}
-          type={type}
-          id={id}
-          aria-label={placeholder}
-          ref={ref}
-          name={name}
-          className={className}
-        />
-        {children}
-      </label>
+      <input ref={ref} name={name} />
     );
   },
 );
 
-const MyButton = ({ type, id, value, form, children }) => {
-  return (
-    <label className={id} htmlFor={id}>
-      <button value={value} type={type} form={form} id={id}>
-        {children}
-      </button>
-    </label>
-  );
-};
-
-const MyForm = () => {
-  const { register, handleSubmit, errors } = useForm({ mode: 'onBlur' });
-  const onSubmit = (data, event) => {
-    event.target.reset(); // reset the form after submission
-    console.log(data); // handle the data here
-  };
-  return (
-    <>
-      <form id="email-submit" onSubmit={handleSubmit(onSubmit)}>
-        <MyInput
-          placeholder="First Name"
-          type="text"
-          id="firstName"
-          aria-invalid={errors.firstName ? 'true' : 'false'}
-          aria-describedby="error-firstName-required error-firstName-maxLength"
-          className={errors.firstName ? 'inputError' : ''}
-          ref={register({
-            required: (
-              <p role="alert" id="error-firstName-required">
-                First Name cannot be empty
-              </p>
-            ),
-            minLength: {
-              value: 2,
-              message: (
-                <p role="alert" id="error-firstName-maxLength">
-                  First Name must be at least 2 characters
-                </p>
-              ),
-            },
-          })}
-          name="firstName"
-        >
-          {errors.firstName && errors.firstName.message}
-        </MyInput>
-
-        <MyInput
-          id="email"
-          type="email"
-          placeholder="Email Address"
-          name="email"
-          aria-invalid={errors.email ? 'true' : 'false'}
-          aria-describedby="error-email-required error-email-pattern"
-          className={errors.email ? 'inputError' : ''}
-          ref={register({
-            required: (
-              <p role="alert" id="error-email-required">
-                Email cannot be empty
-              </p>
-            ),
-            pattern: {
-              value: /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,
-              message: (
-                <p role="alert" id="error-email-pattern">
-                  Email must be a valid email address
-                </p>
-              ),
-            },
-          })}
-        >
-          {errors.email && errors.email.message}
-        </MyInput>
-
-        <MyButton value="submit" type="submit" form="email-submit" id="my-form">
-          Subscribe your email
-        </MyButton>
-      </form>
-    </>
-  );
-};
 export default function App() {
-  return <MyForm />;
+  const { register, handleSubmit } = useForm();
+  const onSubmit = (data, event) => {
+    console.log(data);
+  };
+  
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <MyInput ref={register} name="firstName" />
+
+      <button>Submit</button>
+    </form>
+  );
 }

--- a/examples/forwardRefToPassRefProp.tsx
+++ b/examples/forwardRefToPassRefProp.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { useForm } from 'react-hook-form';
 
-const MyInput = React.forwardRef(
-  ({ name, children }, ref) => {
+const Input = React.forwardRef(
+  ({ name }, ref) => {
     return (
       <input ref={ref} name={name} />
     );
@@ -18,7 +17,8 @@ export default function App() {
   
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <MyInput ref={register} name="firstName" />
+      <Input ref={register} name="firstName" />
+      <Input ref={register} name="lastName" />
 
       <button>Submit</button>
     </form>


### PR DESCRIPTION
I added an example of how to pass the Ref down to a functional component by wrapping the component in React.forwardRef.

Added a link in the README to a working version of the example on Codesandbox. 

https://codesandbox.io/s/rhfex-en254

Please let me know if any changes are needed.

(I don't know about this TypeScript stuff, but I kept the .tsx file convention to match the docs...) 