### PR TITLE
fix handleSubmit type for native multiple input

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -371,8 +371,8 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
   getValues<TFieldName extends keyof TFieldValues>(
     names: TFieldName[],
   ): UnpackNestedValue<Pick<TFieldValues, TFieldName>>;
-  handleSubmit: (
-    callback: OnSubmit<TFieldValues>,
+  handleSubmit: <TSubmitFieldValues extends FieldValues = TFieldValues>(
+    callback: OnSubmit<TSubmitFieldValues>,
   ) => (e?: React.BaseSyntheticEvent) => Promise<void>;
   control: Control<TFieldValues>;
 };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1080,7 +1080,9 @@ export function useForm<
       }
     },
     [isWeb, reRender, resolverRef, submitFocusError, validateAllFieldCriteria],
-  );
+  ) as <TSubmitFieldValues extends FieldValues = TFieldValues>(
+    callback: OnSubmit<TSubmitFieldValues>,
+  ) => (e?: React.BaseSyntheticEvent) => Promise<void>;
 
   const resetRefs = ({
     errors,


### PR DESCRIPTION
In the case of native multiple input, submit value type is wrong.

```ts
const { register, errors, handleSubmit } = useForm<{
   email: NestedValue<string[]>;
}>();

const onSubmit = handleSubmit(data => {
  // data.email type is incorrect. The string is correct, not the string[]
  // (parameter) data: {
  //  email: string[];
  // }
  console.log(data);
});

<input
  multiple
  type="email"
  name="email"
  list="email"
  ref={register({ required: 'This is required.' })}
/>
```

The solution is to add a generics parameter to handleSubmit and allow the user to define the type of submit value.

```ts
handleSubmit<{ email: string }>(data => {
  console.log(data);
});
// const handleSubmit: <{
//     email: string;
// }>(callback: OnSubmit<{
//     email: string;
// }>) => (e?: React.BaseSyntheticEvent<object, any, any> | undefined) => Promise<void>
```

Resolved CodeSandbox: https://codesandbox.io/s/react-hook-form-native-multiple-input-tyhue