### PR TITLE
Reduced code in executeSchemaOrResolverValidation method

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -350,7 +350,6 @@ export function useForm<
         | InternalFieldName<TFieldValues>
         | InternalFieldName<TFieldValues>[],
     ) => {
-      // Use non-null assertion due to resolverRef is checked with trigger.
       const { errors } = await resolverRef.current!(
         getFieldArrayValueByName(fieldsRef.current),
         contextRef.current,


### PR DESCRIPTION
I removed conditional expression in `executeSchemaOrResolverValidation()`, because this method is used with only `trigger()`, and duplicated conditional expression.