### PR TITLE
improved bundle size with production code

### DIFF
--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -49,7 +49,10 @@ describe('useForm', () => {
     });
 
     it('should call console.worn when ref name is undefined', () => {
-      const mockConsoleWarn = spyOn(console, 'warn');
+      process.env.NODE_ENV = 'development';
+      const mockConsoleWarn = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
       const Component = () => {
         const { register } = useForm();
         return <input ref={register} />;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -759,7 +759,7 @@ export function useForm<
     ref: TFieldElement & Ref,
     validateOptions: ValidationRules | null = {},
   ): ((name: InternalFieldName<TFieldValues>) => void) | void {
-    if (!ref.name) {
+    if (process.env.NODE_ENV !== 'production' && !ref.name) {
       // eslint-disable-next-line no-console
       return console.warn('Missing name @', ref);
     }


### PR DESCRIPTION
I think error message (like `console.warn`) is needed only in development mode. Therefore we need to remove this line with tree shaking.