### PR TITLE
remove unnecessary `deps` in `useForm` hook

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -66,6 +66,15 @@ import {
 } from './types/form';
 import { LiteralToPrimitive, DeepPartial, NonUndefined } from './types/utils';
 
+export const isWindowUndefined = typeof window === UNDEFINED;
+export const isWeb =
+  typeof document !== UNDEFINED &&
+  !isWindowUndefined &&
+  !isUndefined(window.HTMLElement);
+export const isProxyEnabled = isWeb
+  ? 'Proxy' in window
+  : typeof Proxy !== UNDEFINED;
+
 export function useForm<
   TFieldValues extends FieldValues = FieldValues,
   TContext extends object = object
@@ -122,12 +131,6 @@ export function useForm<
     modeChecker(mode),
   ).current;
   const validateAllFieldCriteria = criteriaMode === VALIDATION_MODE.all;
-  const isWindowUndefined = typeof window === UNDEFINED;
-  const isWeb =
-    typeof document !== UNDEFINED &&
-    !isWindowUndefined &&
-    !isUndefined(window.HTMLElement);
-  const isProxyEnabled = isWeb ? 'Proxy' in window : typeof Proxy !== UNDEFINED;
   const readFormStateRef = React.useRef<ReadFormState>({
     isDirty: !isProxyEnabled,
     dirtyFields: !isProxyEnabled,
@@ -189,7 +192,7 @@ export function useForm<
         return true;
       }
     },
-    [reRender, resolverRef],
+    [reRender],
   );
 
   const setFieldValue = React.useCallback(
@@ -236,7 +239,7 @@ export function useForm<
         ref.value = value;
       }
     },
-    [isWeb],
+    [],
   );
 
   const setDirty = React.useCallback(
@@ -345,7 +348,7 @@ export function useForm<
         return !error;
       }
     },
-    [reRender, shouldRenderBaseOnError, validateAllFieldCriteria, resolverRef],
+    [reRender, shouldRenderBaseOnError, validateAllFieldCriteria],
   );
 
   const trigger = React.useCallback(
@@ -368,12 +371,7 @@ export function useForm<
 
       return await executeValidation(fields);
     },
-    [
-      executeSchemaOrResolverValidation,
-      executeValidation,
-      reRender,
-      resolverRef,
-    ],
+    [executeSchemaOrResolverValidation, executeValidation, reRender],
   );
 
   const setInternalValues = React.useCallback(
@@ -567,7 +565,7 @@ export function useForm<
         }
       });
     },
-    [reRender, validateAllFieldCriteria, resolverRef],
+    [reRender, validateAllFieldCriteria],
   );
 
   const removeFieldEventListener = React.useCallback(
@@ -619,7 +617,7 @@ export function useForm<
         }
       }
     },
-    [reRender, validateResolver, removeFieldEventListener, resolverRef],
+    [reRender, validateResolver, removeFieldEventListener],
   );
 
   function clearErrors(
@@ -973,7 +971,7 @@ export function useForm<
         reRender();
       }
     },
-    [isWeb, reRender, resolverRef, shouldFocusError, validateAllFieldCriteria],
+    [reRender, shouldFocusError, validateAllFieldCriteria],
   );
 
   const resetRefs = ({

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -66,14 +66,12 @@ import {
 } from './types/form';
 import { LiteralToPrimitive, DeepPartial, NonUndefined } from './types/utils';
 
-export const isWindowUndefined = typeof window === UNDEFINED;
-export const isWeb =
+const isWindowUndefined = typeof window === UNDEFINED;
+const isWeb =
   typeof document !== UNDEFINED &&
   !isWindowUndefined &&
   !isUndefined(window.HTMLElement);
-export const isProxyEnabled = isWeb
-  ? 'Proxy' in window
-  : typeof Proxy !== UNDEFINED;
+const isProxyEnabled = isWeb ? 'Proxy' in window : typeof Proxy !== UNDEFINED;
 
 export function useForm<
   TFieldValues extends FieldValues = FieldValues,


### PR DESCRIPTION
this PR will remove refs in dependency list of `useCallback` and also will move some static variables out of hook body to not need to add them to dependency list 

** NOTE: isWindowUndefined and isWeb and isProxyEnabled are static(constant) variables and can not be changed after first run of js file on same engine **