### PR TITLE
Removed mapCurrentFieldsValueWithState in useFieldArray

### DIFF
--- a/src/useFieldArray.test.ts
+++ b/src/useFieldArray.test.ts
@@ -57,9 +57,6 @@ describe('useFieldArray', () => {
         useFieldArray({
           control: {
             ...reconfigureControl(),
-            getValues: () => ({
-              test: [],
-            }),
             readFormStateRef: {
               current: {
                 touched: true,
@@ -169,9 +166,6 @@ describe('useFieldArray', () => {
         useFieldArray({
           control: {
             ...reconfigureControl(),
-            getValues: () => ({
-              test: [],
-            }),
             readFormStateRef: {
               current: {
                 touched: true,
@@ -251,9 +245,6 @@ describe('useFieldArray', () => {
         useFieldArray({
           control: {
             ...reconfigureControl(),
-            getValues: () => ({
-              test: [],
-            }),
             errorsRef: errorsRef as any,
           },
           name: 'test',
@@ -291,9 +282,6 @@ describe('useFieldArray', () => {
         useFieldArray({
           control: {
             ...reconfigureControl(),
-            getValues: () => ({
-              test: [],
-            }),
             touchedFieldsRef: touchedFieldsRef as any,
             readFormStateRef: {
               current: {
@@ -348,9 +336,6 @@ describe('useFieldArray', () => {
               defaultValuesRef: {
                 current: { test: [{ test: '1' }, { test: '2' }] },
               },
-              getValues: () => ({
-                test: [],
-              }),
               readFormStateRef: {
                 current: {
                   touched: true,
@@ -396,9 +381,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             errorsRef: errorsRef as any,
             fieldsRef: {
               current: {
@@ -431,9 +413,6 @@ describe('useFieldArray', () => {
       const { result } = renderHook(() =>
         useFieldArray({
           control: reconfigureControl({
-            getValues: () => ({
-              test: [],
-            }),
             readFormStateRef: {
               current: {
                 touched: true,
@@ -542,9 +521,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }, { test: '3' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             fieldsRef: {
               current: {
                 'test[0]': { ref: { name: 'test[0]', value: { test: '1' } } },
@@ -608,11 +584,6 @@ describe('useFieldArray', () => {
                 },
               },
             },
-            getValues: () => ({
-              test: {
-                data: [],
-              },
-            }),
           }),
           name: 'test.data',
         }),
@@ -650,9 +621,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             fieldsRef: {
               current: {
                 'test[0]': { ref: { name: 'test[0]', value: { test: '1' } } },
@@ -724,9 +692,6 @@ describe('useFieldArray', () => {
                 touched: true,
               },
             } as any,
-            getValues: () => ({
-              test: [],
-            }),
             touchedFieldsRef: touchedFieldsRef as any,
             fieldsRef: {
               current: {
@@ -786,9 +751,6 @@ describe('useFieldArray', () => {
         useFieldArray({
           control: {
             ...reconfigureControl(),
-            getValues: () => ({
-              test: [],
-            }),
             errorsRef: errorsRef as any,
             fieldsRef: {
               current: {
@@ -863,9 +825,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             fieldsRef: {
               current: {
                 'test[0]': { ref: { name: 'test[0]', value: { test: '1' } } },
@@ -920,9 +879,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             errorsRef: errorsRef as any,
             fieldsRef: {
               current: {
@@ -957,9 +913,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             readFormStateRef: {
               current: {
                 touched: true,
@@ -1011,9 +964,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }, { test: '3' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             readFormStateRef: {
               current: {
                 dirtyFields: true,
@@ -1070,9 +1020,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }, { test: '3' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             errorsRef: errorsRef as any,
           }),
           name: 'test',
@@ -1101,9 +1048,6 @@ describe('useFieldArray', () => {
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }, { test: '3' }] },
             },
-            getValues: () => ({
-              test: [],
-            }),
             readFormStateRef: {
               current: {
                 touched: true,
@@ -1133,9 +1077,6 @@ describe('useFieldArray', () => {
         useFieldArray({
           control: reconfigureControl({
             resetFieldArrayFunctionRef,
-            getValues: () => ({
-              test: [],
-            }),
             defaultValuesRef: {
               current: { test: [{ test: '1' }, { test: '2' }, { test: '3' }] },
             },

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -42,7 +42,6 @@ export const useFieldArray = <
     fieldArrayNamesRef,
     reRender,
     fieldsRef,
-    getValues,
     defaultValuesRef,
     removeFieldEventListener,
     errorsRef,
@@ -133,22 +132,6 @@ export const useFieldArray = <
     }
   };
 
-  const mapCurrentFieldsValueWithState = () => {
-    const currentFieldsValue: Partial<TFieldArrayValues>[] = get(
-      getValues(),
-      name,
-    );
-
-    if (isArray(currentFieldsValue)) {
-      for (let i = 0; i < currentFieldsValue.length; i++) {
-        allFields.current[i] = {
-          ...allFields.current[i],
-          ...currentFieldsValue[i],
-        };
-      }
-    }
-  };
-
   const append = (
     value: Partial<TFieldArrayValues> | Partial<TFieldArrayValues>[],
     shouldFocus = true,
@@ -220,10 +203,6 @@ export const useFieldArray = <
 
   const remove = (index?: number | number[]) => {
     shouldRender = false;
-
-    if (!isUndefined(index)) {
-      mapCurrentFieldsValueWithState();
-    }
 
     resetFields(
       removeArrayAt(getFieldValueByName(fieldsRef.current, name), index),
@@ -312,7 +291,6 @@ export const useFieldArray = <
     shouldRender = false;
     const emptyArray = fillEmptyArray(value);
 
-    mapCurrentFieldsValueWithState();
     resetFields(insertAt(getFieldValueByName(fieldsRef.current, name), index));
     setFieldAndValidState(
       insertAt(
@@ -360,7 +338,6 @@ export const useFieldArray = <
   const swap = (indexA: number, indexB: number) => {
     shouldRender = false;
 
-    mapCurrentFieldsValueWithState();
     const fieldValues = getFieldValueByName(fieldsRef.current, name);
     swapArrayAt(fieldValues, indexA, indexB);
     resetFields(fieldValues);
@@ -390,7 +367,6 @@ export const useFieldArray = <
 
   const move = (from: number, to: number) => {
     shouldRender = false;
-    mapCurrentFieldsValueWithState();
     const fieldValues = getFieldValueByName(fieldsRef.current, name);
     moveArrayAt(fieldValues, from, to);
     resetFields(fieldValues);


### PR DESCRIPTION
I think `mapCurrentFieldsValueWithState` is unnecessary in `useFieldArray`. Because allFields is always new value.

Are there the reason why `mapCurrentFieldsValueWithState` is used in `useFieldArray`?