### PR TITLE
#1580 Controller with render props API

### DIFF
--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -55,7 +55,7 @@ export default function Field(props: any) {
         <section id="input-checkbox">
           <label>MUI Checkbox</label>
           <Controller
-            render={(props) => <Checkbox {...props} checked={props.value} />}
+            as={<Checkbox />}
             name="Checkbox"
             control={control}
             rules={{ required: true }}
@@ -92,7 +92,7 @@ export default function Field(props: any) {
         <section id="input-textField">
           <label>MUI TextField</label>
           <Controller
-            render={(props) => <TextField {...props} />}
+            as={<TextField />}
             name="TextField"
             control={control}
             rules={{ required: true }}
@@ -122,9 +122,7 @@ export default function Field(props: any) {
         <section id="input-switch">
           <label>MUI Switch</label>
           <Controller
-            render={(props) => (
-              <Switch value="checkedA" {...props} checked={props.value} />
-            )}
+            as={<Switch value="checkedA" />}
             name="switch"
             rules={{ required: true }}
             control={control}

--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -55,7 +55,7 @@ export default function Field(props: any) {
         <section id="input-checkbox">
           <label>MUI Checkbox</label>
           <Controller
-            as={<Checkbox />}
+            render={(props) => <Checkbox {...props} checked={props.value} />}
             name="Checkbox"
             control={control}
             rules={{ required: true }}
@@ -67,8 +67,8 @@ export default function Field(props: any) {
         <section id="input-radio-group">
           <label>Radio Group</label>
           <Controller
-            as={
-              <RadioGroup aria-label="gender" name="gender1">
+            render={(props) => (
+              <RadioGroup aria-label="gender" name="gender1" {...props}>
                 <FormControlLabel
                   value="female"
                   control={<Radio />}
@@ -80,7 +80,7 @@ export default function Field(props: any) {
                   label="Male"
                 />
               </RadioGroup>
-            }
+            )}
             rules={{ required: true }}
             name="RadioGroup"
             control={control}
@@ -92,7 +92,7 @@ export default function Field(props: any) {
         <section id="input-textField">
           <label>MUI TextField</label>
           <Controller
-            as={<TextField />}
+            render={(props) => <TextField {...props} />}
             name="TextField"
             control={control}
             rules={{ required: true }}
@@ -104,13 +104,13 @@ export default function Field(props: any) {
         <section id="input-select">
           <label>MUI Select</label>
           <Controller
-            as={
-              <Select>
+            render={(props) => (
+              <Select {...props}>
                 <MenuItem value={10}>Ten</MenuItem>
                 <MenuItem value={20}>Twenty</MenuItem>
                 <MenuItem value={30}>Thirty</MenuItem>
               </Select>
-            }
+            )}
             rules={{ required: true }}
             name="Select"
             control={control}
@@ -122,7 +122,7 @@ export default function Field(props: any) {
         <section id="input-switch">
           <label>MUI Switch</label>
           <Controller
-            as={<Switch value="checkedA" />}
+            render={(props) => <Switch value="checkedA" {...props} />}
             name="switch"
             rules={{ required: true }}
             control={control}
@@ -134,11 +134,17 @@ export default function Field(props: any) {
         <section id="input-ReactSelect">
           <label>React Select</label>
           <Controller
-            as={<ReactSelect isClearable options={options} />}
+            render={(props) => (
+              <ReactSelect
+                isClearable
+                options={options}
+                {...props}
+                onChange={props.onChange((data: any) => data) as any}
+              />
+            )}
             name="ReactSelect"
             control={control}
             rules={{ required: true }}
-            onChange={(data: any) => data}
           />
         </section>
 

--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -122,7 +122,9 @@ export default function Field(props: any) {
         <section id="input-switch">
           <label>MUI Switch</label>
           <Controller
-            render={(props) => <Switch value="checkedA" {...props} />}
+            render={(props) => (
+              <Switch value="checkedA" {...props} checked={props.value} />
+            )}
             name="switch"
             rules={{ required: true }}
             control={control}
@@ -135,12 +137,7 @@ export default function Field(props: any) {
           <label>React Select</label>
           <Controller
             render={(props) => (
-              <ReactSelect
-                isClearable
-                options={options}
-                {...props}
-                onChange={props.onChange((data: any) => data) as any}
-              />
+              <ReactSelect isClearable options={options} {...props} />
             )}
             name="ReactSelect"
             control={control}

--- a/app/src/useFieldArray.tsx
+++ b/app/src/useFieldArray.tsx
@@ -73,7 +73,7 @@ const UseFieldArray: React.FC = (props: any) => {
               />
             ) : (
               <Controller
-                as={<input id={`field${index}`} />}
+                render={(props) => <input id={`field${index}`} {...props} />}
                 control={control}
                 rules={{
                   required: 'This is required',

--- a/app/src/useFieldArray.tsx
+++ b/app/src/useFieldArray.tsx
@@ -83,9 +83,11 @@ const UseFieldArray: React.FC = (props: any) => {
                 data-order={index}
               />
             )}
-            <ErrorMessage errors={errors} name={`data[${index}].name`}>
-              {({ message }) => <p id={`error${index}`}>{message}</p>}
-            </ErrorMessage>
+            <ErrorMessage
+              errors={errors}
+              name={`data[${index}].name`}
+              render={({ message }) => <p id={`error${index}`}>{message}</p>}
+            />
             <button id={`delete${index}`} onClick={() => remove(index)}>
               Delete
             </button>

--- a/app/src/useWatch.tsx
+++ b/app/src/useWatch.tsx
@@ -110,10 +110,14 @@ export default () => {
       <Controller
         name={'test1'}
         control={control}
-        placeholder="👀 watching me :)"
-        autoComplete="off"
-        style={{ fontSize: 20 }}
-        as={<input />}
+        render={(props) => (
+          <input
+            {...props}
+            placeholder="👀 watching me :)"
+            autoComplete="off"
+            style={{ fontSize: 20 }}
+          />
+        )}
         defaultValue=""
       />
 

--- a/app/src/useWatch.tsx
+++ b/app/src/useWatch.tsx
@@ -112,10 +112,11 @@ export default () => {
         control={control}
         render={(props) => (
           <input
-            {...props}
             placeholder="👀 watching me :)"
             autoComplete="off"
+            name={'test1'}
             style={{ fontSize: 20 }}
+            {...props}
           />
         )}
         defaultValue=""

--- a/cypress/integration/controller.ts
+++ b/cypress/integration/controller.ts
@@ -11,7 +11,7 @@ context('controller basic form validation', () => {
     cy.get('#switch').contains('switch Error');
 
     cy.get('#input-checkbox input').click();
-    cy.get('#input-radio-group input').click({ multiple: true });
+    cy.get('input[name="gender1"]').first().click();
     cy.get('#input-textField input').type('test');
     cy.get('#input-select > div > div').click();
     cy.get('.MuiPopover-root ul > li:first-child').click();
@@ -19,7 +19,7 @@ context('controller basic form validation', () => {
     cy.get('#input-ReactSelect > div').click();
     cy.get('#input-ReactSelect > div > div').eq(1).click();
 
-    cy.get('p').should('have.length', 2);
+    cy.get('p').should('have.length', 0);
     cy.get('#renderCount').contains('8');
   });
 

--- a/cypress/integration/controller.ts
+++ b/cypress/integration/controller.ts
@@ -19,7 +19,7 @@ context('controller basic form validation', () => {
     cy.get('#input-ReactSelect > div').click();
     cy.get('#input-ReactSelect > div > div').eq(1).click();
 
-    cy.get('p').should('have.length', 0);
+    cy.get('p').should('have.length', 2);
     cy.get('#renderCount').contains('8');
   });
 

--- a/cypress/integration/controller.ts
+++ b/cypress/integration/controller.ts
@@ -19,8 +19,8 @@ context('controller basic form validation', () => {
     cy.get('#input-ReactSelect > div').click();
     cy.get('#input-ReactSelect > div > div').eq(1).click();
 
-    cy.get('p').should('have.length', 2);
-    cy.get('#renderCount').contains('8');
+    cy.get('.container > p').should('have.length', 6);
+    cy.get('#renderCount').contains('2');
   });
 
   it('should validate the form with onBlur mode and reset the form', () => {

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -9,20 +9,11 @@ exports[`Controller should render correctly with as with component 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Controller should render correctly with as with string 1`] = `
-<DocumentFragment>
-  <input
-    name="test"
-    value=""
-  />
-</DocumentFragment>
-`;
-
 exports[`Controller should support custom value name 1`] = `
 <DocumentFragment>
   <input
     name="test"
-    selectedkey=""
+    value=""
   />
 </DocumentFragment>
 `;

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Controller should render correctly with as with component 1`] = `
+<DocumentFragment>
+  <input />
+</DocumentFragment>
+`;
+
 exports[`Controller should support custom value name 1`] = `
 <DocumentFragment>
   <input

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -1,18 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Controller should render correctly with as with component 1`] = `
-<DocumentFragment>
-  <input
-    name="test"
-    value=""
-  />
-</DocumentFragment>
-`;
-
 exports[`Controller should support custom value name 1`] = `
 <DocumentFragment>
   <input
-    name="test"
     value=""
   />
 </DocumentFragment>
@@ -21,7 +11,6 @@ exports[`Controller should support custom value name 1`] = `
 exports[`Controller should support default value from hook form 1`] = `
 <DocumentFragment>
   <input
-    name="test"
     value="data"
   />
 </DocumentFragment>

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Controller should render correctly with as with string 1`] = `
 exports[`Controller should support custom value name 1`] = `
 <DocumentFragment>
   <input
-    value=""
+    value="test"
   />
 </DocumentFragment>
 `;

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -2,7 +2,17 @@
 
 exports[`Controller should render correctly with as with component 1`] = `
 <DocumentFragment>
-  <input />
+  <input
+    value=""
+  />
+</DocumentFragment>
+`;
+
+exports[`Controller should render correctly with as with string 1`] = `
+<DocumentFragment>
+  <input
+    value=""
+  />
 </DocumentFragment>
 `;
 

--- a/src/__snapshots__/errorMessage.test.tsx.snap
+++ b/src/__snapshots__/errorMessage.test.tsx.snap
@@ -54,17 +54,15 @@ exports[`React Hook Form Error Message should render correctly with flat errors 
 
 exports[`React Hook Form Error Message should render correctly with flat multiple errors and as with component and children 1`] = `
 <DocumentFragment>
-  <div>
-    <span>
-      flat1
-    </span>
-    <span>
-      flat2
-    </span>
-    <span>
-      flat3
-    </span>
-  </div>
+  <span>
+    flat1
+  </span>
+  <span>
+    flat2
+  </span>
+  <span>
+    flat3
+  </span>
 </DocumentFragment>
 `;
 
@@ -142,17 +140,15 @@ exports[`React Hook Form Error Message should render correctly with nested error
 
 exports[`React Hook Form Error Message should render correctly with nested multiple errors and as with component and children 1`] = `
 <DocumentFragment>
-  <div>
-    <span>
-      object1
-    </span>
-    <span>
-      object2
-    </span>
-    <span>
-      object3
-    </span>
-  </div>
+  <span>
+    object1
+  </span>
+  <span>
+    object2
+  </span>
+  <span>
+    object3
+  </span>
 </DocumentFragment>
 `;
 
@@ -172,17 +168,15 @@ exports[`React Hook Form Error Message should render correctly with nested multi
 
 exports[`React Hook Form Error Message should render correctly with nested multiple errors array and as with component and children 1`] = `
 <DocumentFragment>
-  <div>
-    <span>
-      array1
-    </span>
-    <span>
-      array2
-    </span>
-    <span>
-      array3
-    </span>
-  </div>
+  <span>
+    array1
+  </span>
+  <span>
+    array2
+  </span>
+  <span>
+    array3
+  </span>
 </DocumentFragment>
 `;
 

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -9,39 +9,14 @@ jest.spyOn(console, 'warn').mockImplementation(() => {});
 const Input = ({ onChange, onBlur, placeholder }: any) => (
   <input
     placeholder={placeholder}
-    onChange={() => onChange?.(1, 2)}
+    onChange={() => {
+      onChange?.(1, 2);
+    }}
     onBlur={() => onBlur?.(1, 2)}
   />
 );
 
 describe('Controller', () => {
-  it('should render correctly with as with string', () => {
-    const control = reconfigureControl();
-    const fieldsRef = {
-      current: {},
-    };
-
-    const { asFragment } = render(
-      <Controller
-        defaultValue=""
-        name="test"
-        render={<input />}
-        control={
-          {
-            ...control,
-            register: (payload: any) => {
-              // @ts-ignore
-              fieldsRef.current[payload.name] = 'test';
-            },
-            fieldsRef,
-          } as any
-        }
-      />,
-    );
-
-    expect(asFragment()).toMatchSnapshot();
-  });
-
   it('should render correctly with as with component', () => {
     const control = reconfigureControl();
     const fieldsRef = {
@@ -199,13 +174,8 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        render={({ onChange, onBlur, value }) => {
-          return (
-            <Input
-              placeholder="test"
-              {...{ onChange: () => onChange(), onBlur, value }}
-            />
-          );
+        render={({ onBlur, onChange, value }) => {
+          return <Input placeholder="test" {...{ onChange, onBlur, value }} />;
         }}
         control={
           {
@@ -227,7 +197,6 @@ describe('Controller', () => {
     });
 
     expect(setValue).toBeCalled();
-    expect(onChange).toBeCalledWith(1, 2);
   });
 
   it('should invoke custom onBlur method', () => {
@@ -243,13 +212,8 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        render={({ onChange, onBlur, value }) => {
-          return (
-            <Input
-              placeholder="test"
-              {...{ onChange, onBlur: () => onBlur(), value }}
-            />
-          );
+        render={({ onChange, value }) => {
+          return <Input placeholder="test" {...{ onChange, onBlur, value }} />;
         }}
         control={
           {

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -9,26 +9,50 @@ jest.spyOn(console, 'warn').mockImplementation(() => {});
 const Input = ({ onChange, onBlur, placeholder }: any) => (
   <input
     placeholder={placeholder}
-    onChange={() => {
-      onChange?.(1, 2);
-    }}
+    onChange={() => onChange?.(1, 2)}
     onBlur={() => onBlur?.(1, 2)}
   />
 );
 
 describe('Controller', () => {
-  it('should render correctly with as with component', () => {
+  it('should render correctly with as with string', () => {
     const control = reconfigureControl();
     const fieldsRef = {
       current: {},
     };
-    const Input = () => <input />;
 
     const { asFragment } = render(
       <Controller
         defaultValue=""
         name="test"
-        render={Input}
+        as={'input' as 'input'}
+        control={
+          {
+            ...control,
+            register: (payload: any) => {
+              // @ts-ignore
+              fieldsRef.current[payload.name] = 'test';
+            },
+            fieldsRef,
+          } as any
+        }
+      />,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render correctly with as with component', () => {
+    const control = reconfigureControl();
+    const fieldsRef = {
+      current: {},
+    };
+
+    const { asFragment } = render(
+      <Controller
+        defaultValue=""
+        name="test"
+        as={<input />}
         control={
           {
             ...control,
@@ -59,7 +83,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        render={(props) => <input placeholder="test" {...props} />}
+        as={<input placeholder="test" />}
         control={
           {
             ...control,
@@ -96,7 +120,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        render={(props) => <input placeholder="test" {...props} />}
+        as={<input placeholder="test" />}
         control={
           {
             ...control,
@@ -253,7 +277,7 @@ describe('Controller', () => {
     const { asFragment } = render(
       <Controller
         name="test"
-        render={(props) => <input {...props} />}
+        as={'input' as 'input'}
         control={
           {
             ...control,

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -17,32 +17,32 @@ const Input = ({ onChange, onBlur, placeholder }: any) => (
 );
 
 describe('Controller', () => {
-  it('should render correctly with as with component', () => {
-    const control = reconfigureControl();
-    const fieldsRef = {
-      current: {},
-    };
-
-    const { asFragment } = render(
-      <Controller
-        defaultValue=""
-        name="test"
-        render={<input />}
-        control={
-          {
-            ...control,
-            register: (payload: any) => {
-              // @ts-ignore
-              fieldsRef.current[payload.name] = 'test';
-            },
-            fieldsRef,
-          } as any
-        }
-      />,
-    );
-
-    expect(asFragment()).toMatchSnapshot();
-  });
+  // it('should render correctly with as with component', () => {
+  //   const control = reconfigureControl();
+  //   const fieldsRef = {
+  //     current: {},
+  //   };
+  //
+  //   const { asFragment } = render(
+  //     <Controller
+  //       defaultValue=""
+  //       name="test"
+  //       render={<input />}
+  //       control={
+  //         {
+  //           ...control,
+  //           register: (payload: any) => {
+  //             // @ts-ignore
+  //             fieldsRef.current[payload.name] = 'test';
+  //           },
+  //           fieldsRef,
+  //         } as any
+  //       }
+  //     />,
+  //   );
+  //
+  //   expect(asFragment()).toMatchSnapshot();
+  // });
 
   it("should trigger component's onChange method and invoke setValue method", () => {
     const setValue = jest.fn();
@@ -58,7 +58,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        render={<input placeholder="test" />}
+        render={(props) => <input placeholder="test" {...props} />}
         control={
           {
             ...control,
@@ -95,7 +95,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        render={<input placeholder="test" />}
+        render={(props) => <input placeholder="test" {...props} />}
         control={
           {
             ...control,
@@ -252,7 +252,7 @@ describe('Controller', () => {
     const { asFragment } = render(
       <Controller
         name="test"
-        render={<input />}
+        render={(props) => <input {...props} />}
         control={
           {
             ...control,
@@ -279,7 +279,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        render={<input />}
+        render={(props) => <input {...props} />}
         control={
           {
             ...control,
@@ -304,7 +304,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test[0]"
-        render={<input />}
+        render={(props) => <input {...props} />}
         control={{
           ...control,
           removeFieldEventListener,

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -17,32 +17,33 @@ const Input = ({ onChange, onBlur, placeholder }: any) => (
 );
 
 describe('Controller', () => {
-  // it('should render correctly with as with component', () => {
-  //   const control = reconfigureControl();
-  //   const fieldsRef = {
-  //     current: {},
-  //   };
-  //
-  //   const { asFragment } = render(
-  //     <Controller
-  //       defaultValue=""
-  //       name="test"
-  //       render={<input />}
-  //       control={
-  //         {
-  //           ...control,
-  //           register: (payload: any) => {
-  //             // @ts-ignore
-  //             fieldsRef.current[payload.name] = 'test';
-  //           },
-  //           fieldsRef,
-  //         } as any
-  //       }
-  //     />,
-  //   );
-  //
-  //   expect(asFragment()).toMatchSnapshot();
-  // });
+  it('should render correctly with as with component', () => {
+    const control = reconfigureControl();
+    const fieldsRef = {
+      current: {},
+    };
+    const Input = () => <input />;
+
+    const { asFragment } = render(
+      <Controller
+        defaultValue=""
+        name="test"
+        render={Input}
+        control={
+          {
+            ...control,
+            register: (payload: any) => {
+              // @ts-ignore
+              fieldsRef.current[payload.name] = 'test';
+            },
+            fieldsRef,
+          } as any
+        }
+      />,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 
   it("should trigger component's onChange method and invoke setValue method", () => {
     const setValue = jest.fn();

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -25,7 +25,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        as={'input' as 'input'}
+        render={<input />}
         control={
           {
             ...control,
@@ -52,7 +52,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        as={<input />}
+        render={<input />}
         control={
           {
             ...control,
@@ -83,7 +83,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        as={<input placeholder="test" />}
+        render={<input placeholder="test" />}
         control={
           {
             ...control,
@@ -120,7 +120,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        as={<input placeholder="test" />}
+        render={<input placeholder="test" />}
         control={
           {
             ...control,
@@ -157,8 +157,9 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        as={<input placeholder="test" />}
-        onChangeName="onChange"
+        render={(props) => {
+          return <input placeholder="test" {...props} />;
+        }}
         control={
           {
             ...control,
@@ -198,8 +199,14 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        as={<Input placeholder="test" />}
-        onChange={onChange}
+        render={({ onChange, onBlur, value }) => {
+          return (
+            <Input
+              placeholder="test"
+              {...{ onChange: () => onChange(), onBlur, value }}
+            />
+          );
+        }}
         control={
           {
             ...control,
@@ -236,8 +243,14 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        as={<Input placeholder="test" />}
-        onBlur={onBlur}
+        render={({ onChange, onBlur, value }) => {
+          return (
+            <Input
+              placeholder="test"
+              {...{ onChange, onBlur: () => onBlur(), value }}
+            />
+          );
+        }}
         control={
           {
             ...control,
@@ -275,7 +288,7 @@ describe('Controller', () => {
     const { asFragment } = render(
       <Controller
         name="test"
-        as={'input' as 'input'}
+        render={<input />}
         control={
           {
             ...control,
@@ -302,8 +315,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test"
-        as={'input' as 'input'}
-        valueName="selectedkey"
+        render={<input />}
         control={
           {
             ...control,
@@ -328,8 +340,7 @@ describe('Controller', () => {
       <Controller
         defaultValue=""
         name="test[0]"
-        as={'input' as 'input'}
-        valueName="selectedkey"
+        render={<input />}
         control={{
           ...control,
           removeFieldEventListener,

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -299,12 +299,19 @@ describe('Controller', () => {
     const fieldsRef = {
       current: {},
     };
+    const Input = ({ onChange, onBlur, selectedkey }: any) => (
+      <input
+        onChange={() => onChange?.(1, 2)}
+        onBlur={() => onBlur?.(1, 2)}
+        value={selectedkey}
+      />
+    );
 
     const { asFragment } = render(
       <Controller
-        defaultValue=""
+        defaultValue="test"
         name="test"
-        render={(props) => <input {...props} />}
+        render={(props) => <Input {...props} selectedkey={props.value} />}
         control={
           {
             ...control,

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import isBoolean from './utils/isBoolean';
 import isUndefined from './utils/isUndefined';
-import isReactComponentClass from './utils/isReactComponentClass';
 import get from './utils/get';
 import set from './utils/set';
 import getInputValue from './logic/getInputValue';
@@ -15,11 +14,10 @@ import { ControllerProps } from './types/props';
 const Controller = <TControl extends Control = Control>({
   name,
   rules,
-  render: InnerComponent,
+  render,
   defaultValue,
   control,
   onFocus,
-  ...rest
 }: ControllerProps<TControl>) => {
   const methods = useFormContext();
   const {
@@ -154,22 +152,11 @@ const Controller = <TControl extends Control = Control>({
       );
   }
 
-  return isReactComponentClass(InnerComponent) ? (
-    <InnerComponent
-      {...{
-        onChange,
-        onBlur,
-        ...{ [isCheckboxInput ? 'checked' : VALUE]: value },
-        ...rest,
-      }}
-    />
-  ) : (
-    InnerComponent({
-      onChange,
-      onBlur,
-      value,
-    })
-  );
+  return render({
+    onChange,
+    onBlur,
+    value,
+  });
 };
 
 export { Controller };

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -142,16 +142,12 @@ const Controller = <TControl extends Control = Control>({
   function onChange(
     ...callbackOrEvent: any[]
   ): ((...event: any[]) => void) | void {
-    if (!isFunction(callbackOrEvent[0])) {
-      setValue(name, commonTask(...callbackOrEvent), shouldValidate());
-    }
+    const [firstArg] = callbackOrEvent;
 
-    return (event: any) =>
-      setValue(
-        name,
-        commonTask(callbackOrEvent[0](...event)),
-        shouldValidate(),
-      );
+    return isFunction(firstArg)
+      ? (event: any) =>
+          setValue(name, commonTask(firstArg(event)), shouldValidate())
+      : setValue(name, commonTask(...callbackOrEvent), shouldValidate());
   }
 
   return render({

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import isBoolean from './utils/isBoolean';
 import isUndefined from './utils/isUndefined';
+import isReactComponentClass from './utils/isReactComponentClass';
 import get from './utils/get';
 import set from './utils/set';
 import getInputValue from './logic/getInputValue';
@@ -11,22 +12,15 @@ import { VALUE } from './constants';
 import { Control, Field } from './types/form';
 import { ControllerProps } from './types/props';
 
-const Controller = <
-  TAs extends
-    | React.ReactElement
-    | React.ComponentType<any>
-    | keyof JSX.IntrinsicElements,
-  TControl extends Control = Control
->({
+const Controller = <TControl extends Control = Control>({
   name,
   rules,
-  render,
-  as,
+  render: InnerComponent,
   defaultValue,
   control,
   onFocus,
   ...rest
-}: ControllerProps<TAs, TControl>) => {
+}: ControllerProps<TControl>) => {
   const methods = useFormContext();
   const {
     defaultValuesRef,
@@ -152,15 +146,15 @@ const Controller = <
     onBlur: handleBlur,
   };
 
-  return as
-    ? React.isValidElement(as)
-      ? React.cloneElement(as, props)
-      : React.createElement(as as string, props)
-    : render({
-        value,
-        handleChange,
-        handleBlur,
-      });
+  return isReactComponentClass(InnerComponent) ? (
+    <InnerComponent {...props} />
+  ) : (
+    InnerComponent({
+      value,
+      handleChange,
+      handleBlur,
+    })
+  );
 };
 
 export { Controller };

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -136,8 +136,23 @@ const Controller = <TControl extends Control = Control>({
     }
   };
 
-  const onChange = (event: any): any =>
-    setValue(name, commonTask(event), shouldValidate());
+  function onChange(...event: any[]): void;
+  function onChange(
+    callback: (...args: any[]) => any,
+  ): (...event: any[]) => void;
+  function onChange(
+    ...callbackOrEvent: any[]
+  ): ((...event: any[]) => void) | void {
+    if (typeof callbackOrEvent[0] !== 'function') {
+      setValue(name, commonTask(callbackOrEvent), shouldValidate());
+    }
+    return (event: any) =>
+      setValue(
+        name,
+        commonTask(callbackOrEvent[0](...event)),
+        shouldValidate(),
+      );
+  }
 
   return isReactComponentClass(InnerComponent) ? (
     <InnerComponent

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -145,6 +145,9 @@ const Controller = <
 
   function onChange(...event: any[]): void;
   function onChange(
+    callback: (...args: any[]) => any,
+  ): (...event: any[]) => void;
+  function onChange(
     ...callbackOrEvent: any[]
   ): ((...event: any[]) => void) | void {
     const [firstArg] = callbackOrEvent;

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -63,7 +63,7 @@ const Controller = <TControl extends Control = Control>({
     });
 
   const commonTask = (event: any[]) => {
-    const data = getInputValue(event, isCheckboxInput);
+    const data = getInputValue(event[0], isCheckboxInput);
     setInputStateValue(data);
     valueRef.current = data;
     return data;
@@ -147,7 +147,7 @@ const Controller = <TControl extends Control = Control>({
     return isFunction(firstArg)
       ? (event: any) =>
           setValue(name, commonTask(firstArg(event)), shouldValidate())
-      : setValue(name, commonTask(...callbackOrEvent), shouldValidate());
+      : setValue(name, commonTask(callbackOrEvent), shouldValidate());
   }
 
   return render({

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -9,7 +9,7 @@ import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
 import { useFormContext } from './useFormContext';
 import { VALUE } from './constants';
-import { Control, Field } from './types/form';
+import { Control, Field, EventFunction } from './types/form';
 import { ControllerProps } from './types/props';
 
 const Controller = <TControl extends Control = Control>({
@@ -19,7 +19,6 @@ const Controller = <TControl extends Control = Control>({
   defaultValue,
   control,
   onFocus,
-  ...rest
 }: ControllerProps<TControl>) => {
   const methods = useFormContext();
   const {
@@ -140,20 +139,15 @@ const Controller = <TControl extends Control = Control>({
     setValue(name, commonTask(event), shouldValidate());
 
   const props = {
-    name,
-    ...rest,
-    onChange: onChange,
-    onBlur: onBlur,
+    onChange,
+    onBlur,
+    value,
   };
 
   return isReactComponentClass(InnerComponent) ? (
     <InnerComponent {...props} />
   ) : (
-    InnerComponent({
-      value,
-      onChange,
-      onBlur,
-    })
+    InnerComponent(props)
   );
 };
 

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -62,8 +62,8 @@ const Controller = <TControl extends Control = Control>({
       isSubmitted,
     });
 
-  const commonTask = (...event: any[]) => {
-    const data = getInputValue(event[0], isCheckboxInput);
+  const commonTask = (event: any[]) => {
+    const data = getInputValue(event, isCheckboxInput);
     setInputStateValue(data);
     valueRef.current = data;
     return data;

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -9,7 +9,7 @@ import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
 import { useFormContext } from './useFormContext';
 import { VALUE } from './constants';
-import { Control, Field, EventFunction } from './types/form';
+import { Control, Field } from './types/form';
 import { ControllerProps } from './types/props';
 
 const Controller = <TControl extends Control = Control>({

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -7,7 +7,7 @@ import getInputValue from './logic/getInputValue';
 import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
 import { useFormContext } from './useFormContext';
-import { VALUE } from './constants';
+import { VALIDATION_MODE, VALUE } from './constants';
 import { Control, Field } from './types/form';
 import { ControllerProps } from './types/props';
 
@@ -148,8 +148,8 @@ const Controller = <
   const props = {
     name,
     ...rest,
-    onChange: handleChange,
-    onBlur: handleBlur,
+    [VALIDATION_MODE.onChange]: handleChange,
+    [VALIDATION_MODE.onBlur]: handleBlur,
   };
 
   return as

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -150,7 +150,7 @@ const Controller = <TControl extends Control = Control>({
       : setValue(name, commonTask(callbackOrEvent), shouldValidate());
   }
 
-  return React.createElement(render, {
+  return render({
     onChange,
     onBlur,
     value,

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -3,7 +3,6 @@ import isBoolean from './utils/isBoolean';
 import isUndefined from './utils/isUndefined';
 import get from './utils/get';
 import set from './utils/set';
-import isFunction from './utils/isFunction';
 import getInputValue from './logic/getInputValue';
 import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
@@ -143,19 +142,8 @@ const Controller = <
     }
   };
 
-  function onChange(...event: any[]): void;
-  function onChange(
-    callback: (...args: any[]) => any,
-  ): (...event: any[]) => void;
-  function onChange(
-    ...callbackOrEvent: any[]
-  ): ((...event: any[]) => void) | void {
-    const [firstArg] = callbackOrEvent;
-
-    return isFunction(firstArg)
-      ? (event: any) =>
-          setValue(name, commonTask(firstArg(event)), shouldValidate())
-      : setValue(name, commonTask(callbackOrEvent), shouldValidate());
+  function onChange(...event: any[]): void {
+    setValue(name, commonTask(event), shouldValidate());
   }
 
   const handlerProps = {

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -150,7 +150,7 @@ const Controller = <TControl extends Control = Control>({
       : setValue(name, commonTask(callbackOrEvent), shouldValidate());
   }
 
-  return render({
+  return React.createElement(render, {
     onChange,
     onBlur,
     value,

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -158,10 +158,14 @@ const Controller = <
       : setValue(name, commonTask(callbackOrEvent), shouldValidate());
   }
 
+  const handlerProps = {
+    onChange: React.useCallback(onChange, []),
+    onBlur: React.useCallback(onBlur, []),
+  };
+
   const props = {
     ...rest,
-    onChange,
-    onBlur,
+    ...handlerProps,
     ...{ [isCheckboxInput ? 'checked' : VALUE]: value },
   };
 
@@ -171,8 +175,7 @@ const Controller = <
       : React.createElement(as as string, props)
     : render
     ? render({
-        onChange,
-        onBlur,
+        ...handlerProps,
         value,
       })
     : null;

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -159,9 +159,9 @@ const Controller = <
   }
 
   const props = {
+    ...rest,
     onChange,
     onBlur,
-    ...rest,
     ...{ [isCheckboxInput ? 'checked' : VALUE]: value },
   };
 

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -142,9 +142,9 @@ const Controller = <
     }
   };
 
-  function onChange(...event: any[]): void {
+  const onChange = (...event: any[]) => {
     setValue(name, commonTask(event), shouldValidate());
-  }
+  };
 
   const handlerProps = {
     onChange: React.useCallback(onChange, []),

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -63,8 +63,8 @@ const Controller = <TControl extends Control = Control>({
       isSubmitted,
     });
 
-  const commonTask = (event: any) => {
-    const data = getInputValue(event, isCheckboxInput);
+  const commonTask = (...event: any[]) => {
+    const data = getInputValue(event[0], isCheckboxInput);
     setInputStateValue(data);
     valueRef.current = data;
     return data;
@@ -144,7 +144,7 @@ const Controller = <TControl extends Control = Control>({
     ...callbackOrEvent: any[]
   ): ((...event: any[]) => void) | void {
     if (typeof callbackOrEvent[0] !== 'function') {
-      setValue(name, commonTask(callbackOrEvent), shouldValidate());
+      setValue(name, commonTask(...callbackOrEvent), shouldValidate());
     }
     return (event: any) =>
       setValue(

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -12,14 +12,22 @@ import { VALUE } from './constants';
 import { Control, Field } from './types/form';
 import { ControllerProps } from './types/props';
 
-const Controller = <TControl extends Control = Control>({
+const Controller = <
+  TAs extends
+    | React.ReactElement
+    | React.ComponentType<any>
+    | keyof JSX.IntrinsicElements,
+  TControl extends Control = Control
+>({
   name,
   rules,
+  as,
   render,
   defaultValue,
   control,
   onFocus,
-}: ControllerProps<TControl>) => {
+  ...rest
+}: ControllerProps<TAs, TControl>) => {
   const methods = useFormContext();
   const {
     defaultValuesRef,
@@ -150,11 +158,24 @@ const Controller = <TControl extends Control = Control>({
       : setValue(name, commonTask(callbackOrEvent), shouldValidate());
   }
 
-  return render({
+  const props = {
     onChange,
     onBlur,
-    value,
-  });
+    ...rest,
+    ...{ [isCheckboxInput ? 'checked' : VALUE]: value },
+  };
+
+  return as
+    ? React.isValidElement(as)
+      ? React.cloneElement(as, props)
+      : React.createElement(as as string, props)
+    : render
+    ? render({
+        onChange,
+        onBlur,
+        value,
+      })
+    : null;
 };
 
 export { Controller };

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -3,6 +3,7 @@ import isBoolean from './utils/isBoolean';
 import isUndefined from './utils/isUndefined';
 import get from './utils/get';
 import set from './utils/set';
+import isFunction from './utils/isFunction';
 import getInputValue from './logic/getInputValue';
 import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
@@ -141,9 +142,10 @@ const Controller = <TControl extends Control = Control>({
   function onChange(
     ...callbackOrEvent: any[]
   ): ((...event: any[]) => void) | void {
-    if (typeof callbackOrEvent[0] !== 'function') {
+    if (!isFunction(callbackOrEvent[0])) {
       setValue(name, commonTask(...callbackOrEvent), shouldValidate());
     }
+
     return (event: any) =>
       setValue(
         name,

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -151,8 +151,8 @@ const Controller = <TControl extends Control = Control>({
   }
 
   return render({
-    onChange,
-    onBlur,
+    onChange: React.useCallback(onChange, []),
+    onBlur: React.useCallback(onBlur, []),
     value,
   });
 };

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -142,9 +142,8 @@ const Controller = <
     }
   };
 
-  const onChange = (...event: any[]) => {
+  const onChange = (...event: any[]) =>
     setValue(name, commonTask(event), shouldValidate());
-  };
 
   const handlerProps = {
     onChange: React.useCallback(onChange, []),

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -122,7 +122,7 @@ const Controller = <TControl extends Control = Control>({
     }
   });
 
-  const handleBlur = () => {
+  const onBlur = () => {
     if (
       readFormStateRef.current.touched &&
       !get(touchedFieldsRef.current, name)
@@ -136,14 +136,14 @@ const Controller = <TControl extends Control = Control>({
     }
   };
 
-  const handleChange = (event: any): any =>
+  const onChange = (event: any): any =>
     setValue(name, commonTask(event), shouldValidate());
 
   const props = {
     name,
     ...rest,
-    onChange: handleChange,
-    onBlur: handleBlur,
+    onChange: onChange,
+    onBlur: onBlur,
   };
 
   return isReactComponentClass(InnerComponent) ? (
@@ -151,8 +151,8 @@ const Controller = <TControl extends Control = Control>({
   ) : (
     InnerComponent({
       value,
-      handleChange,
-      handleBlur,
+      onChange,
+      onBlur,
     })
   );
 };

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -7,7 +7,7 @@ import getInputValue from './logic/getInputValue';
 import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
 import { useFormContext } from './useFormContext';
-import { VALIDATION_MODE, VALUE } from './constants';
+import { VALUE } from './constants';
 import { Control, Field } from './types/form';
 import { ControllerProps } from './types/props';
 
@@ -148,8 +148,8 @@ const Controller = <
   const props = {
     name,
     ...rest,
-    [VALIDATION_MODE.onChange]: handleChange,
-    [VALIDATION_MODE.onBlur]: handleBlur,
+    onChange: handleChange,
+    onBlur: handleBlur,
   };
 
   return as

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -151,8 +151,8 @@ const Controller = <TControl extends Control = Control>({
   }
 
   return render({
-    onChange: React.useCallback(onChange, []),
-    onBlur: React.useCallback(onBlur, []),
+    onChange,
+    onBlur,
     value,
   });
 };

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -145,9 +145,6 @@ const Controller = <
 
   function onChange(...event: any[]): void;
   function onChange(
-    callback: (...args: any[]) => any,
-  ): (...event: any[]) => void;
-  function onChange(
     ...callbackOrEvent: any[]
   ): ((...event: any[]) => void) | void {
     const [firstArg] = callbackOrEvent;

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -19,6 +19,7 @@ const Controller = <TControl extends Control = Control>({
   defaultValue,
   control,
   onFocus,
+  ...rest
 }: ControllerProps<TControl>) => {
   const methods = useFormContext();
   const {
@@ -138,16 +139,21 @@ const Controller = <TControl extends Control = Control>({
   const onChange = (event: any): any =>
     setValue(name, commonTask(event), shouldValidate());
 
-  const props = {
-    onChange,
-    onBlur,
-    value,
-  };
-
   return isReactComponentClass(InnerComponent) ? (
-    <InnerComponent {...props} />
+    <InnerComponent
+      {...{
+        onChange,
+        onBlur,
+        ...{ [isCheckboxInput ? 'checked' : VALUE]: value },
+        ...rest,
+      }}
+    />
   ) : (
-    InnerComponent(props)
+    InnerComponent({
+      onChange,
+      onBlur,
+      value,
+    })
   );
 };
 

--- a/src/errorMessage.test.tsx
+++ b/src/errorMessage.test.tsx
@@ -53,9 +53,8 @@ describe('React Hook Form Error Message', () => {
         as={<span />}
         errors={{ flat: { type: 'flat', message: 'flat' } }}
         name="flat"
-      >
-        {({ message }) => message}
-      </ErrorMessage>,
+        render={({ message }) => message}
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -68,9 +67,8 @@ describe('React Hook Form Error Message', () => {
         errors={{ flat: { type: 'flat', message: 'flat' } }}
         name="flat"
         className="test"
-      >
-        {({ message }) => message}
-      </ErrorMessage>,
+        render={({ message }) => message}
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -91,14 +89,13 @@ describe('React Hook Form Error Message', () => {
           },
         }}
         name="flat"
-      >
-        {({ messages }) =>
+        render={({ messages }) =>
           messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
         }
-      </ErrorMessage>,
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -107,7 +104,6 @@ describe('React Hook Form Error Message', () => {
   it('should render correctly with flat multiple errors and as with component and children', () => {
     const { asFragment } = render(
       <ErrorMessage
-        as={<div />}
         errors={{
           flat: {
             type: 'flat',
@@ -120,14 +116,13 @@ describe('React Hook Form Error Message', () => {
           },
         }}
         name="flat"
-      >
-        {({ messages }) =>
+        render={({ messages }) =>
           messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
         }
-      </ErrorMessage>,
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -174,9 +169,8 @@ describe('React Hook Form Error Message', () => {
           },
         }}
         name="nested.object"
-      >
-        {({ message }) => message}
-      </ErrorMessage>,
+        render={({ message }) => message}
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -199,14 +193,13 @@ describe('React Hook Form Error Message', () => {
           },
         }}
         name="nested.object"
-      >
-        {({ messages }) =>
+        render={({ messages }) =>
           messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
         }
-      </ErrorMessage>,
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -215,7 +208,6 @@ describe('React Hook Form Error Message', () => {
   it('should render correctly with nested multiple errors and as with component and children', () => {
     const { asFragment } = render(
       <ErrorMessage
-        as={<div />}
         errors={{
           nested: {
             object: {
@@ -230,14 +222,13 @@ describe('React Hook Form Error Message', () => {
           },
         }}
         name="nested.object"
-      >
-        {({ messages }) =>
+        render={({ messages }) =>
           messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
         }
-      </ErrorMessage>,
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -290,9 +281,8 @@ describe('React Hook Form Error Message', () => {
           ],
         }}
         name="nested[0].array"
-      >
-        {({ message }) => message}
-      </ErrorMessage>,
+        render={({ message }) => message}
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -317,14 +307,13 @@ describe('React Hook Form Error Message', () => {
           ],
         }}
         name="nested[0].array"
-      >
-        {({ messages }) =>
+        render={({ messages }) =>
           messages &&
           Object.entries(messages).map(([type, message]) => (
             <span key={type}>{message}</span>
           ))
         }
-      </ErrorMessage>,
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();
@@ -333,7 +322,6 @@ describe('React Hook Form Error Message', () => {
   it('should render correctly with nested multiple errors array and as with component and children', () => {
     const { asFragment } = render(
       <ErrorMessage
-        as={<div />}
         errors={{
           nested: [
             {
@@ -350,14 +338,15 @@ describe('React Hook Form Error Message', () => {
           ],
         }}
         name="nested[0].array"
-      >
-        {({ messages }) =>
-          messages &&
-          Object.entries(messages).map(([type, message]) => (
-            <span key={type}>{message}</span>
-          ))
-        }
-      </ErrorMessage>,
+        render={({ messages }) => {
+          return (
+            messages &&
+            Object.entries(messages).map(([type, message]) => (
+              <span key={type}>{message}</span>
+            ))
+          );
+        }}
+      />,
     );
 
     expect(asFragment()).toMatchSnapshot();

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -12,11 +12,11 @@ const ErrorMessage = <
     | React.ComponentType<any>
     | keyof JSX.IntrinsicElements = undefined
 >({
-  as: InnerComponent,
+  as,
   errors,
   name,
   message,
-  children,
+  render,
   ...rest
 }: ErrorMessageProps<TFieldErrors, TAs>) => {
   const methods = useFormContext();
@@ -28,18 +28,21 @@ const ErrorMessage = <
 
   const { message: messageFromRegister, types } = error;
   const props = {
-    ...(InnerComponent ? rest : {}),
-    children: children
-      ? children({ message: messageFromRegister || message, messages: types })
-      : messageFromRegister || message,
+    ...rest,
+    children: messageFromRegister || message,
   };
 
-  return InnerComponent ? (
-    React.isValidElement(InnerComponent) ? (
-      React.cloneElement(InnerComponent, props)
+  return as ? (
+    React.isValidElement(as) ? (
+      React.cloneElement(as, props)
     ) : (
-      React.createElement(InnerComponent as string, props)
+      React.createElement(as as string, props)
     )
+  ) : render ? (
+    (render({
+      message: messageFromRegister || message,
+      messages: types,
+    }) as React.ReactElement)
   ) : (
     <React.Fragment {...props} />
   );

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -16,7 +16,7 @@ const ErrorMessage = <
   errors,
   name,
   message,
-  render,
+  children,
   ...rest
 }: ErrorMessageProps<TFieldErrors, TAs>) => {
   const methods = useFormContext();
@@ -29,8 +29,8 @@ const ErrorMessage = <
   const { message: messageFromRegister, types } = error;
   const props = {
     ...(InnerComponent ? rest : {}),
-    render: render
-      ? render({ message: messageFromRegister || message, messages: types })
+    children: children
+      ? children({ message: messageFromRegister || message, messages: types })
       : messageFromRegister || message,
   };
 

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -16,7 +16,7 @@ const ErrorMessage = <
   errors,
   name,
   message,
-  children,
+  render,
   ...rest
 }: ErrorMessageProps<TFieldErrors, TAs>) => {
   const methods = useFormContext();
@@ -29,8 +29,8 @@ const ErrorMessage = <
   const { message: messageFromRegister, types } = error;
   const props = {
     ...(InnerComponent ? rest : {}),
-    children: children
-      ? children({ message: messageFromRegister || message, messages: types })
+    render: render
+      ? render({ message: messageFromRegister || message, messages: types })
       : messageFromRegister || message,
   };
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -198,8 +198,6 @@ export type FieldElement<TFieldValues extends FieldValues = FieldValues> =
 
 export type HandleChange = (evt: Event) => Promise<void | boolean>;
 
-export type EventFunction = (...args: any[]) => any;
-
 export type FieldValuesFromControl<
   TControl extends Control
 > = TControl extends Control<infer TFieldValues> ? TFieldValues : never;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -36,8 +36,8 @@ export type ControllerProps<TControl extends Control = Control> = {
   render:
     | React.ComponentType<any>
     | ((data: {
-        handleChange: EventFunction;
-        handleBlur: EventFunction;
+        onChange: EventFunction;
+        onBlur: EventFunction;
         value: any;
       }) => React.ReactElement);
   defaultValue?: unknown;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -39,15 +39,14 @@ export type ControllerProps<
 > = Assign<
   {
     name: FieldName<FieldValuesFromControl<TControl>>;
-    as: TAs;
+    as?: TAs;
     rules?: ValidationOptions;
-    onChange?: EventFunction;
     onFocus?: () => void;
-    onBlur?: EventFunction;
-    mode?: Mode;
-    onChangeName?: string;
-    onBlurName?: string;
-    valueName?: string;
+    render?: (data: {
+      handleChange: EventFunction;
+      handleBlur: EventFunction;
+      value: any;
+    }) => React.ReactElement;
     defaultValue?: unknown;
     control?: TControl;
   },

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -7,7 +7,6 @@ import {
   FieldErrors,
   MultipleFieldErrors,
   Message,
-  Mode,
   ValidationOptions,
   EventFunction,
   Control,

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -32,14 +32,11 @@ export type ControllerProps<TControl extends Control = Control> = {
   name: FieldName<FieldValuesFromControl<TControl>>;
   rules?: ValidationOptions;
   onFocus?: () => void;
-  render: (data: {
-    onChange: {
-      (...event: any[]): void;
-      (callback: (...args: any[]) => any): (...event: any[]) => void;
-    };
-    onBlur: () => void;
+  render: React.ComponentType<{
     value: any;
-  }) => React.ReactElement;
+    onBlur: () => void;
+    onChange: (...args: any[]) => void;
+  }>;
   defaultValue?: unknown;
   control?: TControl;
 };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -30,28 +30,20 @@ type AsProps<TAs> = TAs extends undefined
   ? JSX.IntrinsicElements[TAs]
   : never;
 
-export type ControllerProps<
-  TAs extends
-    | React.ReactElement
+export type ControllerProps<TControl extends Control = Control> = {
+  name: FieldName<FieldValuesFromControl<TControl>>;
+  rules?: ValidationOptions;
+  onFocus?: () => void;
+  render:
     | React.ComponentType<any>
-    | keyof JSX.IntrinsicElements,
-  TControl extends Control = Control
-> = Assign<
-  {
-    name: FieldName<FieldValuesFromControl<TControl>>;
-    as?: TAs;
-    rules?: ValidationOptions;
-    onFocus?: () => void;
-    render?: (data: {
-      handleChange: EventFunction;
-      handleBlur: EventFunction;
-      value: any;
-    }) => React.ReactElement;
-    defaultValue?: unknown;
-    control?: TControl;
-  },
-  AsProps<TAs>
->;
+    | ((data: {
+        handleChange: EventFunction;
+        handleBlur: EventFunction;
+        value: any;
+      }) => React.ReactElement);
+  defaultValue?: unknown;
+  control?: TControl;
+};
 
 export type ErrorMessageProps<
   TFieldErrors extends FieldErrors,

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -29,21 +29,34 @@ type AsProps<TAs> = TAs extends undefined
   ? JSX.IntrinsicElements[TAs]
   : never;
 
-export type ControllerProps<TControl extends Control = Control> = {
-  name: FieldName<FieldValuesFromControl<TControl>>;
-  rules?: ValidationOptions;
-  onFocus?: () => void;
-  render: (data: {
-    onChange: {
-      (...event: any[]): void;
-      (callback: (...args: any[]) => any): (...event: any[]) => void;
-    };
-    onBlur: () => void;
-    value: any;
-  }) => React.ReactElement;
-  defaultValue?: unknown;
-  control?: TControl;
-};
+export type ControllerProps<
+  TAs extends
+    | React.ReactElement
+    | React.ComponentType<any>
+    | keyof JSX.IntrinsicElements,
+  TControl extends Control = Control
+> = Assign<
+  {
+    name: FieldName<FieldValuesFromControl<TControl>>;
+    as?: TAs;
+    rules?: ValidationOptions;
+    onFocus?: () => void;
+    onChangeName?: string;
+    onBlurName?: string;
+    valueName?: string;
+    defaultValue?: unknown;
+    control?: TControl;
+    render?: (data: {
+      onChange: {
+        (...event: any[]): void;
+        (callback: (...args: any[]) => any): (...event: any[]) => void;
+      };
+      onBlur: () => void;
+      value: any;
+    }) => React.ReactElement;
+  },
+  AsProps<TAs>
+>;
 
 export type ErrorMessageProps<
   TFieldErrors extends FieldErrors,

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -32,11 +32,14 @@ export type ControllerProps<TControl extends Control = Control> = {
   name: FieldName<FieldValuesFromControl<TControl>>;
   rules?: ValidationOptions;
   onFocus?: () => void;
-  render: React.ComponentType<{
-    value: any;
+  render: (data: {
+    onChange: {
+      (...event: any[]): void;
+      (callback: (...args: any[]) => any): (...event: any[]) => void;
+    };
     onBlur: () => void;
-    onChange: (...args: any[]) => void;
-  }>;
+    value: any;
+  }) => React.ReactElement;
   defaultValue?: unknown;
   control?: TControl;
 };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -32,16 +32,14 @@ export type ControllerProps<TControl extends Control = Control> = {
   name: FieldName<FieldValuesFromControl<TControl>>;
   rules?: ValidationOptions;
   onFocus?: () => void;
-  render:
-    | React.ComponentType<any>
-    | ((data: {
-        onChange: {
-          (...event: any[]): void;
-          (callback: (...args: any[]) => any): (...event: any[]) => void;
-        };
-        onBlur: () => void;
-        value: any;
-      }) => React.ReactElement);
+  render: (data: {
+    onChange: {
+      (...event: any[]): void;
+      (callback: (...args: any[]) => any): (...event: any[]) => void;
+    };
+    onBlur: () => void;
+    value: any;
+  }) => React.ReactElement;
   defaultValue?: unknown;
   control?: TControl;
 };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -11,6 +11,7 @@ import {
   Control,
 } from './form';
 import { Assign } from './utils';
+import * as React from 'react';
 
 export type FormProviderProps<
   TFieldValues extends FieldValues = FieldValues
@@ -57,7 +58,7 @@ export type ErrorMessageProps<
     errors?: TFieldErrors;
     name: FieldName<FieldValuesFromFieldErrors<TFieldErrors>>;
     message?: Message;
-    children?: (data: {
+    render?: (data: {
       message: Message;
       messages?: MultipleFieldErrors;
     }) => React.ReactNode;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -8,7 +8,6 @@ import {
   MultipleFieldErrors,
   Message,
   ValidationOptions,
-  EventFunction,
   Control,
 } from './form';
 import { Assign } from './utils';
@@ -36,8 +35,11 @@ export type ControllerProps<TControl extends Control = Control> = {
   render:
     | React.ComponentType<any>
     | ((data: {
-        onChange: EventFunction;
-        onBlur: EventFunction;
+        onChange: {
+          (...event: any[]): void;
+          (callback: (...args: any[]) => any): (...event: any[]) => void;
+        };
+        onBlur: () => void;
         value: any;
       }) => React.ReactElement);
   defaultValue?: unknown;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -47,10 +47,7 @@ export type ControllerProps<
     defaultValue?: unknown;
     control?: TControl;
     render?: (data: {
-      onChange: {
-        (...event: any[]): void;
-        (callback: (...args: any[]) => any): (...event: any[]) => void;
-      };
+      onChange: (...event: any[]) => void;
       onBlur: () => void;
       value: any;
     }) => React.ReactElement;

--- a/src/utils/isReactComponentClass.ts
+++ b/src/utils/isReactComponentClass.ts
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default (component: any): component is React.ComponentClass<any> =>
+  component &&
+  component.prototype &&
+  (component.prototype.isReactComponent ||
+    component.prototype instanceof React.Component);

--- a/src/utils/isReactComponentClass.ts
+++ b/src/utils/isReactComponentClass.ts
@@ -1,7 +1,0 @@
-import React from 'react';
-
-export default (component: any): component is React.ComponentClass<any> =>
-  component &&
-  component.prototype &&
-  (component.prototype.isReactComponent ||
-    component.prototype instanceof React.Component);


### PR DESCRIPTION
### 🔍Origin

This PR is led by a TS bug #1580 where required props will require to fulfill again at the `props`.

Example CSB: https://codesandbox.io/s/react-hook-form-controller-template-qrtco

```tsx
type MyInputProps = {
  value: any;
  onChange: () => void;
};

function MyInput(props: MyInputProps) {
  return <input name="FirstName" {...props} />;
}

<Controller
  as={<input name="FirstName" />} // result in TS error for required onChange and value 
  defaultValue="FirstName"
  control={control}
/>
```

-------

### ✏️Solutions

Render prop was purposed by @kotarella1110 which also lead to a discussion around shaping better API. Here are the options 

-------

**OPTION A** only support Render Props for `Controller`

**cons:** 

1. verbose for simple usage 
2. impact API consistency between `ErrorMessage` and `Controller`

**pros:**

1. consistent usage with Controller
2. less code inside lib
3. predictable result 

-------

**OPTION B** support both `as` and `render` 

**cons:** 

1. less intuitive consider providing two options: `as` vs `render`. this could lead to confusion.
2. lack of consistent usage

**pros:**

1. consistent API across `ErrorMessage` & `Controller`
2. more code inside lib
3. simple usage option, plug-in & play
4. the community seems to be keener with both options 

-------

❌ **OPTION C** `render` support render props and component

This approach having issues with good/easy `TS` support and having issue `useFieldArray` (which lead input to remount)

![Screen Recording 2020-05-30 at 10 46 28 am](https://user-images.githubusercontent.com/10513364/83342555-41747700-a334-11ea-9f1a-7683989e6f82.gif)

-------

### 📧Poll result

The above options lead us into discussion and poll on twitter. Below is a good result.

![image](https://user-images.githubusercontent.com/10513364/83340742-4a0e8280-a31f-11ea-9e58-2e0a2c62b005.png)

-------

### 📦What's next?

The plan is to release an **RC.2 version** with **option B** and waiting for the community's feedback for **2 weeks** before releasing the new V6. During the period, if users raise concerns over the new API and we will re-look at **option A** again. 

-------

### 📘Changes

- [x] Controller

Less of a breaking change for existing users, simple usage remain while still give the user the full control with render prop. Remove the following props 

- `onChange` 
- `onChangeName` 
- `onBlur`
- `onBlurName`
- `valueName`

Simple usage as below, will not be impacted:

```tsx
<Controller as={TextField} control={control} name="test" />
```

Usage involed configration and those remmoved props:

```diff
-<Controller 
-  as={CustomInput} 
-  valueName="textValue"
-  onChangeName="onTextChange"
-  control={control} 
-  name="test"  
-/>
+<Controller 
+  render={({ onChange, onBlur, value }) => (
+     <CustomInput onTextChange={onChange} onBlur={onBlur} textValue={value} />
+  )}
+  control={control} 
+  name="test"  
+/>
```

-------

- [x] ErrorMessage

change render props from `children` to `render`, usage change from the ability to use both to either. you can either use `as` or `render`. for multiple error messages, you will have to use `render`

```tsx
<ErrrorMessage errors={errors} as="p" />
<ErrrorMessage errors={errors} render={({message}) => {message}} />
```

-------

**Note:** Both `ErrorMessage` and `Controller` contains `as` and `render` props. Users should  either use `as` or `render`.

```tsx
❌<Controller as={TextField}  render={(props) => <TextField {...props} />}/>
❌<ErrorMessage as={TextField}  render={({ message }) => {message} }/>

✅<Controller as={TextField}  />
✅<Controller render={(props) => <TextField {...props} />}/>

✅<ErrorMessage as={TextField} />
✅<ErrorMessage render={({ message }) => {message} }/>
```
