### PR TITLE
Fix docs contributing links with valid path

### DIFF
--- a/docs/README.de-DE.md
+++ b/docs/README.de-DE.md
@@ -102,7 +102,7 @@ Unser Dank geht auch an folgende wundervolle Organisationen! [[Spenden](https://
 
 ## Kontributoren
 
-Unser Dank geht auch an folgende wundervolle Personen! [[Werde auch ein Kontributor](CONTRIBUTING.md)].
+Unser Dank geht auch an folgende wundervolle Personen! [[Werde auch ein Kontributor](../CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.es-ES.md
+++ b/docs/README.es-ES.md
@@ -99,7 +99,7 @@ Gracias a estas maravillosas organizaciones! [[Contribuir](https://opencollectiv
 
 ## Colaboradores
 
-Gracias a estas personas maravillosas! [[Hazte colaborador](CONTRIBUTING.md)].
+Gracias a estas personas maravillosas! [[Hazte colaborador](../CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.fr-FR.md
+++ b/docs/README.fr-FR.md
@@ -83,7 +83,7 @@ function App() {
 
 ## Contributeurs
 
-Merci à ces gens merveilleux! [[Become a contributor](CONTRIBUTING.md)].
+Merci à ces gens merveilleux! [[Become a contributor](../CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.it-IT.md
+++ b/docs/README.it-IT.md
@@ -83,7 +83,7 @@ function App() {
 
 ## Contributors
 
-Grazie a queste splendide persone! [[Diventa un contributor](CONTRIBUTING.md)].
+Grazie a queste splendide persone! [[Diventa un contributor](../CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -82,7 +82,7 @@ function App() {
 
 ## コントリビューター
 
-これらの素晴らしい人々に感謝します![[コントリビューターになる](CONTRIBUTING.md)]
+これらの素晴らしい人々に感謝します![[コントリビューターになる](../CONTRIBUTING.md)]
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.ko-KR.md
+++ b/docs/README.ko-KR.md
@@ -83,7 +83,7 @@ function App() {
 
 ## 기여자
 
-모든 기여자 분들께 감사합니다! [[기여하기](CONTRIBUTING.md)]
+모든 기여자 분들께 감사합니다! [[기여하기](../CONTRIBUTING.md)]
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -83,7 +83,7 @@ function App() {
 
 ## Contribuidores
 
-Um obrigado especial para estas pessoas incríveis! [[Seja um contribuidor](CONTRIBUTING.md)].
+Um obrigado especial para estas pessoas incríveis! [[Seja um contribuidor](../CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.ru-RU.md
+++ b/docs/README.ru-RU.md
@@ -99,7 +99,7 @@ function App() {
 
 ## Участники
 
-Спасибо этим замечательным людям! [[Стать участником](CONTRIBUTING.md)].
+Спасибо этим замечательным людям! [[Стать участником](../CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.tr-TR.md
+++ b/docs/README.tr-TR.md
@@ -102,7 +102,7 @@ Bu harika organizasyonlar için çok teşekkürler! [[Katkıda bulunun](https://
 
 ## Katkıda bulunanlar
 
-Bu harika insanlara çok teşekkürler! [[Katkıda bulunun](CONTRIBUTING.md)].
+Bu harika insanlara çok teşekkürler! [[Katkıda bulunun](../CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -92,7 +92,7 @@ function App() {
 
 ## 贡献者
 
-感谢这些出色的人！ [[成为贡献者](CONTRIBUTING.md)].
+感谢这些出色的人！ [[成为贡献者](../CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />


### PR DESCRIPTION
At the moment at `docs/README**-**.md` files we can see the links with invalid path at `Contributors` title. I think it's better to have the link to `root/CONTRIBUTING.md` file if we don't have translations of this files to each language directly.