### PR TITLE
Fixed isHTMLElement method

### DIFF
--- a/src/utils/isHTMLElement.ts
+++ b/src/utils/isHTMLElement.ts
@@ -1,4 +1,2 @@
-import isObject from './isObject';
-
 export default (value: any): value is HTMLElement =>
-  isObject(value) && (value as HTMLElement).nodeType === Node.ELEMENT_NODE;
+  value instanceof HTMLElement;


### PR DESCRIPTION
I think the way to check if value is HTMLElement is sufficient only `instanceof`. What does it have problem ?