### PR TITLE
Fix getValues when shouldUnregister set to false

### DIFF
--- a/src/logic/getFieldsValues.test.ts
+++ b/src/logic/getFieldsValues.test.ts
@@ -78,4 +78,28 @@ describe('getFieldsValues', () => {
       tex: 'test',
     });
   });
+
+  it('should return unmounted values', () => {
+    expect(
+      getFieldsValues(
+        {
+          current: {
+            test: {
+              ref: { name: 'test' },
+            },
+          },
+        },
+        {
+          current: {
+            test1: {
+              ref: { name: 'test1' },
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      test: 'test',
+      test1: 'test',
+    });
+  });
 });

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -14,8 +14,12 @@ export default <TFieldValues extends FieldValues>(
     | { nest: boolean },
 ) => {
   const output = {} as TFieldValues;
+  const fields = {
+    ...fieldsRef.current,
+    ...(unmountFieldsStateRef && unmountFieldsStateRef.current),
+  };
 
-  for (const name in fieldsRef.current) {
+  for (const name in fields) {
     if (
       isUndefined(search) ||
       (isString(search)


### PR DESCRIPTION
This is the reproducible bug when using `getValues`.
https://codesandbox.io/s/clever-spence-tcdn1

I didn't notice it when merging the PR from before but this problem showed for me when I created a multi-step form and only the last values got displayed on the screen even though I set `shouldUnregister` to `false`.