### PR TITLE
Fix undefined ref in options

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -218,7 +218,7 @@ export function useForm<
           : rawValue;
 
       if (isRadioInput(ref) && options) {
-        options.filter(Boolean).forEach(
+        options.forEach(
           ({ ref: radioRef }: { ref: HTMLInputElement }) =>
             (radioRef.checked = radioRef.value === value),
         );
@@ -897,7 +897,7 @@ export function useForm<
       field = isRadioOrCheckbox
         ? {
             options: [
-              ...((field && field.options) || []),
+              ...((field && field.options.filter(Boolean)) || []),
               {
                 ref,
                 mutationWatcher,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -218,7 +218,7 @@ export function useForm<
           : rawValue;
 
       if (isRadioInput(ref) && options) {
-        options.forEach(
+        options.filter(Boolean).forEach(
           ({ ref: radioRef }: { ref: HTMLInputElement }) =>
             (radioRef.checked = radioRef.value === value),
         );

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -897,7 +897,7 @@ export function useForm<
       field = isRadioOrCheckbox
         ? {
             options: [
-              ...((field && field.options.filter(Boolean)) || []),
+              ...unique((field && field.options) || []),
               {
                 ref,
                 mutationWatcher,


### PR DESCRIPTION
Fix #1718


@bluebill1049 , At first I put the `filter` to `setFieldValue` function but resulted in below image
![Screenshot from 2020-05-29 12-43-49](https://user-images.githubusercontent.com/32805276/83222197-4d343200-a1aa-11ea-91a7-11e5ffcdffe8.jpg)

then I tried to move it to `registerFieldsRef` function instead and resulted in below image:
![Screenshot from 2020-05-29 12-52-10](https://user-images.githubusercontent.com/32805276/83222647-64bfea80-a1ab-11ea-9545-4fde28802ba6.jpg)

