### PR TITLE
improve useWatch type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -367,10 +367,10 @@ export type OmitResetState = Partial<{
   submitCount: boolean;
 }>;
 
-export type UseWatchOptions<TControl extends Control = Control> = {
+export type UseWatchOptions = {
   defaultValue?: unknown;
   name?: string | string[];
-  control?: TControl;
+  control?: Control;
 };
 
 export type FieldValuesFromFieldErrors<

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -3,13 +3,38 @@ import { useFormContext } from './useFormContext';
 import isUndefined from './utils/isUndefined';
 import isString from './utils/isString';
 import generateId from './logic/generateId';
-import { Control, UseWatchOptions } from './types';
+import {
+  UseWatchOptions,
+  FieldValues,
+  UnpackNestedValue,
+  Control,
+  DeepPartial,
+  LiteralToPrimitive,
+} from './types';
 
-export const useWatch = <TWatchValues, TControl extends Control = Control>({
+export function useWatch<TWatchFieldValues extends FieldValues>(props: {
+  defaultValue?: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+  control?: Control;
+}): UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+export function useWatch<TWatchFieldValue extends any>(props: {
+  name: string;
+  control?: Control;
+}): undefined | UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
+export function useWatch<TWatchFieldValue extends any>(props: {
+  name: string;
+  defaultValue: UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
+  control?: Control;
+}): UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
+export function useWatch<TWatchFieldValues extends FieldValues>(props: {
+  name: string[];
+  defaultValue?: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+  control?: Control;
+}): UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
+export function useWatch<TWatchFieldValues>({
   control,
   name,
   defaultValue,
-}: UseWatchOptions<TControl>): TWatchValues => {
+}: UseWatchOptions): TWatchFieldValues {
   const methods = useFormContext();
   const { watchFieldsHookRef, watchFieldsHookRenderRef, watchInternal } =
     control || methods.control;
@@ -53,5 +78,5 @@ export const useWatch = <TWatchValues, TControl extends Control = Control>({
     defaultValueRef,
   ]);
 
-  return (isUndefined(value) ? defaultValue : value) as TWatchValues;
-};
+  return (isUndefined(value) ? defaultValue : value) as TWatchFieldValues;
+}


### PR DESCRIPTION
Related PR: https://github.com/react-hook-form/react-hook-form/pull/1612

```ts
// usage
const none = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({});
// const none: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const defaultValueOnly = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({ defaultValue: { test: 'test' } });
// const defaultValueOnly: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const nameOnly1 = useWatch<string>({ name: 'test' });
// const nameOnly1: string | undefined
const nameOnly2 = useWatch<number>({ name: 'test1' });
// const nameOnly2: number | undefined
const nameOnly3 = useWatch<boolean>({ name: 'test2' });
// const nameOnly3: boolean | undefined
const namesOnly1 = useWatch<{ test: string }>({ name: ['test'] });
// const namesOnly1: {
//   test?: string | undefined;
// }
const namesOnly2 = useWatch<{
  test: string;
  test1: number;
}>({ name: ['test', 'test1'] });
// const namesOnly2: {
//   test?: string | undefined;
//   test1?: number | undefined;
// }
const namesOnly3 = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({ name: ['test', 'test1', 'test2'] });
// const namesOnly3: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const controlOnly = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({ control });
// const controlOnly: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const defaultValueAndControl = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({
  defaultValue: { test: 'test' },
  control,
});
// const defaultValueAndControl: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const defaultValueAndName1 = useWatch<string>({
  name: 'test',
  defaultValue: 'test',
});
// const defaultValueAndName1: string
const defaultValueAndName2 = useWatch<number>({
  name: 'test1',
  defaultValue: 1,
});
// const defaultValueAndName2: number
const defaultValueAndName3 = useWatch<boolean>({
  name: 'test2',
  defaultValue: true,
});
// const defaultValueAndName3: boolean
const defaultValueAndNames1 = useWatch<{ test: string }>({
  defaultValue: { test: 'test' },
  name: ['test'],
});
// const defaultValueAndNames1: {
//   test?: string | undefined;
// }
const defaultValueAndNames2 = useWatch<{
  test: string;
  test1: number;
}>({
  defaultValue: { test: 'test', test1: 1 },
  name: ['test', 'test1'],
});
// const defaultValueAndNames2: {
//   test?: string | undefined;
//   test1?: number | undefined;
// }
const defaultValueAndNames3 = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({
  defaultValue: { test: 'test', test1: 1, test2: true },
  name: ['test', 'test1', 'test2'],
});
// const defaultValueAndNames3: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
const nameAndControl = useWatch<number>({ name: 'test1', control });
// const nameAndControl: number | undefined
const namesAndControl = useWatch<{
  test: string;
  test1: number;
}>({ name: ['test', 'test1'], control });
// const namesAndControl: {
//   test?: string | undefined;
//   test1?: number | undefined;
// }
const defaultValueAndNameAndControl1 = useWatch<number>({
  defaultValue: 1,
  name: 'test1',
  control,
});
// const defaultValueAndNameAndControl1: number
const defaultValueAndNamesAndControl2 = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({
  name: ['test', 'test1', 'test2'],
  defaultValue: { test: 'test', test1: 1, test2: true },
  control,
});
// const defaultValueAndNamesAndControl2: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }

// type error
const error1 = useWatch<string>({ control, name: 'test', defaultValue: 1 }); // ❌
const output2 = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({
  control,
  name: ['test', 'test2'],
  defaultValue: { test: 1, test2: true },
}); // ❌
const output3 = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({
  control,
  name: ['test', 'test2'],
  defaultValue: { notExists: 'notExists', test2: true },
}); // ❌

// expect type error, but no type error because support nested object
const expectTypError = useWatch<{
  test: string;
  test1: number;
  test2: boolean;
}>({ control, name: ['test1', 'notExists'] }); // ✅
// const expectTypError: {
//   test?: string | undefined;
//   test1?: number | undefined;
//   test2?: boolean | undefined;
// }
```