### PR TITLE
[WIP] improve useWatch type

### DIFF
--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -5,6 +5,7 @@ import isString from './utils/isString';
 import generateId from './logic/generateId';
 import {
   UseWatchOptions,
+  FieldValues,
   FieldValuesFromControl,
   UnpackNestedValue,
   Control,
@@ -49,7 +50,9 @@ export function useWatch<
 >(props: {
   name: TFieldName[];
   control?: TControl;
-}): UnpackNestedValue<DeepPartial<Pick<TWatchFieldValues, TFieldName>>>;
+}): FieldValues extends TWatchFieldValues
+  ? Partial<FieldValues>
+  : UnpackNestedValue<DeepPartial<Pick<TWatchFieldValues, TFieldName>>>;
 export function useWatch<
   TWatchFieldValues extends FieldValuesFromControl<TControl>,
   TFieldName extends keyof TWatchFieldValues = keyof TWatchFieldValues,
@@ -65,9 +68,17 @@ export function useWatch<
   TControl extends Control = Control
 >(props: {
   name: TFieldName[];
-  defaultValue?: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
   control?: TControl;
 }): UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+export function useWatch<
+  TWatchFieldValues extends FieldValuesFromControl<TControl>,
+  TFieldName extends string = string,
+  TControl extends Control = Control
+>(props: {
+  name: TFieldName[];
+  defaultValue: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+  control?: TControl;
+}): UnpackNestedValue<TWatchFieldValues>;
 export function useWatch<
   TWatchFieldValues,
   TControl extends Control = Control

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -3,13 +3,61 @@ import { useFormContext } from './useFormContext';
 import isUndefined from './utils/isUndefined';
 import isString from './utils/isString';
 import generateId from './logic/generateId';
-import { Control, UseWatchOptions } from './types';
+import {
+  UseWatchOptions,
+  FieldValuesFromControl,
+  UnpackNestedValue,
+  FieldName,
+  Control,
+  DeepPartial,
+  EmptyObject,
+  LiteralToPrimitive,
+} from './types';
 
-export const useWatch = <TWatchValues, TControl extends Control = Control>({
+export function useWatch<
+  TWatchValues extends FieldValuesFromControl<TControl>,
+  TControl extends Control = Control
+>(props: {
+  control?: TControl;
+  defaultValue?: UnpackNestedValue<DeepPartial<TWatchValues>>;
+}): EmptyObject | UnpackNestedValue<TWatchValues>;
+export function useWatch<
+  TWatchValue extends unknown,
+  TFieldName extends FieldName<FieldValuesFromControl<TControl>>,
+  TControl extends Control = Control
+>(props: {
+  name: TFieldName;
+  control?: TControl;
+  defaultValue?: TFieldName extends keyof FieldValuesFromControl<TControl>
+    ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
+    : LiteralToPrimitive<TWatchValue>;
+}):
+  | undefined
+  | (TFieldName extends keyof FieldValuesFromControl<TControl>
+      ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
+      : LiteralToPrimitive<TWatchValue>);
+export function useWatch<
+  TWatchValues extends FieldValuesFromControl<TControl>,
+  TFieldName extends keyof TWatchValues,
+  TControl extends Control = Control
+>(props: {
+  name: TFieldName[];
+  control?: TControl;
+  defaultValue?: UnpackNestedValue<DeepPartial<TWatchValues>>;
+}): EmptyObject | UnpackNestedValue<Pick<TWatchValues, TFieldName>>;
+export function useWatch<
+  TWatchValues extends FieldValuesFromControl<TControl>,
+  TControl extends Control = Control
+>(props: {
+  name: string[];
+  control?: TControl;
+  defaultValue?: UnpackNestedValue<DeepPartial<TWatchValues>>;
+}): EmptyObject | UnpackNestedValue<DeepPartial<TWatchValues>>;
+export function useWatch<TWatchValues, TControl extends Control = Control>({
   control,
   name,
   defaultValue,
-}: UseWatchOptions<TControl>): TWatchValues => {
+}: UseWatchOptions<TControl>): TWatchValues {
   const methods = useFormContext();
   const { watchFieldsHookRef, watchFieldsHookRenderRef, watchInternal } =
     control || methods.control;
@@ -54,4 +102,4 @@ export const useWatch = <TWatchValues, TControl extends Control = Control>({
   ]);
 
   return (isUndefined(value) ? defaultValue : value) as TWatchValues;
-};
+}

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -10,14 +10,13 @@ import {
   FieldName,
   Control,
   DeepPartial,
-  EmptyObject,
   LiteralToPrimitive,
 } from './types';
 
 export function useWatch<
   TWatchValues extends FieldValuesFromControl<TControl>,
   TControl extends Control = Control
->(props: { control?: TControl }): EmptyObject | UnpackNestedValue<TWatchValues>;
+>(props: { control?: TControl }): UnpackNestedValue<DeepPartial<TWatchValues>>;
 export function useWatch<
   TWatchValues extends FieldValuesFromControl<TControl>,
   TControl extends Control = Control
@@ -57,7 +56,7 @@ export function useWatch<
 >(props: {
   name: TFieldName[];
   control?: TControl;
-}): EmptyObject | UnpackNestedValue<Pick<TWatchValues, TFieldName>>;
+}): UnpackNestedValue<DeepPartial<Pick<TWatchValues, TFieldName>>>;
 export function useWatch<
   TWatchValues extends FieldValuesFromControl<TControl>,
   TFieldName extends keyof TWatchValues,
@@ -72,14 +71,7 @@ export function useWatch<
   TControl extends Control = Control
 >(props: {
   name: string[];
-  control?: TControl;
-}): EmptyObject | UnpackNestedValue<DeepPartial<TWatchValues>>;
-export function useWatch<
-  TWatchValues extends FieldValuesFromControl<TControl>,
-  TControl extends Control = Control
->(props: {
-  name: string[];
-  defaultValue: UnpackNestedValue<DeepPartial<TWatchValues>>;
+  defaultValue?: UnpackNestedValue<DeepPartial<TWatchValues>>;
   control?: TControl;
 }): UnpackNestedValue<DeepPartial<TWatchValues>>;
 export function useWatch<TWatchValues, TControl extends Control = Control>({

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -14,16 +14,18 @@ import {
 } from './types';
 
 export function useWatch<
-  TWatchValues extends FieldValuesFromControl<TControl>,
-  TControl extends Control = Control
->(props: { control?: TControl }): UnpackNestedValue<DeepPartial<TWatchValues>>;
-export function useWatch<
-  TWatchValues extends FieldValuesFromControl<TControl>,
+  TWatchFieldValues extends FieldValuesFromControl<TControl>,
   TControl extends Control = Control
 >(props: {
-  defaultValue: UnpackNestedValue<DeepPartial<TWatchValues>>;
   control?: TControl;
-}): UnpackNestedValue<TWatchValues>;
+}): UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+export function useWatch<
+  TWatchFieldValues extends FieldValuesFromControl<TControl>,
+  TControl extends Control = Control
+>(props: {
+  defaultValue: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+  control?: TControl;
+}): UnpackNestedValue<TWatchFieldValues>;
 export function useWatch<
   TWatchValue extends unknown,
   TFieldName extends FieldName<FieldValuesFromControl<TControl>>,
@@ -50,35 +52,38 @@ export function useWatch<
   ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
   : LiteralToPrimitive<TWatchValue>;
 export function useWatch<
-  TWatchValues extends FieldValuesFromControl<TControl>,
-  TFieldName extends keyof TWatchValues,
+  TWatchFieldValues extends FieldValuesFromControl<TControl>,
+  TFieldName extends keyof TWatchFieldValues,
   TControl extends Control = Control
 >(props: {
   name: TFieldName[];
   control?: TControl;
-}): UnpackNestedValue<DeepPartial<Pick<TWatchValues, TFieldName>>>;
+}): UnpackNestedValue<DeepPartial<Pick<TWatchFieldValues, TFieldName>>>;
 export function useWatch<
-  TWatchValues extends FieldValuesFromControl<TControl>,
-  TFieldName extends keyof TWatchValues,
+  TWatchFieldValues extends FieldValuesFromControl<TControl>,
+  TFieldName extends keyof TWatchFieldValues,
   TControl extends Control = Control
 >(props: {
   name: TFieldName[];
-  defaultValue: UnpackNestedValue<DeepPartial<TWatchValues>>;
+  defaultValue: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
   control?: TControl;
-}): UnpackNestedValue<Pick<TWatchValues, TFieldName>>;
+}): UnpackNestedValue<Pick<TWatchFieldValues, TFieldName>>;
 export function useWatch<
-  TWatchValues extends FieldValuesFromControl<TControl>,
+  TWatchFieldValues extends FieldValuesFromControl<TControl>,
   TControl extends Control = Control
 >(props: {
   name: string[];
-  defaultValue?: UnpackNestedValue<DeepPartial<TWatchValues>>;
+  defaultValue?: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
   control?: TControl;
-}): UnpackNestedValue<DeepPartial<TWatchValues>>;
-export function useWatch<TWatchValues, TControl extends Control = Control>({
+}): UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+export function useWatch<
+  TWatchFieldValues,
+  TControl extends Control = Control
+>({
   control,
   name,
   defaultValue,
-}: UseWatchOptions<TControl>): TWatchValues {
+}: UseWatchOptions<TControl>): TWatchFieldValues {
   const methods = useFormContext();
   const { watchFieldsHookRef, watchFieldsHookRenderRef, watchInternal } =
     control || methods.control;
@@ -122,5 +127,5 @@ export function useWatch<TWatchValues, TControl extends Control = Control>({
     defaultValueRef,
   ]);
 
-  return (isUndefined(value) ? defaultValue : value) as TWatchValues;
+  return (isUndefined(value) ? defaultValue : value) as TWatchFieldValues;
 }

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -27,7 +27,7 @@ export function useWatch<
   control?: TControl;
 }): UnpackNestedValue<TWatchFieldValues>;
 export function useWatch<
-  TWatchValue extends unknown,
+  TWatchFieldValue extends unknown,
   TFieldName extends FieldName<FieldValuesFromControl<TControl>>,
   TControl extends Control = Control
 >(props: {
@@ -37,20 +37,20 @@ export function useWatch<
   | undefined
   | (TFieldName extends keyof FieldValuesFromControl<TControl>
       ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
-      : LiteralToPrimitive<TWatchValue>);
+      : LiteralToPrimitive<TWatchFieldValue>);
 export function useWatch<
-  TWatchValue extends unknown,
+  TWatchFieldValue extends unknown,
   TFieldName extends FieldName<FieldValuesFromControl<TControl>>,
   TControl extends Control = Control
 >(props: {
   name: TFieldName;
   defaultValue: TFieldName extends keyof FieldValuesFromControl<TControl>
     ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
-    : LiteralToPrimitive<TWatchValue>;
+    : LiteralToPrimitive<TWatchFieldValue>;
   control?: TControl;
 }): TFieldName extends keyof FieldValuesFromControl<TControl>
   ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
-  : LiteralToPrimitive<TWatchValue>;
+  : LiteralToPrimitive<TWatchFieldValue>;
 export function useWatch<
   TWatchFieldValues extends FieldValuesFromControl<TControl>,
   TFieldName extends keyof TWatchFieldValues,

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -17,10 +17,14 @@ import {
 export function useWatch<
   TWatchValues extends FieldValuesFromControl<TControl>,
   TControl extends Control = Control
+>(props: { control?: TControl }): EmptyObject | UnpackNestedValue<TWatchValues>;
+export function useWatch<
+  TWatchValues extends FieldValuesFromControl<TControl>,
+  TControl extends Control = Control
 >(props: {
+  defaultValue: UnpackNestedValue<DeepPartial<TWatchValues>>;
   control?: TControl;
-  defaultValue?: UnpackNestedValue<DeepPartial<TWatchValues>>;
-}): EmptyObject | UnpackNestedValue<TWatchValues>;
+}): UnpackNestedValue<TWatchValues>;
 export function useWatch<
   TWatchValue extends unknown,
   TFieldName extends FieldName<FieldValuesFromControl<TControl>>,
@@ -28,14 +32,24 @@ export function useWatch<
 >(props: {
   name: TFieldName;
   control?: TControl;
-  defaultValue?: TFieldName extends keyof FieldValuesFromControl<TControl>
-    ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
-    : LiteralToPrimitive<TWatchValue>;
 }):
   | undefined
   | (TFieldName extends keyof FieldValuesFromControl<TControl>
       ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
       : LiteralToPrimitive<TWatchValue>);
+export function useWatch<
+  TWatchValue extends unknown,
+  TFieldName extends FieldName<FieldValuesFromControl<TControl>>,
+  TControl extends Control = Control
+>(props: {
+  name: TFieldName;
+  defaultValue: TFieldName extends keyof FieldValuesFromControl<TControl>
+    ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
+    : LiteralToPrimitive<TWatchValue>;
+  control?: TControl;
+}): TFieldName extends keyof FieldValuesFromControl<TControl>
+  ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
+  : LiteralToPrimitive<TWatchValue>;
 export function useWatch<
   TWatchValues extends FieldValuesFromControl<TControl>,
   TFieldName extends keyof TWatchValues,
@@ -43,16 +57,31 @@ export function useWatch<
 >(props: {
   name: TFieldName[];
   control?: TControl;
-  defaultValue?: UnpackNestedValue<DeepPartial<TWatchValues>>;
 }): EmptyObject | UnpackNestedValue<Pick<TWatchValues, TFieldName>>;
+export function useWatch<
+  TWatchValues extends FieldValuesFromControl<TControl>,
+  TFieldName extends keyof TWatchValues,
+  TControl extends Control = Control
+>(props: {
+  name: TFieldName[];
+  defaultValue: UnpackNestedValue<DeepPartial<TWatchValues>>;
+  control?: TControl;
+}): UnpackNestedValue<Pick<TWatchValues, TFieldName>>;
 export function useWatch<
   TWatchValues extends FieldValuesFromControl<TControl>,
   TControl extends Control = Control
 >(props: {
   name: string[];
   control?: TControl;
-  defaultValue?: UnpackNestedValue<DeepPartial<TWatchValues>>;
 }): EmptyObject | UnpackNestedValue<DeepPartial<TWatchValues>>;
+export function useWatch<
+  TWatchValues extends FieldValuesFromControl<TControl>,
+  TControl extends Control = Control
+>(props: {
+  name: string[];
+  defaultValue: UnpackNestedValue<DeepPartial<TWatchValues>>;
+  control?: TControl;
+}): UnpackNestedValue<DeepPartial<TWatchValues>>;
 export function useWatch<TWatchValues, TControl extends Control = Control>({
   control,
   name,

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -44,7 +44,7 @@ export function useWatch<
 }): UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
 export function useWatch<
   TWatchFieldValues extends FieldValuesFromControl<TControl>,
-  TFieldName extends keyof TWatchFieldValues,
+  TFieldName extends keyof TWatchFieldValues = keyof TWatchFieldValues,
   TControl extends Control = Control
 >(props: {
   name: TFieldName[];
@@ -52,7 +52,7 @@ export function useWatch<
 }): UnpackNestedValue<DeepPartial<Pick<TWatchFieldValues, TFieldName>>>;
 export function useWatch<
   TWatchFieldValues extends FieldValuesFromControl<TControl>,
-  TFieldName extends keyof TWatchFieldValues,
+  TFieldName extends keyof TWatchFieldValues = keyof TWatchFieldValues,
   TControl extends Control = Control
 >(props: {
   name: TFieldName[];
@@ -61,9 +61,10 @@ export function useWatch<
 }): UnpackNestedValue<Pick<TWatchFieldValues, TFieldName>>;
 export function useWatch<
   TWatchFieldValues extends FieldValuesFromControl<TControl>,
+  TFieldName extends string = string,
   TControl extends Control = Control
 >(props: {
-  name: string[];
+  name: TFieldName[];
   defaultValue?: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
   control?: TControl;
 }): UnpackNestedValue<DeepPartial<TWatchFieldValues>>;

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -7,7 +7,6 @@ import {
   UseWatchOptions,
   FieldValuesFromControl,
   UnpackNestedValue,
-  FieldName,
   Control,
   DeepPartial,
   LiteralToPrimitive,
@@ -27,30 +26,22 @@ export function useWatch<
   control?: TControl;
 }): UnpackNestedValue<TWatchFieldValues>;
 export function useWatch<
-  TWatchFieldValue extends unknown,
-  TFieldName extends FieldName<FieldValuesFromControl<TControl>>,
+  TWatchFieldValue extends FieldValuesFromControl<TControl>[TFieldName],
+  TFieldName extends string = string,
   TControl extends Control = Control
 >(props: {
   name: TFieldName;
   control?: TControl;
-}):
-  | undefined
-  | (TFieldName extends keyof FieldValuesFromControl<TControl>
-      ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
-      : LiteralToPrimitive<TWatchFieldValue>);
+}): undefined | UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
 export function useWatch<
-  TWatchFieldValue extends unknown,
-  TFieldName extends FieldName<FieldValuesFromControl<TControl>>,
+  TWatchFieldValue extends FieldValuesFromControl<TControl>[TFieldName],
+  TFieldName extends string = string,
   TControl extends Control = Control
 >(props: {
   name: TFieldName;
-  defaultValue: TFieldName extends keyof FieldValuesFromControl<TControl>
-    ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
-    : LiteralToPrimitive<TWatchFieldValue>;
+  defaultValue: UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
   control?: TControl;
-}): TFieldName extends keyof FieldValuesFromControl<TControl>
-  ? UnpackNestedValue<FieldValuesFromControl<TControl>>[TFieldName]
-  : LiteralToPrimitive<TWatchFieldValue>;
+}): UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
 export function useWatch<
   TWatchFieldValues extends FieldValuesFromControl<TControl>,
   TFieldName extends keyof TWatchFieldValues,


### PR DESCRIPTION
## 1. Flat Fields

```ts
type FlatFormValues = {
  test: string;
  test1: number;
  test2: boolean;
};

const { control } = useForm<FlatFormValues>();
```

### 1.1. don’t use generics (infer `TWatchFieldValue`/`TWatchFieldVales` from control object) 

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=119&ssc=1&pln=109&pc=1#code/KYDwDg9gTgLgBDAnmYcAixhgAoENYCWuANgDwAqAfHALxwDeAUHHANoDScBAdnANbBEEAGZxyAXQD8ALjEdxcUDGDcAJgGc4AQShRciUj2HAocAKqVmLOJO279pDFjyESpC5etxZ5eYpDKapoASsC4qhDcxIg6egZGJuae1rah4ZHRsQ5OOPgwRGQeViw+fkoqGnChAMbQqqTqMFA8AOYANHAArtx83BAA7tzJLLY5Lvluvuziw95y0wDcjAC+S4ygkLAIyKgAMgTKesTkENjNALYHBABuwBT+gZW43IjUdOQPFZqNzdwtVrYfq0rD5PkE4NxOucAEYmAEQqGwqAgsRgyrQiAQYhhbjwjFYnEo8hrVTAarEfCoWrcRpwAAkADlgI1gKoAGokTrAWTdAgARy5cHUiBhWLWG2g8CQKDgTJZ7M5d3IHOIgvK4OeiFYCgAPnAINCAFZk+B0TXauB6g3G6owN4MKysRnM5QK1XAcSybjAW5QJbLOAAMjEKq54vAku2MrM3DAuGqfDlrtDSvtDMiMdJwh4rIo1HVlSTrJThm4xlMFnhZhR6e4meA2e99SoaM01pN8PobE4PH4ghEYk95lj8cTLuLioo8moyyJ4c2Up2sozagbOeb9o+Bc03Sz65sEJ9iR888j0tQADECMBiG6uZo6DU6g0mq0OprKKetue4ABhSJNFiFBXjed7Mq2cAgbeKYPpB17QYq6j2kwLDCLgAg+FBYHqCsjDrBG35LlhMEXlAEDnP+3CAWQVjkJR1EQfRZHEIwm5MVijEAcxpblmIxGIdQtjkPx7qaF6R5+nhpLkpScDCN0toEJEXTqMAADquAwNUAAWpC0RpWnaSJ94QcZzKkeR7FkHRXFYpQbS0VZnFUcxtB-rZLGUAAFGAZFgOosgoXA1LUTIYhWf6ACUsgxnGCZFmBjiYLkrjWQZOlmUhn6MNJFJQKg8ncIpymdKp6W6fpmkZfB2GmTVJFkRRHkUFZ9mOR5zkMXQVmsT5fkBQ6LBZrgnTEDAKYxSO8XjolYx5AUFDlZllDZSwIXMWFNkuWKKzRcOcVjvKJbkEt9UCUsuWyYVxW8KV6lVRVLAnQ9Zl1aBDWWc1W3UZQrDCTVDK4OcHoOU9WGA8DEFAn8bnQ+07XbcQnWud1Hm9b5ED+YFVjcED3J8QDeNLGtHmbRFu08qujaspa+2jglJb7IcJAnGcBCXPktyLS9Z3uitF1knlBUKfkJVlQ9elPad72Km9CGiRZTWIy1Hm-f9oEQyDtHg3jUOvjDdBw6D4Uddu7mI25PXeRjWODRCeOYYTwPE3Aw2jeNiqTQdDOTkzJgs6cFxXFzz2GWZ-NWOtWJkx5UVe-TM2Mwc-vHIH7PB0q0vy1yEeXflcki0pt3i4ZktiFntVm5litWSriNtWDTuoGbAhCKIofVTLolua3A4d0ZvP3sb32uWbTmo4j6P9djLC48Djsa3j2ou1HxAx4jcdwV3Jlm-3mXwuMC3LSisUJ0dk5zalpDYAQCbc2Hg-Mh06u3prK3ZXnwtFaLxf3aXlUP23uBKuj91A1y+q1YeOtIYt37O3CuMEe5wPLjzIB6hh5OTHh1Ce1Ep6YwGkFOe+MX6qE1svKwbsxoTTptNc+7okrOHmpMBBAlVrBVJj4cmyw9qn1ocmScN87571Ac-aBwBc6CyuoXMWf8dJl2EWguW2FwHKxHnZKBTc9a-BaLDfW8MnqYICF8c2XUTHMTwbbQhDsCaL2BuQkmiN17UU3rww6-D6GXwmGlVB2dmQSJkvna6P8VKyMeigwBvjNAgLQSo6idcfoaNsc3Ix4I4a6O0Rg02KTKjjzMViCxBCcbWJIWQ8QLtKEe3dPHPhE4PHJUPswnx2EI4ONCpw2OFMaFuNqVye+ndInZUYD+C8FIYAXmgOcRBdAgrKEaLIOGLtZkwAAIxekRCYRZLoABMsh8TYmeP6Ekkj87UlpKvWQtcRmaXGVASZ508KnPgH0b0bk7rlS8vQbhSwAD03z2E0ieZEfGTBfnWFYCAeZeihyah+X82cjzXYNhGlQxUAB5KIiBXklx0h8xFaF3bUK7Es2QAByJZJK4ABi+YwUFCKKkpnRdEbGoKWDEqFHo2FlLGAIqIYyxAyysWhNxUQ0l5LKWRU5TyvGfLVlwE1NyyItJeUYq2YK95XYRVwDJS6ZZFLqW0sVU86VKrZDyqlcDPlABmNVD1hXWO1Y0LZeqJU0r+ea4AVrTUvAVQC+2wN1AyptYZO1882AOpgCShQ+q3WGr9cyGVsgGlkCfFAeoRs5UvBWj6pVeMA0qqDTijV1jWDhpJR0cNuqo0uoNb6ohebog7LgEm0gKa016PfJmyw7r62IGtXQN5tqi2hpLeS8tSzdVju2ZG8VkrY11s9U2phyayTPnTR+LtsbV58oLdpXFq8Z2uv+WcjyfLmV-NZS6MKaS9S7jXE2TlF7GjLLCpCGEiQb1U3XA+hA2ywp7JxLTW91NVCcvhbG+liotBqFyQO4NQUINVIYD+uZWqxXLGNqvBy0aj3wAQ1yKDqgrJnusGyhZh7H0rLWW+ySLLkMwEbf+g5h6wO+rw8AAjmsBX9uxbuod+NS0dDY6Kl0zrZ2saRQSyDahOOQu0dm3DEmUXug43jVV3GhV8eE0+steLkWVK5LIAV2G6WKf0+x6TqmqNInk7pyTymLPAz7SE9VcatP0Z00JhAUBBTGfA6ZlMKnHO7MxPs3EJn8VKfww55kXHnODoof5z2SG2WlspcbTVI6RPiCw9WmN4mItmcCzF4jFHZOtFAzZtjRX1Bqbi3BhLBXCV0bczp8dhm0tFOHQJ1DOrI05bE7SKr0Waslea+y7R362sImoxV8LemAvDac7BwtDX5tJaJS6FrHQpvLO29s2QTQfPpeLd1itOnw1Ouy7tAbCnGtSdIbmy1o3SMcvI3R2Vr6kSTf23ARj3BZtzrxgRmDPGQ38fHTp-dvna1A+gx5Kz76uifqbDZutwPsF1cLa5sNo6evaey-8hi0Oc3+vR4jZ7l6ysww-Xue9b3x0vvWaYGnd7WQA-y2t+zD3gZk+orF5bvHVt2YM3AXbnXwe9Ywx5frh65vC-M9zhXVkPtM8q4lrnmt1C8+YrVgXHzxeyEy40c7EPJ2Or60LyLwKxvdZ23tx1B3vOoHQ5HaX13Zd+buxr3N2usSNpBeesbZHaNTc+xs+nP2-ugaAA)

```ts
const none = useWatch({});
// const none: {
//   [x: string]: any;
// }
const defaultValueOnly = useWatch({ defaultValue: { test: 'test' } });
// const defaultValueOnly: {
//   test: string;
// }
const nameOnly1 = useWatch({ name: 'test' });
// const nameOnly1: any
const nameOnly2 = useWatch({ name: 'test1' });
// const nameOnly2: any
const nameOnly3 = useWatch({ name: 'test2' });
// const nameOnly3: any
const namesOnly1 = useWatch({ name: ['test'] });
// const namesOnly1: Partial<Record<string, any>>
const namesOnly2 = useWatch({ name: ['test', 'test1'] });
// const namesOnly2: Partial<Record<string, any>>
const namesOnly3 = useWatch({ name: ['test', 'test1', 'test2'] });
// const namesOnly3: Partial<Record<string, any>>
const controlOnly = useWatch({ control });
// const controlOnly: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const defaultValueAndControl = useWatch({
  defaultValue: { test: 'test' },
  control,
});
// const defaultValueAndControl: {
//   test: string;
//   test1: number;
//   test2: boolean;
// }
const defaultValueAndName1 = useWatch({ name: 'test', defaultValue: 'test' });
// const defaultValueAndName1: string
const defaultValueAndName2 = useWatch({ name: 'test1', defaultValue: 1 });
// const defaultValueAndName2: number
const defaultValueAndName3 = useWatch({ name: 'test2', defaultValue: true });
// const defaultValueAndName3: boolean
const defaultValueAndNames1 = useWatch({
  defaultValue: { test: 'test' },
  name: ['test'],
});
// const defaultValueAndNames1: {
//   test: string;
// }
const defaultValueAndNames2 = useWatch({
  defaultValue: { test: 'test', test1: 1 },
  name: ['test', 'test1'],
});
// const defaultValueAndNames2: {
//   test: string;
//   test1: number;
// }
const defaultValueAndNames3 = useWatch({
  defaultValue: { test: 'test', test1: 1, test2: true },
  name: ['test', 'test1', 'test2'],
});
// const defaultValueAndNames3: {
//   test: string;
//   test1: number;
//   test2: boolean;
// }
const nameAndControl = useWatch({ name: 'test1', control });
// const nameAndControl: number | undefined
const namesAndControl = useWatch({ name: ['test', 'test1'], control });
// const namesAndControl: {
//   test?: string | undefined;
//   test1?: number | undefined;
// }
const defaultValueAndNameAndControl1 = useWatch({
  defaultValue: 1,
  name: 'test1',
  control,
});
// const defaultValueAndNameAndControl1: number
const defaultValueAndNamesAndControl2 = useWatch({
  name: ['test', 'test1', 'test2'],
  defaultValue: { test: 'test', test1: 1, test2: true },
  control,
});
// const defaultValueAndNamesAndControl2: {
//   test: string;
//   test1: number;
//   test2: boolean;
// }
```

### 1.2. use generics (don't infer `TWatchFieldValue`/`TWatchFieldValues` from control object)

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=205&ssc=5&pln=118&pc=1#code/KYDwDg9gTgLgBDAnmYcAixhgAoENYCWuANgDwAqAfHALxwDeAUHHANoDScBAdnANbBEEAGZxyAXQD8ALjEdxcUDGDcAJgGc4AQShRciUj2HAocAKqVmLOJO279pDFjyESpC5etxZ5eYpDKapoASsC4qhDcxIg6egZGJuae1rah4ZHRsQ5OOPgwRGQeViw+fkoqGnChAMbQqqTqMFA8AOYANHAArtx83BAA7tzJLLY5Lvluvuziw95y0wDcjAC+S4ygkLAIyKgAMgTKesTkENjNALYHBABuwBT+gZW43IjUdOQPFZqNzdwtVrYfq0rD5PkE4NxOucAEYmAEQqGwqAgsRgyrQiAQYhhbjwjFYnEo8hrVTAarEfCoWrcRpwAAkADlgI1gKoAGokTrAWTdAgARy5cHUiBhWLWG2g8CQKDgTJZ7M5d3IHOIgvK4OeiFYCgAPnAINCAFZk+B0TXauB6g3G6owN4MKysRnM5QK1XAcSybjAW5QJbLOAAMjEKq54vAku2MrM3DAuGqfDlrtDSvtDMiMdJwh4rIo1HVlSTrJThm4xlMFnhZhR6e4meA2e99SoaM01pN8PobE4PH4ghEYk95lj8cTLuLioo8moyyJ4c2Up2sozagbOeb9o+Bc03Sz65sEJ9iR888j0tQADECMBiG6uZo6DU6g0mq0OprKKetue4ABhSJNFiFBXjed7Mq2cAgbeKYPpB17QYq6j2kwLDCLgAg+FBYHqCsjDrBG35LlhMEXlAEDnP+3CAWQVjkJR1EQfRZHEIwm5MVijEAcxpblmIxGIdQtjkPx7qaF6R5+nhpLkpScDCN0toEJEXTqMAADquAwNUAAWpC0RpWnaSJ94QcZzKkeR7FkHRXFYpQbS0VZnFUcxtB-rZLGUAAFGAZFgOosgoXA1LUTIYhWf6ACUsgxnGCZFmBjiYLkrjWQZOlmUhn6MNJFJQKg8ncIpymdKp6W6fpmkZfB2GmTVJFkRRHkUFZ9mOR5zkMXQVmsT5fkBQ6LBZrgnTEDAKYxSO8XjolYx5AUFDlZllDZSwIXMWFNkuWKKzRcOcVjvKJbkEt9UCUsuWyYVxW8KV6lVRVLAnQ9Zl1aBDWWc1W3UZQrDCTVDK4OcHoOU9WGA8DEFAn8bnQ+07XbcQnWud1Hm9b5ED+YFVjcED3J8QDeNLGtHmbRFu08qujaspa+2jglJb7IcJAnGcBCXPktyLS9Z3uitF1knlBUKfkJVlQ9elPad72Km9CGiRZTWIy1Hm-f9oEQyDtHg3jUOvjDdBw6D4Uddu7mI25PXeRjWODRCeOYYTwPE3Aw2jeNiqTQdDOTkzJgs6cFxXFzz2GWZ-NWOtWJkx5UVe-TM2Mwc-vHIH7PB0q0vy1yEeXflcki0pt3i4ZktiFntVm5litWSriNtWDTuoGbAhCKIofVTLolua3A4d0ZvP3sb32uWbTmo4j6P9djLC48Djsa3j2ou1HxAx4jcdwV3Jlm-3mXwuMC3LSisUJ0dk5zalpDYAQCbc2Hg-Mh06u3prK3ZXnwtFaLxf3aXlUP23uBKuj91A1y+q1YeOtIYt37O3CuMEe5wPLjzIB6hh5OTHh1Ce1Ep6YwGkFOe+MX6qE1svKwbsxoTTptNc+7okrOHmpMBBAlVrBVJj4cmyw9qn1ocmScN87571Ac-aBwBc6CyuoXMWf8dJl2EWguW2FwHKxHnZKBTc9a-BaLDfW8MnqYICF8c2XUTHMTwbbQhDsCaL2BuQkmiN17UU3rww6-D6GXwmGlVB2dmQSJkvna6P8VKyMeigwBvjNAgLQSo6idcfoaNsc3Ix4I4a6O0Rg02KTKjjzMViCxBCcbWJIWQ8QLtKEe3dPHPhE4PHJUPswnx2EI4ONCpw2OFMaFuNqVye+ndInZUYD+C8FIYAXmgOcRBdAgrKEaLIOGLtZkwAAIxekRCYRZLoABMsh8TYmeP6Ekkj87UlpKvWQtcRmaXGVASZ508KnPgH0b0bk7rlVIDMl08y9GbMaKshEMINlWCWTsuAeycT+m8vQbhSwAD0sL2E0ieZEfGTB4XWCWWFNJepdxribHChFLAlnLLCpCQFpgcVU3XASjF2ywrgueLTXF1NVA0tnI812DYRpUMVAAeSiIgV5Jc5GfLmUKH5wKXT-LJUiX5MBQUMu4JCryXYKnUK7Es2QAByJZWq4ABhhXAdF5BeVoF5YwdFHK1V8oFdjdFRKvniu0TSh1fy1nkpdQgbZuzMT7KVRahF7LIi0iIfy6IyyhWhJfNoqF9t55wB1S6PVMKA2IpDXjMNiB-nYq6FSpsjAOWhoFVsyN7yZUmFjUQ7VxLk2RRpYWjNxb3VIiZXm1kBbg1PMbdEAAzKWiWirK3WMTY0LZtb62drjcATNPafUEkZZSvc+aG3A3UJmiNdA3kSw1Y6tJywh3xtYCOmAWqFApstZOoha6BX-LRYSr1jQsV6NbUu1kbKO1Iqnde6IJbN3Ct0qKmA3znWSrdQC2VKwD34yPbqjox7lmnv1XW1NK7mSZtBXe2lj7gOtBfXit9qbXUrNJesilubX2stTUGz9V6Z39tLoBnDfw5XStI3KhVvqIWQZVVO2QMGk1wZrYJ7ZiHz0ItQ9+xAs6HT2ofTAJ92i8Mss9cSkj5KlPUsI3JrZ9LOMLvI-hyj6LqNnI8pm+jIrQNAada0FjzagVEY4-O-1+6eOryQxOz9q9M12vvZipjOjF2GZU1KtTLagvKa0yC3TzmNP4qox+2k1r3RaDULkrdDGrMBbs+Bhz2m51+uVUFZLXJApyerUm-VxtV4OTE2m+AJXgCpdUFZXzWHrMLIS1arl7sUzNc1hukJ7y4ZQqKfG49WrjaNYq40Sbu1PNJZ6zylLagBsBcSw1pblSuT9bxr+obEty1QFG7PYdQmKFbeocs2ryGL2fsa7t4GoKjsbc5WhXripHvAD7X+qNg6VVjfxsesdU3LuewQFALkN2Fubfe8tnbq28bScVa9h7iPV2DYyyK8rNmYaueK2DqpDAccTaq4DvjE3xDQ5Q5OtHpC8bqFvVF3dErjOo8Jwj+nq79tY4A1l3HLQctHaKxduH23UUk9g3J-5EbljGyrWwCbwm-mnup3dxbYu+vo+ZBh5nYrOuyeJfZySbPuua8+9r9QP2DuZaI9lqzrGPVWac4V7jBPzdE53WKpX0vZDXfyxDwUcvyeK6l-BybCaQWq-mzT+7HOmuW+k5hu3AuQtgeF3r+VBWuOm8vXjZr6X-2kCO1BmbKyI-ubq6hgvHljdxfbRJmvFtfvvMY6nh3xuiu8dDwJyPUrVeIoYlXvPq6m-UTa0RhTuGIuacN6FuvM-4u57jx7znmsx-MUx0XkvAOhrx79-Ls7-fqseTV+J2n8evsb6xI7pE7PV8J658ya-xAedF7b51ojt+8sguzwct3Ie-Gs2yu5eIBY6VOou3K4uZWmqfewBvucA-uv+geqAwerSzEZ+9Wb2UBWuT+6gL+uuc++urOfmUqnemeLuOegaQAA)

```ts
const none = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({});
// const none: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const defaultValueOnly = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({ defaultValue: { test: 'test' } }); // TODO
// const defaultValueOnly: {
//   test: string;
//   test1: number;
//   test2: boolean;
// }
const nameOnly1 = useWatch<string>({ name: 'test' });
// const nameOnly1: string | undefined
const nameOnly2 = useWatch<number>({ name: 'test1' });
// const nameOnly2: number | undefined
const nameOnly3 = useWatch<boolean>({ name: 'test2' });
// const nameOnly3: boolean | undefined
const namesOnly1 = useWatch<{ test: string }>({ name: ['test'] });
// const namesOnly1: {
//   test?: string | undefined;
// }
const namesOnly2 = useWatch<{
  test: string;
  test1: number;
}>({ name: ['test', 'test1'] });
// const namesOnly2: {
//   test?: string | undefined;
//   test1?: number | undefined;
// }
const namesOnly3 = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({ name: ['test', 'test1', 'test2'] });
// const namesOnly3: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const controlOnly = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({ control });
// const controlOnly: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const defaultValueAndControl = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({
  defaultValue: { test: 'test' },
  control,
});
// const defaultValueAndControl: {
//   test: string;
// }
const defaultValueAndName1 = useWatch<string>({
  name: 'test',
  defaultValue: 'test',
});
// const defaultValueAndName1: string
const defaultValueAndName2 = useWatch<number>({
  name: 'test1',
  defaultValue: 1,
});
// const defaultValueAndName2: number
const defaultValueAndName3 = useWatch<boolean>({
  name: 'test2',
  defaultValue: true,
});
// const defaultValueAndName3: boolean
const defaultValueAndNames1 = useWatch<{ test: string }>({
  defaultValue: { test: 'test' },
  name: ['test'],
});
// const defaultValueAndNames1: {
//   test: string;
// }
const defaultValueAndNames2 = useWatch<{
  test: string;
  test1: number;
}>({
  defaultValue: { test: 'test', test1: 1 },
  name: ['test', 'test1'],
});
// const defaultValueAndNames2: {
//   test: string;
//   test1: number;
// }
const defaultValueAndNames3 = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({
  defaultValue: { test: 'test', test1: 1, test2: true },
  name: ['test', 'test1', 'test2'],
});
// const defaultValueAndNames3: {
//   test: string;
//   test1: number;
//   test2: boolean;
// }
const nameAndControl = useWatch<number>({ name: 'test1', control });
// const nameAndControl: number | undefined
const namesAndControl = useWatch<{
  test: string;
  test1: number;
}>({ name: ['test', 'test1'], control });
// const namesAndControl: {
//   test?: string | undefined;
//   test1?: number | undefined;
// }
const defaultValueAndNameAndControl1 = useWatch<number>({
  defaultValue: 1,
  name: 'test1',
  control,
});
// const defaultValueAndNameAndControl1: number
const defaultValueAndNamesAndControl2 = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({
  name: ['test', 'test1', 'test2'],
  defaultValue: { test: 'test', test1: 1, test2: true },
  control,
});
// const defaultValueAndNamesAndControl2: {
//   test: string;
//   test1: number;
//   test2: boolean;
// }
```

### 1.3. type error

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=262&ssc=5&pln=118&pc=1#code/KYDwDg9gTgLgBDAnmYcAixhgAoENYCWuANgDwAqAfHALxwDeAUHHANoDScBAdnANbBEEAGZxyAXQD8ALjEdxcUDGDcAJgGc4AQShRciUj2HAocAKqVmLOJO279pDFjyESpC5etxZ5eYpDKapoASsC4qhDcxIg6egZGJuae1rah4ZHRsQ5OOPgwRGQeViw+fkoqGnChAMbQqqTqMFA8AOYANHAArtx83BAA7tzJLLY5Lvluvuziw95y0wDcjAC+S4ygkLAIyKgAMgTKesTkENjNALYHBABuwBT+gZW43IjUdOQPFZqNzdwtVrYfq0rD5PkE4NxOucAEYmAEQqGwqAgsRgyrQiAQYhhbjwjFYnEo8hrVTAarEfCoWrcRpwAAkADlgI1gKoAGokTrAWTdAgARy5cHUiBhWLWG2g8CQKDgTJZ7M5d3IHOIgvK4OeiFYCgAPnAINCAFZk+B0TXauB6g3G6owN4MKysRnM5QK1XAcSybjAW5QJbLOAAMjEKq54vAku2MrM3DAuGqfDlrtDSvtDMiMdJwh4rIo1HVlSTrJThm4xlMFnhZhR6e4meA2e99SoaM01pN8PobE4PH4ghEYk95lj8cTLuLioo8moyyJ4c2Up2sozagbOeb9o+Bc03Sz65sEJ9iR888j0tQADECMBiG6uZo6DU6g0mq0OprKKetue4ABhSJNFiFBXjed7Mq2cAgbeKYPpB17QYq6j2kwLDCLgAg+FBYHqCsjDrBG35LlhMEXlAEDnP+3CAWQVjkJR1EQfRZHEIwm5MVijEAcxpblmIxGIdQtjkPx7qaF6R5+nhpLkpScDCN0toEJEXTqMAADquAwNUAAWpC0RpWnaSJ94QcZzKkeR7FkHRXFYpQbS0VZnFUcxtB-rZLGUAAFGAZFgOosgoXA1LUTIYhWf6ACUsgxnGCZFmBjiYLkrjWQZOlmUhn6MNJFJQKg8ncIpymdKp6W6fpmkZfB2GmTVJFkRRHkUFZ9mOR5zkMXQVmsT5fkBQ6LBZrgnTEDAKYxSO8XjolYx5AUFDlZllDZSwIXMWFNkuWKKzRcOcVjvKJbkEt9UCUsuWyYVxW8KV6lVRVLAnQ9Zl1aBDWWc1W3UZQrDCTVDK4OcHoOU9WGA8DEFAn8bnQ+07XbcQnWud1Hm9b5ED+YFVjcED3J8QDeNLGtHmbRFu08qujaspa+2jglJb7IcJAnGcBCXPktyLS9Z3uitF1knlBUKfkJVlQ9elPad72Km9CGiRZTWIy1Hm-f9oEQyDtHg3jUOvjDdBw6D4Uddu7mI25PXeRjWODRCeOYYTwPE3Aw2jeNiqTQdDOTkzJgs6cFxXFzz2GWZ-NWOtWJkx5UVe-TM2Mwc-vHIH7PB0q0vy1yEeXflcki0pt3i4ZktiFntVm5litWSriNtWDTuoGbAhCKIofVTLolua3A4d0ZvP3sb32uWbTmo4j6P9djLC48Djsa3j2ou1HxAx4jcdwV3Jlm-3mXwuMC3LSisUJ0dk5zalpDYAQCbc2Hg-Mh06u3prK3ZXnwtFaLxf3aXlUP23uBKuj91A1y+q1YeOtIYt37O3CuMEe5wPLjzIB6hh5OTHh1Ce1Ep6YwGkFOe+MX6qE1svKwbsxoTTptNc+7okrOHmpMBBAlVrBVJj4cmyw9qn1ocmScN87571Ac-aBwBc6CyuoXMWf8dJl2EWguW2FwHKxHnZKBTc9a-BaLDfW8MnqYICF8c2XUTHMTwbbQhDsCaL2BuQkmiN17UU3rww6-D6GXwmGlVB2dmQSJkvna6P8VKyMeigwBvjNAgLQSo6idcfoaNsc3Ix4I4a6O0Rg02KTKjjzMViCxBCcbWJIWQ8QLtKEe3dPHPhE4PHJUPswnx2EI4ONCpw2OFMaFuNqVye+ndInZUYD+C8FIYAXmgOcRBdAgrKEaLIOGLtZkwAAIxekRCYRZLoABMsh8TYmeP6Ekkj87UlpKvWQtcRmaXGVASZ508KnPgCYMiUBlluTuuVLyXZV4dCIbIAA5Es-5HQKnULedwhYcAAD0UK4CABlyRgjz9SdBgGAFFWz3klx0l8yOHljZ-LYICl0wK4BEsaFs-54hjags9gwBALpZDLI6EsnZCAoCCmWA5CF0LYUIqRRAFFaKYAAGZMWhJxa05i+LrGsDJTAElcqKVUooQ2EaVDaVdj6DAAAoiAAgjQBr-K1bq-VMB1AkpZbIJoHKuWRUhTC+FQA)

```ts
const error1 = useWatch({ control, name: 'test', defaultValue: 1 }); // ❌
const output2 = useWatch({
  control,
  name: ['test', 'test2'],
  defaultValue: { test: 1, test2: true },
}); // ❌
const output3 = useWatch({
  control,
  name: ['test', 'test2'],
  defaultValue: { notExists: 'notExists', test2: true },
}); // ❌
```

### 1.4. expect type error, but no type error because support nested object

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=128&ssc=9&pln=118&pc=1#code/KYDwDg9gTgLgBDAnmYcAixhgAoENYCWuANgDwAqAfHALxwDeAUHHANoDScBAdnANbBEEAGZxyAXQD8ALjEdxcUDGDcAJgGc4AQShRciUj2HAocAKqVmLOJO279pDFjyESpC5etxZ5eYpDKapoASsC4qhDcxIg6egZGJuae1rah4ZHRsQ5OOPgwRGQeViw+fkoqGnChAMbQqqTqMFA8AOYANHAArtx83BAA7tzJLLY5Lvluvuziw95y0wDcjAC+S4ygkLAIyKgAMgTKesTkENjNALYHBABuwBT+gZW43IjUdOQPFZqNzdwtVrYfq0rD5PkE4NxOucAEYmAEQqGwqAgsRgyrQiAQYhhbjwjFYnEo8hrVTAarEfCoWrcRpwAAkADlgI1gKoAGokTrAWTdAgARy5cHUiBhWLWG2g8CQKDgTJZ7M5d3IHOIgvK4OeiFYCgAPnAINCAFZk+B0TXauB6g3G6owN4MKysRnM5QK1XAcSybjAW5QJbLOAAMjEKq54vAku2MrM3DAuGqfDlrtDSvtDMiMdJwh4rIo1HVlSTrJThm4xlMFnhZhR6e4meA2e99SoaM01pN8PobE4PH4ghEYk95lj8cTLuLioo8moyyJ4c2Up2sozagbOeb9o+Bc03Sz65sEJ9iR888j0tQADECMBiG6uZo6DU6g0mq0OprKKetue4ABhSJNFiFBXjed7Mq2cAgbeKYPpB17QYq6j2kwLDCLgAg+FBYHqCsjDrBG35LlhMEXlAEDnP+3CAWQVjkJR1EQfRZHEIwm5MVijEAcxpblmIxGIdQtjkPx7qaF6R5+nhpLkpScDCN0toEJEXTqMAADquAwNUAAWpC0RpWnaSJ94QcZzKkeR7FkHRXFYpQbS0VZnFUcxtB-rZLGUAAFGAZFgOosgoXA1LUTIYhWf6ACUsgxnGCZFmBjiYLkrjWQZOlmUhn6MNJFJQKg8ncIpymdKp6W6fpmkZfB2GmTVJFkRRHkUFZ9mOR5zkMXQVmsT5fkBQ6LBZrgnTEDAKYxSO8XjolYx5AUFDlZllDZSwIXMWFNkuWKKzRcOcVjvKJbkEt9UCUsuWyYVxW8KV6lVRVLAnQ9Zl1aBDWWc1W3UZQrDCTVDK4OcHoOU9WGA8DEFAn8bnQ+07XbcQnWud1Hm9b5ED+YFVjcED3J8QDeNLGtHmbRFu08qujaspa+2jglJb7IcJAnGcBCXPktyLS9Z3uitF1knlBUKfkJVlQ9elPad72Km9CGiRZTWIy1Hm-f9oEQyDtHg3jUOvjDdBw6D4Uddu7mI25PXeRjWODRCeOYYTwPE3Aw2jeNiqTQdDOTkzJgs6cFxXFzz2GWZ-NWOtWJkx5UVe-TM2Mwc-vHIH7PB0q0vy1yEeXflcki0pt3i4ZktiFntVm5litWSriNtWDTuoGbAhCKIofVTLolua3A4d0ZvP3sb32uWbTmo4j6P9djLC48Djsa3j2ou1HxAx4jcdwV3Jlm-3mXwuMC3LSisUJ0dk5zalpDYAQCbc2Hg-Mh06u3prK3ZXnwtFaLxf3aXlUP23uBKuj91A1y+q1YeOtIYt37O3CuMEe5wPLjzIB6hh5OTHh1Ce1Ep6YwGkFOe+MX6qE1svKwbsxoTTptNc+7okrOHmpMBBAlVrBVJj4cmyw9qn1ocmScN87571Ac-aBwBc6CyuoXMWf8dJl2EWguW2FwHKxHnZKBTc9a-BaLDfW8MnqYICF8c2XUTHMTwbbQhDsCaL2BuQkmiN17UU3rww6-D6GXwmGlVB2dmQSJkvna6P8VKyMeigwBvjNAgLQSo6idcfoaNsc3Ix4I4a6O0Rg02KTKjjzMViCxBCcbWJIWQ8QLtKEe3dPHPhE4PHJUPswnx2EI4ONCpw2OFMaFuNqVye+ndInZUYD+C8FIYAXmgOcRBdAgrKEaLIOGLtZkwAAIxekRCYRZLoABMsh8TYmeP6Ekkj87UlpKvWQtcRmaXGVASZ508KnPgBsE05BkAAFFdDQDcndcqXkuyrw6EQ2QrAADkSzlkgo6CCvoMA3kgAII0dQIKFDcIWHAAA9OiuAgBQckYJi9hNInngBee8z5UBsb4pYEssKaS9S7jXE2JYlKEAumWWFSEMJEh0qpuuJlWKqXbLCnsnEtN6XU1UHyuAywgA)

```ts
const expectTypError = useWatch({ control, name: ['test1', 'notExists'] }); // ✅
// const expectTypError: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
```

## 2. Nested Fields

```ts
type NestedFormValues = {
  test: string;
  test1: {
    test: number;
  };
  test2: boolean[];
};

const { control } = useForm<NestedFormValues>();
```

### 2.1. don’t use generics (infer `TWatchFieldValue`/`TWatchFieldVales` from control object) 

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=218&ssc=5&pln=120&pc=1#code/KYDwDg9gTgLgBDAnmYcAixhgAoENYCWuANgDwAqAfHALxwDeAUHHANoDScBAdnANbBEEAGZxyAXQD8ALjEdxcUDGDcAJgGc4AQShRciUj2HAocAKqVmLOJO279pDFjyESpC5etxZ5eYpDKapoASsC4qhDcxIg6egZGJuae1rah4ZHRsQ5OOPgwRGQeViw+fkoqGnChAMbQqqTqMFA8AOYANHAArtx83BAA7tzJLLY5Lvluvuziw95y0wDcjAC+S4ygkLAIyKgAMgTKesTkENjNALYHBABuwBT+gZW43IjUdOQPFZqNzdwtVrYfq0rD5PkE4NxOucAEYmAEQqGwqAgsRgyrQiAQYhhbjwjFYnEo8hrVTAarEfCoWrcRpwAAkADlgI1gKoAGokTrAWTdAgARy5cHUiBhWLWG2g8CQKDgTJZ7M5d3IHOIgvK4OeiFYCgAPnAINCAFZk+B0TXauB6g3G6owN4MKysRnM5QK1XAcSybjAW5QJbLOAAMjEKq54vAku2MrM3DAuGqfDlrtDSvtDMiMdJwh4rIo1HVlSTrJThm4xlMFnhZhR6e4meA2e99SoaM01pN8PobE4PH4ghEYk95lj8cTLuLioo8moyyJ4c2Up2sozagbOeb9o+Bc03Sz65sEJ9iR888j0tQADECMBiG6uZo6DU6g0mq0OprKKetue4ABhSJNFiFBXjed7Mq2cAgbeKYPpB17QYq6j2kwLDCLgAg+FBYHqCsjDrBG35LlhMEXlAEDnP+3CAWQVjkJR1EQfRZHEIwm5MVijEAcxpblmIxGIdQtjkPx7qaF6R5+nhpLkpScDCN0toEJEXTqMAADquAwNUAAWpC0RpWnaSJ94QcZzKkeR7FkHRXFYpQbS0VZnFUcxtB-rZLGUAAFGAZFgOosgoXA1LUTIYhWf6ACUsgxnGCZFmBjiYLkrjWQZOlmUhn6MNJFJQKg8ncIpymdKp6W6fpmkZfB2GmTVJFkRRHkUFZ9mOR5zkMXQVmsT5fkBQ6LBZrgnTEDAKYxSO8XjolYx5AUFDlZllDZSwIXMWFNkuWKKzRcOcVjvKJbkEt9UCUsuWyYVxW8KV6lVRVLAnQ9Zl1aBDWWc1W3UZQrDCTVDK4OcHoOU9WGA8DEFAn8bnQ+07XbcQnWud1Hm9b5ED+YFVjcED3J8QDeNLGtHmbRFu08qujaspa+2jglJb7IcJAnGcBCXPktyLS9Z3uitF1knlBUKfkJVlQ9elPad72Km9CGiRZTWIy1Hm-f9oEQyDtHg3jUOvjDdBw6D4Uddu7mI25PXeRjWODRCeOYYTwPE3Aw2jeNiqTQdDOTkzJgs6cFxXFzz2GWZ-NWOtWJkx5UVe-TM2Mwc-vHIH7PB0q0vy1yEeXflcki0pt3i4ZktiFntVm5litWSriNtWDTuoGbAhCKIofVTLolua3A4d0ZvP3sb32uWbTmo4j6P9djLC48Djsa3j2ou1HxAx4jcdwV3Jlm-3mXwuMC3LSisUJ0dk5zalpDYAQCbc2Hg-Mh06u3prK3ZXnwtFaLxf3aXlUP23uBKuj91A1y+q1YeOtIYt37O3CuMEe5wPLjzIB6hh5OTHh1Ce1Ep6YwGkFOe+MX6qE1svKwbsxoTTptNc+7okrOHmpMBBAlVrBVJj4cmyw9qn1ocmScN87571Ac-aBwBc6CyuoXMWf8dJl2EWguW2FwHKxHnZKBTc9a-BaLDfW8MnqYICF8c2XUTHMTwbbQhDsCaL2BuQkmiN17UU3rww6-D6GXwmGlVB2dmQSJkvna6P8VKyMeigwBvjNAgLQSo6idcfoaNsc3Ix4I4a6O0Rg02KTKjjzMViCxBCcbWJIWQ8QLtKEe3dPHPhE4PHJUPswnx2EI4ONCpw2OFMaFuNqVye+ndInZUYD+BKF5oDnEQXQIKyhGiyDhi7aZMAACMM9rALK9IiEwLtVhWAWQAJlkPibEzxyHbJypI-O1JaSr1kLXEZYyYKDMufAPo3o3J3XKl5eg3ClgAHofnsJpM8yI+MmB-OsKwEAsy9FDk1L8-5s4nmuwbCNKhioADyUREBvJLjpT5SK0Lu2oV2NZcAADkCzSVwADN8xgYLEUVJTBi6I2MwUsBJXM2l8LGCIqIUyxAizsWhLxUQ2Q5KXSUppXSyItJeWYuWXATU3LpXPLxny3ZgqPldhFWShZiyAB0FKqWRThQCmVqrMX7IVS8JVgL7bAz5QAZg1Q9YV1ixWNF2awAADOICVxrOWmpVfazFDrZCKp5XjdQfKBV0HeS6rV1jWDupgKShQkr-kRuBlGuVsgGlkCfFAeoRsrWvEsJm5karnWGVdfPNgybSUdGTfqilabjVwDBeQNFaA0WyGzCAAN5bs3REtXm0gBai16PfC8FaNqzVZsdVW3FCba1JopY23VBrxXrpdJ6n1qajUmsHY63NTD81kmfMWj8ZblUAuonyxd2k8WrwPQOm9q8+Usv+V4BZYU0l6l3GuJsJrv0ukWWFUFX6vCrJdGFSEMJEj-qpuuYD1gAyIb3EBgNIGPVhUOTiC06HAOshNQim9DLFRaDULkuN1agrkaqQwBALpRWGuWMbVeDl02BvxSiypXJKOqCsp+qD7K9EobZaB4TUHoMzIRPBySrLUPiaYx6g5mIjncHIWC0jtr6P8bUJrGNITNV2vxvWjoemzOsf9VK3TyLCUUYM3jeVcNZ3wEswJzW6rY04sfcuqzoHN2NAbTxhzDGBVcfpfZ1F7pPN40tXBpEbnQsxf06QvGTqfNCv8yxnd3rfUWei3x-GTRBSRbI0VlMcXgahrgHh54yWPNOazUZmjS6KGVc9oxkl9aqXG21au8V4hOM2YzRVglqXgDVeZPKiDMmYBQu0SRxrnXYvNeZN54z8aOsTeK4FFTC2dVboO7Ng7sgIt9aKSu8zR3GjNqGyNw943eNVfW+oS1c2JOyY5Yp3V6z5PLai7t176Ws2Za27RnbL2uvEuY7dlNHQ-vdbhxFxHO7ZCsFKx6S7s9E03abUFhH8Pd2+uG7tJ7dngeOdB8yWrn2ztCjE1hk7Un5v-aRCh7Zv30d1fU-hspAadNzqm1R7BEOl2mdy3dwnIXn3ldtUQgTQmug9D6IMZLRD1BK7F21vzku61rvh-d4Lw3b2uXl8LrXovEas5-Yt1otMAPU1UCh3V4HmfYZgLBjZphCPO8547pDmHuc4bUwSY5uoVcYeI4LlbVO1s0+14jVrvnPlQ7C1yc7-W3UbrXZHDyj3X2U+hwnzWSfqLysS3CIHJe0uayt4Jjym3ddp9x9dw3BOO97Py6m42ln9s9cN0j2HsnUcHctZjqAXI03sYL+TovtIms04b1ZD7HuGc-cg19pZrPpMkqrwprfVLlN7LDxprT8KgA)

```ts
const none = useWatch({});
// const none: {
//   [x: string]: any;
// }
const defaultValueOnly = useWatch({ defaultValue: { test: 'test' } });
// const defaultValueOnly: {
//   test: string;
// }
const nameOnly1 = useWatch({ name: 'test' });
// const nameOnly1: any
const nameOnly2 = useWatch({ name: 'test1.test' });
// const nameOnly2: any
const nameOnly3 = useWatch({ name: 'test2[0]' });
// const nameOnly3: any
const namesOnly1 = useWatch({ name: ['test'] });
// const namesOnly1: Partial<Record<string, any>>
const namesOnly2 = useWatch({ name: ['test', 'test1.test'] }); // TODO: fix
// const namesOnly2: Partial<Record<string, any>>
const namesOnly3 = useWatch({ name: ['test', 'test1.test', 'test2[0]'] });
// const namesOnly3: Partial<Record<string, any>>
const controlOnly = useWatch({ control });
// const controlOnly: {
//     test?: string | undefined;
//     test1?: {
//         test?: number | undefined;
//     } | undefined;
//     test2?: boolean[] | undefined;
// }
const defaultValueAndControl = useWatch({
  defaultValue: { test: 'test' },
  control,
});
// const defaultValueAndControl: {
//     test: string;
//     test1: {
//         test: number;
//     };
//     test2: boolean[];
// }
const defaultValueAndName1 = useWatch({ name: 'test', defaultValue: 'test' });
// const defaultValueAndName1: string
const defaultValueAndName2 = useWatch({ name: 'test1.test', defaultValue: 1 });
// const defaultValueAndName2: number
const defaultValueAndName3 = useWatch({ name: 'test2[0]', defaultValue: true });
// const defaultValueAndName3: boolean
const defaultValueAndNames1 = useWatch({
  defaultValue: { test: 'test' },
  name: ['test'],
});
// const defaultValueAndNames1: {
//   test: string;
// }
const defaultValueAndNames2 = useWatch({
  defaultValue: { test: 'test', test1: { test: 1 } },
  name: ['test', 'test1.test'],
});
// const defaultValueAndNames2: {
//   test: string;
//   test1: number;
// }
const defaultValueAndNames3 = useWatch({
  defaultValue: { test: 'test', test1: { test: 1 }, test2: [true] },
  name: ['test', 'test1.test', 'test2[0]'],
});
// const defaultValueAndNames3: {
//   test: string;
//   test1: {
//     test: number;
//   };
//   test2: boolean[];
// }
const nameAndControl = useWatch({ name: 'test1.test', control });
// const nameAndControl: unknown
const namesAndControl = useWatch({ name: ['test', 'test1.test'], control });
// const namesAndControl: {
//   test?: string | undefined;
//   test1?: {
//       test?: number | undefined;
//   } | undefined;
//   test2?: boolean[] | undefined;
// }
const defaultValueAndNameAndControl1 = useWatch({
  defaultValue: 1,
  name: 'test1.test',
  control,
});
// const defaultValueAndNameAndControl1: number
const defaultValueAndNamesAndControl2 = useWatch({
  name: ['test', 'test1.test', 'test2[0]'],
  defaultValue: { test: 'test', test1: { test: 1 }, test2: [true] },
  control,
});
// const defaultValueAndNamesAndControl2: {
//     test: string;
//     test1: {
//         test: number;
//     };
//     test2: boolean[];
// }
```

### 2.2. use generics (don't infer `TWatchFieldValue`/`TWatchFieldValues` from control object)

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=308&ssc=5&pln=120&pc=1#code/KYDwDg9gTgLgBDAnmYcAixhgAoENYCWuANgDwAqAfHALxwDeAUHHANoDScBAdnANbBEEAGZxyAXQD8ALjEdxcUDGDcAJgGc4AQShRciUj2HAocAKqVmLOJO279pDFjyESpC5etxZ5eYpDKapoASsC4qhDcxIg6egZGJuae1rah4ZHRsQ5OOPgwRGQeViw+fkoqGnChAMbQqqTqMFA8AOYANHAArtx83BAA7tzJLLY5Lvluvuziw95y0wDcjAC+S4ygkLAIyKgAMgTKesTkENjNALYHBABuwBT+gZW43IjUdOQPFZqNzdwtVrYfq0rD5PkE4NxOucAEYmAEQqGwqAgsRgyrQiAQYhhbjwjFYnEo8hrVTAarEfCoWrcRpwAAkADlgI1gKoAGokTrAWTdAgARy5cHUiBhWLWG2g8CQKDgTJZ7M5d3IHOIgvK4OeiFYCgAPnAINCAFZk+B0TXauB6g3G6owN4MKysRnM5QK1XAcSybjAW5QJbLOAAMjEKq54vAku2MrM3DAuGqfDlrtDSvtDMiMdJwh4rIo1HVlSTrJThm4xlMFnhZhR6e4meA2e99SoaM01pN8PobE4PH4ghEYk95lj8cTLuLioo8moyyJ4c2Up2sozagbOeb9o+Bc03Sz65sEJ9iR888j0tQADECMBiG6uZo6DU6g0mq0OprKKetue4ABhSJNFiFBXjed7Mq2cAgbeKYPpB17QYq6j2kwLDCLgAg+FBYHqCsjDrBG35LlhMEXlAEDnP+3CAWQVjkJR1EQfRZHEIwm5MVijEAcxpblmIxGIdQtjkPx7qaF6R5+nhpLkpScDCN0toEJEXTqMAADquAwNUAAWpC0RpWnaSJ94QcZzKkeR7FkHRXFYpQbS0VZnFUcxtB-rZLGUAAFGAZFgOosgoXA1LUTIYhWf6ACUsgxnGCZFmBjiYLkrjWQZOlmUhn6MNJFJQKg8ncIpymdKp6W6fpmkZfB2GmTVJFkRRHkUFZ9mOR5zkMXQVmsT5fkBQ6LBZrgnTEDAKYxSO8XjolYx5AUFDlZllDZSwIXMWFNkuWKKzRcOcVjvKJbkEt9UCUsuWyYVxW8KV6lVRVLAnQ9Zl1aBDWWc1W3UZQrDCTVDK4OcHoOU9WGA8DEFAn8bnQ+07XbcQnWud1Hm9b5ED+YFVjcED3J8QDeNLGtHmbRFu08qujaspa+2jglJb7IcJAnGcBCXPktyLS9Z3uitF1knlBUKfkJVlQ9elPad72Km9CGiRZTWIy1Hm-f9oEQyDtHg3jUOvjDdBw6D4Uddu7mI25PXeRjWODRCeOYYTwPE3Aw2jeNiqTQdDOTkzJgs6cFxXFzz2GWZ-NWOtWJkx5UVe-TM2Mwc-vHIH7PB0q0vy1yEeXflcki0pt3i4ZktiFntVm5litWSriNtWDTuoGbAhCKIofVTLolua3A4d0ZvP3sb32uWbTmo4j6P9djLC48Djsa3j2ou1HxAx4jcdwV3Jlm-3mXwuMC3LSisUJ0dk5zalpDYAQCbc2Hg-Mh06u3prK3ZXnwtFaLxf3aXlUP23uBKuj91A1y+q1YeOtIYt37O3CuMEe5wPLjzIB6hh5OTHh1Ce1Ep6YwGkFOe+MX6qE1svKwbsxoTTptNc+7okrOHmpMBBAlVrBVJj4cmyw9qn1ocmScN87571Ac-aBwBc6CyuoXMWf8dJl2EWguW2FwHKxHnZKBTc9a-BaLDfW8MnqYICF8c2XUTHMTwbbQhDsCaL2BuQkmiN17UU3rww6-D6GXwmGlVB2dmQSJkvna6P8VKyMeigwBvjNAgLQSo6idcfoaNsc3Ix4I4a6O0Rg02KTKjjzMViCxBCcbWJIWQ8QLtKEe3dPHPhE4PHJUPswnx2EI4ONCpw2OFMaFuNqVye+ndInZUYD+BKF5oDnEQXQIKyhGiyDhi7aZMAACMM9rALK9IiEwLtVhWAWQAJlkPibEzxyHbJypI-O1JaSr1kLXEZYyYKDMufAPo3o3J3XKqQKZLpZl6PmS6ZZdsWBrIRDCTZVhtlApdPsuAhycQnO8vQbhSwAD0yL2E0meZEfGTBUWrJdGFNJepdxribCitFkLGiLLCji8lXgED4vWaC0wRKqbrjJdYAMLK9yksYLiilMBdlhVhcc3UXRWU8txbOJ5rsGwjSoYqAA8lERAbyS5yK+TMoUvydn-JWfyxlSItl-MaNC4V3B4VeS7BU6hXZgUAHIFl2rgAGJFvK0XSutYq5V2M+X0s1XMt1eLKU+tpV4YFkImXspYNs31eyDmYiOeaspgapWRFpEQpV0RFmqtCS+bRCL7bzzgA6l0TrXW4ulRm5VALCViu5ayRgla8aZsQLsnNHyI1IgLUQ2QJbKUADpHXOsiuyptwMW3Qs7YkLlJKG1juAC2gAzO2iWZru3WL7QK1gAAGcQZaR2BvnUu+NBJni02JdTVQja03PLxuoFt2a6DvIlra75WrtHOvXUW1gm67UKHLe6m9hbmQPpDUGmABK9HnvFaydlqaMXAfvcqttT61W6Q1TAH52jjVLL1X6zDILDXgv9F+-GP7HUdE3Yswdpb-0HorUBohSHojQppeByDH6Z2XqjfhqlYGw0MsI9Outs7VA8c5SJ7jKbr0IaY0uldpcMNYdaDhgFQV9VCcktGnDpqE1wuTcsUjshyOlsows6jFHi17J3Xuujo7GN3uPQ6WNgna0XrZYG-lfHnOhvw2FKdzLJMed9RJ9zEraV7KFXpkV0H61iek9K1eLaFPqp1f67VXm8Pho2Vp51OmT2JotV2Vew77MIaS96nzdKFkcdaLF0TPGvPUs89VwTAX6tSd9dGjrwXfORYK-pnr4XnUydpJ690Wg1C5OfYptLBGA2ZcBfhg1YLtNzd06epNJHLUUNle7G1y2rOludcbVeDkAPorG3t+VE2pseX4+B5TfxGu8YewJzVAWXsxr61CgbIq4OjfgONrkk3SF40fSEj5cMEVFKLb+42wP8bw92mVq7aF9uKlB5rGtejAcyvRzdkHahNYochxLALMPZ4bvMzRxodqEfXcqVyWQizzv0cAwhxHWO8aTpy3jrnxO8bLtQ7mtdO2qdw+s7u+nu2CdM-xk0LkbPUdA8ZymbnwNF1-dxB6tXmPBfA3UBDmbqWNMBsM+L-Hcr5eBUO7+k7sOyO-vEMrw9QGBdg8N2plrwKA2Sv53r27nvmSk5N+hubT2Wiqay2+z7xGViU6txjqpDA7eWfM7b4F2aXXGx7WweHR2B2Opdyjt3nPA9E+D+oVjPu31+4i7qqr72CNx5CwD3Xcv1cG+ZMLsns2zcZde0t7Lkb4-8o24VgzifEeZ7fQXjPqes8nfw9C1giuPQO4l07yzVHacwHp4Xrd0uS8XY79brvVetdN8O-X8D3uuuHdb7S774GJ-6fbw54GoPptodIBTy1wGvaNOlmJWp+n+wA3+92mmQ2c64B6gkBFsIuHySm76Kmc23uzeK2uW2yFuXYeeJmdOZm-ye+f6HQoB7Ol2t6huCB1Eb2fmkeMB8WD+5mzWD+ze-mOWjBX2XBCW7uFeEB3eNBzExuv+-+QUM+cArOjuQBxBFGkcHkruDG5ene+uweQhWIAKAWAeKhQems8Bd2iMoev+KBC2Q+6mj+OWRq622uRW0h+eO+wBpmh+uyNmpBsu5+nsi+c+6ejer6mq2eHQcabA6+-6p2ChpeShaOHhuhd66hxANeLm6W2Gtewa1+GmT+HKPGQRZq5CkqQAA)

```ts
const none = useWatch<{
  test: string;
  test1: {
    test: number;
  };
  test2: boolean[];
}>({});
// const none: {
//   test?: string | undefined;
//   test1?: {
//       test?: number | undefined;
//   } | undefined;
//   test2?: boolean[] | undefined;
// }
const defaultValueOnly = useWatch<{
  test: string;
  test1: {
    test: number;
  };
  test2: boolean[];
}>({ defaultValue: { test: 'test' } });
// const defaultValueOnly: {
//   test: string;
//   test1: {
//       test: number;
//   };
//   test2: boolean[];
// }
const nameOnly1 = useWatch<string>({ name: 'test' });
// const nameOnly1: string | undefined
const nameOnly2 = useWatch<number>({ name: 'test1.test' });
// const nameOnly2: number | undefined
const nameOnly3 = useWatch<boolean>({ name: 'test2[0]' });
// const nameOnly3: boolean | undefined
const namesOnly1 = useWatch<{ test: string }>({ name: ['test'] });
// const namesOnly1: {
//   test?: string | undefined;
// }
const namesOnly2 = useWatch<{
  test: string;
  test1: {
    test: number;
  };
}>({ name: ['test', 'test1.test'] });
// const namesOnly2: {
//   test?: string | undefined;
//   test1?: {
//     test?: number | undefined;
//   } | undefined;
// }
const namesOnly3 = useWatch<{
  test: string;
  test1: {
    test: number;
  };
  test2: boolean[];
}>({ name: ['test', 'test1.test', 'test2[0]'] });
// const namesOnly3: {
//   test?: string | undefined;
//   test1?: {
//     test?: number | undefined;
//   } | undefined;
//   test2?: boolean[] | undefined;
// }
const controlOnly = useWatch<{
  test: string;
  test1: {
    test: number;
  };
  test2: boolean[];
}>({ control });
// const controlOnly: {
//     test?: string | undefined;
//     test1?: {
//       test?: number | undefined;
//     } | undefined;
//     test2?: boolean[] | undefined;
// }
const defaultValueAndControl = useWatch<{
  test: string;
  test1: {
    test: number;
  };
  test2: boolean[];
}>({
  defaultValue: { test: 'test' },
  control,
});
// const defaultValueAndControl: {
//     test: string;
//     test1: {
//       test: number;
//     };
//     test2: boolean[];
// }
const defaultValueAndName1 = useWatch<string>({
  name: 'test',
  defaultValue: 'test',
});
// const defaultValueAndName1: string
const defaultValueAndName2 = useWatch<number>({
  name: 'test1.test',
  defaultValue: 1,
});
// const defaultValueAndName2: number
const defaultValueAndName3 = useWatch<boolean>({
  name: 'test2[0]',
  defaultValue: true,
});
// const defaultValueAndName3: boolean
const defaultValueAndNames1 = useWatch<{
  test: string;
}>({
  defaultValue: { test: 'test' },
  name: ['test'],
});
// const defaultValueAndNames1: {
//   test: string;
// }
const defaultValueAndNames2 = useWatch<{
  test: string;
  test1: {
    test: number;
  };
}>({
  defaultValue: { test: 'test', test1: { test: 1 } },
  name: ['test', 'test1.test'],
});
// const defaultValueAndNames2: {
//   test: string;
//   test1: {
//     test: number;
//   };
// }
const defaultValueAndNames3 = useWatch<{
  test: string;
  test1: {
    test: number;
  };
  test2: boolean[];
}>({
  defaultValue: { test: 'test', test1: { test: 1 }, test2: [true] },
  name: ['test', 'test1.test', 'test2[0]'],
});
// const defaultValueAndNames3: {
//   test: string;
//   test1: {
//     test: number;
//   };
//   test2: boolean[];
// }
const nameAndControl = useWatch<number>({ name: 'test1.test', control });
// const nameAndControl: number | undefined
const namesAndControl = useWatch<{
  test: string;
  test1: {
    test: number;
  };
}>({ name: ['test', 'test1.test'], control });
// const namesAndControl: {
//     test?: string | undefined;
//     test1?: {
//         test?: number | undefined;
//     } | undefined;
// }
const defaultValueAndNameAndControl1 = useWatch<number>({
  defaultValue: 1,
  name: 'test1.test',
  control,
});
// const defaultValueAndNameAndControl1: number
const defaultValueAndNamesAndControl2 = useWatch<{
  test: string;
  test1: {
    test: number;
  };
  test2: boolean[];
}>({
  name: ['test', 'test1.test', 'test2[0]'],
  defaultValue: { test: 'test', test1: { test: 1 }, test2: [true] },
  control,
});
// const defaultValueAndNamesAndControl2: {
//   test: string;
//   test1: {
//     test: number;
//   };
//   test2: boolean[];
// }
```

### 2.3. type error

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=308&ssc=5&pln=120&pc=1#code/KYDwDg9gTgLgBDAnmYcAixhgAoENYCWuANgDwAqAfHALxwDeAUHHANoDScBAdnANbBEEAGZxyAXQD8ALjEdxcUDGDcAJgGc4AQShRciUj2HAocAKqVmLOJO279pDFjyESpC5etxZ5eYpDKapoASsC4qhDcxIg6egZGJuae1rah4ZHRsQ5OOPgwRGQeViw+fkoqGnChAMbQqqTqMFA8AOYANHAArtx83BAA7tzJLLY5Lvluvuziw95y0wDcjAC+S4ygkLAIyKgAMgTKesTkENjNALYHBABuwBT+gZW43IjUdOQPFZqNzdwtVrYfq0rD5PkE4NxOucAEYmAEQqGwqAgsRgyrQiAQYhhbjwjFYnEo8hrVTAarEfCoWrcRpwAAkADlgI1gKoAGokTrAWTdAgARy5cHUiBhWLWG2g8CQKDgTJZ7M5d3IHOIgvK4OeiFYCgAPnAINCAFZk+B0TXauB6g3G6owN4MKysRnM5QK1XAcSybjAW5QJbLOAAMjEKq54vAku2MrM3DAuGqfDlrtDSvtDMiMdJwh4rIo1HVlSTrJThm4xlMFnhZhR6e4meA2e99SoaM01pN8PobE4PH4ghEYk95lj8cTLuLioo8moyyJ4c2Up2sozagbOeb9o+Bc03Sz65sEJ9iR888j0tQADECMBiG6uZo6DU6g0mq0OprKKetue4ABhSJNFiFBXjed7Mq2cAgbeKYPpB17QYq6j2kwLDCLgAg+FBYHqCsjDrBG35LlhMEXlAEDnP+3CAWQVjkJR1EQfRZHEIwm5MVijEAcxpblmIxGIdQtjkPx7qaF6R5+nhpLkpScDCN0toEJEXTqMAADquAwNUAAWpC0RpWnaSJ94QcZzKkeR7FkHRXFYpQbS0VZnFUcxtB-rZLGUAAFGAZFgOosgoXA1LUTIYhWf6ACUsgxnGCZFmBjiYLkrjWQZOlmUhn6MNJFJQKg8ncIpymdKp6W6fpmkZfB2GmTVJFkRRHkUFZ9mOR5zkMXQVmsT5fkBQ6LBZrgnTEDAKYxSO8XjolYx5AUFDlZllDZSwIXMWFNkuWKKzRcOcVjvKJbkEt9UCUsuWyYVxW8KV6lVRVLAnQ9Zl1aBDWWc1W3UZQrDCTVDK4OcHoOU9WGA8DEFAn8bnQ+07XbcQnWud1Hm9b5ED+YFVjcED3J8QDeNLGtHmbRFu08qujaspa+2jglJb7IcJAnGcBCXPktyLS9Z3uitF1knlBUKfkJVlQ9elPad72Km9CGiRZTWIy1Hm-f9oEQyDtHg3jUOvjDdBw6D4Uddu7mI25PXeRjWODRCeOYYTwPE3Aw2jeNiqTQdDOTkzJgs6cFxXFzz2GWZ-NWOtWJkx5UVe-TM2Mwc-vHIH7PB0q0vy1yEeXflcki0pt3i4ZktiFntVm5litWSriNtWDTuoGbAhCKIofVTLolua3A4d0ZvP3sb32uWbTmo4j6P9djLC48Djsa3j2ou1HxAx4jcdwV3Jlm-3mXwuMC3LSisUJ0dk5zalpDYAQCbc2Hg-Mh06u3prK3ZXnwtFaLxf3aXlUP23uBKuj91A1y+q1YeOtIYt37O3CuMEe5wPLjzIB6hh5OTHh1Ce1Ep6YwGkFOe+MX6qE1svKwbsxoTTptNc+7okrOHmpMBBAlVrBVJj4cmyw9qn1ocmScN87571Ac-aBwBc6CyuoXMWf8dJl2EWguW2FwHKxHnZKBTc9a-BaLDfW8MnqYICF8c2XUTHMTwbbQhDsCaL2BuQkmiN17UU3rww6-D6GXwmGlVB2dmQSJkvna6P8VKyMeigwBvjNAgLQSo6idcfoaNsc3Ix4I4a6O0Rg02KTKjjzMViCxBCcbWJIWQ8QLtKEe3dPHPhE4PHJUPswnx2EI4ONCpw2OFMaFuNqVye+ndInZUYD+BKF5oDnEQXQIKyhGiyDhi7aZMAACMM9rALK9IiEwLtVhWAWQAJlkPibEzxyHbJypI-O1JaSr1kLXEZYyYKDMufAEwZEoCLLcndcqXkuyrw6EQ2QAByBZAKOgVOoe87hCw4AAHpoVwEADLkjAnn6k6DAMAqLdkfJLjpb5kcPLG3+WwIFLoQVwGJY0XZALxDGzBZ7BgCAXSyEWR0PZsgmiCmWA5SFMK4WIuRRAVF6KYAAGYsWhNxa05iBLrGsHJTAUlcrKXUooQ2EaVC6Vdj6DAAAoiAAgjQBoAq1bq-VMB1CktZQgKAHKuWRShbChFQA)

```ts
const error1 = useWatch({ control, name: 'test', defaultValue: 1 }); // ❌
const output2 = useWatch({
  control,
  name: ['test', 'test2'],
  defaultValue: { test: 1, test2: [true] },
}); // ❌
const output3 = useWatch({
  control,
  name: ['test', 'test2'],
  defaultValue: { notExists: 'notExists', test2: [true] },
}); // ❌
```

### 2.4. expect type error, but no type error because support nested object

[TypeScript Playground](https://www.typescriptlang.org/play/?ssl=130&ssc=9&pln=120&pc=1#code/KYDwDg9gTgLgBDAnmYcAixhgAoENYCWuANgDwAqAfHALxwDeAUHHANoDScBAdnANbBEEAGZxyAXQD8ALjEdxcUDGDcAJgGc4AQShRciUj2HAocAKqVmLOJO279pDFjyESpC5etxZ5eYpDKapoASsC4qhDcxIg6egZGJuae1rah4ZHRsQ5OOPgwRGQeViw+fkoqGnChAMbQqqTqMFA8AOYANHAArtx83BAA7tzJLLY5Lvluvuziw95y0wDcjAC+S4ygkLAIyKgAMgTKesTkENjNALYHBABuwBT+gZW43IjUdOQPFZqNzdwtVrYfq0rD5PkE4NxOucAEYmAEQqGwqAgsRgyrQiAQYhhbjwjFYnEo8hrVTAarEfCoWrcRpwAAkADlgI1gKoAGokTrAWTdAgARy5cHUiBhWLWG2g8CQKDgTJZ7M5d3IHOIgvK4OeiFYCgAPnAINCAFZk+B0TXauB6g3G6owN4MKysRnM5QK1XAcSybjAW5QJbLOAAMjEKq54vAku2MrM3DAuGqfDlrtDSvtDMiMdJwh4rIo1HVlSTrJThm4xlMFnhZhR6e4meA2e99SoaM01pN8PobE4PH4ghEYk95lj8cTLuLioo8moyyJ4c2Up2sozagbOeb9o+Bc03Sz65sEJ9iR888j0tQADECMBiG6uZo6DU6g0mq0OprKKetue4ABhSJNFiFBXjed7Mq2cAgbeKYPpB17QYq6j2kwLDCLgAg+FBYHqCsjDrBG35LlhMEXlAEDnP+3CAWQVjkJR1EQfRZHEIwm5MVijEAcxpblmIxGIdQtjkPx7qaF6R5+nhpLkpScDCN0toEJEXTqMAADquAwNUAAWpC0RpWnaSJ94QcZzKkeR7FkHRXFYpQbS0VZnFUcxtB-rZLGUAAFGAZFgOosgoXA1LUTIYhWf6ACUsgxnGCZFmBjiYLkrjWQZOlmUhn6MNJFJQKg8ncIpymdKp6W6fpmkZfB2GmTVJFkRRHkUFZ9mOR5zkMXQVmsT5fkBQ6LBZrgnTEDAKYxSO8XjolYx5AUFDlZllDZSwIXMWFNkuWKKzRcOcVjvKJbkEt9UCUsuWyYVxW8KV6lVRVLAnQ9Zl1aBDWWc1W3UZQrDCTVDK4OcHoOU9WGA8DEFAn8bnQ+07XbcQnWud1Hm9b5ED+YFVjcED3J8QDeNLGtHmbRFu08qujaspa+2jglJb7IcJAnGcBCXPktyLS9Z3uitF1knlBUKfkJVlQ9elPad72Km9CGiRZTWIy1Hm-f9oEQyDtHg3jUOvjDdBw6D4Uddu7mI25PXeRjWODRCeOYYTwPE3Aw2jeNiqTQdDOTkzJgs6cFxXFzz2GWZ-NWOtWJkx5UVe-TM2Mwc-vHIH7PB0q0vy1yEeXflcki0pt3i4ZktiFntVm5litWSriNtWDTuoGbAhCKIofVTLolua3A4d0ZvP3sb32uWbTmo4j6P9djLC48Djsa3j2ou1HxAx4jcdwV3Jlm-3mXwuMC3LSisUJ0dk5zalpDYAQCbc2Hg-Mh06u3prK3ZXnwtFaLxf3aXlUP23uBKuj91A1y+q1YeOtIYt37O3CuMEe5wPLjzIB6hh5OTHh1Ce1Ep6YwGkFOe+MX6qE1svKwbsxoTTptNc+7okrOHmpMBBAlVrBVJj4cmyw9qn1ocmScN87571Ac-aBwBc6CyuoXMWf8dJl2EWguW2FwHKxHnZKBTc9a-BaLDfW8MnqYICF8c2XUTHMTwbbQhDsCaL2BuQkmiN17UU3rww6-D6GXwmGlVB2dmQSJkvna6P8VKyMeigwBvjNAgLQSo6idcfoaNsc3Ix4I4a6O0Rg02KTKjjzMViCxBCcbWJIWQ8QLtKEe3dPHPhE4PHJUPswnx2EI4ONCpw2OFMaFuNqVye+ndInZUYD+BKF5oDnEQXQIKyhGiyDhi7aZMAACMM9rALK9IiEwLtVhWAWQAJlkPibEzxyHbJypI-O1JaSr1kLXEZYyYKDMufADYJpyDIAAKK6GgG5O65UvJdlXh0IhshWAAHIFmLNBR0UFfQYDvJAAQRo6hQUKG4QsOAAB6DFcBACg5IwLF7CaTPPAK8j5XyoDYwJSwBZYU0l6l3GuJsSwqUIBdIssKTAWXUpdGFSEMJEj0qpuuZl2KWABkFXuJl+LRWssaLssKhycQWglYy1kIq4DLCAA)

```ts
const expectTypError = useWatch({ control, name: ['test1', 'notExists'] }); // ✅
// const expectTypError: {
//   test?: string | undefined;
//   test1?: {
//     test?: number | undefined;
//   } | undefined;
//   test2?: boolean[] | undefined;
// }
```