### PR TITLE
working in progress with Controller

### DIFF
--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -50,11 +50,7 @@ export default function Field(props: any) {
   renderCount++;
 
   return (
-    <form
-      onSubmit={handleSubmit((d) => {
-        console.log(d);
-      })}
-    >
+    <form onSubmit={handleSubmit(() => {})}>
       <div className="container">
         <section id="input-checkbox">
           <label>MUI Checkbox</label>

--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -50,15 +50,24 @@ export default function Field(props: any) {
   renderCount++;
 
   return (
-    <form onSubmit={handleSubmit(() => {})}>
+    <form
+      onSubmit={handleSubmit((d) => {
+        console.log(d);
+      })}
+    >
       <div className="container">
         <section id="input-checkbox">
           <label>MUI Checkbox</label>
           <Controller
-            as={<Checkbox />}
             name="Checkbox"
             control={control}
             rules={{ required: true }}
+            render={(props) => (
+              <Checkbox
+                {...props}
+                onChange={(e) => props.onChange(e.target.checked)}
+              />
+            )}
           />
         </section>
 
@@ -122,9 +131,14 @@ export default function Field(props: any) {
         <section id="input-switch">
           <label>MUI Switch</label>
           <Controller
-            as={<Switch value="checkedA" />}
             name="switch"
             rules={{ required: true }}
+            render={(props) => (
+              <Switch
+                {...props}
+                onChange={(e) => props.onChange(e.target.checked)}
+              />
+            )}
             control={control}
           />
         </section>

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Controller should be assigned method.control variable if wrap with FormProvider 1`] = `
 <DocumentFragment>
   <input
+    name="test"
     value=""
   />
 </DocumentFragment>
@@ -11,6 +12,7 @@ exports[`Controller should be assigned method.control variable if wrap with Form
 exports[`Controller should render correctly with as with component 1`] = `
 <DocumentFragment>
   <input
+    name="test"
     value=""
   />
 </DocumentFragment>
@@ -19,6 +21,7 @@ exports[`Controller should render correctly with as with component 1`] = `
 exports[`Controller should render correctly with as with string 1`] = `
 <DocumentFragment>
   <input
+    name="test"
     value=""
   />
 </DocumentFragment>
@@ -35,6 +38,7 @@ exports[`Controller should support custom value name 1`] = `
 exports[`Controller should support default value from hook form 1`] = `
 <DocumentFragment>
   <input
+    name="test"
     value="data"
   />
 </DocumentFragment>

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`Controller should support custom value name 1`] = `
 exports[`Controller should support default value from hook form 1`] = `
 <DocumentFragment>
   <input
+    checked=""
     name="test"
     value="data"
   />

--- a/src/__snapshots__/controller.test.tsx.snap
+++ b/src/__snapshots__/controller.test.tsx.snap
@@ -38,7 +38,6 @@ exports[`Controller should support custom value name 1`] = `
 exports[`Controller should support default value from hook form 1`] = `
 <DocumentFragment>
   <input
-    checked=""
     name="test"
     value="data"
   />

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import isUndefined from './utils/isUndefined';
 import get from './utils/get';
 import set from './utils/set';
-import isCheckBoxInput from './utils/isCheckBoxInput';
 import getInputValue from './logic/getInputValue';
 import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
@@ -72,7 +71,7 @@ const Controller = <
     });
 
   const commonTask = ([event]: any[]) => {
-    const data = getInputValue(event, isCheckBoxInput(event));
+    const data = getInputValue(event);
     setInputStateValue(data);
     valueRef.current = data;
     return data;
@@ -147,7 +146,6 @@ const Controller = <
     onBlur,
     name,
     value,
-    checked: value,
   };
 
   return as

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import isBoolean from './utils/isBoolean';
 import isUndefined from './utils/isUndefined';
 import get from './utils/get';
 import set from './utils/set';
+import isCheckBoxInput from './utils/isCheckBoxInput';
 import getInputValue from './logic/getInputValue';
 import skipValidation from './logic/skipValidation';
 import isNameInFieldArray from './logic/isNameInFieldArray';
@@ -57,7 +57,6 @@ const Controller = <
       : defaultValue;
   const [value, setInputStateValue] = React.useState(getInitialValue());
   const valueRef = React.useRef(value);
-  const isCheckboxInput = isBoolean(value);
   const onFocusRef = React.useRef(onFocus);
   const isSubmitted = isSubmittedRef.current;
 
@@ -73,7 +72,7 @@ const Controller = <
     });
 
   const commonTask = ([event]: any[]) => {
-    const data = getInputValue(event);
+    const data = getInputValue(event, isCheckBoxInput(event));
     setInputStateValue(data);
     valueRef.current = data;
     return data;
@@ -148,7 +147,7 @@ const Controller = <
     onBlur,
     name,
     value,
-    ...(isCheckboxInput ? { checked: value } : {}),
+    checked: value,
   };
 
   return as

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -146,7 +146,9 @@ const Controller = <
     ...rest,
     onChange,
     onBlur,
-    ...{ [isCheckboxInput ? 'checked' : VALUE]: value },
+    name,
+    value,
+    ...(isCheckboxInput ? { checked: value } : {}),
   };
 
   return as

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -72,8 +72,8 @@ const Controller = <
       isSubmitted,
     });
 
-  const commonTask = (event: any[]) => {
-    const data = getInputValue(event[0], isCheckboxInput);
+  const commonTask = ([event]: any[]) => {
+    const data = getInputValue(event);
     setInputStateValue(data);
     valueRef.current = data;
     return data;

--- a/src/logic/getInputValue.test.ts
+++ b/src/logic/getInputValue.test.ts
@@ -1,17 +1,17 @@
 import getInputValue from './getInputValue';
 
 test('getInputValue should return correct value', () => {
-  expect(
-    getInputValue({ target: { checked: true }, type: 'test' }, false),
-  ).toEqual(true);
-  expect(getInputValue({ target: { checked: true } }, false)).toEqual({
+  expect(getInputValue({ target: { checked: true }, type: 'test' })).toEqual(
+    true,
+  );
+  expect(getInputValue({ target: { checked: true } })).toEqual({
     target: { checked: true },
   });
-  expect(
-    getInputValue({ target: { value: 'test' }, type: 'test' }, false),
-  ).toEqual('test');
-  expect(getInputValue({ data: 'test' }, false)).toEqual({ data: 'test' });
-  expect(getInputValue('test', false)).toEqual('test');
-  expect(getInputValue(undefined, false)).toEqual(undefined);
-  expect(getInputValue(null, false)).toEqual(null);
+  expect(getInputValue({ target: { value: 'test' }, type: 'test' })).toEqual(
+    'test',
+  );
+  expect(getInputValue({ data: 'test' })).toEqual({ data: 'test' });
+  expect(getInputValue('test')).toEqual('test');
+  expect(getInputValue(undefined)).toEqual(undefined);
+  expect(getInputValue(null)).toEqual(null);
 });

--- a/src/logic/getInputValue.test.ts
+++ b/src/logic/getInputValue.test.ts
@@ -1,17 +1,17 @@
 import getInputValue from './getInputValue';
 
 test('getInputValue should return correct value', () => {
-  expect(getInputValue({ target: { checked: true }, type: 'test' })).toEqual(
-    true,
-  );
-  expect(getInputValue({ target: { checked: true } })).toEqual({
+  expect(
+    getInputValue({ target: { checked: true }, type: 'test' }, false),
+  ).toEqual(true);
+  expect(getInputValue({ target: { checked: true } }, false)).toEqual({
     target: { checked: true },
   });
-  expect(getInputValue({ target: { value: 'test' }, type: 'test' })).toEqual(
-    'test',
-  );
-  expect(getInputValue({ data: 'test' })).toEqual({ data: 'test' });
-  expect(getInputValue('test')).toEqual('test');
-  expect(getInputValue(undefined)).toEqual(undefined);
-  expect(getInputValue(null)).toEqual(null);
+  expect(
+    getInputValue({ target: { value: 'test' }, type: 'test' }, false),
+  ).toEqual('test');
+  expect(getInputValue({ data: 'test' }, false)).toEqual({ data: 'test' });
+  expect(getInputValue('test', false)).toEqual('test');
+  expect(getInputValue(undefined, false)).toEqual(undefined);
+  expect(getInputValue(null, false)).toEqual(null);
 });

--- a/src/logic/getInputValue.ts
+++ b/src/logic/getInputValue.ts
@@ -2,11 +2,11 @@ import isUndefined from '../utils/isUndefined';
 import isObject from '../utils/isObject';
 import isPrimitive from '../utils/isPrimitive';
 
-export default (event: any, isCheckboxInput: boolean) =>
+export default (event: any) =>
   isPrimitive(event) ||
   !isObject(event.target) ||
   (isObject(event.target) && !event.type)
     ? event
-    : isCheckboxInput || isUndefined(event.target.value)
-    ? event.target.checked
-    : event.target.value;
+    : isUndefined(event.target.checked)
+    ? event.target.value
+    : event.target.checked;

--- a/src/logic/getInputValue.ts
+++ b/src/logic/getInputValue.ts
@@ -2,11 +2,11 @@ import isUndefined from '../utils/isUndefined';
 import isObject from '../utils/isObject';
 import isPrimitive from '../utils/isPrimitive';
 
-export default (event: any) =>
+export default (event: any, isCheckboxInput: boolean) =>
   isPrimitive(event) ||
   !isObject(event.target) ||
   (isObject(event.target) && !event.type)
     ? event
-    : isUndefined(event.target.checked)
-    ? event.target.value
-    : event.target.checked;
+    : isCheckboxInput || isUndefined(event.target.value)
+    ? event.target.checked
+    : event.target.value;

--- a/src/logic/getInputValue.ts
+++ b/src/logic/getInputValue.ts
@@ -2,11 +2,11 @@ import isUndefined from '../utils/isUndefined';
 import isObject from '../utils/isObject';
 import isPrimitive from '../utils/isPrimitive';
 
-export default (event: any, isCheckboxInput: boolean) =>
+export default (event: any) =>
   isPrimitive(event) ||
   !isObject(event.target) ||
   (isObject(event.target) && !event.type)
     ? event
-    : isCheckboxInput || isUndefined(event.target.value)
+    : isUndefined(event.target.value)
     ? event.target.checked
     : event.target.value;


### PR DESCRIPTION
`checkbox` will not be determined inside the `Controller`, instead, use `render` prop. This is due to detecting `checkbox` before render leads to bug, because `select` component can have value as `true` or `false`, and it shouldn't be the case to determine if it's a `checkbox`.

- [x] fix tests
- [x] upddate doc

close #2139