### PR TITLE
config for auto un-register

### DIFF
--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
+import AutoUnregister from './autoUnregister';
 import Basic from './basic';
 import Watch from './watch';
 import BasicSchemaValidation from './basicSchemaValidation';
@@ -87,6 +88,7 @@ const App: React.FC = () => {
         exact
         component={CustomSchemaValidation}
       />
+      <Route path="/autoUnregister" exact component={AutoUnregister} />
       <Route path="/useWatch" exact component={useWatch} />
     </Router>
   );

--- a/app/src/autoUnregister.tsx
+++ b/app/src/autoUnregister.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import ReactSelect from 'react-select';
+import { useForm, Controller } from 'react-hook-form';
+
+const options = [
+  { value: 'chocolate', label: 'Chocolate' },
+  { value: 'strawberry', label: 'Strawberry' },
+  { value: 'vanilla', label: 'Vanilla' },
+];
+
+export default function AutoUnregister() {
+  const { register, control, handleSubmit } = useForm({
+    autoUnregister: false,
+  });
+  const [show, setShow] = useState(true);
+
+  return (
+    <form onSubmit={handleSubmit((d) => console.log(d))}>
+      {show && (
+        <>
+          <Controller
+            defaultValue=""
+            control={control}
+            as={<input name={'test'} />}
+            name="test"
+          />
+          <section id="input-ReactSelect">
+            <Controller
+              render={(props) => (
+                <ReactSelect isClearable options={options} {...props} />
+              )}
+              name="ReactSelect"
+              control={control}
+              rules={{ required: true }}
+            />
+          </section>
+
+          <input name="test1" ref={register} />
+          <input name="test2" type="checkbox" ref={register} />
+          <input name="test3" type="radio" ref={register} />
+          <select name="test4" ref={register}>
+            <option>Select...</option>
+            <option value="bill">Bill</option>
+          </select>
+        </>
+      )}
+
+      <button type="button" onClick={() => setShow(!show)}>
+        Toggle Modal
+      </button>
+
+      <input type="submit" />
+    </form>
+  );
+}

--- a/app/src/autoUnregister.tsx
+++ b/app/src/autoUnregister.tsx
@@ -10,7 +10,7 @@ const options = [
 
 export default function AutoUnregister() {
   const { register, control, handleSubmit } = useForm({
-    autoUnregister: false,
+    shouldUnregister: false,
   });
   const [show, setShow] = useState(true);
 

--- a/cypress/integration/autoUnregister.tsx
+++ b/cypress/integration/autoUnregister.tsx
@@ -1,0 +1,22 @@
+context('autoUnregister', () => {
+  it('should keep all inputs data when inputs get unmounted', () => {
+    cy.visit('http://localhost:3000/autoUnregister');
+    cy.get('input[name="test"]').type('test');
+    cy.get('input[name="test1"]').type('test1');
+    cy.get('input[name="test2"]').check();
+    cy.get('input[name="test3"]').check();
+    cy.get('select[name="test4"]').select('Bill');
+    cy.get('#input-ReactSelect > div').click();
+    cy.get('#input-ReactSelect > div > div').eq(1).click();
+
+    cy.get('button').click();
+    cy.get('button').click();
+
+    cy.get('input[name="test"]').should('has.value', 'test');
+    cy.get('input[name="test1"]').should('has.value', 'test1');
+    cy.get('input[name="test2"]').should('be.checked');
+    cy.get('input[name="test3"]').should('be.checked');
+    cy.get('select[name="test4"]').should('has.value', 'bill');
+    cy.get('#input-ReactSelect > div > div > div > div').contains('Strawberry');
+  });
+});

--- a/src/__mocks__/reconfigureControl.ts
+++ b/src/__mocks__/reconfigureControl.ts
@@ -3,7 +3,7 @@ import { Control } from '../types';
 export const reconfigureControl = (
   controlOverrides: Partial<Control> = {},
 ): Control => ({
-  unmountFieldsState: {
+  unmountFieldsStateRef: {
     current: {},
   },
   defaultValuesRef: {

--- a/src/__mocks__/reconfigureControl.ts
+++ b/src/__mocks__/reconfigureControl.ts
@@ -3,6 +3,9 @@ import { Control } from '../types';
 export const reconfigureControl = (
   controlOverrides: Partial<Control> = {},
 ): Control => ({
+  unmountFieldsState: {
+    current: {},
+  },
   defaultValuesRef: {
     current: {},
   },

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -686,7 +686,7 @@ describe('Controller', () => {
         control={
           {
             ...control,
-            unmountFieldsState: {
+            unmountFieldsStateRef: {
               current: {
                 test: 'what',
               },
@@ -716,7 +716,7 @@ describe('Controller', () => {
         control={
           {
             ...control,
-            unmountFieldsState: {
+            unmountFieldsStateRef: {
               current: {
                 test: 'what',
               },

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -674,4 +674,67 @@ describe('Controller', () => {
     // @ts-ignore
     expect(fieldsRef.current.test.required).toBeFalsy();
   });
+
+  it('should set initial state from unmount state', () => {
+    const control = reconfigureControl();
+
+    const { getByPlaceholderText } = render(
+      <Controller
+        defaultValue=""
+        name="test"
+        as={<input placeholder="test" />}
+        control={
+          {
+            ...control,
+            unmountFieldsState: {
+              current: {
+                test: 'what',
+              },
+            },
+            fieldsRef: {
+              current: {
+                test: {},
+              },
+            },
+          } as any
+        }
+      />,
+    );
+
+    // @ts-ignore
+    expect(getByPlaceholderText('test').value).toEqual('what');
+  });
+
+  it('should not set initial state from unmount state when input is part of field array', () => {
+    const control = reconfigureControl();
+
+    const { getByPlaceholderText } = render(
+      <Controller
+        defaultValue=""
+        name="test[0]"
+        as={<input placeholder="test" />}
+        control={
+          {
+            ...control,
+            unmountFieldsState: {
+              current: {
+                test: 'what',
+              },
+            },
+            fieldsRef: {
+              current: {
+                test: {},
+              },
+            },
+            fieldArrayNamesRef: {
+              current: new Set(['test']),
+            },
+          } as any
+        }
+      />,
+    );
+
+    // @ts-ignore
+    expect(getByPlaceholderText('test').value).toEqual('');
+  });
 });

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -45,9 +45,12 @@ const Controller = <
     reRender,
     fieldsRef,
     fieldArrayNamesRef,
+    getValues,
   } = control || methods.control;
   const [value, setInputStateValue] = React.useState(
-    isUndefined(defaultValue)
+    !autoUnregister && !isUndefined(getValues(name))
+      ? getValues(name)
+      : isUndefined(defaultValue)
       ? get(defaultValuesRef.current, name)
       : defaultValue,
   );

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -44,12 +44,12 @@ const Controller = <
     reRender,
     fieldsRef,
     fieldArrayNamesRef,
-    unmountFieldsState,
+    unmountFieldsStateRef,
   } = control || methods.control;
   const isNotFieldArray = !isNameInFieldArray(fieldArrayNamesRef.current, name);
   const getInitialValue = () =>
-    !isUndefined(unmountFieldsState.current[name]) && isNotFieldArray
-      ? unmountFieldsState.current[name]
+    !isUndefined(unmountFieldsStateRef.current[name]) && isNotFieldArray
+      ? unmountFieldsStateRef.current[name]
       : isUndefined(defaultValue)
       ? get(defaultValuesRef.current, name)
       : defaultValue;

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -46,8 +46,9 @@ const Controller = <
     fieldArrayNamesRef,
     unmountFieldsState,
   } = control || methods.control;
+  const isNotFieldArray = !isNameInFieldArray(fieldArrayNamesRef.current, name);
   const [value, setInputStateValue] = React.useState(
-    !isUndefined(unmountFieldsState.current[name])
+    !isUndefined(unmountFieldsState.current[name]) && isNotFieldArray
       ? unmountFieldsState.current[name]
       : isUndefined(defaultValue)
       ? get(defaultValuesRef.current, name)
@@ -56,7 +57,6 @@ const Controller = <
   const valueRef = React.useRef(value);
   const isCheckboxInput = isBoolean(value);
   const onFocusRef = React.useRef(onFocus);
-  const isNotFieldArray = !isNameInFieldArray(fieldArrayNamesRef.current, name);
   const isSubmitted = isSubmittedRef.current;
 
   const shouldValidate = () =>

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -47,13 +47,13 @@ const Controller = <
     unmountFieldsState,
   } = control || methods.control;
   const isNotFieldArray = !isNameInFieldArray(fieldArrayNamesRef.current, name);
-  const [value, setInputStateValue] = React.useState(
+  const getInitialValue = () =>
     !isUndefined(unmountFieldsState.current[name]) && isNotFieldArray
       ? unmountFieldsState.current[name]
       : isUndefined(defaultValue)
       ? get(defaultValuesRef.current, name)
-      : defaultValue,
-  );
+      : defaultValue;
+  const [value, setInputStateValue] = React.useState(getInitialValue());
   const valueRef = React.useRef(value);
   const isCheckboxInput = isBoolean(value);
   const onFocusRef = React.useRef(onFocus);
@@ -127,11 +127,7 @@ const Controller = <
     if (!fieldsRef.current[name]) {
       registerField();
       if (isNotFieldArray) {
-        setInputStateValue(
-          isUndefined(defaultValue)
-            ? get(defaultValuesRef.current, name)
-            : defaultValue,
-        );
+        setInputStateValue(getInitialValue());
       }
     }
   });

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -44,12 +44,11 @@ const Controller = <
     reRender,
     fieldsRef,
     fieldArrayNamesRef,
-    getValues,
-    autoUnregister,
+    unmountFieldsStore,
   } = control || methods.control;
   const [value, setInputStateValue] = React.useState(
-    !autoUnregister && !isUndefined(getValues(name))
-      ? getValues(name)
+    unmountFieldsStore.current[name]
+      ? unmountFieldsStore.current[name]
       : isUndefined(defaultValue)
       ? get(defaultValuesRef.current, name)
       : defaultValue,
@@ -114,11 +113,9 @@ const Controller = <
 
   React.useEffect(
     () => () => {
-      autoUnregister &&
-        !isNameInFieldArray(fieldArrayNamesRef.current, name) &&
-        unregister(name);
+      !isNameInFieldArray(fieldArrayNamesRef.current, name) && unregister(name);
     },
-    [unregister, name, autoUnregister, fieldArrayNamesRef],
+    [unregister, name, fieldArrayNamesRef],
   );
 
   React.useEffect(() => {

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -44,11 +44,11 @@ const Controller = <
     reRender,
     fieldsRef,
     fieldArrayNamesRef,
-    unmountFieldsStore,
+    unmountFieldsState,
   } = control || methods.control;
   const [value, setInputStateValue] = React.useState(
-    unmountFieldsStore.current[name]
-      ? unmountFieldsStore.current[name]
+    unmountFieldsState.current[name]
+      ? unmountFieldsState.current[name]
       : isUndefined(defaultValue)
       ? get(defaultValuesRef.current, name)
       : defaultValue,

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -47,7 +47,7 @@ const Controller = <
     unmountFieldsState,
   } = control || methods.control;
   const [value, setInputStateValue] = React.useState(
-    unmountFieldsState.current[name]
+    !isUndefined(unmountFieldsState.current[name])
       ? unmountFieldsState.current[name]
       : isUndefined(defaultValue)
       ? get(defaultValuesRef.current, name)

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -25,6 +25,7 @@ const Controller = <
   defaultValue,
   control,
   onFocus,
+  autoUnregister,
   ...rest
 }: ControllerProps<TAs, TControl>) => {
   const methods = useFormContext();
@@ -110,9 +111,11 @@ const Controller = <
 
   React.useEffect(
     () => () => {
-      !isNameInFieldArray(fieldArrayNamesRef.current, name) && unregister(name);
+      autoUnregister &&
+        !isNameInFieldArray(fieldArrayNamesRef.current, name) &&
+        unregister(name);
     },
-    [unregister, name, fieldArrayNamesRef],
+    [unregister, name, autoUnregister, fieldArrayNamesRef],
   );
 
   React.useLayoutEffect(() => {

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -25,7 +25,6 @@ const Controller = <
   defaultValue,
   control,
   onFocus,
-  autoUnregister,
   ...rest
 }: ControllerProps<TAs, TControl>) => {
   const methods = useFormContext();
@@ -46,6 +45,7 @@ const Controller = <
     fieldsRef,
     fieldArrayNamesRef,
     getValues,
+    autoUnregister,
   } = control || methods.control;
   const [value, setInputStateValue] = React.useState(
     !autoUnregister && !isUndefined(getValues(name))

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -32,16 +32,20 @@ const ErrorMessage = <
     children: messageFromRegister || message,
   };
 
-  return as
-    ? React.isValidElement(as)
-      ? React.cloneElement(as, props)
-      : React.createElement(as as string, props)
-    : render
-    ? render({
-        message: messageFromRegister || message,
-        messages: types,
-      })
-    : null;
+  return as ? (
+    React.isValidElement(as) ? (
+      React.cloneElement(as, props)
+    ) : (
+      React.createElement(as as string, props)
+    )
+  ) : render ? (
+    (render({
+      message: messageFromRegister || message,
+      messages: types,
+    }) as React.ReactElement)
+  ) : (
+    <React.Fragment {...props} />
+  );
 };
 
 export { ErrorMessage };

--- a/src/errorMessage.tsx
+++ b/src/errorMessage.tsx
@@ -32,20 +32,16 @@ const ErrorMessage = <
     children: messageFromRegister || message,
   };
 
-  return as ? (
-    React.isValidElement(as) ? (
-      React.cloneElement(as, props)
-    ) : (
-      React.createElement(as as string, props)
-    )
-  ) : render ? (
-    (render({
-      message: messageFromRegister || message,
-      messages: types,
-    }) as React.ReactElement)
-  ) : (
-    <React.Fragment {...props} />
-  );
+  return as
+    ? React.isValidElement(as)
+      ? React.cloneElement(as, props)
+      : React.createElement(as as string, props)
+    : render
+    ? render({
+        message: messageFromRegister || message,
+        messages: types,
+      })
+    : null;
 };
 
 export { ErrorMessage };

--- a/src/logic/__snapshots__/validateField.test.tsx.snap
+++ b/src/logic/__snapshots__/validateField.test.tsx.snap
@@ -46,9 +46,7 @@ Object {
 exports[`validateField should return all validation error messages 3`] = `
 Object {
   "test": Object {
-    "message": <p>
-      minLength
-    </p>,
+    "message": "minLength",
     "ref": Object {
       "name": "test",
       "setCustomValidity": [Function],
@@ -57,19 +55,11 @@ Object {
     },
     "type": "minLength",
     "types": Object {
-      "minLength": <p>
-        minLength
-      </p>,
-      "pattern": <p>
-        pattern
-      </p>,
+      "minLength": "minLength",
+      "pattern": "pattern",
       "test": true,
-      "test1": <p>
-        Luo
-      </p>,
-      "test2": <p>
-        Bill
-      </p>,
+      "test1": "Luo",
+      "test2": "Bill",
     },
   },
 }

--- a/src/logic/findRemovedFieldAndRemoveListener.test.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.test.ts
@@ -273,4 +273,30 @@ describe('findMissDomAndClean', () => {
 
     expect(fields).toEqual({});
   });
+
+  it('should store state when component is getting unmount', () => {
+    const state = { current: {} };
+    const fields = {
+      test: {
+        name: 'test',
+        ref: {
+          value: 'test',
+        },
+      },
+    };
+
+    findRemovedFieldAndRemoveListener(
+      fields,
+      () => ({} as any),
+      {
+        ref: { name: 'test', type: 'text' },
+      },
+      state,
+      false,
+    );
+
+    expect(state).toEqual({
+      current: { test: 'test' },
+    });
+  });
 });

--- a/src/logic/findRemovedFieldAndRemoveListener.test.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.test.ts
@@ -20,9 +20,15 @@ describe('findMissDomAndClean', () => {
       test: 'test',
     };
     expect(
-      findRemovedFieldAndRemoveListener(fields as any, () => ({} as any), {
-        ref: { name: 'bill', type: 'radio' },
-      }),
+      findRemovedFieldAndRemoveListener(
+        fields as any,
+        () => ({} as any),
+        {
+          ref: { name: 'bill', type: 'radio' },
+        },
+        {},
+        true,
+      ),
     ).toEqual(undefined);
   });
 
@@ -49,9 +55,15 @@ describe('findMissDomAndClean', () => {
       },
     };
 
-    findRemovedFieldAndRemoveListener(fields, () => ({} as any), {
-      ref,
-    });
+    findRemovedFieldAndRemoveListener(
+      fields,
+      () => ({} as any),
+      {
+        ref,
+      },
+      {},
+      true,
+    );
 
     expect(fields).toEqual({});
   });
@@ -76,12 +88,17 @@ describe('findMissDomAndClean', () => {
       },
     };
 
-    findRemovedFieldAndRemoveListener(fields, () => ({} as any), {
-      ref,
-      mutationWatcher: {
-        disconnect,
+    findRemovedFieldAndRemoveListener(
+      fields,
+      () => ({} as any),
+      {
+        ref,
+        mutationWatcher: {
+          disconnect,
+        },
       },
-    });
+      {},
+    );
 
     expect(fields).toMatchSnapshot();
   });
@@ -109,13 +126,18 @@ describe('findMissDomAndClean', () => {
     };
 
     expect(
-      findRemovedFieldAndRemoveListener(fields, () => ({} as any), {
-        ref: { name: 'test', type: 'radio' },
-        options: [{ ref }],
-        mutationWatcher: {
-          disconnect,
+      findRemovedFieldAndRemoveListener(
+        fields,
+        () => ({} as any),
+        {
+          ref: { name: 'test', type: 'radio' },
+          options: [{ ref }],
+          mutationWatcher: {
+            disconnect,
+          },
         },
-      }),
+        {},
+      ),
     ).toMatchSnapshot();
   });
 
@@ -142,13 +164,18 @@ describe('findMissDomAndClean', () => {
     };
 
     expect(
-      findRemovedFieldAndRemoveListener(fields, () => ({} as any), {
-        ref: { name: 'test', type: 'checkbox' },
-        options: [{ ref }],
-        mutationWatcher: {
-          disconnect,
+      findRemovedFieldAndRemoveListener(
+        fields,
+        () => ({} as any),
+        {
+          ref: { name: 'test', type: 'checkbox' },
+          options: [{ ref }],
+          mutationWatcher: {
+            disconnect,
+          },
         },
-      }),
+        {},
+      ),
     ).toMatchSnapshot();
   });
 
@@ -175,24 +202,34 @@ describe('findMissDomAndClean', () => {
       },
     };
 
-    findRemovedFieldAndRemoveListener(fields, () => ({} as any), {
-      ref: { name: 'test', type: 'text' },
-      options: [
-        {
-          mutationWatcher: {
-            disconnect,
+    findRemovedFieldAndRemoveListener(
+      fields,
+      () => ({} as any),
+      {
+        ref: { name: 'test', type: 'text' },
+        options: [
+          {
+            mutationWatcher: {
+              disconnect,
+            },
+            ref: {},
           },
-          ref: {},
-        },
-      ],
-    });
+        ],
+      },
+      {},
+    );
 
     expect(fields).toMatchSnapshot();
 
     expect(
-      findRemovedFieldAndRemoveListener(fields, () => ({} as any), {
-        ref: { name: 'test', type: 'text' },
-      }),
+      findRemovedFieldAndRemoveListener(
+        fields,
+        () => ({} as any),
+        {
+          ref: { name: 'test', type: 'text' },
+        },
+        {},
+      ),
     ).toMatchSnapshot();
   });
 
@@ -229,6 +266,8 @@ describe('findMissDomAndClean', () => {
           },
         ],
       },
+      {},
+      false,
       true,
     );
 

--- a/src/logic/findRemovedFieldAndRemoveListener.test.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.test.ts
@@ -299,4 +299,28 @@ describe('findMissDomAndClean', () => {
       current: { test: 'test' },
     });
   });
+
+  it('should not store state when component is getting unmount and value is return undefined', () => {
+    const state = { current: {} };
+    const fields = {
+      test: {
+        name: 'test',
+        ref: {},
+      },
+    };
+
+    findRemovedFieldAndRemoveListener(
+      fields,
+      () => ({} as any),
+      {
+        ref: { name: 'test', type: 'text' },
+      },
+      state,
+      false,
+    );
+
+    expect(state).toEqual({
+      current: {},
+    });
+  });
 });

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import removeAllEventListeners from './removeAllEventListeners';
 import isRadioInput from '../utils/isRadioInput';
 import isCheckBoxInput from '../utils/isCheckBoxInput';
@@ -17,7 +18,7 @@ export default function findRemovedFieldAndRemoveListener<
   fields: FieldRefs<TFieldValues>,
   handleChange: ({ type, target }: Event) => Promise<void | boolean>,
   field: Field,
-  unmountFieldsStore: Record<string, any>,
+  unmountFieldsStore: React.MutableRefObject<Record<string, any>>,
   autoUnregister: boolean,
   forceDelete?: boolean,
 ): void {
@@ -29,7 +30,7 @@ export default function findRemovedFieldAndRemoveListener<
   const fieldRef = fields[name] as Field;
 
   if (!autoUnregister) {
-    unmountFieldsStore[name] = getFieldValue(fields, fieldRef.ref);
+    unmountFieldsStore.current[name] = getFieldValue(fields, fieldRef.ref);
   }
 
   if (!type) {

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import removeAllEventListeners from './removeAllEventListeners';
+import getFieldValue from './getFieldValue';
 import isRadioInput from '../utils/isRadioInput';
 import isCheckBoxInput from '../utils/isCheckBoxInput';
 import isDetached from '../utils/isDetached';
 import isArray from '../utils/isArray';
 import unset from '../utils/unset';
 import unique from '../utils/unique';
-import { Field, FieldRefs, FieldValues, Ref } from '../types/form';
-import getFieldValue from './getFieldValue';
 import isUndefined from '../utils/isUndefined';
+import { Field, FieldRefs, FieldValues, Ref } from '../types/form';
 
 const isSameRef = (fieldValue: Field, ref: Ref) =>
   fieldValue && fieldValue.ref === ref;

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -18,7 +18,7 @@ export default function findRemovedFieldAndRemoveListener<
   fields: FieldRefs<TFieldValues>,
   handleChange: ({ type, target }: Event) => Promise<void | boolean>,
   field: Field,
-  unmountFieldsStore: React.MutableRefObject<Record<string, any>>,
+  unmountFieldsState: React.MutableRefObject<Record<string, any>>,
   autoUnregister: boolean,
   forceDelete?: boolean,
 ): void {
@@ -30,7 +30,7 @@ export default function findRemovedFieldAndRemoveListener<
   const fieldRef = fields[name] as Field;
 
   if (!autoUnregister) {
-    unmountFieldsStore.current[name] = getFieldValue(fields, fieldRef.ref);
+    unmountFieldsState.current[name] = getFieldValue(fields, fieldRef.ref);
   }
 
   if (!type) {

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -20,7 +20,7 @@ export default function findRemovedFieldAndRemoveListener<
   handleChange: ({ type, target }: Event) => Promise<void | boolean>,
   field: Field,
   unmountFieldsState: React.MutableRefObject<Record<string, any>>,
-  autoUnregister?: boolean,
+  shouldUnregister?: boolean,
   forceDelete?: boolean,
 ): void {
   const {
@@ -30,7 +30,7 @@ export default function findRemovedFieldAndRemoveListener<
   } = field;
   const fieldRef = fields[name] as Field;
 
-  if (!autoUnregister) {
+  if (!shouldUnregister) {
     const value = getFieldValue(fields, fieldRef.ref);
 
     if (!isUndefined(value)) {

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -8,6 +8,7 @@ import unset from '../utils/unset';
 import unique from '../utils/unique';
 import { Field, FieldRefs, FieldValues, Ref } from '../types/form';
 import getFieldValue from './getFieldValue';
+import isUndefined from '../utils/isUndefined';
 
 const isSameRef = (fieldValue: Field, ref: Ref) =>
   fieldValue && fieldValue.ref === ref;
@@ -30,7 +31,11 @@ export default function findRemovedFieldAndRemoveListener<
   const fieldRef = fields[name] as Field;
 
   if (!autoUnregister) {
-    unmountFieldsState.current[name] = getFieldValue(fields, fieldRef.ref);
+    const value = getFieldValue(fields, fieldRef.ref);
+
+    if (!isUndefined(value)) {
+      unmountFieldsState.current[name] = value;
+    }
   }
 
   if (!type) {

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -20,7 +20,7 @@ export default function findRemovedFieldAndRemoveListener<
   handleChange: ({ type, target }: Event) => Promise<void | boolean>,
   field: Field,
   unmountFieldsState: React.MutableRefObject<Record<string, any>>,
-  autoUnregister: boolean,
+  autoUnregister?: boolean,
   forceDelete?: boolean,
 ): void {
   const {

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -16,6 +16,7 @@ export default function findRemovedFieldAndRemoveListener<
   fields: FieldRefs<TFieldValues>,
   handleChange: ({ type, target }: Event) => Promise<void | boolean>,
   field: Field,
+  autoUnregister: boolean,
   forceDelete?: boolean,
 ): void {
   const {
@@ -24,6 +25,10 @@ export default function findRemovedFieldAndRemoveListener<
     mutationWatcher,
   } = field;
   const fieldValue = fields[name] as Field;
+
+  if (autoUnregister) {
+    return;
+  }
 
   if (!type) {
     delete fields[name];

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -19,7 +19,7 @@ export default function findRemovedFieldAndRemoveListener<
   fields: FieldRefs<TFieldValues>,
   handleChange: ({ type, target }: Event) => Promise<void | boolean>,
   field: Field,
-  unmountFieldsState: React.MutableRefObject<Record<string, any>>,
+  unmountFieldsStateRef: React.MutableRefObject<Record<string, any>>,
   shouldUnregister?: boolean,
   forceDelete?: boolean,
 ): void {
@@ -34,7 +34,7 @@ export default function findRemovedFieldAndRemoveListener<
     const value = getFieldValue(fields, fieldRef.ref);
 
     if (!isUndefined(value)) {
-      unmountFieldsState.current[name] = value;
+      unmountFieldsStateRef.current[name] = value;
     }
   }
 

--- a/src/logic/getValueAndMessage.ts
+++ b/src/logic/getValueAndMessage.ts
@@ -2,15 +2,14 @@ import isObject from '../utils/isObject';
 import isRegex from '../utils/isRegex';
 import { ValidationOption, ValidationValueMessage } from '../types/form';
 
-export default (validationData?: ValidationOption) => {
-  const isValueMessage = (
-    value?: ValidationOption,
-  ): value is ValidationValueMessage => isObject(value) && !isRegex(value);
+const isValueMessage = (
+  value?: ValidationOption,
+): value is ValidationValueMessage => isObject(value) && !isRegex(value);
 
-  return isValueMessage(validationData)
+export default (validationData?: ValidationOption) =>
+  isValueMessage(validationData)
     ? validationData
     : {
         value: validationData,
         message: '',
       };
-};

--- a/src/logic/validateField.test.tsx
+++ b/src/logic/validateField.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import validateField from './validateField';
 import getRadioValue from './getRadioValue';
 import getCheckboxValue from './getCheckboxValue';
@@ -47,12 +46,12 @@ describe('validateField', () => {
     expect(
       await validateField({} as any, false, {
         ref: { type: 'text', value: '', name: 'test', setCustomValidity },
-        required: <p>required</p>,
+        required: 'required',
       }),
     ).toEqual({
       test: {
         ref: { type: 'text', value: '', name: 'test', setCustomValidity },
-        message: <p>required</p>,
+        message: 'required',
         type: 'required',
       },
     });
@@ -78,13 +77,13 @@ describe('validateField', () => {
         ref: { type: 'text', value: '', name: 'test', setCustomValidity },
         required: {
           value: true,
-          message: <p>required</p>,
+          message: 'required',
         },
       }),
     ).toEqual({
       test: {
         ref: { type: 'text', value: '', name: 'test', setCustomValidity },
-        message: <p>required</p>,
+        message: 'required',
         type: 'required',
       },
     });
@@ -261,13 +260,13 @@ describe('validateField', () => {
         required: true,
         max: {
           value: 0,
-          message: <p>max</p>,
+          message: 'max',
         },
       }),
     ).toEqual({
       test: {
         type: 'max',
-        message: <p>max</p>,
+        message: 'max',
         ref: { type: 'number', name: 'test', value: 10, valueAsNumber: 10 },
       },
     });
@@ -405,13 +404,13 @@ describe('validateField', () => {
         required: true,
         min: {
           value: 0,
-          message: <p>min</p>,
+          message: 'min',
         },
       }),
     ).toEqual({
       test: {
         type: 'min',
-        message: <p>min</p>,
+        message: 'min',
         ref: { type: 'number', name: 'test', value: -1, valueAsNumber: -1 },
       },
     });
@@ -492,13 +491,13 @@ describe('validateField', () => {
         required: true,
         min: {
           value: '2019-3-12',
-          message: <p>min</p>,
+          message: 'min',
         },
       }),
     ).toEqual({
       test: {
         type: 'min',
-        message: <p>min</p>,
+        message: 'min',
         ref: {
           type: 'date',
           name: 'test',
@@ -626,7 +625,7 @@ describe('validateField', () => {
         required: true,
         maxLength: {
           value: 12,
-          message: <p>maxLength</p>,
+          message: 'maxLength',
         },
       }),
     ).toEqual({
@@ -637,7 +636,7 @@ describe('validateField', () => {
           value: 'This is a long text input',
           setCustomValidity,
         },
-        message: <p>maxLength</p>,
+        message: 'maxLength',
         type: 'maxLength',
       },
     });
@@ -706,7 +705,7 @@ describe('validateField', () => {
         required: true,
         minLength: {
           value: 200,
-          message: <p>minLength</p>,
+          message: 'minLength',
         },
       }),
     ).toEqual({
@@ -717,7 +716,7 @@ describe('validateField', () => {
           value: 'This is a long text input',
           setCustomValidity,
         },
-        message: <p>minLength</p>,
+        message: 'minLength',
         type: 'minLength',
       },
     });
@@ -788,7 +787,7 @@ describe('validateField', () => {
         required: true,
         pattern: {
           value: emailRegex,
-          message: <p>regex failed</p>,
+          message: 'regex failed',
         },
       }),
     ).toEqual({
@@ -799,7 +798,7 @@ describe('validateField', () => {
           value: 'This is a long text input',
           setCustomValidity,
         },
-        message: <p>regex failed</p>,
+        message: 'regex failed',
         type: 'pattern',
       },
     });
@@ -1054,7 +1053,7 @@ describe('validateField', () => {
           validate: {
             test: (value) => {
               if (value.toString().length > 3) {
-                return <p>max 3</p>;
+                return 'max 3';
               }
               return true;
             },
@@ -1064,7 +1063,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'test',
-        message: <p>max 3</p>,
+        message: 'max 3',
         ref: {
           type: 'text',
           name: 'test',
@@ -1126,13 +1125,13 @@ describe('validateField', () => {
             value: 'This is a long text input',
             setCustomValidity,
           },
-          validate: (value) => value.toString().length < 3 || <p>bill</p>,
+          validate: (value) => value.toString().length < 3 || 'bill',
         },
       ),
     ).toEqual({
       test: {
         type: 'validate',
-        message: <p>bill</p>,
+        message: 'bill',
         ref: {
           type: 'text',
           name: 'test',
@@ -1238,19 +1237,19 @@ describe('validateField', () => {
     expect(
       await validateField({ current: {} }, true, {
         ref: { type: 'text', value: 'bil', name: 'test', setCustomValidity },
-        required: <p>test</p>,
+        required: 'test',
         minLength: {
           value: 10,
-          message: <p>minLength</p>,
+          message: 'minLength',
         },
         pattern: {
           value: /d/i,
-          message: <p>pattern</p>,
+          message: 'pattern',
         },
         validate: {
-          test: (value) => value === <p>test</p>,
-          test1: (value) => value == 'test' || <p>Luo</p>,
-          test2: (value) => value == 'test' || <p>Bill</p>,
+          test: (value) => value === 'test',
+          test1: (value) => value == 'test' || 'Luo',
+          test2: (value) => value == 'test' || 'Bill',
         },
       }),
     ).toMatchSnapshot();

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -89,6 +89,7 @@ export type UseFormOptions<
   resolver: Resolver<TFieldValues, TContext>;
   context: TContext;
   submitFocusError: boolean;
+  autoUnregister: boolean;
   criteriaMode: 'firstError' | 'all';
 }>;
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -241,7 +241,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = Pick<
   resetFieldArrayFunctionRef: React.MutableRefObject<
     Record<string, (values: any) => void>
   >;
-  autoUnregister: boolean;
+  unmountFieldsStore: Record<string, any>;
   fieldArrayNamesRef: React.MutableRefObject<Set<string>>;
   isDirtyRef: React.MutableRefObject<boolean>;
   isSubmittedRef: React.MutableRefObject<boolean>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -241,7 +241,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = Pick<
   resetFieldArrayFunctionRef: React.MutableRefObject<
     Record<string, (values: any) => void>
   >;
-  unmountFieldsStore: Record<string, any>;
+  unmountFieldsState: Record<string, any>;
   fieldArrayNamesRef: React.MutableRefObject<Set<string>>;
   isDirtyRef: React.MutableRefObject<boolean>;
   isSubmittedRef: React.MutableRefObject<boolean>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -241,7 +241,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = Pick<
   resetFieldArrayFunctionRef: React.MutableRefObject<
     Record<string, (values: any) => void>
   >;
-  unmountFieldsState: Record<string, any>;
+  unmountFieldsStateRef: Record<string, any>;
   fieldArrayNamesRef: React.MutableRefObject<Set<string>>;
   isDirtyRef: React.MutableRefObject<boolean>;
   isSubmittedRef: React.MutableRefObject<boolean>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -98,7 +98,7 @@ export type MutationWatcher = {
   observe?: any;
 };
 
-export type Message = string | React.ReactElement;
+export type Message = string;
 
 export type ValidationValue = boolean | number | string | RegExp;
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -89,7 +89,7 @@ export type UseFormOptions<
   resolver: Resolver<TFieldValues, TContext>;
   context: TContext;
   shouldFocusError: boolean;
-  autoUnregister: boolean;
+  shouldUnregister: boolean;
   criteriaMode: 'firstError' | 'all';
 }>;
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -241,6 +241,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = Pick<
   resetFieldArrayFunctionRef: React.MutableRefObject<
     Record<string, (values: any) => void>
   >;
+  autoUnregister: boolean;
   fieldArrayNamesRef: React.MutableRefObject<Set<string>>;
   isDirtyRef: React.MutableRefObject<boolean>;
   isSubmittedRef: React.MutableRefObject<boolean>;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -42,6 +42,7 @@ export type ControllerProps<
     rules?: ValidationOptions;
     onFocus?: () => void;
     defaultValue?: unknown;
+    autoUnregister: boolean;
     control?: TControl;
     render?: (data: {
       onChange: (...event: any[]) => void;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -42,7 +42,6 @@ export type ControllerProps<
     rules?: ValidationOptions;
     onFocus?: () => void;
     defaultValue?: unknown;
-    autoUnregister: boolean;
     control?: TControl;
     render?: (data: {
       onChange: (...event: any[]) => void;

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -64,7 +64,7 @@ export type ErrorMessageProps<
     as?: TAs;
     errors?: TFieldErrors;
     name: FieldName<FieldValuesFromFieldErrors<TFieldErrors>>;
-    message?: Message;
+    message?: string | React.ReactElement;
     render?: (data: {
       message: Message;
       messages?: MultipleFieldErrors;

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -14,6 +14,7 @@ import * as shouldRenderBasedOnError from './logic/shouldRenderBasedOnError';
 export const reconfigureControl = (
   controlOverrides: Partial<Control> = {},
 ): Control => ({
+  autoUnregister: true,
   defaultValuesRef: {
     current: {},
   },

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1593,14 +1593,15 @@ describe('useForm', () => {
       });
 
       act(() => {
-        result.current.setError('input', 'test', <p>test</p>);
+        result.current.setError('input', 'test', 'test');
       });
       expect(result.current.errors).toEqual({
         input: {
           type: 'test',
           isManual: true,
-          message: <p>test</p>,
+          message: 'test',
           ref: {},
+          types: undefined,
         },
       });
 
@@ -1623,7 +1624,7 @@ describe('useForm', () => {
       act(() => {
         result.current.setError('input', {
           test1: 'test1',
-          test2: <p>test2</p>,
+          test2: 'test2',
         });
       });
 
@@ -1634,7 +1635,7 @@ describe('useForm', () => {
           message: undefined,
           types: {
             test1: 'test1',
-            test2: <p>test2</p>,
+            test2: 'test2',
           },
           ref: {},
         },
@@ -1725,7 +1726,7 @@ describe('useForm', () => {
           {
             type: 'test2',
             name: 'input2',
-            message: <p>wow2</p>,
+            message: 'wow2',
           },
         ]);
       });
@@ -1746,7 +1747,7 @@ describe('useForm', () => {
         input2: {
           type: 'test2',
           isManual: true,
-          message: <p>wow2</p>,
+          message: 'wow2',
           ref: {},
         },
       });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -113,7 +113,7 @@ export function useForm<
   const submitCountRef = React.useRef(0);
   const isSubmittingRef = React.useRef(false);
   const handleChangeRef = React.useRef<HandleChange>();
-  const unmountFieldsState = React.useRef<Record<string, any>>({});
+  const unmountFieldsStateRef = React.useRef<Record<string, any>>({});
   const resetFieldArrayFunctionRef = React.useRef({});
   const contextRef = React.useRef(context);
   const resolverRef = React.useRef(resolver);
@@ -597,7 +597,7 @@ export function useForm<
           fieldsRef.current,
           handleChangeRef.current,
           field,
-          unmountFieldsState,
+          unmountFieldsStateRef,
           shouldUnregister,
           forceDelete,
         );
@@ -625,7 +625,6 @@ export function useForm<
           fieldsWithValidationRef,
           validFieldsRef,
           watchFieldsRef,
-          unmountFieldsState,
         ].forEach((data) => data.current.delete(field.ref.name));
 
         if (
@@ -887,11 +886,11 @@ export function useForm<
 
     if (
       !isEmptyObject(defaultValuesRef.current) ||
-      !isUndefined(unmountFieldsState.current[name])
+      !isUndefined(unmountFieldsStateRef.current[name])
     ) {
-      defaultValue = isUndefined(unmountFieldsState.current[name])
+      defaultValue = isUndefined(unmountFieldsStateRef.current[name])
         ? get(defaultValuesRef.current, name)
-        : unmountFieldsState.current[name];
+        : unmountFieldsStateRef.current[name];
       isEmptyDefaultValue = isUndefined(defaultValue);
       isFieldArray = isNameInFieldArray(fieldArrayNamesRef.current, name);
 
@@ -991,7 +990,7 @@ export function useForm<
       }
       let fieldErrors: FieldErrors<TFieldValues> = {};
       let fieldValues: FieldValues = {
-        ...unmountFieldsState.current,
+        ...unmountFieldsStateRef.current,
         ...getFieldsValues(fieldsRef.current),
       };
 
@@ -1097,7 +1096,7 @@ export function useForm<
       TFieldValues
     >;
     fieldArrayDefaultValues.current = {};
-    unmountFieldsState.current = {};
+    unmountFieldsStateRef.current = {};
     watchFieldsRef.current = new Set();
     isWatchAllRef.current = false;
   };
@@ -1269,7 +1268,7 @@ export function useForm<
     isSubmittedRef,
     readFormStateRef,
     defaultValuesRef,
-    unmountFieldsState,
+    unmountFieldsStateRef,
     ...commonProps,
   };
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -891,8 +891,13 @@ export function useForm<
 
     fields[name] = field;
 
-    if (!isEmptyObject(defaultValuesRef.current)) {
-      defaultValue = get(defaultValuesRef.current, name);
+    if (
+      !isEmptyObject(defaultValuesRef.current) ||
+      !isUndefined(unmountFieldsStore.current[name])
+    ) {
+      defaultValue = autoUnregister
+        ? get(defaultValuesRef.current, name)
+        : unmountFieldsStore.current[name];
       isEmptyDefaultValue = isUndefined(defaultValue);
       isFieldArray = isNameInFieldArray(fieldArrayNamesRef.current, name);
 
@@ -927,12 +932,9 @@ export function useForm<
       !defaultValuesAtRenderRef.current[name] &&
       !(isFieldArray && isEmptyDefaultValue)
     ) {
-      defaultValuesAtRenderRef.current[name] =
-        !autoUnregister && !isUndefined(unmountFieldsStore.current[name])
-          ? unmountFieldsStore.current[name]
-          : isEmptyDefaultValue
-          ? getFieldValue(fields, field.ref)
-          : defaultValue;
+      defaultValuesAtRenderRef.current[name] = isEmptyDefaultValue
+        ? getFieldValue(fields, field.ref)
+        : defaultValue;
     }
 
     if (type) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -884,11 +884,12 @@ export function useForm<
 
     fields[name] = field;
 
-    if (
-      !isEmptyObject(defaultValuesRef.current) ||
-      !isUndefined(unmountFieldsStateRef.current[name])
-    ) {
-      defaultValue = isUndefined(unmountFieldsStateRef.current[name])
+    const isEmptyUnmountFields = isUndefined(
+      unmountFieldsStateRef.current[name],
+    );
+
+    if (!isEmptyObject(defaultValuesRef.current) || !isEmptyUnmountFields) {
+      defaultValue = isEmptyUnmountFields
         ? get(defaultValuesRef.current, name)
         : unmountFieldsStateRef.current[name];
       isEmptyDefaultValue = isUndefined(defaultValue);

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -625,6 +625,7 @@ export function useForm<
           fieldsWithValidationRef,
           validFieldsRef,
           watchFieldsRef,
+          unmountFieldsState,
         ].forEach((data) => data.current.delete(field.ref.name));
 
         if (

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -895,7 +895,7 @@ export function useForm<
       !isEmptyObject(defaultValuesRef.current) ||
       !isUndefined(unmountFieldsState.current[name])
     ) {
-      defaultValue = autoUnregister
+      defaultValue = isUndefined(unmountFieldsState.current[name])
         ? get(defaultValuesRef.current, name)
         : unmountFieldsState.current[name];
       isEmptyDefaultValue = isUndefined(defaultValue);
@@ -1110,6 +1110,7 @@ export function useForm<
       TFieldValues
     >;
     fieldArrayDefaultValues.current = {};
+    unmountFieldsState.current = {};
     watchFieldsRef.current = new Set();
     isWatchAllRef.current = false;
   };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -113,7 +113,7 @@ export function useForm<
   const submitCountRef = React.useRef(0);
   const isSubmittingRef = React.useRef(false);
   const handleChangeRef = React.useRef<HandleChange>();
-  const unmountFieldsStore = React.useRef<Record<string, any>>({});
+  const unmountFieldsState = React.useRef<Record<string, any>>({});
   const resetFieldArrayFunctionRef = React.useRef({});
   const contextRef = React.useRef(context);
   const resolverRef = React.useRef(resolver);
@@ -603,7 +603,7 @@ export function useForm<
           fieldsRef.current,
           handleChangeRef.current,
           field,
-          unmountFieldsStore,
+          unmountFieldsState,
           autoUnregister,
           forceDelete,
         );
@@ -893,11 +893,11 @@ export function useForm<
 
     if (
       !isEmptyObject(defaultValuesRef.current) ||
-      !isUndefined(unmountFieldsStore.current[name])
+      !isUndefined(unmountFieldsState.current[name])
     ) {
       defaultValue = autoUnregister
         ? get(defaultValuesRef.current, name)
-        : unmountFieldsStore.current[name];
+        : unmountFieldsState.current[name];
       isEmptyDefaultValue = isUndefined(defaultValue);
       isFieldArray = isNameInFieldArray(fieldArrayNamesRef.current, name);
 
@@ -996,7 +996,10 @@ export function useForm<
         e.persist();
       }
       let fieldErrors: FieldErrors<TFieldValues> = {};
-      let fieldValues: FieldValues = getFieldsValues(fieldsRef.current);
+      let fieldValues: FieldValues = {
+        ...(autoUnregister ? {} : unmountFieldsState.current),
+        ...getFieldsValues(fieldsRef.current),
+      };
 
       if (readFormStateRef.current.isSubmitting) {
         isSubmittingRef.current = true;
@@ -1039,13 +1042,7 @@ export function useForm<
         if (isEmptyObject(fieldErrors)) {
           errorsRef.current = {};
           reRender();
-          await callback(
-            transformToNestObject({
-              ...(autoUnregister ? {} : unmountFieldsStore.current),
-              ...fieldValues,
-            }),
-            e,
-          );
+          await callback(transformToNestObject(fieldValues), e);
         } else {
           errorsRef.current = fieldErrors;
           if (submitFocusError && isWeb) {
@@ -1284,7 +1281,7 @@ export function useForm<
     isSubmittedRef,
     readFormStateRef,
     defaultValuesRef,
-    unmountFieldsStore,
+    unmountFieldsState,
     ...commonProps,
   };
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -848,7 +848,6 @@ export function useForm<
     let defaultValue;
 
     if (
-      autoUnregister &&
       field &&
       (isRadioOrCheckbox
         ? isArray(field.options) &&
@@ -997,7 +996,7 @@ export function useForm<
       }
       let fieldErrors: FieldErrors<TFieldValues> = {};
       let fieldValues: FieldValues = {
-        ...(autoUnregister ? {} : unmountFieldsState.current),
+        ...unmountFieldsState.current,
         ...getFieldsValues(fieldsRef.current),
       };
 
@@ -1056,14 +1055,7 @@ export function useForm<
         reRender();
       }
     },
-    [
-      isWeb,
-      reRender,
-      resolverRef,
-      submitFocusError,
-      validateAllFieldCriteria,
-      autoUnregister,
-    ],
+    [isWeb, reRender, resolverRef, submitFocusError, validateAllFieldCriteria],
   );
 
   const resetRefs = ({

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1284,7 +1284,7 @@ export function useForm<
     isSubmittedRef,
     readFormStateRef,
     defaultValuesRef,
-    autoUnregister,
+    unmountFieldsStore,
     ...commonProps,
   };
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1037,7 +1037,13 @@ export function useForm<
         if (isEmptyObject(fieldErrors)) {
           errorsRef.current = {};
           reRender();
-          await callback(transformToNestObject(fieldValues), e);
+          await callback(
+            transformToNestObject({
+              ...(autoUnregister ? {} : unmountFieldsStore.current),
+              ...fieldValues,
+            }),
+            e,
+          );
         } else {
           errorsRef.current = fieldErrors;
           if (submitFocusError && isWeb) {
@@ -1051,7 +1057,14 @@ export function useForm<
         reRender();
       }
     },
-    [isWeb, reRender, resolverRef, submitFocusError, validateAllFieldCriteria],
+    [
+      isWeb,
+      reRender,
+      resolverRef,
+      submitFocusError,
+      validateAllFieldCriteria,
+      autoUnregister,
+    ],
   );
 
   const resetRefs = ({

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -602,11 +602,12 @@ export function useForm<
           fieldsRef.current,
           handleChangeRef.current,
           field,
+          autoUnregister,
           forceDelete,
         );
       }
     },
-    [],
+    [autoUnregister],
   );
 
   const removeFieldEventListenerAndRef = React.useCallback(
@@ -845,6 +846,7 @@ export function useForm<
     let defaultValue;
 
     if (
+      autoUnregister &&
       field &&
       (isRadioOrCheckbox
         ? isArray(field.options) &&
@@ -861,9 +863,9 @@ export function useForm<
     }
 
     if (type) {
-      const mutationWatcher = autoUnregister
-        ? onDomRemove(ref, () => removeFieldEventListenerAndRef(field))
-        : undefined;
+      const mutationWatcher = onDomRemove(ref, () =>
+        removeFieldEventListenerAndRef(field),
+      );
 
       field = isRadioOrCheckbox
         ? {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -113,6 +113,7 @@ export function useForm<
   const submitCountRef = React.useRef(0);
   const isSubmittingRef = React.useRef(false);
   const handleChangeRef = React.useRef<HandleChange>();
+  const unmountFieldsStore = React.useRef<Record<string, any>>({});
   const resetFieldArrayFunctionRef = React.useRef({});
   const contextRef = React.useRef(context);
   const resolverRef = React.useRef(resolver);
@@ -602,6 +603,7 @@ export function useForm<
           fieldsRef.current,
           handleChangeRef.current,
           field,
+          unmountFieldsStore,
           autoUnregister,
           forceDelete,
         );
@@ -925,9 +927,12 @@ export function useForm<
       !defaultValuesAtRenderRef.current[name] &&
       !(isFieldArray && isEmptyDefaultValue)
     ) {
-      defaultValuesAtRenderRef.current[name] = isEmptyDefaultValue
-        ? getFieldValue(fields, field.ref)
-        : defaultValue;
+      defaultValuesAtRenderRef.current[name] =
+        !autoUnregister && !isUndefined(unmountFieldsStore.current[name])
+          ? unmountFieldsStore.current[name]
+          : isEmptyDefaultValue
+          ? getFieldValue(fields, field.ref)
+          : defaultValue;
     }
 
     if (type) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -77,7 +77,7 @@ export function useForm<
   context,
   defaultValues = {} as UnpackNestedValue<DeepPartial<TFieldValues>>,
   shouldFocusError = true,
-  autoUnregister = true,
+  shouldUnregister = true,
   criteriaMode,
 }: UseFormOptions<TFieldValues, TContext> = {}): UseFormMethods<TFieldValues> {
   const fieldsRef = React.useRef<FieldRefs<TFieldValues>>({});
@@ -598,12 +598,12 @@ export function useForm<
           handleChangeRef.current,
           field,
           unmountFieldsState,
-          autoUnregister,
+          shouldUnregister,
           forceDelete,
         );
       }
     },
-    [autoUnregister],
+    [shouldUnregister],
   );
 
   const removeFieldEventListenerAndRef = React.useCallback(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -77,6 +77,7 @@ export function useForm<
   context,
   defaultValues = {} as UnpackNestedValue<DeepPartial<TFieldValues>>,
   submitFocusError = true,
+  autoUnregister = true,
   criteriaMode,
 }: UseFormOptions<TFieldValues, TContext> = {}): UseFormMethods<TFieldValues> {
   const fieldsRef = React.useRef<FieldRefs<TFieldValues>>({});
@@ -860,9 +861,9 @@ export function useForm<
     }
 
     if (type) {
-      const mutationWatcher = onDomRemove(ref, () =>
-        removeFieldEventListenerAndRef(field),
-      );
+      const mutationWatcher = autoUnregister
+        ? onDomRemove(ref, () => removeFieldEventListenerAndRef(field))
+        : undefined;
 
       field = isRadioOrCheckbox
         ? {
@@ -1261,6 +1262,7 @@ export function useForm<
     isSubmittedRef,
     readFormStateRef,
     defaultValuesRef,
+    autoUnregister,
     ...commonProps,
   };
 


### PR DESCRIPTION
**V6 feature:**

This feature will solve an issue when users want to persis their inputs without `unregister` invoked by `mutationObserver`. 

```tsx
useform({
  shouldUnregister: false
})
```

above config will disable `unregister` when inputs get unmounted and give user the option to keep value inside the hook store.

https://codesandbox.io/s/autounregister-4e91k?file=/src/src/logic/findRemovedFieldAndRemoveListener.ts

fix #1713 for the error message to be strictly typed for `string`.