### PR TITLE
reduced code for removeFieldEventListener in useForm

### DIFF
--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 import { Controller } from './controller';
 import { reconfigureControl } from './__mocks__/reconfigureControl';
-import { Field } from './types/form';
 import * as set from './utils/set';
 import { FormProvider } from './useFormContext';
 import { renderHook } from '@testing-library/react-hooks';
@@ -593,33 +592,6 @@ describe('Controller', () => {
     );
 
     expect(asFragment()).toMatchSnapshot();
-  });
-
-  it('should invoke removeFieldEventListener to remove field with Field Array item', () => {
-    const control = reconfigureControl();
-    const removeFieldEventListener = jest.fn();
-
-    render(
-      <Controller
-        defaultValue=""
-        name="test[0]"
-        render={(props) => <input {...props} />}
-        control={{
-          ...control,
-          removeFieldEventListener,
-          fieldsRef: {
-            current: {
-              'test[1]': {} as Field,
-            },
-          },
-          fieldArrayNamesRef: {
-            current: new Set(['test']),
-          },
-        }}
-      />,
-    );
-
-    expect(removeFieldEventListener).toBeCalled();
   });
 
   it('should be null if as and render props are not given', () => {

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -8,7 +8,7 @@ import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
 import { useFormContext } from './useFormContext';
 import { VALUE } from './constants';
-import { Control, Field } from './types/form';
+import { Control } from './types/form';
 import { ControllerProps } from './types/props';
 
 const Controller = <
@@ -34,7 +34,6 @@ const Controller = <
     register,
     unregister,
     errorsRef,
-    removeFieldEventListener,
     trigger,
     mode: { isOnSubmit, isOnBlur, isOnChange },
     reValidateMode: { isReValidateOnBlur, isReValidateOnSubmit },
@@ -81,10 +80,6 @@ const Controller = <
         ...rules,
       };
     } else {
-      if (!isNotFieldArray) {
-        removeFieldEventListener(fieldsRef.current[name] as Field, true);
-      }
-
       register(
         Object.defineProperty({ name, focus: onFocusRef.current }, VALUE, {
           set(data) {
@@ -98,15 +93,7 @@ const Controller = <
         rules,
       );
     }
-  }, [
-    isNotFieldArray,
-    fieldsRef,
-    rules,
-    name,
-    onFocusRef,
-    register,
-    removeFieldEventListener,
-  ]);
+  }, [fieldsRef, rules, name, onFocusRef, register]);
 
   React.useEffect(
     () => () => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -590,14 +590,12 @@ export function useForm<
 
   const removeFieldEventListener = React.useCallback(
     (field: Field, forceDelete?: boolean) => {
-      if (handleChangeRef.current && field) {
-        findRemovedFieldAndRemoveListener(
-          fieldsRef.current,
-          handleChangeRef.current,
-          field,
-          forceDelete,
-        );
-      }
+      findRemovedFieldAndRemoveListener(
+        fieldsRef.current,
+        handleChangeRef.current!,
+        field,
+        forceDelete,
+      );
     },
     [],
   );


### PR DESCRIPTION
- I reduced code in `removeFieldEventListener()`, because this function's conditions are unused
- I think `handleChangeRef` will not be undefined, because this function is defined before `removeFieldEventListener()` is called
- And `field` will be not undefined too, because `field` is checked before this function is called