### PR TITLE
export UseFormMethods type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,7 @@
-export { NestedValue, Resolver, OnSubmit, Control } from './form';
+export {
+  NestedValue,
+  Resolver,
+  OnSubmit,
+  Control,
+  UseFormMethods,
+} from './form';


### PR DESCRIPTION
There are a certain number of users who want to use `UseFormMethods` type.

related: https://github.com/react-hook-form/react-hook-form/pull/1697