### PR TITLE
fix/improve setError & clearError

### DIFF
--- a/app/src/setError.tsx
+++ b/app/src/setError.tsx
@@ -36,7 +36,6 @@ const SetError: React.FC = () => {
       setError(name as any, { type, message }),
     );
     setError('username', {
-      type: 'error',
       types: {
         required: 'This is required',
         minLength: 'This is minLength',

--- a/app/src/setError.tsx
+++ b/app/src/setError.tsx
@@ -2,14 +2,14 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
 const SetError: React.FC = () => {
-  const { register, setError, clearError, errors } = useForm<{
+  const { register, setError, clearErrors, errors } = useForm<{
     firstName: string;
     lastName: string;
     age: string;
     test: string;
-    test1: string,
-    test2: string,
-    username: string,
+    test1: string;
+    test2: string;
+    username: string;
   }>();
 
   useEffect(() => {
@@ -17,11 +17,11 @@ const SetError: React.FC = () => {
     register({ name: 'lastName' });
     register({ name: 'age' });
 
-    setError('firstName', 'wrong');
-    setError('lastName', 'wrong');
-    setError('age', 'wrong');
-    setError('test', 'test', 'testMessage');
-    setError([
+    setError('firstName', { type: 'wrong' });
+    setError('lastName', { type: 'wrong' });
+    setError('age', { type: 'wrong' });
+    setError('test', { type: 'test', message: 'testMessage' });
+    [
       {
         type: 'required',
         name: 'test1',
@@ -32,10 +32,15 @@ const SetError: React.FC = () => {
         name: 'test2',
         message: 'Minlength is 10',
       },
-    ]);
+    ].forEach(({ name, type, message }) =>
+      setError(name as any, { type, message }),
+    );
     setError('username', {
-      required: 'This is required',
-      minLength: 'This is minLength',
+      type: 'error',
+      types: {
+        required: 'This is required',
+        minLength: 'This is minLength',
+      },
     });
   }, [register, setError]);
 
@@ -66,7 +71,7 @@ const SetError: React.FC = () => {
         value="clearError1"
         type="button"
         onClick={() => {
-          clearError('firstName');
+          clearErrors('firstName');
         }}
       />
 
@@ -75,7 +80,7 @@ const SetError: React.FC = () => {
         value="clearError2"
         type="button"
         onClick={() => {
-          clearError('lastName');
+          clearErrors('lastName');
         }}
       />
 
@@ -84,7 +89,7 @@ const SetError: React.FC = () => {
         value="clearErrorArray"
         type="button"
         onClick={() => {
-          clearError(['firstName', 'lastName']);
+          clearErrors(['firstName', 'lastName']);
         }}
       />
 
@@ -93,7 +98,7 @@ const SetError: React.FC = () => {
         value="clearError"
         type="button"
         onClick={() => {
-          clearError();
+          clearErrors();
         }}
       />
     </div>

--- a/app/src/validateFieldCriteria.tsx
+++ b/app/src/validateFieldCriteria.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 let renderCounter = 0;
 
 const ValidateFieldCriteria: React.FC = () => {
-  const { register, handleSubmit, errors, setError, clearError } = useForm<{
+  const { register, handleSubmit, errors, setError, clearErrors } = useForm<{
     firstName: string;
     lastName: string;
     min: string;
@@ -167,8 +167,11 @@ const ValidateFieldCriteria: React.FC = () => {
         id="trigger"
         onClick={() => {
           setError('firstName', {
-            minLength: 'test1',
-            required: 'test2',
+            type: 'test',
+            types: {
+              minLength: 'test1',
+              required: 'test2',
+            },
           });
         }}
       >
@@ -179,7 +182,7 @@ const ValidateFieldCriteria: React.FC = () => {
         type="button"
         id="clear"
         onClick={() => {
-          clearError('firstName');
+          clearErrors('firstName');
         }}
       >
         Clear Error

--- a/app/src/validateFieldCriteria.tsx
+++ b/app/src/validateFieldCriteria.tsx
@@ -167,7 +167,6 @@ const ValidateFieldCriteria: React.FC = () => {
         id="trigger"
         onClick={() => {
           setError('firstName', {
-            type: 'test',
             types: {
               minLength: 'test1',
               required: 'test2',

--- a/src/logic/shouldRenderBasedOnError.test.ts
+++ b/src/logic/shouldRenderBasedOnError.test.ts
@@ -77,7 +77,7 @@ describe('shouldUpdateWithError', () => {
     expect(
       shouldRenderBasedOnError({
         errors: {
-          test: { isManual: true, message: 'test', type: 'input' },
+          test: { message: 'test', type: 'input' },
         } as any,
         name: 'test',
         error: { test: { type: 'input', message: 'test' } } as any,
@@ -120,6 +120,6 @@ describe('shouldUpdateWithError', () => {
         validFields: new Set(),
         fieldsWithValidation: new Set(),
       }),
-    ).toBeTruthy();
+    ).toBeFalsy();
   });
 });

--- a/src/logic/shouldRenderBasedOnError.test.ts
+++ b/src/logic/shouldRenderBasedOnError.test.ts
@@ -77,7 +77,7 @@ describe('shouldUpdateWithError', () => {
     expect(
       shouldRenderBasedOnError({
         errors: {
-          test: { isManual: true, message: 'test', type: 'input' },
+          test: { message: 'test', type: 'input' },
         } as any,
         name: 'test',
         error: { test: { type: 'input', message: 'test' } } as any,

--- a/src/logic/shouldRenderBasedOnError.test.ts
+++ b/src/logic/shouldRenderBasedOnError.test.ts
@@ -77,7 +77,7 @@ describe('shouldUpdateWithError', () => {
     expect(
       shouldRenderBasedOnError({
         errors: {
-          test: { message: 'test', type: 'input' },
+          test: { isManual: true, message: 'test', type: 'input' },
         } as any,
         name: 'test',
         error: { test: { type: 'input', message: 'test' } } as any,
@@ -120,6 +120,6 @@ describe('shouldUpdateWithError', () => {
         validFields: new Set(),
         fieldsWithValidation: new Set(),
       }),
-    ).toBeFalsy();
+    ).toBeTruthy();
   });
 });

--- a/src/logic/shouldRenderBasedOnError.ts
+++ b/src/logic/shouldRenderBasedOnError.ts
@@ -28,10 +28,7 @@ export default function shouldRenderBasedOnError<
   const currentFieldError = get(error, name);
   const existFieldError = get(errors, name);
 
-  if (
-    (isFieldValid && validFields.has(name)) ||
-    (existFieldError && existFieldError.isManual)
-  ) {
+  if ((isFieldValid && validFields.has(name)) || existFieldError) {
     return false;
   }
 

--- a/src/logic/shouldRenderBasedOnError.ts
+++ b/src/logic/shouldRenderBasedOnError.ts
@@ -28,7 +28,7 @@ export default function shouldRenderBasedOnError<
   const currentFieldError = get(error, name);
   const existFieldError = get(errors, name);
 
-  if ((isFieldValid && validFields.has(name)) || existFieldError) {
+  if (isFieldValid && validFields.has(name)) {
     return false;
   }
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -143,6 +143,15 @@ export type ManualFieldError<TFieldValues extends FieldValues> = {
   message?: Message;
 };
 
+export type ErrorOption =
+  | {
+      types: MultipleFieldErrors;
+    }
+  | {
+      message?: Message;
+      type: string;
+    };
+
 export type Field = {
   ref: Ref;
   mutationWatcher?: MutationWatcher;
@@ -335,17 +344,7 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
     names: string[],
     defaultValues?: UnpackNestedValue<DeepPartial<TFieldValues>>,
   ): UnpackNestedValue<DeepPartial<TFieldValues>>;
-  setError(
-    name: FieldName<TFieldValues>,
-    error:
-      | {
-          types: MultipleFieldErrors;
-        }
-      | {
-          message?: Message;
-          type: string;
-        },
-  ): void;
+  setError(name: FieldName<TFieldValues>, error: ErrorOption): void;
   clearErrors(name?: FieldName<TFieldValues> | FieldName<TFieldValues>[]): void;
   setValue<
     TFieldName extends string,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -342,7 +342,7 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
           types: MultipleFieldErrors;
         }
       | {
-          message: Message;
+          message?: Message;
           type: string;
         },
   ): void;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -134,7 +134,6 @@ export type FieldError = {
   ref?: Ref;
   types?: MultipleFieldErrors;
   message?: Message;
-  isManual?: boolean;
 };
 
 export type ManualFieldError<TFieldValues extends FieldValues> = {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -337,12 +337,14 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
   ): UnpackNestedValue<DeepPartial<TFieldValues>>;
   setError(
     name: FieldName<TFieldValues>,
-    error: Partial<{
-      types: MultipleFieldErrors;
-      message: Message;
-    }> & {
-      type: string;
-    },
+    error:
+      | {
+          types: MultipleFieldErrors;
+        }
+      | {
+          message: Message;
+          type: string;
+        },
   ): void;
   clearErrors(name?: FieldName<TFieldValues> | FieldName<TFieldValues>[]): void;
   setValue<

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -336,14 +336,16 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
     names: string[],
     defaultValues?: UnpackNestedValue<DeepPartial<TFieldValues>>,
   ): UnpackNestedValue<DeepPartial<TFieldValues>>;
-  setError(name: FieldName<TFieldValues>, type: MultipleFieldErrors): void;
   setError(
     name: FieldName<TFieldValues>,
-    type: string,
-    message?: Message,
+    error: Partial<{
+      types: MultipleFieldErrors;
+      message: Message;
+    }> & {
+      type: string;
+    },
   ): void;
-  setError(name: ManualFieldError<TFieldValues>[]): void;
-  clearError(name?: FieldName<TFieldValues> | FieldName<TFieldValues>[]): void;
+  clearErrors(name?: FieldName<TFieldValues> | FieldName<TFieldValues>[]): void;
   setValue<
     TFieldName extends string,
     TFieldValue extends TFieldValues[TFieldName]

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1965,6 +1965,36 @@ describe('useForm', () => {
       act(() => result.current.clearErrors());
       expect(result.current.errors).toEqual({});
     });
+
+    it('should prevent the submission if there is a custom error', async () => {
+      const submit = jest.fn();
+      const { result } = renderHook(() =>
+        useForm<{ data: string; whatever: string }>(),
+      );
+
+      (validateField as any).mockImplementation(async () => {
+        return {};
+      });
+
+      act(() => {
+        result.current.register('data');
+        result.current.setError('whatever', { type: 'missing' });
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit(submit)();
+        expect(submit).not.toBeCalled();
+      });
+
+      act(() => {
+        result.current.clearErrors('whatever');
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit(submit)();
+        expect(submit).toBeCalled();
+      });
+    });
   });
 
   describe('formState', () => {

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1779,7 +1779,7 @@ describe('useForm', () => {
         input: {
           type: 'test',
           message: undefined,
-          ref: {},
+          ref: undefined,
         },
       });
 
@@ -1790,7 +1790,7 @@ describe('useForm', () => {
         input: {
           type: 'test',
           message: 'test',
-          ref: {},
+          ref: undefined,
         },
       });
 
@@ -1801,7 +1801,7 @@ describe('useForm', () => {
         input: {
           type: 'test',
           message: 'test',
-          ref: {},
+          ref: undefined,
           types: undefined,
         },
       });
@@ -1813,13 +1813,11 @@ describe('useForm', () => {
       });
       expect(result.current.errors).toEqual({
         input: {
-          type: '',
-          message: undefined,
           types: {
             test1: 'test1',
             test2: 'test2',
           },
-          ref: {},
+          ref: undefined,
         },
       });
 
@@ -1834,13 +1832,11 @@ describe('useForm', () => {
 
       expect(result.current.errors).toEqual({
         input: {
-          type: '',
-          message: undefined,
           types: {
             test1: 'test1',
             test2: 'test2',
           },
-          ref: {},
+          ref: undefined,
         },
       });
       expect(result.current.formState.isValid).toBeFalsy();
@@ -1898,19 +1894,19 @@ describe('useForm', () => {
       const errors = {
         input: {
           message: 'message',
-          ref: {},
+          ref: undefined,
           type: 'test',
           types: undefined,
         },
         input1: {
           message: 'message',
-          ref: {},
+          ref: undefined,
           type: 'test',
           types: undefined,
         },
         input2: {
           message: 'message',
-          ref: {},
+          ref: undefined,
           type: 'test',
           types: undefined,
         },
@@ -1942,19 +1938,19 @@ describe('useForm', () => {
       expect(result.current.errors).toEqual({
         input: {
           message: 'message',
-          ref: {},
+          ref: undefined,
           type: 'test',
           types: undefined,
         },
         input1: {
           message: 'message',
-          ref: {},
+          ref: undefined,
           type: 'test',
           types: undefined,
         },
         input2: {
           message: 'message',
-          ref: {},
+          ref: undefined,
           type: 'test',
           types: undefined,
         },
@@ -2242,7 +2238,7 @@ describe('useForm', () => {
             type: 'data',
             message: 'data',
           });
-        });
+        }, [setError]);
 
         return (
           <div>

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1773,7 +1773,7 @@ describe('useForm', () => {
     it('should only set an error when it is not existed', () => {
       const { result } = renderHook(() => useForm<{ input: string }>());
       act(() => {
-        result.current.setError('input', 'test');
+        result.current.setError('input', { type: 'test' });
       });
       expect(result.current.errors).toEqual({
         input: {
@@ -1785,7 +1785,7 @@ describe('useForm', () => {
       });
 
       act(() => {
-        result.current.setError('input', 'test', 'test');
+        result.current.setError('input', { type: 'test', message: 'test' });
       });
       expect(result.current.errors).toEqual({
         input: {
@@ -1797,7 +1797,7 @@ describe('useForm', () => {
       });
 
       act(() => {
-        result.current.setError('input', 'test', 'test');
+        result.current.setError('input', { type: 'test', message: 'test' });
       });
       expect(result.current.errors).toEqual({
         input: {
@@ -1810,7 +1810,10 @@ describe('useForm', () => {
       });
 
       act(() => {
-        result.current.setError('input', { test1: 'test1', test2: 'test2' });
+        result.current.setError('input', {
+          types: { test1: 'test1', test2: 'test2' },
+          type: '',
+        });
       });
       expect(result.current.errors).toEqual({
         input: {
@@ -1827,8 +1830,11 @@ describe('useForm', () => {
 
       act(() => {
         result.current.setError('input', {
-          test1: 'test1',
-          test2: 'test2',
+          types: {
+            test1: 'test1',
+            test2: 'test2',
+          },
+          type: '',
         });
       });
 
@@ -1848,12 +1854,15 @@ describe('useForm', () => {
     });
   });
 
-  describe('clearError', () => {
+  describe('clearErrors', () => {
     it('should remove error', () => {
       const { result } = renderHook(() => useForm<{ input: string }>());
       act(() => {
-        result.current.setError('input', 'test', 'message');
-        result.current.clearError('input');
+        result.current.setError('input', {
+          type: 'test',
+          message: 'message',
+        });
+        result.current.clearErrors('input');
       });
       expect(result.current.errors).toEqual({});
     });
@@ -1863,11 +1872,13 @@ describe('useForm', () => {
         useForm<{ input: { nested: string } }>(),
       );
       act(() => {
-        result.current.setError('input.nested', 'test');
+        result.current.setError('input.nested', {
+          type: 'test',
+        });
       });
       expect(result.current.errors.input?.nested).toBeDefined();
       act(() => {
-        result.current.clearError('input.nested');
+        result.current.clearErrors('input.nested');
       });
       expect(result.current.errors.input?.nested).toBeUndefined();
     });
@@ -1877,9 +1888,18 @@ describe('useForm', () => {
         useForm<{ input: string; input1: string; input2: string }>(),
       );
       act(() => {
-        result.current.setError('input', 'test', 'message');
-        result.current.setError('input1', 'test', 'message');
-        result.current.setError('input2', 'test', 'message');
+        result.current.setError('input', {
+          type: 'test',
+          message: 'message',
+        });
+        result.current.setError('input1', {
+          type: 'test',
+          message: 'message',
+        });
+        result.current.setError('input2', {
+          type: 'test',
+          message: 'message',
+        });
       });
 
       const errors = {
@@ -1907,7 +1927,7 @@ describe('useForm', () => {
       };
       expect(result.current.errors).toEqual(errors);
 
-      act(() => result.current.clearError(['input', 'input1']));
+      act(() => result.current.clearErrors(['input', 'input1']));
       expect(result.current.errors).toEqual({ input2: errors.input2 });
     });
 
@@ -1916,9 +1936,18 @@ describe('useForm', () => {
         useForm<{ input: string; input1: string; input2: string }>(),
       );
       act(() => {
-        result.current.setError('input', 'test', 'message');
-        result.current.setError('input1', 'test', 'message');
-        result.current.setError('input2', 'test', 'message');
+        result.current.setError('input', {
+          type: 'test',
+          message: 'message',
+        });
+        result.current.setError('input1', {
+          type: 'test',
+          message: 'message',
+        });
+        result.current.setError('input2', {
+          type: 'test',
+          message: 'message',
+        });
       });
       expect(result.current.errors).toEqual({
         input: {
@@ -1944,56 +1973,8 @@ describe('useForm', () => {
         },
       });
 
-      act(() => result.current.clearError());
+      act(() => result.current.clearErrors());
       expect(result.current.errors).toEqual({});
-    });
-  });
-
-  describe('setErrors', () => {
-    it('should set multiple errors for the form', () => {
-      const { result } = renderHook(() =>
-        useForm<{ input: string; input1: string; input2: string }>(),
-      );
-      act(() => {
-        result.current.setError([
-          {
-            type: 'test',
-            name: 'input',
-            message: 'wow',
-          },
-          {
-            type: 'test1',
-            name: 'input1',
-            message: 'wow1',
-          },
-          {
-            type: 'test2',
-            name: 'input2',
-            message: 'wow2',
-          },
-        ]);
-      });
-
-      expect(result.current.errors).toEqual({
-        input: {
-          type: 'test',
-          isManual: true,
-          message: 'wow',
-          ref: {},
-        },
-        input1: {
-          type: 'test1',
-          isManual: true,
-          message: 'wow1',
-          ref: {},
-        },
-        input2: {
-          type: 'test2',
-          isManual: true,
-          message: 'wow2',
-          ref: {},
-        },
-      });
     });
   });
 
@@ -2240,7 +2221,10 @@ describe('useForm', () => {
         const { register, setError, errors } = useForm();
 
         React.useEffect(() => {
-          setError('test', 'data', 'data');
+          setError('test', {
+            type: 'data',
+            message: 'data',
+          });
         });
 
         return (

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1778,7 +1778,6 @@ describe('useForm', () => {
       expect(result.current.errors).toEqual({
         input: {
           type: 'test',
-          isManual: true,
           message: undefined,
           ref: {},
         },
@@ -1790,7 +1789,6 @@ describe('useForm', () => {
       expect(result.current.errors).toEqual({
         input: {
           type: 'test',
-          isManual: true,
           message: 'test',
           ref: {},
         },
@@ -1802,7 +1800,6 @@ describe('useForm', () => {
       expect(result.current.errors).toEqual({
         input: {
           type: 'test',
-          isManual: true,
           message: 'test',
           ref: {},
           types: undefined,
@@ -1818,7 +1815,6 @@ describe('useForm', () => {
       expect(result.current.errors).toEqual({
         input: {
           type: '',
-          isManual: true,
           message: undefined,
           types: {
             test1: 'test1',
@@ -1841,7 +1837,6 @@ describe('useForm', () => {
       expect(result.current.errors).toEqual({
         input: {
           type: '',
-          isManual: true,
           message: undefined,
           types: {
             test1: 'test1',
@@ -1904,21 +1899,18 @@ describe('useForm', () => {
 
       const errors = {
         input: {
-          isManual: true,
           message: 'message',
           ref: {},
           type: 'test',
           types: undefined,
         },
         input1: {
-          isManual: true,
           message: 'message',
           ref: {},
           type: 'test',
           types: undefined,
         },
         input2: {
-          isManual: true,
           message: 'message',
           ref: {},
           type: 'test',
@@ -1951,21 +1943,18 @@ describe('useForm', () => {
       });
       expect(result.current.errors).toEqual({
         input: {
-          isManual: true,
           message: 'message',
           ref: {},
           type: 'test',
           types: undefined,
         },
         input1: {
-          isManual: true,
           message: 'message',
           ref: {},
           type: 'test',
           types: undefined,
         },
         input2: {
-          isManual: true,
           message: 'message',
           ref: {},
           type: 'test',

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1809,7 +1809,6 @@ describe('useForm', () => {
       act(() => {
         result.current.setError('input', {
           types: { test1: 'test1', test2: 'test2' },
-          type: '',
         });
       });
       expect(result.current.errors).toEqual({
@@ -1830,7 +1829,6 @@ describe('useForm', () => {
             test1: 'test1',
             test2: 'test2',
           },
-          type: '',
         });
       });
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -663,17 +663,20 @@ export function useForm<
 
   function setError(
     name: FieldName<TFieldValues>,
-    error: Partial<{
-      types: MultipleFieldErrors;
-      message: Message;
-    }> & {
-      type: string;
-    },
+    error:
+      | {
+          types: MultipleFieldErrors;
+        }
+      | {
+          message: Message;
+          type: string;
+        },
   ): void {
     isValidRef.current = false;
 
     setInternalError({
       name,
+      type: '',
       ...error,
       shouldRender: true,
     });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -983,13 +983,20 @@ export function useForm<
           }
         }
 
-        // need to figure out the erorr here
-        if (isEmptyObject(fieldErrors)) {
+        if (
+          isEmptyObject(fieldErrors) &&
+          Object.keys(errorsRef.current).every((name) =>
+            Object.keys(fieldsRef.current).includes(name),
+          )
+        ) {
           errorsRef.current = {};
           reRender();
           await callback(transformToNestObject(fieldValues), e);
         } else {
-          errorsRef.current = fieldErrors;
+          errorsRef.current = {
+            ...errorsRef.current,
+            ...fieldErrors,
+          };
           if (shouldFocusError && isWeb) {
             focusOnErrorField(fieldsRef.current, fieldErrors);
           }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -64,6 +64,7 @@ import {
   FlatFieldErrors,
   NestedValue,
   SetValueConfig,
+  ErrorOption,
 } from './types/form';
 import { LiteralToPrimitive, DeepPartial, NonUndefined } from './types/utils';
 
@@ -661,17 +662,7 @@ export function useForm<
     }
   };
 
-  function setError(
-    name: FieldName<TFieldValues>,
-    error:
-      | {
-          types: MultipleFieldErrors;
-        }
-      | {
-          message?: Message;
-          type: string;
-        },
-  ): void {
+  function setError(name: FieldName<TFieldValues>, error: ErrorOption): void {
     isValidRef.current = false;
 
     setInternalError({

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -632,7 +632,7 @@ export function useForm<
 
     set(errorsRef.current, name, {
       ...error,
-      ref: fieldsRef.current[name]!.ref,
+      ref: (fieldsRef.current[name] || {})!.ref,
     });
 
     reRender();

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -52,14 +52,12 @@ import {
   FieldElement,
   FormStateProxy,
   ReadFormState,
-  MultipleFieldErrors,
   Ref,
   HandleChange,
   Touched,
   FieldError,
   RadioOrCheckboxOption,
   OmitResetState,
-  Message,
   DefaultValuesAtRender,
   FlatFieldErrors,
   NestedValue,
@@ -629,48 +627,15 @@ export function useForm<
     reRender();
   }
 
-  const setInternalError = ({
-    name,
-    type,
-    types,
-    message,
-    shouldRender,
-  }: {
-    name: InternalFieldName<TFieldValues>;
-    type: string;
-    types?: MultipleFieldErrors;
-    message?: Message;
-    shouldRender?: boolean;
-  }) => {
-    if (
-      !isSameError(get(errorsRef.current, name), {
-        type,
-        message,
-        types,
-      })
-    ) {
-      set(errorsRef.current, name, {
-        type,
-        types,
-        message,
-        ref: fieldsRef.current[name] ? fieldsRef.current[name]!.ref : {},
-      });
-
-      if (shouldRender) {
-        reRender();
-      }
-    }
-  };
-
   function setError(name: FieldName<TFieldValues>, error: ErrorOption): void {
     isValidRef.current = false;
 
-    setInternalError({
-      name,
-      type: '',
+    set(errorsRef.current, name, {
       ...error,
-      shouldRender: true,
+      ref: fieldsRef.current[name]!.ref,
     });
+
+    reRender();
   }
 
   const watchInternal = React.useCallback(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -653,7 +653,6 @@ export function useForm<
         types,
         message,
         ref: fieldsRef.current[name] ? fieldsRef.current[name]!.ref : {},
-        isManual: true,
       });
 
       if (shouldRender) {
@@ -984,6 +983,7 @@ export function useForm<
           }
         }
 
+        // need to figure out the erorr here
         if (isEmptyObject(fieldErrors)) {
           errorsRef.current = {};
           reRender();

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -665,39 +665,20 @@ export function useForm<
 
   function setError(
     name: FieldName<TFieldValues>,
-    type: MultipleFieldErrors,
-  ): void;
-  function setError(
-    name: FieldName<TFieldValues>,
-    type: string,
-    message?: Message,
-  ): void;
-  function setError(name: ManualFieldError<TFieldValues>[]): void;
-  function setError(
-    name: FieldName<TFieldValues> | ManualFieldError<TFieldValues>[],
-    type: string | MultipleFieldErrors = '',
-    message?: Message,
+    error: Partial<{
+      types: MultipleFieldErrors;
+      message: Message;
+    }> & {
+      type: string;
+    },
   ): void {
     isValidRef.current = false;
 
-    if (isArray(name)) {
-      name.forEach((error) => setInternalError(error));
-      reRender();
-    } else {
-      setInternalError({
-        name,
-        ...(isObject(type)
-          ? {
-              types: type,
-              type: '',
-            }
-          : {
-              type,
-              message,
-            }),
-        shouldRender: true,
-      });
-    }
+    setInternalError({
+      name,
+      ...error,
+      shouldRender: true,
+    });
   }
 
   const watchInternal = React.useCallback(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -668,7 +668,7 @@ export function useForm<
           types: MultipleFieldErrors;
         }
       | {
-          message: Message;
+          message?: Message;
           type: string;
         },
   ): void {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -52,7 +52,6 @@ import {
   FieldElement,
   FormStateProxy,
   ReadFormState,
-  ManualFieldError,
   MultipleFieldErrors,
   Ref,
   HandleChange,
@@ -615,7 +614,7 @@ export function useForm<
     [reRender, validateResolver, removeFieldEventListener, resolverRef],
   );
 
-  function clearError(
+  function clearErrors(
     name?: FieldName<TFieldValues> | FieldName<TFieldValues>[],
   ): void {
     if (name) {
@@ -1228,7 +1227,7 @@ export function useForm<
     handleSubmit,
     reset: React.useCallback(reset, []),
     getValues: React.useCallback(getValues, []),
-    clearError: React.useCallback(clearError, []),
+    clearErrors: React.useCallback(clearErrors, []),
     setError: React.useCallback(setError, []),
     errors: errorsRef.current,
     ...commonProps,


### PR DESCRIPTION
### setError

`setError` will focus one error at a time and remove confusing set multiple errors, behavior change.

- `setError` will persis an error if it's not part of the form, which requires manual remove with `clearError`
- `setError` error will be removed by validation rules, rules always take over errors

**Reason**

should focus an error at a time just like the name suggested, refine the API and remove multiple errors set.

``` diff
- setError('test', 'test', 'test')
+ setErrror('test', { type: 'test, message: 'bill'})
```

----

### clearError

Rename to `clearErrors`

**Reason**

This function allow remove multiple errors, so make sense to rename it to clearErrors

``` diff
- clearError()
+ clearErrors()
```

fix https://github.com/react-hook-form/react-hook-form/issues/1908