### PR TITLE
should unregister shouldn't clear error and internal form state

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -586,7 +586,7 @@ export function useForm<
       ) {
         removeFieldEventListener(field, forceDelete);
 
-        if (!shouldUnregister) {
+        if (shouldUnregister) {
           [
             errorsRef,
             touchedFieldsRef,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -586,26 +586,28 @@ export function useForm<
       ) {
         removeFieldEventListener(field, forceDelete);
 
-        [
-          errorsRef,
-          touchedFieldsRef,
-          dirtyFieldsRef,
-          defaultValuesAtRenderRef,
-        ].forEach((data) => unset(data.current, field.ref.name));
-        [
-          fieldsWithValidationRef,
-          validFieldsRef,
-          watchFieldsRef,
-        ].forEach((data) => data.current.delete(field.ref.name));
+        if (!shouldUnregister) {
+          [
+            errorsRef,
+            touchedFieldsRef,
+            dirtyFieldsRef,
+            defaultValuesAtRenderRef,
+          ].forEach((data) => unset(data.current, field.ref.name));
+          [
+            fieldsWithValidationRef,
+            validFieldsRef,
+            watchFieldsRef,
+          ].forEach((data) => data.current.delete(field.ref.name));
 
-        if (
-          readFormStateRef.current.isValid ||
-          readFormStateRef.current.touched
-        ) {
-          reRender();
+          if (
+            readFormStateRef.current.isValid ||
+            readFormStateRef.current.touched
+          ) {
+            reRender();
 
-          if (resolverRef.current) {
-            validateResolver();
+            if (resolverRef.current) {
+              validateResolver();
+            }
           }
         }
       }


### PR DESCRIPTION
`shouldUnregister` will not clear input error when input gets unmounted and user will have to clear that error manually.

- [ ] update doc