### PR TITLE
be able to use regex in triggerValidation

### DIFF
--- a/app/src/triggerValidation.tsx
+++ b/app/src/triggerValidation.tsx
@@ -8,6 +8,8 @@ function TriggerValidation() {
     test: string;
     test1: string;
     test2: string;
+    test3: string;
+    test4: string;
   }>();
 
   renderCounter++;
@@ -23,6 +25,12 @@ function TriggerValidation() {
       <input name="test2" ref={register({ required: true })} />
       <div id="test2Error">{errors.test2 && 'required'}</div>
 
+      <input name="test3" ref={register({ required: true })} />
+      <div id="test3Error">{errors.test3 && 'required'}</div>
+
+      <input name="test4" ref={register({ required: true })} />
+      <div id="test4Error">{errors.test4 && 'required'}</div>
+
       <button
         id="single"
         type="button"
@@ -37,6 +45,14 @@ function TriggerValidation() {
         onClick={() => triggerValidation(['test1', 'test2'])}
       >
         trigger multiple
+      </button>
+
+      <button
+        id="regex"
+        type="button"
+        onClick={() => triggerValidation(/test[3|4]/)}
+      >
+        trigger multiple by regex
       </button>
 
       <div id="renderCount">{renderCounter}</div>

--- a/cypress/integration/triggerValidation.ts
+++ b/cypress/integration/triggerValidation.ts
@@ -5,6 +5,8 @@ context('form triggerValidation', () => {
     cy.get('#testError').should('be.empty');
     cy.get('#test1Error').should('be.empty');
     cy.get('#test2Error').should('be.empty');
+    cy.get('#test3Error').should('be.empty');
+    cy.get('#test4Error').should('be.empty');
 
     cy.get('#single').click();
     cy.get('#testError').contains('required');
@@ -14,9 +16,13 @@ context('form triggerValidation', () => {
     cy.get('#test1Error').contains('required');
     cy.get('#test2Error').contains('required');
 
-    cy.get('#renderCount').contains('3');
+    cy.get('#regex').click();
+    cy.get('#test3Error').contains('required');
+    cy.get('#test4Error').contains('required');
+
+    cy.get('#renderCount').contains('4');
 
     cy.get('#multiple').click();
-    cy.get('#renderCount').contains('4');
+    cy.get('#renderCount').contains('5');
   });
 });

--- a/examples/triggerFieldValidation.tsx
+++ b/examples/triggerFieldValidation.tsx
@@ -9,7 +9,7 @@ export default function App() {
 
   return (
     <div className="App">
-      <h1>validationFeild</h1>
+      <h1>validationField</h1>
       <label>First name: </label>
       <input name="firstName" ref={register({ required: true })} />
 
@@ -19,13 +19,14 @@ export default function App() {
       <button
         type="button"
         onClick={async () => {
+          console.log('firstName', await triggerValidation('firstName'));
           console.log(
-            'firstName',
-            await triggerValidation({ name: 'firstName' }),
+            'firstName & lastName',
+            await triggerValidation(['firstName', 'lastName']),
           );
           console.log(
-            'lastName',
-            await triggerValidation({ name: 'lastName', value: 'test' }),
+            'firstName & lastName by regex',
+            await triggerValidation(/.*Name/),
           );
         }}
       >

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -106,7 +106,8 @@ export type FormContextValues<FormValues extends FieldValues = FieldValues> = {
           : string)
       | (IsFlatObject<FormValues> extends true
           ? Extract<keyof FormValues, string>
-          : string)[],
+          : string)[]
+      | RegExp,
   ): Promise<boolean>;
   errors: FieldErrors<FormValues>;
   formState: FormStateProxy<FormValues>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,7 +285,8 @@ export type Control<FormValues extends FieldValues = FieldValues> = {
           : string)
       | (IsFlatObject<FormValues> extends true
           ? Extract<keyof FormValues, string>
-          : string)[],
+          : string)[]
+      | RegExp,
   ): Promise<boolean>;
   register<
     Element extends FieldElement<FormValues> = FieldElement<FormValues>

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -778,6 +778,50 @@ describe('useForm', () => {
         { ref: { name: 'test1' } },
       );
     });
+
+    it('should trigger multiple fields validation by regex', async () => {
+      const { result } = renderHook(() =>
+        useForm<{ test: string; test1: string }>({
+          mode: VALIDATION_MODE.onChange,
+        }),
+      );
+
+      (validateField as any).mockImplementation(async () => ({}));
+
+      act(() => {
+        result.current.register({
+          name: 'test',
+        });
+        result.current.register({
+          name: 'test1',
+        });
+      });
+
+      await act(async () => {
+        await result.current.triggerValidation(/test.*/ as any);
+      });
+
+      expect(validateField).toBeCalledWith(
+        {
+          current: {
+            test: { ref: { name: 'test' } },
+            test1: { ref: { name: 'test1' } },
+          },
+        },
+        false,
+        { ref: { name: 'test' } },
+      );
+      expect(validateField).toBeCalledWith(
+        {
+          current: {
+            test: { ref: { name: 'test' } },
+            test1: { ref: { name: 'test1' } },
+          },
+        },
+        false,
+        { ref: { name: 'test1' } },
+      );
+    });
   });
 
   describe('triggerValidation with schema', () => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -402,9 +402,13 @@ export function useForm<
             : string)
         | (IsFlatObject<FormValues> extends true
             ? Extract<keyof FormValues, string>
-            : string)[],
+            : string)[]
+        | RegExp,
     ): Promise<boolean> => {
-      const fields = payload || Object.keys(fieldsRef.current);
+      const fields =
+        payload instanceof RegExp
+          ? Object.keys(fieldsRef.current).filter((name) => payload.test(name))
+          : payload || Object.keys(fieldsRef.current);
 
       if (shouldValidateSchemaOrResolver) {
         return executeSchemaOrResolverValidation(fields);


### PR DESCRIPTION
First of all, awesome project!

I encountered a problem with `triggerValidation` when I wanted to validate a subset of fields. 
For example, afaik there is no way to trigger validation for all `person` and all `children` fields  for the following form example:

```ts
interface Form {
  person: {
    firstName: string;
    lastName: string;
  };
  children: {
    firstName: string;
    lastName: string;
  }[];
  foo: string;
  bar: string;
}
```

With the proposed change that would be possible by calling 
```ts
triggerValidation(/(person.*|children.*)/)
```

That would be awesome especially for use cases in conjunction with `useFieldArray` where the user can add and delete fields e.g. as in the. example above.