### PR TITLE
plan B #1711 support both as and render

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -12,14 +12,22 @@ import { VALUE } from './constants';
 import { Control, Field } from './types/form';
 import { ControllerProps } from './types/props';
 
-const Controller = <TControl extends Control = Control>({
+const Controller = <
+  TAs extends
+    | React.ReactElement
+    | React.ComponentType<any>
+    | keyof JSX.IntrinsicElements,
+  TControl extends Control = Control
+>({
   name,
   rules,
   render,
+  as,
   defaultValue,
   control,
   onFocus,
-}: ControllerProps<TControl>) => {
+  ...rest
+}: ControllerProps<TAs, TControl>) => {
   const methods = useFormContext();
   const {
     defaultValuesRef,
@@ -150,11 +158,22 @@ const Controller = <TControl extends Control = Control>({
       : setValue(name, commonTask(callbackOrEvent), shouldValidate());
   }
 
-  return render({
+  const props = {
     onChange,
     onBlur,
     value,
-  });
+    ...rest,
+  };
+
+  return as
+    ? React.isValidElement(as)
+      ? React.cloneElement(as, props)
+      : React.createElement(as as string, props)
+    : render({
+        onChange,
+        onBlur,
+        value,
+      });
 };
 
 export { Controller };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -28,21 +28,34 @@ type AsProps<TAs> = TAs extends undefined
   ? JSX.IntrinsicElements[TAs]
   : never;
 
-export type ControllerProps<TControl extends Control = Control> = {
-  name: FieldName<FieldValuesFromControl<TControl>>;
-  rules?: ValidationOptions;
-  onFocus?: () => void;
-  render: (data: {
-    onChange: {
-      (...event: any[]): void;
-      (callback: (...args: any[]) => any): (...event: any[]) => void;
-    };
-    onBlur: () => void;
-    value: any;
-  }) => React.ReactElement;
-  defaultValue?: unknown;
-  control?: TControl;
-};
+export type ControllerProps<
+  TAs extends
+    | React.ReactElement
+    | React.ComponentType<any>
+    | keyof JSX.IntrinsicElements,
+  TControl extends Control = Control
+> = Assign<
+  {
+    name: FieldName<FieldValuesFromControl<TControl>>;
+    as: TAs;
+    rules?: ValidationOptions;
+    onFocus?: () => void;
+    render: (data: {
+      onChange: {
+        (...event: any[]): void;
+        (callback: (...args: any[]) => any): (...event: any[]) => void;
+      };
+      onBlur: () => void;
+      value: any;
+    }) => React.ReactElement;
+    onChangeName?: string;
+    onBlurName?: string;
+    valueName?: string;
+    defaultValue?: unknown;
+    control?: TControl;
+  },
+  AsProps<TAs>
+>;
 
 export type ErrorMessageProps<
   TFieldErrors extends FieldErrors,


### PR DESCRIPTION
plan B to support both 

`as`: with an issue with TS with required type.

`render`: type-safe