### PR TITLE
Allow a function to be passed to `message` for validations

### DIFF
--- a/src/utils/isMessage.test.ts
+++ b/src/utils/isMessage.test.ts
@@ -5,6 +5,7 @@ describe('isBoolean', () => {
   it('should return true when value is a Message', () => {
     expect(isMessage('test')).toBeTruthy();
     expect(isMessage(React.createElement('p'))).toBeTruthy();
+    expect(isMessage(() => 'p')).toBeTruthy();
   });
 
   it('should return false when value is not a Message', () => {

--- a/src/utils/isMessage.ts
+++ b/src/utils/isMessage.ts
@@ -2,6 +2,12 @@ import { isValidElement } from 'react';
 import isString from '../utils/isString';
 import isObject from '../utils/isObject';
 import { Message } from '../types/form';
+import isFunction from './isFunction';
 
-export default (value: unknown): value is Message =>
-  isString(value) || (isObject(value) && isValidElement(value));
+export default (value: unknown): value is Message => {
+  return (
+    isString(value) ||
+    (isObject(value) && isValidElement(value)) ||
+    (isFunction(value) && isString(value()))
+  );
+};


### PR DESCRIPTION
When react-hook-form is used with [`react-i18next`](https://github.com/i18next/react-i18next), we get a type error when setting up messages for validations, e.g.

```tsx
<input
  name="title"
  ref={register({
    required: t("form.validations.required"),
    maxLength: {
      value: 50,
      message: t("form.validations.maxLength"),
    },
  })}
/>
```

<img width="1535" alt="Screen Shot 2020-06-30 at 4 41 07 PM" src="https://user-images.githubusercontent.com/58678/86184687-ea5bf080-baf1-11ea-949d-d50fa613b16d.png">

In #1275, `isMessage` was adjusted to accept a `ReactElement`. This PR proposes to allow a function such that we can seamlessly use i18n.
