### PR TITLE
leave off exporting utility functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,5 @@ export * from './controller';
 export * from './errorMessage';
 export * from './useFormContext';
 export * from './logic';
-export * from './utils';
-
 export * from './contextTypes';
 export * from './types';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,0 @@
-import get from './get';
-
-export { get };


### PR DESCRIPTION
leave off exporting utility functions due to reverted ErrorMessage removal.

related: https://github.com/react-hook-form/react-hook-form/pull/1592