### PR TITLE
Feature/set value should not set `dirty` to true and give users options

### DIFF
--- a/app/src/manualRegisterForm.tsx
+++ b/app/src/manualRegisterForm.tsx
@@ -41,58 +41,94 @@ const ManualRegisterForm: React.FC = () => {
       <input
         name="firstName"
         placeholder="firstName"
-        onChange={e => setValue('firstName', e.target.value, true)}
+        onChange={(e) =>
+          setValue('firstName', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.firstName && <p>firstName error</p>}
       <input
         name="lastName"
         placeholder="lastName"
-        onChange={e => setValue('lastName', e.target.value, true)}
+        onChange={(e) =>
+          setValue('lastName', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.lastName && <p>lastName error</p>}
       <input
         type="number"
         name="min"
         placeholder="min"
-        onChange={e => setValue('min', e.target.value, true)}
+        onChange={(e) =>
+          setValue('min', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.min && <p>min error</p>}
       <input
         type="number"
         name="max"
         placeholder="max"
-        onChange={e => setValue('max', e.target.value, true)}
+        onChange={(e) =>
+          setValue('max', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.max && <p>max error</p>}
       <input
         type="date"
         name="minDate"
         placeholder="minDate"
-        onChange={e => setValue('minDate', e.target.value, true)}
+        onChange={(e) =>
+          setValue('minDate', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.minDate && <p>minDate error</p>}
       <input
         type="date"
         name="maxDate"
         placeholder="maxDate"
-        onChange={e => setValue('maxDate', e.target.value, true)}
+        onChange={(e) =>
+          setValue('maxDate', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.maxDate && <p>maxDate error</p>}
       <input
         name="minLength"
         placeholder="minLength"
-        onChange={e => setValue('minLength', e.target.value, true)}
+        onChange={(e) =>
+          setValue('minLength', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.minLength && <p>minLength error</p>}
       <input
         name="minRequiredLength"
         placeholder="minRequiredLength"
-        onChange={e => setValue('minRequiredLength', e.target.value, true)}
+        onChange={(e) =>
+          setValue('minRequiredLength', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.minRequiredLength && <p>minRequiredLength error</p>}
       <select
         name="selectNumber"
-        onChange={e => setValue('selectNumber', e.target.value, true)}
+        onChange={(e) =>
+          setValue('selectNumber', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       >
         <option value="">Select</option>
         <option value={1}>1</option>
@@ -102,7 +138,11 @@ const ManualRegisterForm: React.FC = () => {
       <input
         name="pattern"
         placeholder="pattern"
-        onChange={e => setValue('pattern', e.target.value, true)}
+        onChange={(e) =>
+          setValue('pattern', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.pattern && <p>pattern error</p>}
       Radio1
@@ -110,27 +150,43 @@ const ManualRegisterForm: React.FC = () => {
         type="radio"
         name="radio"
         value="1"
-        onChange={e => setValue('radio', e.target.value, true)}
+        onChange={(e) =>
+          setValue('radio', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       Radio2
       <input
         type="radio"
         name="radio"
         value="2"
-        onChange={e => setValue('radio', e.target.value, true)}
+        onChange={(e) =>
+          setValue('radio', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       Radio3
       <input
         type="radio"
         name="radio"
         value="3"
-        onChange={e => setValue('radio', e.target.value, true)}
+        onChange={(e) =>
+          setValue('radio', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.radio && <p>radio error</p>}
       <input
         type="checkbox"
         name="checkbox"
-        onChange={e => setValue('checkbox', e.target.value, true)}
+        onChange={(e) =>
+          setValue('checkbox', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.checkbox && <p>checkbox error</p>}
       <button id="submit">Submit</button>

--- a/app/src/manualRegisterForm.tsx
+++ b/app/src/manualRegisterForm.tsx
@@ -44,6 +44,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('firstName', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -54,6 +55,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('lastName', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -65,6 +67,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('min', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -76,6 +79,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('max', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -87,6 +91,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('minDate', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -98,6 +103,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('maxDate', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -108,6 +114,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('minLength', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -118,6 +125,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('minRequiredLength', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -127,6 +135,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('selectNumber', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       >
@@ -141,6 +150,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('pattern', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -153,6 +163,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('radio', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -164,6 +175,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('radio', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -175,6 +187,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('radio', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -185,6 +198,7 @@ const ManualRegisterForm: React.FC = () => {
         onChange={(e) =>
           setValue('checkbox', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />

--- a/app/src/setValue.tsx
+++ b/app/src/setValue.tsx
@@ -27,7 +27,7 @@ const SetValue: React.FC = () => {
     register({ name: 'lastName' }, { required: true });
     setValue('firstName', 'wrong');
     setValue('age', '2');
-    setValue('trigger', '', true);
+    setValue('trigger', '', { shouldValidate: true });
     setValue('checkbox', true);
     setValue('checkboxArray', ['2', '3']);
     setValue('radio', 'radio');
@@ -39,7 +39,9 @@ const SetValue: React.FC = () => {
       lastName: 'lastName',
       middleName: 'middleName',
     });
-    setValue('nestedValue', [], true);
+    setValue('nestedValue', [], {
+      shouldValidate: true,
+    });
   }, [register, setValue]);
 
   renderCounter++;
@@ -111,17 +113,13 @@ const SetValue: React.FC = () => {
         type="button"
         id="setMultipleValues"
         onClick={() => {
-          setValue([
-            {
-              object: {
-                firstName: 'firstName1',
-                lastName: 'lastName1',
-                middleName: 'middleName1',
-              },
-            },
-            { array: ['array[0]1', 'array[1]1', 'array[2]1'] },
-            { nestedValue: ['a', 'b'] },
-          ]);
+          setValue('object', {
+            firstName: 'firstName1',
+            lastName: 'lastName1',
+            middleName: 'middleName1',
+          });
+          setValue('array', ['array[0]1', 'array[1]1', 'array[2]1']);
+          setValue('nestedValue', ['a', 'b']);
         }}
       >
         Set Multiple Values

--- a/app/src/setValue.tsx
+++ b/app/src/setValue.tsx
@@ -25,22 +25,32 @@ const SetValue: React.FC = () => {
 
   useEffect(() => {
     register({ name: 'lastName' }, { required: true });
-    setValue('firstName', 'wrong');
-    setValue('age', '2');
-    setValue('trigger', '', { shouldValidate: true });
-    setValue('checkbox', true);
-    setValue('checkboxArray', ['2', '3']);
-    setValue('radio', 'radio');
-    setValue('select', 'a');
-    setValue('multiple', ['a', 'b']);
-    setValue('array', ['array[0]', 'array[1]', 'array[2]']);
-    setValue('object', {
-      firstName: 'firstName',
-      lastName: 'lastName',
-      middleName: 'middleName',
+    setValue('firstName', 'wrong', { shouldDirty: true });
+    setValue('age', '2', { shouldDirty: true });
+    setValue('trigger', '', { shouldDirty: true, shouldValidate: true });
+    setValue('checkbox', true, { shouldDirty: true });
+    setValue('checkboxArray', ['2', '3'], {
+      shouldDirty: true,
+      shouldValidate: true,
     });
+    setValue('radio', 'radio', { shouldDirty: true });
+    setValue('select', 'a', { shouldDirty: true });
+    setValue('multiple', ['a', 'b'], { shouldDirty: true });
+    setValue('array', ['array[0]', 'array[1]', 'array[2]'], {
+      shouldDirty: true,
+    });
+    setValue(
+      'object',
+      {
+        firstName: 'firstName',
+        lastName: 'lastName',
+        middleName: 'middleName',
+      },
+      { shouldDirty: true },
+    );
     setValue('nestedValue', [], {
       shouldValidate: true,
+      shouldDirty: true,
     });
   }, [register, setValue]);
 
@@ -113,13 +123,19 @@ const SetValue: React.FC = () => {
         type="button"
         id="setMultipleValues"
         onClick={() => {
-          setValue('object', {
-            firstName: 'firstName1',
-            lastName: 'lastName1',
-            middleName: 'middleName1',
+          setValue(
+            'object',
+            {
+              firstName: 'firstName1',
+              lastName: 'lastName1',
+              middleName: 'middleName1',
+            },
+            { shouldDirty: true },
+          );
+          setValue('array', ['array[0]1', 'array[1]1', 'array[2]1'], {
+            shouldDirty: true,
           });
-          setValue('array', ['array[0]1', 'array[1]1', 'array[2]1']);
-          setValue('nestedValue', ['a', 'b']);
+          setValue('nestedValue', ['a', 'b'], { shouldDirty: true });
         }}
       >
         Set Multiple Values

--- a/app/src/setValueCustomRegister.tsx
+++ b/app/src/setValueCustomRegister.tsx
@@ -29,14 +29,14 @@ const SetValueCustomRegister: React.FC = () => {
       <button
         id="TriggerDirty"
         type="button"
-        onClick={() => setValue('lastName', 'test')}
+        onClick={() => setValue('lastName', 'test', { shouldDirty: true })}
       >
         TriggerDirty
       </button>
       <button
         id="TriggerNothing"
         type="button"
-        onClick={() => setValue('firstName', '')}
+        onClick={() => setValue('firstName', '', { shouldDirty: true })}
       >
         TriggerNothing
       </button>
@@ -55,6 +55,7 @@ const SetValueCustomRegister: React.FC = () => {
         onClick={() =>
           setValue('firstName', 'true', {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       >

--- a/app/src/setValueCustomRegister.tsx
+++ b/app/src/setValueCustomRegister.tsx
@@ -43,14 +43,20 @@ const SetValueCustomRegister: React.FC = () => {
       <button
         id="WithError"
         type="button"
-        onClick={() => setValue('firstName', '', true)}
+        onClick={() =>
+          setValue('firstName', '', { shouldValidate: true, shouldDirty: true })
+        }
       >
         WithError
       </button>
       <button
         id="WithoutError"
         type="button"
-        onClick={() => setValue('firstName', 'true', true)}
+        onClick={() =>
+          setValue('firstName', 'true', {
+            shouldValidate: true,
+          })
+        }
       >
         WithOutError
       </button>

--- a/app/src/setValueWithSchema.tsx
+++ b/app/src/setValueWithSchema.tsx
@@ -38,7 +38,9 @@ const SetValueWithSchema: React.FC = () => {
         name="firstName"
         placeholder="firstName"
         onChange={(e) => {
-          setValue('firstName', e.target.value, true);
+          setValue('firstName', e.target.value, {
+            shouldValidate: true,
+          });
         }}
       />
       {errors.firstName && <p>firstName error</p>}
@@ -47,7 +49,9 @@ const SetValueWithSchema: React.FC = () => {
         name="lastName"
         placeholder="lastName"
         onChange={(e) => {
-          setValue('lastName', e.target.value, true);
+          setValue('lastName', e.target.value, {
+            shouldValidate: true,
+          });
         }}
       />
       {errors.lastName && <p>lastName error</p>}
@@ -56,7 +60,9 @@ const SetValueWithSchema: React.FC = () => {
         name="age"
         ref={register}
         onChange={(e) => {
-          setValue('age', e.target.value, true);
+          setValue('age', e.target.value, {
+            shouldValidate: true,
+          });
         }}
       />
 
@@ -67,7 +73,9 @@ const SetValueWithSchema: React.FC = () => {
         type="button"
         id="setValue"
         onClick={() => {
-          setValue('requiredField', 'test123456789', true);
+          setValue('requiredField', 'test123456789', {
+            shouldValidate: true,
+          });
         }}
       >
         firstName reset

--- a/app/src/setValueWithSchema.tsx
+++ b/app/src/setValueWithSchema.tsx
@@ -40,6 +40,7 @@ const SetValueWithSchema: React.FC = () => {
         onChange={(e) => {
           setValue('firstName', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           });
         }}
       />
@@ -51,6 +52,7 @@ const SetValueWithSchema: React.FC = () => {
         onChange={(e) => {
           setValue('lastName', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           });
         }}
       />
@@ -62,6 +64,7 @@ const SetValueWithSchema: React.FC = () => {
         onChange={(e) => {
           setValue('age', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           });
         }}
       />
@@ -75,6 +78,7 @@ const SetValueWithSchema: React.FC = () => {
         onClick={() => {
           setValue('requiredField', 'test123456789', {
             shouldValidate: true,
+            shouldDirty: true,
           });
         }}
       >

--- a/app/src/setValueWithTrigger.tsx
+++ b/app/src/setValueWithTrigger.tsx
@@ -48,6 +48,7 @@ const SetValueWithTrigger: React.FC = () => {
         onChange={(e) =>
           setValue('firstName', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />
@@ -59,6 +60,7 @@ const SetValueWithTrigger: React.FC = () => {
         onChange={(e) =>
           setValue('lastName', e.target.value, {
             shouldValidate: true,
+            shouldDirty: true,
           })
         }
       />

--- a/app/src/setValueWithTrigger.tsx
+++ b/app/src/setValueWithTrigger.tsx
@@ -23,7 +23,7 @@ const SetValueWithTrigger: React.FC = () => {
     register(
       { name: 'lastName' },
       {
-        validate: data => {
+        validate: (data) => {
           if (data === 'bill') {
             return true;
           }
@@ -45,14 +45,22 @@ const SetValueWithTrigger: React.FC = () => {
       <input
         name="firstName"
         placeholder="firstName"
-        onChange={e => setValue('firstName', e.target.value, true)}
+        onChange={(e) =>
+          setValue('firstName', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.firstName && <p>{errors.firstName.message}</p>}
 
       <input
         name="lastName"
         placeholder="lastName"
-        onChange={e => setValue('lastName', e.target.value, true)}
+        onChange={(e) =>
+          setValue('lastName', e.target.value, {
+            shouldValidate: true,
+          })
+        }
       />
       {errors.lastName && <p>{errors.lastName.message}</p>}
 

--- a/cypress/integration/controller.ts
+++ b/cypress/integration/controller.ts
@@ -20,7 +20,7 @@ describe('controller basic form validation', () => {
     cy.get('#input-ReactSelect > div > div').eq(1).click();
 
     cy.get('.container > p').should('have.length', 0);
-    cy.get('#renderCount').contains('8');
+    cy.get('#renderCount').contains('9');
   });
 
   it('should validate the form with onBlur mode and reset the form', () => {

--- a/cypress/integration/setValue.ts
+++ b/cypress/integration/setValue.ts
@@ -47,6 +47,6 @@ describe('form setValue', () => {
     cy.get('input[name="object.lastName').should('have.value', 'lastName1');
     cy.get('input[name="object.middleName').should('have.value', 'middleName1');
     cy.get('input[name="nestedValue"]').should('have.value', 'a,b');
-    cy.get('#renderCount').contains('9');
+    cy.get('#renderCount').contains('8');
   });
 });

--- a/cypress/integration/setValue.ts
+++ b/cypress/integration/setValue.ts
@@ -37,7 +37,7 @@ describe('form setValue', () => {
 
     cy.get('#submit').click();
     cy.get('p').should('have.length', 0);
-    cy.get('#renderCount').contains('8');
+    cy.get('#renderCount').contains('10');
 
     cy.get('#setMultipleValues').click();
     cy.get('input[name="array[0]"]').should('have.value', 'array[0]1');
@@ -47,6 +47,6 @@ describe('form setValue', () => {
     cy.get('input[name="object.lastName').should('have.value', 'lastName1');
     cy.get('input[name="object.middleName').should('have.value', 'middleName1');
     cy.get('input[name="nestedValue"]').should('have.value', 'a,b');
-    cy.get('#renderCount').contains('8');
+    cy.get('#renderCount').contains('11');
   });
 });

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -279,6 +279,7 @@ describe('Controller', () => {
     });
 
     expect(setValue).toBeCalledWith('test', 'test', {
+      shouldDirty: true,
       shouldValidate: false,
     });
   });
@@ -448,6 +449,7 @@ describe('Controller', () => {
     });
 
     expect(setValue).toBeCalledWith('test', 'test', {
+      shouldDirty: true,
       shouldValidate: false,
     });
   });

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -278,7 +278,9 @@ describe('Controller', () => {
       },
     });
 
-    expect(setValue).toBeCalledWith('test', 'test', false);
+    expect(setValue).toBeCalledWith('test', 'test', {
+      shouldValidate: false,
+    });
   });
 
   it("should trigger component's onBlur method and invoke setValue method", () => {
@@ -445,7 +447,9 @@ describe('Controller', () => {
       },
     });
 
-    expect(setValue).toBeCalledWith('test', 'test', false);
+    expect(setValue).toBeCalledWith('test', 'test', {
+      shouldValidate: false,
+    });
   });
 
   it('should invoke custom onChange method', () => {

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -136,7 +136,9 @@ const Controller = <
   };
 
   const onChange = (...event: any[]) =>
-    setValue(name, commonTask(event), shouldValidate());
+    setValue(name, commonTask(event), {
+      shouldValidate: shouldValidate(),
+    });
 
   const props = {
     ...rest,

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -138,6 +138,7 @@ const Controller = <
   const onChange = (...event: any[]) =>
     setValue(name, commonTask(event), {
       shouldValidate: shouldValidate(),
+      shouldDirty: true,
     });
 
   const props = {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -344,16 +344,13 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
     TFieldValue extends TFieldValues[TFieldName]
   >(
     name: TFieldName,
-    value: NonUndefined<TFieldValue> extends NestedValue<infer U>
+    value?: NonUndefined<TFieldValue> extends NestedValue<infer U>
       ? U
       : UnpackNestedValue<DeepPartial<LiteralToPrimitive<TFieldValue>>>,
-    shouldValidate?: boolean,
-  ): void;
-  setValue<TFieldName extends keyof TFieldValues>(
-    namesWithValue: UnpackNestedValue<
-      DeepPartial<Pick<TFieldValues, TFieldName>>
-    >[],
-    shouldValidate?: boolean,
+    options?: Partial<{
+      shouldValidate?: boolean;
+      shouldDirty?: boolean;
+    }>,
   ): void;
   trigger(
     name?: FieldName<TFieldValues> | FieldName<TFieldValues>[],

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -172,6 +172,11 @@ export type Dirtied<TFieldValues extends FieldValues> = DeepMap<
   true
 >;
 
+export type SetValueConfig = Partial<{
+  shouldValidate: boolean;
+  shouldDirty: boolean;
+}>;
+
 export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
   isDirty: boolean;
   dirtyFields: Dirtied<TFieldValues>;
@@ -347,10 +352,7 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
     value?: NonUndefined<TFieldValue> extends NestedValue<infer U>
       ? U
       : UnpackNestedValue<DeepPartial<LiteralToPrimitive<TFieldValue>>>,
-    options?: Partial<{
-      shouldValidate?: boolean;
-      shouldDirty?: boolean;
-    }>,
+    options?: SetValueConfig,
   ): void;
   trigger(
     name?: FieldName<TFieldValues> | FieldName<TFieldValues>[],

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1031,6 +1031,26 @@ describe('useForm', () => {
         });
 
         expect(transformToNestObject).not.toHaveBeenCalled();
+        expect(result.current.formState.dirtyFields.test).toBeFalsy();
+      });
+
+      it('should set name to dirtyFieldRef if field value is different with default value and isDirty is true', () => {
+        const { result } = renderHook(() =>
+          useForm<{ test: string }>({
+            defaultValues: { test: 'default' },
+          }),
+        );
+        result.current.control.readFormStateRef.current.isDirty = true;
+
+        act(() => {
+          result.current.register('test');
+        });
+
+        act(() => {
+          result.current.setValue('test', '1', { shouldDirty: true });
+        });
+
+        expect(transformToNestObject).not.toHaveBeenCalled();
         expect(result.current.formState.dirtyFields.test).toBeTruthy();
       });
 
@@ -1088,24 +1108,29 @@ describe('useForm', () => {
         });
 
         act(() => {
-          result.current.setValue('test', [
-            { name: 'default_update' },
-            { name: 'default1' },
-            { name: 'default2' },
-          ]);
+          result.current.setValue(
+            'test',
+            [
+              { name: 'default_update' },
+              { name: 'default1' },
+              { name: 'default2' },
+            ],
+            { shouldDirty: true },
+          );
         });
 
         await waitFor(() => {
-          expect((transformToNestObject as any).mock.calls[2]).toEqual([
-            {
-              'test[0].name': 'default_update',
-              'test[1].name': 'default1',
-              'test[2].name': 'default2',
-            },
-          ]);
-          expect(result.current.formState.dirtyFields.test!).toEqual([
-            { name: true },
-          ]);
+          expect(transformToNestObject).toBeCalled();
+          // expect((transformToNestObject as any).mock.calls[2]).toEqual([
+          //   {
+          //     'test[0].name': 'default_update',
+          //     'test[1].name': 'default1',
+          //     'test[2].name': 'default2',
+          //   },
+          // ]);
+          // expect(result.current.formState.dirtyFields.test!).toEqual([
+          //   { name: true },
+          // ]);
         });
       });
 
@@ -1157,11 +1182,11 @@ describe('useForm', () => {
           ],
         });
         act(() => {
-          result.current.setValue('test', [
-            { name: 'default' },
-            { name: 'default1' },
-            { name: 'default2' },
-          ]);
+          result.current.setValue(
+            'test',
+            [{ name: 'default' }, { name: 'default1' }, { name: 'default2' }],
+            { shouldDirty: true },
+          );
         });
 
         await waitFor(() => {

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -963,58 +963,6 @@ describe('useForm', () => {
       });
     });
 
-    it('should work array of fields', () => {
-      const { result } = renderHook(() => useForm());
-
-      act(() => {
-        result.current.register('test.bill');
-        result.current.register('test.luo');
-        result.current.register('test.test');
-        result.current.register('array[0]');
-        result.current.register('array[1]');
-        result.current.register('array[2]');
-        result.current.register('object.bill');
-        result.current.register('object.luo');
-        result.current.register('object.test');
-      });
-
-      act(() => {
-        result.current.setValue([
-          { 'test.bill': '1' },
-          { array: ['1', '2', '3'] },
-          { object: { bill: '1', luo: '2', test: '3' } },
-        ]);
-
-        expect(result.current.control.fieldsRef.current['test.bill']).toEqual({
-          ref: { name: 'test.bill', value: '1' },
-        });
-
-        expect(result.current.control.fieldsRef.current['array[0]']).toEqual({
-          ref: { name: 'array[0]', value: '1' },
-        });
-        expect(result.current.control.fieldsRef.current['array[1]']).toEqual({
-          ref: { name: 'array[1]', value: '2' },
-        });
-        expect(result.current.control.fieldsRef.current['array[2]']).toEqual({
-          ref: { name: 'array[2]', value: '3' },
-        });
-
-        expect(result.current.control.fieldsRef.current['object.bill']).toEqual(
-          {
-            ref: { name: 'object.bill', value: '1' },
-          },
-        );
-        expect(result.current.control.fieldsRef.current['object.luo']).toEqual({
-          ref: { name: 'object.luo', value: '2' },
-        });
-        expect(result.current.control.fieldsRef.current['object.test']).toEqual(
-          {
-            ref: { name: 'object.test', value: '3' },
-          },
-        );
-      });
-    });
-
     it('should be called trigger method if shouldValidate variable is true', async () => {
       (validateField as any).mockImplementation(async () => ({}));
       const { result } = renderHook(() => useForm());
@@ -1023,29 +971,14 @@ describe('useForm', () => {
         result.current.register({ name: 'test', required: 'required' }),
       );
 
-      act(() => result.current.setValue('test', 'test', true));
-
-      await waitFor(() => expect(validateField).toHaveBeenCalled());
-    });
-
-    it('should be called trigger method if first argument is array', async () => {
-      (validateField as any).mockImplementation(async () => ({}));
-      const { result } = renderHook(() => useForm());
-
-      act(() => {
-        result.current.register({ name: 'test', required: 'required' });
-        result.current.register({ name: 'test1', required: 'required' });
-        result.current.register({ name: 'test2', required: 'required' });
-      });
-
-      await act(async () =>
-        result.current.setValue(
-          [{ test: 'value' }, { test1: 'value1' }, { test2: 'value2' }],
-          true,
-        ),
+      act(() =>
+        result.current.setValue('test', 'test', {
+          shouldValidate: true,
+          shouldDirty: true,
+        }),
       );
 
-      await waitFor(() => expect(validateField).toBeCalledTimes(3));
+      await waitFor(() => expect(validateField).toHaveBeenCalled());
     });
 
     it('should not work if field is not registered', () => {

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1120,17 +1120,16 @@ describe('useForm', () => {
         });
 
         await waitFor(() => {
-          expect(transformToNestObject).toBeCalled();
-          // expect((transformToNestObject as any).mock.calls[2]).toEqual([
-          //   {
-          //     'test[0].name': 'default_update',
-          //     'test[1].name': 'default1',
-          //     'test[2].name': 'default2',
-          //   },
-          // ]);
-          // expect(result.current.formState.dirtyFields.test!).toEqual([
-          //   { name: true },
-          // ]);
+          expect((transformToNestObject as any).mock.calls[2]).toEqual([
+            {
+              'test[0].name': 'default_update',
+              'test[1].name': 'default1',
+              'test[2].name': 'default2',
+            },
+          ]);
+          expect(result.current.formState.dirtyFields.test!).toEqual([
+            { name: true },
+          ]);
         });
       });
 

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1007,7 +1007,7 @@ describe('useForm', () => {
         });
 
         act(() => {
-          result.current.setValue('test', '1');
+          result.current.setValue('test', '1', { shouldDirty: true });
         });
 
         expect(transformToNestObject).not.toHaveBeenCalled();
@@ -1138,11 +1138,15 @@ describe('useForm', () => {
           ],
         });
         act(() => {
-          result.current.setValue('test', [
-            { name: 'default_update' },
-            { name: 'default1' },
-            { name: 'default2' },
-          ]);
+          result.current.setValue(
+            'test',
+            [
+              { name: 'default_update' },
+              { name: 'default1' },
+              { name: 'default2' },
+            ],
+            { shouldDirty: true },
+          );
         });
 
         (transformToNestObject as any).mockReturnValue({

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -376,7 +376,7 @@ export function useForm<
       name: InternalFieldName<TFieldValues>,
       value: FieldValue<TFieldValues>,
       parentFieldName?: string,
-      { shouldDirty, shouldValidate }: SetValueConfig = {},
+      config: SetValueConfig = {},
     ) => {
       for (const key in value) {
         const fieldName = `${parentFieldName || name}${
@@ -385,17 +385,17 @@ export function useForm<
         const field = fieldsRef.current[fieldName];
 
         if (isObject(value[key])) {
-          setInternalValues(name, value[key], fieldName);
+          setInternalValues(name, value[key], fieldName, config);
         }
 
         if (field) {
           setFieldValue(field, value[key]);
 
-          if (shouldDirty) {
+          if (config.shouldDirty) {
             setDirty(fieldName);
           }
 
-          if (shouldValidate) {
+          if (config.shouldValidate) {
             trigger(fieldName as FieldName<TFieldValues>);
           }
         }


### PR DESCRIPTION
`setValue` API refinement

**Reason**

The current API is confusing with support both name as string and array of values. In addition, programmatically set a field should give users the option to set `dirty`, we shouldn't set dirty to `true` when user setValue programmatically by default. 

`setValue(fieldName, values, config)`

---

`setValue('test', 'value',  { shouldValidate: false, shouldDirty: false })`