### PR TITLE
Bug - transformToNestObject does not always merge objects

### DIFF
--- a/src/logic/transformToNestObject.test.ts
+++ b/src/logic/transformToNestObject.test.ts
@@ -38,6 +38,34 @@ describe('transformToNestObject', () => {
     ).toMatchSnapshot();
   });
 
+  it('should combine object objects correctly', () => {
+    expect(
+      transformToNestObject({
+        'date.month': { message: 'Month must be 1-12.' },
+        date: { message: 'Date of birth cannot be in the future.' },
+      }),
+    ).toEqual({
+      date: {
+        message: 'Date of birth cannot be in the future.',
+        month: { message: 'Month must be 1-12.' },
+      },
+    });
+  });
+
+  it('should combine object objects correctly with different key order', () => {
+    expect(
+      transformToNestObject({
+        date: { message: 'Date of birth cannot be in the future.' },
+        'date.month': { message: 'Month must be 1-12.' },
+      }),
+    ).toEqual({
+      date: {
+        message: 'Date of birth cannot be in the future.',
+        month: { message: 'Month must be 1-12.' },
+      },
+    });
+  });
+
   it('should return default name value', () => {
     expect(
       transformToNestObject({


### PR DESCRIPTION
This PR demonstrates a bug in the transform method.

There are two tests in the PR. The only difference is the ordering in the input. I expect the same result from the transform, however the second test fails with the nested object being lost entirely.

```
Summary of all failing tests
 FAIL  src/logic/transformToNestObject.test.ts
  ● transformToNestObject › should combine object objects correctly

    expect(received).toEqual(expected) // deep equality

    - Expected  - 3
    + Received  + 0

      Object {
        "date": Object {
          "message": "Date of birth cannot be in the future.",
    -     "month": Object {
    -       "message": "Month must be 1-12.",
    -     },
        },
      }

      45 |         date: { message: 'Date of birth cannot be in the future.' },
      46 |       }),
    > 47 |     ).toEqual({
         |       ^
      48 |       date: {
      49 |         message: 'Date of birth cannot be in the future.',
      50 |         month: { message: 'Month must be 1-12.' },

      at Object.<anonymous> (src/logic/transformToNestObject.test.ts:47:7)
```