### PR TITLE
improve ControllerProps type

### DIFF
--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -15,7 +15,9 @@ const Controller = <
   TAs extends
     | React.ReactElement
     | React.ComponentType<any>
-    | keyof JSX.IntrinsicElements,
+    | 'input'
+    | 'select'
+    | 'textarea',
   TControl extends Control = Control
 >({
   name,

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -29,7 +29,9 @@ export type ControllerProps<
   TAs extends
     | React.ReactElement
     | React.ComponentType<any>
-    | keyof JSX.IntrinsicElements,
+    | 'input'
+    | 'select'
+    | 'textarea',
   TControl extends Control = Control
 > = Assign<
   {


### PR DESCRIPTION
I think the only uncontrolled component (`JSX.IntrinsicElement`) allowed by Controller is `input`/`select`/`textarea`.
if we don't allow uncontrolled components, we can also remove them.