### PR TITLE
fix issue around error comparison during handle change

### DIFF
--- a/cypress/integration/useFieldArray.ts
+++ b/cypress/integration/useFieldArray.ts
@@ -301,7 +301,7 @@ context('useFieldArray', () => {
     cy.get('#error1').contains('This is required');
   });
 
-  it.only('should return correct touched values', () => {
+  it('should return correct touched values', () => {
     cy.visit('http://localhost:3000/useFieldArray/default');
     cy.get('#field0').type('1');
     cy.get('#field1').type('1');

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
+import { render, fireEvent } from '@testing-library/react';
 import { useForm } from './';
 import attachEventListeners from './logic/attachEventListeners';
 import findRemovedFieldAndRemoveListener from './logic/findRemovedFieldAndRemoveListener';
@@ -1463,6 +1464,47 @@ describe('useForm', () => {
         }).deep;
         expect(deep).toEqual({ values: '5' });
       });
+    });
+  });
+
+  describe('when errors changes', () => {
+    it('should display the latest error message', () => {
+      const Form = () => {
+        const { register, setError, errors } = useForm();
+
+        React.useEffect(() => {
+          setError('test', 'data', 'data');
+        });
+
+        return (
+          <div>
+            <input
+              ref={register({
+                maxLength: {
+                  message: 'max',
+                  value: 3,
+                },
+              })}
+              placeholder="test"
+              name="test"
+            />
+            <p>{errors.test && errors.test.message}</p>
+          </div>
+        );
+      };
+
+      const { getByPlaceholderText, getByText } = render(<Form />);
+
+      getByText('data');
+
+      const textInput = getByPlaceholderText('test');
+      fireEvent.input(textInput, {
+        target: {
+          value: 'test',
+        },
+      });
+
+      expect(getByText('data')).toBeTruthy();
     });
   });
 });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -170,8 +170,12 @@ export function useForm<
 
         errorsRef.current = unset(errorsRef.current, [name]);
       } else {
+        const currentError = get(errorsRef.current, name);
         validFieldsRef.current.delete(name);
-        shouldReRender = shouldReRender || !get(errorsRef.current, name);
+        shouldReRender =
+          shouldReRender ||
+          !currentError ||
+          !isSameError(currentError, error as FieldError);
 
         set(errorsRef.current, name, error[name]);
       }
@@ -672,7 +676,7 @@ export function useForm<
     const field = fieldsRef.current[name];
 
     if (
-      !isSameError(errorsRef.current[name] as FieldError, {
+      !isSameError(get(errorsRef.current, name) as FieldError, {
         type,
         message,
         types,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -170,12 +170,13 @@ export function useForm<
 
         errorsRef.current = unset(errorsRef.current, [name]);
       } else {
-        const currentError = get(errorsRef.current, name);
+        const previousError = get(errorsRef.current, name);
         validFieldsRef.current.delete(name);
         shouldReRender =
           shouldReRender ||
-          !currentError ||
-          !isSameError(currentError, error as FieldError);
+          (previousError
+            ? !isSameError(previousError, error[name] as FieldError)
+            : true);
 
         set(errorsRef.current, name, error[name]);
       }

--- a/src/utils/isSameError.ts
+++ b/src/utils/isSameError.ts
@@ -1,18 +1,10 @@
 import isObject from './isObject';
-import { FieldError, MultipleFieldErrors, ValidateResult } from '../types';
 import compareObject from './compareObject';
+import { FieldError } from '../types';
 
 export default (
   error: FieldError | undefined,
-  {
-    type,
-    types,
-    message,
-  }: {
-    type: string;
-    types?: MultipleFieldErrors;
-    message: ValidateResult;
-  },
+  { type, types, message }: FieldError,
 ): boolean =>
   isObject(error) &&
   error.type === type &&


### PR DESCRIPTION
- [x] unit tests

related issue on spectrum: https://spectrum.chat/react-hook-form/help/using-seterror-doesnt-rerender-if-theres-a-validation-error~bfbd9d63-dcb2-4946-835d-ed32a369f637