### PR TITLE
improve generics type naming

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,10 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-object-literal-type-assertion': 'off',
+    '@typescript-eslint/generic-type-naming': [
+      'error',
+      '(^[A-Z]\\d?$|^T[A-Z][a-zA-Z]+$)',
+    ],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',
     'react/display-name': 'warn',

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -26,24 +26,20 @@ export type FormProps<TFieldValues extends FieldValues = FieldValues> = {
 export type FormContextValues<
   TFieldValues extends FieldValues = FieldValues
 > = {
-  register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(): (ref: Element | null) => void;
-  register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(
+  register<TFieldElement extends FieldElement<TFieldValues>>(): (
+    ref: TFieldElement | null,
+  ) => void;
+  register<TFieldElement extends FieldElement<TFieldValues>>(
     validationOptions: ValidationOptions,
-  ): (ref: Element | null) => void;
+  ): (ref: TFieldElement | null) => void;
   register(
     name: IsFlatObject<TFieldValues> extends true
       ? Extract<keyof TFieldValues, string>
       : string,
     validationOptions?: ValidationOptions,
   ): void;
-  register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(
-    ref: Element,
+  register<TFieldElement extends FieldElement<TFieldValues>>(
+    ref: TFieldElement,
     validationOptions?: ValidationOptions,
   ): void;
   unregister(

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -10,11 +10,11 @@ import { VALIDATION_MODE, VALUE } from './constants';
 import { Control, ControllerProps, EventFunction, Field } from './types';
 
 const Controller = <
-  As extends
+  TAs extends
     | React.ReactElement
     | React.ComponentType<any>
     | keyof JSX.IntrinsicElements,
-  ControlProp extends Control = Control
+  TControl extends Control = Control
 >({
   name,
   rules,
@@ -28,7 +28,7 @@ const Controller = <
   control,
   onFocus,
   ...rest
-}: ControllerProps<As, ControlProp>) => {
+}: ControllerProps<TAs, TControl>) => {
   const methods = useFormContext();
   const {
     defaultValuesRef,

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -9,9 +9,9 @@ import {
 } from './types';
 
 const ErrorMessage = <
-  Errors extends FieldErrors<any>,
-  Name extends FieldName<FieldValuesFromErrors<Errors>>,
-  As extends
+  TFieldErrors extends FieldErrors<any>,
+  TFieldName extends FieldName<FieldValuesFromErrors<TFieldErrors>>,
+  TAs extends
     | undefined
     | React.ReactElement
     | React.ComponentType<any>
@@ -23,7 +23,7 @@ const ErrorMessage = <
   message,
   children,
   ...rest
-}: ErrorMessageProps<Errors, Name, As>) => {
+}: ErrorMessageProps<TFieldErrors, TFieldName, TAs>) => {
   const methods = useFormContext();
   const error = get(errors || methods.errors, name);
 

--- a/src/logic/mapIds.ts
+++ b/src/logic/mapIds.ts
@@ -3,15 +3,15 @@ import isObject from '../utils/isObject';
 import generateId from './generateId';
 import { ArrayField } from '../types';
 
-export const appendId = <Value extends object, KeyName extends string>(
-  value: Value,
-  keyName: KeyName,
-): Partial<ArrayField<Value, KeyName>> => ({
+export const appendId = <TValue extends object, TKeyName extends string>(
+  value: TValue,
+  keyName: TKeyName,
+): Partial<ArrayField<TValue, TKeyName>> => ({
   [keyName]: generateId(),
   ...(isObject(value) ? value : { value }),
 });
 
-export const mapIds = <Data extends object, KeyName extends string>(
-  data: Data | Data[],
-  keyName: KeyName,
+export const mapIds = <TData extends object, TKeyName extends string>(
+  data: TData | TData[],
+  keyName: TKeyName,
 ) => (isArray(data) ? data : []).map((value) => appendId(value, keyName));

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,11 +33,9 @@ export type FieldValue<
 
 declare const $NestedValue: unique symbol;
 
-export type NestedValue<
-  TNestedValue extends any[] | object = any[] | object
-> = {
+export type NestedValue<TValue extends any[] | object = any[] | object> = {
   [$NestedValue]: never;
-} & TNestedValue;
+} & TValue;
 
 export type NonUndefined<T> = T extends undefined ? never : T;
 
@@ -82,7 +80,7 @@ export type SchemaValidateOptions = Partial<{
   context: any;
 }>;
 
-export type EmptyObject = { [key in string | number]: never };
+export type EmptyObject = { [K in string | number]: never };
 
 export type SchemaValidationSuccess<
   TFieldValues extends FieldValues = FieldValues
@@ -104,22 +102,22 @@ export type SchemaValidationResult<
 
 export type ValidationResolver<
   TFieldValues extends FieldValues = FieldValues,
-  ValidationContext extends object = object
+  TValidationContext extends object = object
 > = (
   values: TFieldValues,
-  validationContext?: ValidationContext,
+  validationContext?: TValidationContext,
   validateAllFieldCriteria?: boolean,
 ) => Promise<SchemaValidationResult<TFieldValues>>;
 
 export type UseFormOptions<
   TFieldValues extends FieldValues = FieldValues,
-  ValidationContext extends object = object
+  TValidationContext extends object = object
 > = Partial<{
   mode: Mode;
   reValidateMode: Mode;
   defaultValues: Unpacked<DeepPartial<TFieldValues>>;
-  validationResolver: ValidationResolver<TFieldValues, ValidationContext>;
-  validationContext: ValidationContext;
+  validationResolver: ValidationResolver<TFieldValues, TValidationContext>;
+  validationContext: TValidationContext;
   submitFocusError: boolean;
   validateCriteriaMode: 'firstError' | 'all';
 }>;
@@ -133,14 +131,14 @@ export type Message = string | React.ReactElement;
 
 export type ValidationValue = boolean | number | string | RegExp;
 
-export type ValidationOption<Value extends ValidationValue = ValidationValue> =
-  | Value
-  | ValidationValueMessage<Value>;
+export type ValidationOption<
+  TValidationValue extends ValidationValue = ValidationValue
+> = TValidationValue | ValidationValueMessage<TValidationValue>;
 
 export type ValidationValueMessage<
-  Value extends ValidationValue = ValidationValue
+  TValidationValue extends ValidationValue = ValidationValue
 > = {
-  value: Value;
+  value: TValidationValue;
   message: Message;
 };
 
@@ -187,22 +185,22 @@ export type FieldRefs<TFieldValues extends FieldValues> = Partial<
   Record<FieldName<TFieldValues>, Field>
 >;
 
-export type NestDataObject<TFieldValues, Value> = {
-  [Key in keyof TFieldValues]?: IsAny<TFieldValues[Key]> extends true
+export type NestDataObject<T, TValue> = {
+  [K in keyof T]?: IsAny<T[K]> extends true
     ? any
-    : TFieldValues[Key] extends NestedValue
-    ? Value
-    : TFieldValues[Key] extends Date
-    ? Value
-    : TFieldValues[Key] extends FileList
-    ? Value
-    : TFieldValues[Key] extends Array<infer U>
-    ? Array<NestDataObject<U, Value>>
-    : TFieldValues[Key] extends ReadonlyArray<infer U>
-    ? ReadonlyArray<NestDataObject<U, Value>>
-    : TFieldValues[Key] extends object
-    ? NestDataObject<TFieldValues[Key], Value>
-    : Value;
+    : T[K] extends NestedValue
+    ? TValue
+    : T[K] extends Date
+    ? TValue
+    : T[K] extends FileList
+    ? TValue
+    : T[K] extends Array<infer U>
+    ? Array<NestDataObject<U, TValue>>
+    : T[K] extends ReadonlyArray<infer U>
+    ? ReadonlyArray<NestDataObject<U, TValue>>
+    : T[K] extends object
+    ? NestDataObject<T[K], TValue>
+    : TValue;
 };
 
 export type FieldErrors<TFieldValues> = NestDataObject<
@@ -222,7 +220,7 @@ export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
   isValid: boolean;
 };
 
-export type ReadFormState = { [P in keyof FormStateProxy]: boolean };
+export type ReadFormState = { [K in keyof FormStateProxy]: boolean };
 
 export type RadioOrCheckboxOption = {
   ref: HTMLInputElement;
@@ -249,11 +247,9 @@ export type FieldElement<TFieldValues extends FieldValues = FieldValues> =
 
 export type HandleChange = (evt: Event) => Promise<void | boolean>;
 
-export type FieldValuesFromErrors<Errors> = Errors extends FieldErrors<
-  infer FormValues
->
-  ? FormValues
-  : never;
+export type FieldValuesFromErrors<
+  TFieldErrors
+> = TFieldErrors extends FieldErrors<infer TFieldValues> ? TFieldValues : never;
 
 export type EventFunction = (...args: any[]) => any;
 
@@ -291,24 +287,20 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = {
           ? Extract<keyof TFieldValues, string>
           : string)[],
   ): Promise<boolean>;
-  register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(): (ref: Element | null) => void;
-  register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(
+  register<TFieldElement extends FieldElement<TFieldValues>>(): (
+    ref: TFieldElement | null,
+  ) => void;
+  register<TFieldElement extends FieldElement<TFieldValues>>(
     validationOptions: ValidationOptions,
-  ): (ref: Element | null) => void;
+  ): (ref: TFieldElement | null) => void;
   register(
     name: IsFlatObject<TFieldValues> extends true
       ? Extract<keyof TFieldValues, string>
       : string,
     validationOptions?: ValidationOptions,
   ): void;
-  register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(
-    ref: Element,
+  register<TFieldElement extends FieldElement<TFieldValues>>(
+    ref: TFieldElement,
     validationOptions?: ValidationOptions,
   ): void;
   unregister(
@@ -362,26 +354,26 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = {
 
 export type Assign<T extends object, U extends object> = T & Omit<U, keyof T>;
 
-export type AsProps<As> = As extends undefined
+export type AsProps<TAs> = TAs extends undefined
   ? {}
-  : As extends React.ReactElement
+  : TAs extends React.ReactElement
   ? { [key: string]: any }
-  : As extends React.ComponentType<infer P>
+  : TAs extends React.ComponentType<infer P>
   ? P
-  : As extends keyof JSX.IntrinsicElements
-  ? JSX.IntrinsicElements[As]
+  : TAs extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[TAs]
   : never;
 
 export type ControllerProps<
-  As extends
+  TAs extends
     | React.ReactElement
     | React.ComponentType<any>
     | keyof JSX.IntrinsicElements,
-  ControlProp extends Control = Control
+  TControl extends Control = Control
 > = Assign<
   {
     name: string;
-    as: As;
+    as: TAs;
     rules?: ValidationOptions;
     onChange?: EventFunction;
     onFocus?: () => void;
@@ -391,46 +383,46 @@ export type ControllerProps<
     onBlurName?: string;
     valueName?: string;
     defaultValue?: unknown;
-    control?: ControlProp;
+    control?: TControl;
   },
-  AsProps<As>
+  AsProps<TAs>
 >;
 
 export type ErrorMessageProps<
-  Errors extends FieldErrors<any>,
-  Name extends FieldName<FieldValuesFromErrors<Errors>>,
-  As extends
+  TFieldErrors extends FieldErrors<any>,
+  TName extends FieldName<FieldValuesFromErrors<TFieldErrors>>,
+  TAs extends
     | undefined
     | React.ReactElement
     | React.ComponentType<any>
     | keyof JSX.IntrinsicElements = undefined
 > = Assign<
   {
-    as?: As;
-    errors?: Errors;
-    name: Name;
+    as?: TAs;
+    errors?: TFieldErrors;
+    name: TName;
     message?: Message;
     children?: (data: {
       message: Message;
       messages?: MultipleFieldErrors;
     }) => React.ReactNode;
   },
-  AsProps<As>
+  AsProps<TAs>
 >;
 
 export type UseFieldArrayProps<
-  KeyName extends string = 'id',
-  ControlProp extends Control = Control
+  TKeyName extends string = 'id',
+  TControl extends Control = Control
 > = {
   name: string;
-  keyName?: KeyName;
-  control?: ControlProp;
+  keyName?: TKeyName;
+  control?: TControl;
 };
 
 export type ArrayField<
-  FormArrayValues extends FieldValues = FieldValues,
-  KeyName extends string = 'id'
-> = FormArrayValues & Record<KeyName, string>;
+  TFieldArrayValues extends FieldValues = FieldValues,
+  TKeyName extends string = 'id'
+> = TFieldArrayValues & Record<TKeyName, string>;
 
 export type OmitResetState = Partial<{
   errors: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ export type DeepPartial<T> = {
     ? Array<DeepPartial<U>>
     : T[K] extends ReadonlyArray<infer U>
     ? ReadonlyArray<DeepPartial<U>>
-    : T[K] extends { [key: string]: unknown }
+    : T[K] extends Record<string, unknown>
     ? DeepPartial<T[K]>
     : T[K];
 };
@@ -203,12 +203,14 @@ export type NestDataObject<T, TValue> = {
     : TValue;
 };
 
-export type FieldErrors<TFieldValues> = NestDataObject<
-  TFieldValues,
-  FieldError
->;
+export type FieldErrors<
+  TFieldValues extends FieldValues = FieldValues
+> = NestDataObject<TFieldValues, FieldError>;
 
-export type Touched<TFieldValues> = NestDataObject<TFieldValues, true>;
+export type Touched<TFieldValues extends FieldValues> = NestDataObject<
+  TFieldValues,
+  true
+>;
 
 export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
   dirty: boolean;
@@ -357,7 +359,7 @@ export type Assign<T extends object, U extends object> = T & Omit<U, keyof T>;
 export type AsProps<TAs> = TAs extends undefined
   ? {}
   : TAs extends React.ReactElement
-  ? { [key: string]: any }
+  ? Record<string, any>
   : TAs extends React.ComponentType<infer P>
   ? P
   : TAs extends keyof JSX.IntrinsicElements
@@ -389,7 +391,7 @@ export type ControllerProps<
 >;
 
 export type ErrorMessageProps<
-  TFieldErrors extends FieldErrors<any>,
+  TFieldErrors extends FieldErrors,
   TName extends FieldName<FieldValuesFromErrors<TFieldErrors>>,
   TAs extends
     | undefined

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -26,14 +26,14 @@ import {
 } from './types';
 
 export const useFieldArray = <
-  FormArrayValues extends FieldValues = FieldValues,
-  KeyName extends string = 'id',
-  ControlProp extends Control = Control
+  TFieldArrayValues extends FieldValues = FieldValues,
+  TKeyName extends string = 'id',
+  TControl extends Control = Control
 >({
   control,
   name,
-  keyName = 'id' as KeyName,
-}: UseFieldArrayProps<KeyName, ControlProp>) => {
+  keyName = 'id' as TKeyName,
+}: UseFieldArrayProps<TKeyName, TControl>) => {
   const methods = useFormContext();
   const {
     isWatchAllRef,
@@ -64,15 +64,15 @@ export const useFieldArray = <
       [],
     ),
   ];
-  const memoizedDefaultValues = React.useRef<Partial<FormArrayValues>[]>(
+  const memoizedDefaultValues = React.useRef<Partial<TFieldArrayValues>[]>(
     getDefaultValues(),
   );
   const [fields, setField] = React.useState<
-    Partial<ArrayField<FormArrayValues, KeyName>>[]
+    Partial<ArrayField<TFieldArrayValues, TKeyName>>[]
   >(mapIds(memoizedDefaultValues.current, keyName));
   const [isDeleted, setIsDeleted] = React.useState(false);
   const allFields = React.useRef<
-    Partial<ArrayField<FormArrayValues, KeyName>>[]
+    Partial<ArrayField<TFieldArrayValues, TKeyName>>[]
   >(fields);
   const isNameKey = isKey(name);
 
@@ -82,11 +82,11 @@ export const useFieldArray = <
     fieldArrayDefaultValues.current[name] = memoizedDefaultValues.current;
   }
 
-  const appendValueWithKey = (values: Partial<FormArrayValues>[]) =>
-    values.map((value: Partial<FormArrayValues>) => appendId(value, keyName));
+  const appendValueWithKey = (values: Partial<TFieldArrayValues>[]) =>
+    values.map((value: Partial<TFieldArrayValues>) => appendId(value, keyName));
 
   const setFieldAndValidState = (
-    fieldsValues: Partial<ArrayField<FormArrayValues, KeyName>>[],
+    fieldsValues: Partial<ArrayField<TFieldArrayValues, TKeyName>>[],
   ) => {
     setField(fieldsValues);
 
@@ -108,7 +108,7 @@ export const useFieldArray = <
     shouldRender?: boolean;
     isRemove?: boolean;
     index?: number | number[];
-    value?: Partial<FormArrayValues> | Partial<FormArrayValues>[];
+    value?: Partial<TFieldArrayValues> | Partial<TFieldArrayValues>[];
   } = {}) => {
     let render = shouldRender;
     const values = isArray(value) ? value : [value];
@@ -191,7 +191,9 @@ export const useFieldArray = <
     }
   };
 
-  const resetFields = (flagOrFields?: (Partial<FormArrayValues> | null)[]) => {
+  const resetFields = (
+    flagOrFields?: (Partial<TFieldArrayValues> | null)[],
+  ) => {
     if (readFormStateRef.current.dirty) {
       isDirtyRef.current = isUndefined(flagOrFields)
         ? true
@@ -209,7 +211,7 @@ export const useFieldArray = <
   };
 
   const mapCurrentFieldsValueWithState = () => {
-    const currentFieldsValue: Partial<FormArrayValues>[] = get(
+    const currentFieldsValue: Partial<TFieldArrayValues>[] = get(
       getValues(),
       name,
     );
@@ -225,7 +227,7 @@ export const useFieldArray = <
   };
 
   const append = (
-    value: Partial<FormArrayValues> | Partial<FormArrayValues>[],
+    value: Partial<TFieldArrayValues> | Partial<TFieldArrayValues>[],
   ) => {
     setFieldAndValidState([
       ...allFields.current,
@@ -237,7 +239,7 @@ export const useFieldArray = <
   };
 
   const prepend = (
-    value: Partial<FormArrayValues> | Partial<FormArrayValues>[],
+    value: Partial<TFieldArrayValues> | Partial<TFieldArrayValues>[],
   ) => {
     let shouldRender = false;
 
@@ -347,7 +349,7 @@ export const useFieldArray = <
 
   const insert = (
     index: number,
-    value: Partial<FormArrayValues> | Partial<FormArrayValues>[],
+    value: Partial<TFieldArrayValues> | Partial<TFieldArrayValues>[],
   ) => {
     mapCurrentFieldsValueWithState();
     resetFields(insertAt(getFieldValueByName(fieldsRef.current, name), index));

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -67,7 +67,7 @@ import {
 
 export function useForm<
   TFieldValues extends FieldValues = FieldValues,
-  ValidationContext extends object = object
+  TValidationContext extends object = object
 >({
   mode = VALIDATION_MODE.onSubmit,
   reValidateMode = VALIDATION_MODE.onChange,
@@ -76,7 +76,7 @@ export function useForm<
   defaultValues = {} as Unpacked<DeepPartial<TFieldValues>>,
   submitFocusError = true,
   validateCriteriaMode,
-}: UseFormOptions<TFieldValues, ValidationContext> = {}): FormContextValues<
+}: UseFormOptions<TFieldValues, TValidationContext> = {}): FormContextValues<
   TFieldValues
 > {
   const fieldsRef = React.useRef<FieldRefs<TFieldValues>>({});
@@ -827,8 +827,8 @@ export function useForm<
     }
   }
 
-  function registerFieldsRef<Element extends FieldElement<TFieldValues>>(
-    ref: Element,
+  function registerFieldsRef<TFieldElement extends FieldElement<TFieldValues>>(
+    ref: TFieldElement,
     validateOptions: ValidationOptions | null = {},
   ): ((name: FieldName<TFieldValues>) => void) | void {
     if (!ref.name) {
@@ -948,33 +948,32 @@ export function useForm<
     }
   }
 
-  function register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(): (ref: Element | null) => void;
-  function register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(validationOptions: ValidationOptions): (ref: Element | null) => void;
+  function register<TFieldElement extends FieldElement<TFieldValues>>(): (
+    ref: TFieldElement | null,
+  ) => void;
+  function register<TFieldElement extends FieldElement<TFieldValues>>(
+    validationOptions: ValidationOptions,
+  ): (ref: TFieldElement | null) => void;
   function register(
     name: IsFlatObject<TFieldValues> extends true
       ? Extract<keyof TFieldValues, string>
       : string,
     validationOptions?: ValidationOptions,
   ): void;
-  function register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(ref: Element, validationOptions?: ValidationOptions): void;
-  function register<
-    Element extends FieldElement<TFieldValues> = FieldElement<TFieldValues>
-  >(
+  function register<TFieldElement extends FieldElement<TFieldValues>>(
+    ref: TFieldElement,
+    validationOptions?: ValidationOptions,
+  ): void;
+  function register<TFieldElement extends FieldElement<TFieldValues>>(
     refOrValidationOptions?:
       | (IsFlatObject<TFieldValues> extends true
           ? Extract<keyof TFieldValues, string>
           : string)
       | ValidationOptions
-      | Element
+      | TFieldElement
       | null,
     validationOptions?: ValidationOptions,
-  ): ((ref: Element | null) => void) | void {
+  ): ((ref: TFieldElement | null) => void) | void {
     if (isWindowUndefined) {
       return;
     }
@@ -989,7 +988,7 @@ export function useForm<
       return;
     }
 
-    return (ref: Element | null) =>
+    return (ref: TFieldElement | null) =>
       ref && registerFieldsRef(ref, refOrValidationOptions);
   }
 

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -6,16 +6,18 @@ const FormGlobalContext = React.createContext<FormContextValues<
   FieldValues
 > | null>(null);
 
-export function useFormContext<T extends FieldValues>(): FormContextValues<T> {
-  return React.useContext(FormGlobalContext) as FormContextValues<T>;
+export function useFormContext<
+  TFieldValues extends FieldValues
+>(): FormContextValues<TFieldValues> {
+  return React.useContext(FormGlobalContext) as FormContextValues<TFieldValues>;
 }
 
-export function FormContext<T extends FieldValues>({
+export function FormContext<TFieldValues extends FieldValues>({
   children,
   formState,
   errors,
   ...restMethods
-}: FormProps<T>) {
+}: FormProps<TFieldValues>) {
   return (
     <FormGlobalContext.Provider
       value={{ ...restMethods, formState, errors } as FormContextValues}


### PR DESCRIPTION
# Generics Type Parameter Naming Conventions

## simple (abstract) type

if generics type parameter does not `extends` keyword to denote our constraint, etc:

* `T`: Type
* `P`: Generics Parameter
* `K`: Key
* `V`: Value
* `A`: Function Argument
* `R`: Return
* `T`, `U` ,`V`  etc: 1nd, 2rd, 3th types
* `T`, `T1`, `T2` etc: 1nd, 2rd, 3th types

example:

```ts
export type IsAny<T> = boolean extends (T extends never ? true : false)
  ? true
  : false;
export type Assign<T extends object, U extends object> = T & Omit<U, keyof T>;
```

## meaningful (concrete) type

if generics type parameter `extends` keyword to denote our constraint, etc:

add `T` prefix.

example:

```ts
export type OnSubmit<TFieldValues extends FieldValues> = (
  data: Unpacked<TFieldValues>,
  event?: React.BaseSyntheticEvent,
) => void | Promise<void>;
export type ValidationOption<
  TValidationValue extends ValidationValue = ValidationValue
> = TValidationValue | ValidationValueMessage<TValidationValue>;
```

Related PR: https://github.com/react-hook-form/react-hook-form/pull/1538