### PR TITLE
🙌 rename submitFocusError to shouldFocusError

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -88,7 +88,7 @@ export type UseFormOptions<
   defaultValues: UnpackNestedValue<DeepPartial<TFieldValues>>;
   resolver: Resolver<TFieldValues, TContext>;
   context: TContext;
-  submitFocusError: boolean;
+  shouldFocusError: boolean;
   criteriaMode: 'firstError' | 'all';
 }>;
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -76,7 +76,7 @@ export function useForm<
   resolver,
   context,
   defaultValues = {} as UnpackNestedValue<DeepPartial<TFieldValues>>,
-  submitFocusError = true,
+  shouldFocusError = true,
   criteriaMode,
 }: UseFormOptions<TFieldValues, TContext> = {}): UseFormMethods<TFieldValues> {
   const fieldsRef = React.useRef<FieldRefs<TFieldValues>>({});
@@ -1026,7 +1026,7 @@ export function useForm<
           await callback(transformToNestObject(fieldValues), e);
         } else {
           errorsRef.current = fieldErrors;
-          if (submitFocusError && isWeb) {
+          if (shouldFocusError && isWeb) {
             focusOnErrorField(fieldsRef.current, fieldErrors);
           }
         }
@@ -1037,7 +1037,7 @@ export function useForm<
         reRender();
       }
     },
-    [isWeb, reRender, resolverRef, submitFocusError, validateAllFieldCriteria],
+    [isWeb, reRender, resolverRef, shouldFocusError, validateAllFieldCriteria],
   );
 
   const resetRefs = ({


### PR DESCRIPTION
Rename `submitFocusError` -> `shouldFocusError`

**Reason:**

Consistency between config attribute. https://github.com/react-hook-form/react-hook-form/pull/1809

```
useForm({
  shouldFocusError: true
})
```