### PR TITLE
rename FormContext to FormProvider

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ you can view the source code within the folder or visit code sand box to see how
 | Dirty/Touched/Submitted                 | https://codesandbox.io/s/7o2wrp86k6                                           |
 | Disable Native Validation               | https://codesandbox.io/s/keen-mccarthy-4pqn6                                  |
 | Field Array                             | https://codesandbox.io/s/6j1760jkjk                                           |
-| FormContext                             | https://codesandbox.io/s/react-hook-form-form-context-dkvjz                   |
+| FormProvider                            | https://codesandbox.io/s/react-hook-form-form-context-dkvjz                   |
 | Parse and format input value            | https://codesandbox.io/s/react-hook-form-parse-and-format-textarea-furtc      |
 | Nested Fields                           | https://codesandbox.io/s/react-hook-form-nested-fields-mv1bb                  |
 | Normalize/Format/Mask Field             | https://codesandbox.io/s/387z7njwzp                                           |

--- a/examples/formProvider.tsx
+++ b/examples/formProvider.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { useForm, FormContext, useFormContext } from 'react-hook-form';
+import { useForm, FormProvider, useFormContext } from 'react-hook-form';
 
 export default function App() {
   const methods = useForm();
   const { register, handleSubmit } = methods;
   return (
-    <FormContext {...methods}>
-      <form onSubmit={handleSubmit(data => console.log(data))}>
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit((data) => console.log(data))}>
         <label>Test</label>
         <input name="test" ref={register({ required: true })} />
         <label>Nested Input</label>
         <Test />
         <input type="submit" />
       </form>
-    </FormContext>
+    </FormProvider>
   );
 }
 

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -19,7 +19,9 @@ import {
   IsAny,
 } from './types';
 
-export type FormProps<TFieldValues extends FieldValues = FieldValues> = {
+export type FormProviderProps<
+  TFieldValues extends FieldValues = FieldValues
+> = {
   children: React.ReactNode;
 } & FormContextValues<TFieldValues>;
 

--- a/src/useFormContext.test.tsx
+++ b/src/useFormContext.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { FormContext, useFormContext } from './useFormContext';
+import { FormProvider, useFormContext } from './useFormContext';
 
-describe('FormContext', () => {
+describe('FormProvider', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
@@ -13,7 +13,7 @@ describe('FormContext', () => {
       /* eslint-disable-next-line react/display-name */
       wrapper: (props: { children?: React.ReactNode }) => (
         // @ts-ignore
-        <FormContext register={mockRegister} {...props} />
+        <FormProvider register={mockRegister} {...props} />
       ),
     });
     const { register } = result.current;

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { FieldValues } from './types';
 import { FormContextValues, FormProviderProps } from './contextTypes';
 
-const FormContext = React.createContext<FormContextValues<FieldValues> | null>(
-  null,
-);
+export const FormContext = React.createContext<FormContextValues<
+  FieldValues
+> | null>(null);
 
 export const useFormContext = <
   TFieldValues extends FieldValues

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,28 +1,21 @@
 import * as React from 'react';
 import { FieldValues } from './types';
-import { FormContextValues, FormProps } from './contextTypes';
+import { FormContextValues, FormProviderProps } from './contextTypes';
 
-const FormGlobalContext = React.createContext<FormContextValues<
-  FieldValues
-> | null>(null);
+const FormContext = React.createContext<FormContextValues<FieldValues> | null>(
+  null,
+);
 
-export function useFormContext<
+export const useFormContext = <
   TFieldValues extends FieldValues
->(): FormContextValues<TFieldValues> {
-  return React.useContext(FormGlobalContext) as FormContextValues<TFieldValues>;
-}
+>(): FormContextValues<TFieldValues> =>
+  React.useContext(FormContext) as FormContextValues<TFieldValues>;
 
-export function FormContext<TFieldValues extends FieldValues>({
+export const FormProvider = <TFieldValues extends FieldValues>({
   children,
-  formState,
-  errors,
-  ...restMethods
-}: FormProps<TFieldValues>) {
-  return (
-    <FormGlobalContext.Provider
-      value={{ ...restMethods, formState, errors } as FormContextValues}
-    >
-      {children}
-    </FormGlobalContext.Provider>
-  );
-}
+  ...props
+}: FormProviderProps<TFieldValues>) => (
+  <FormContext.Provider value={{ ...props } as FormContextValues}>
+    {children}
+  </FormContext.Provider>
+);


### PR DESCRIPTION
1. `FormContext` rename to `FormProvider`

**Reason:** Align name with all those big libraries such as Redux, styled-components and etc.

```diff
- <FormContext />
+ <FormProvider />
```

2. export `FormContext`

**Reason:** Some users may want to use `FormContext.Consumer`.

```jsx
import { FormContext } from 'react-hook-form';

// in your connected component
render() {
  return (
    <FormContext.Consumer>
      {({ register, handleSubmit }) => {
        // do something with the useForm methods here
      }}
    </FormContext.Consumer>
  )
};
```