### PR TITLE
fix ReplaceFieldValue type to support optional FieldValues type

### DIFF
--- a/app/src/basic.tsx
+++ b/app/src/basic.tsx
@@ -44,7 +44,7 @@ const Basic: React.FC = (props: any) => {
         placeholder="arrayItem[0].test1"
         ref={register({ required: true })}
       />
-      {errors.arrayItem?.[0].test1 && <p>array item 1 error</p>}
+      {errors.arrayItem?.[0]?.test1 && <p>array item 1 error</p>}
       <input
         name="firstName"
         ref={register({ required: true })}
@@ -156,7 +156,7 @@ const Basic: React.FC = (props: any) => {
         type="validate"
         placeholder="validate"
         ref={register({
-          validate: value => value === 'test',
+          validate: (value) => value === 'test',
         })}
       />
       {errors.validate && <p>validate error</p>}

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,29 +176,29 @@ export type FieldRefs<TFieldValues extends FieldValues> = Partial<
   Record<InternalFieldName<TFieldValues>, Field>
 >;
 
-export type ReplaceFieldValue<T, TValue> = {
+export type DeepMap<T, TValue> = {
   [K in keyof T]?: IsAny<T[K]> extends true
     ? any
-    : T[K] extends NestedValue
+    : NonUndefined<T[K]> extends NestedValue | Date | FileList
     ? TValue
-    : T[K] extends Date
-    ? TValue
-    : T[K] extends FileList
-    ? TValue
-    : T[K] extends Array<infer U>
-    ? Array<ReplaceFieldValue<U, TValue>>
-    : T[K] extends ReadonlyArray<infer U>
-    ? ReadonlyArray<ReplaceFieldValue<U, TValue>>
-    : T[K] extends object
-    ? ReplaceFieldValue<T[K], TValue>
+    : NonUndefined<T[K]> extends object
+    ? DeepMap<T[K], TValue>
+    : NonUndefined<T[K]> extends Array<infer U>
+    ? IsAny<U> extends true
+      ? Array<any>
+      : U extends NestedValue | Date | FileList
+      ? Array<TValue>
+      : U extends object
+      ? Array<DeepMap<U, TValue>>
+      : Array<TValue>
     : TValue;
 };
 
 export type FieldErrors<
   TFieldValues extends FieldValues = FieldValues
-> = ReplaceFieldValue<TFieldValues, FieldError>;
+> = DeepMap<TFieldValues, FieldError>;
 
-export type Touched<TFieldValues extends FieldValues> = ReplaceFieldValue<
+export type Touched<TFieldValues extends FieldValues> = DeepMap<
   TFieldValues,
   true
 >;


### PR DESCRIPTION
1. Rename `ReplaceFieldValue` to `DeepMap`.

2. Resolve [spectrum comment](https://spectrum.chat/react-hook-form/help/ts-errors-on-the-error-useform-object-when-using-fields-that-are-objects~dfc67dae-bbd6-4df7-a3d2-97b4eefa8b7e?m=MTU4ODM2NTIwNDU5NA==) to support optional `FieldValues` type.

<img width="838" alt="スクリーンショット 2020-05-09 23 42 59" src="https://user-images.githubusercontent.com/12913947/81476813-da8d0200-924e-11ea-870a-adcf5497c78b.png">

[Resolved TypeScript Playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcCSBnAggO0QHgBUA+OAXjgCMIIAbYAQxzlBmBwBMM4AKQlkG07ccwAG7AocAPwIoAV1QAuOADMGtDMACUAKDgy5i-XBXrNwANy7doSLATJUAMQCWwWhwBqGxdwoASsAAxtAc+BgwUK44AOYANHBMiMTWtuDQ8EgocAByEDgAqpzAqjHA4STkcPys7Fxw8iVlohyGohJSKoRpHCG0DFCooTiRcAAkucCRFT60iipNrgCOinAYiAC21LRpdpmOOVMz3r7ARHNrdcJJeADaALpwAD5wEJQAViHwFMmPL29Pt9SBQAN4mO6TaZsU7zYAPFQdSTWAC+cAAZDVLlYbPsHNlUAARYDAMAAWQYYCIiUI2JBcHBBjuAGk4DE4ABrYCICCqGoPaQqTC4AiEFkPUjXBpRYwGAyyZImAwqfJFZrlSriyWCercY4w7EAwkMNgAtz0AAyrkiSsMtLOtpVBWKfRaFSIWoEQga7y+wRgttkxNJFKpYuZDxpdMdeWd6taHoj2u93CwUCgDAIMVUkjghWIgfQ2Dw+HzXt1RmAtvlcDTGYIyQLcrlKkK5Zu+tmZyNJtQr3NwCtNubNbrmYuZybI9b7Z9QP91cMY4IwfJlNLUcnU+bKmXE7h29MWLOqL2GXxTjgbg8HAAounoBh8CZCNfPNjuFLuG-YX5qj+P10elV1DIgALODBEh-e8oGgVJcXPLJL2gh8pDBEwCRUSJojiawDE2aYMAYWJgEFdYohiWJTxsXQCSvaBNh-fwGQw6EVGcBiAHl5xgPCEGhAAmdiuJ4x5dBRNI6I4qBNm4v0fhYgxXA4MicHkbZkTgHAGAIsjsMo8SbD6YIBiGOARjGSRYKgDB2PcTwYMffBpMY+yuHg3QLLoYAADpaAgWIeCsx9pB8thIlC5TQoIjAiJI7RrC8+g-ICoLUIwULwpgULtN0nyYrinREoKDBvJSwLgpszLBNCu4AAYBR8qL8sI4iis8kqyv8ir0uqyIBNqhqcp00iWtitqEqAA)
