### PR TITLE
fix #2220 with getValues()

### DIFF
--- a/src/logic/assignWatchFields.test.ts
+++ b/src/logic/assignWatchFields.test.ts
@@ -17,7 +17,7 @@ describe('assignWatchFields', () => {
     const watchFields = new Set();
     expect(
       assignWatchFields<any>(
-        { 'test[0]': '', 'test[1]': '' },
+        { test: ['', ''] },
         'test',
         watchFields as any,
         {},

--- a/src/logic/assignWatchFields.ts
+++ b/src/logic/assignWatchFields.ts
@@ -1,4 +1,3 @@
-import transformToNestObject from './transformToNestObject';
 import get from '../utils/get';
 import getPath from '../utils/getPath';
 import isEmptyObject from '../utils/isEmptyObject';
@@ -27,10 +26,8 @@ export default <TFieldValues extends FieldValues>(
 
   if (isEmptyObject(fieldValues)) {
     value = undefined;
-  } else if (!isUndefined(fieldValues[fieldName])) {
-    value = fieldValues[fieldName];
   } else {
-    value = get(transformToNestObject(fieldValues), fieldName);
+    value = get(fieldValues, fieldName);
 
     if (!isUndefined(value)) {
       getPath<TFieldValues>(fieldName, value).forEach((name: string) =>

--- a/src/logic/getFieldsValues.test.ts
+++ b/src/logic/getFieldsValues.test.ts
@@ -78,28 +78,4 @@ describe('getFieldsValues', () => {
       tex: 'test',
     });
   });
-
-  it('should return unmounted values', () => {
-    expect(
-      getFieldsValues(
-        {
-          current: {
-            test: {
-              ref: { name: 'test' },
-            },
-          },
-        },
-        {
-          current: {
-            test1: {
-              ref: { name: 'test1' },
-            },
-          },
-        },
-      ),
-    ).toEqual({
-      test: 'test',
-      test1: 'test',
-    });
-  });
 });

--- a/src/logic/getFieldsValues.test.ts
+++ b/src/logic/getFieldsValues.test.ts
@@ -78,4 +78,26 @@ describe('getFieldsValues', () => {
       tex: 'test',
     });
   });
+
+  it('should return unmounted values', () => {
+    expect(
+      getFieldsValues(
+        {
+          current: {
+            test: {
+              ref: { name: 'test' },
+            },
+          },
+        },
+        {
+          current: {
+            test1: 'test',
+          },
+        },
+      ),
+    ).toEqual({
+      test: 'test',
+      test1: 'test',
+    });
+  });
 });

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -14,12 +14,8 @@ export default <TFieldValues extends FieldValues>(
     | { nest: boolean },
 ) => {
   const output = {} as TFieldValues;
-  const fields = {
-    ...fieldsRef.current,
-    ...(unmountFieldsStateRef && unmountFieldsStateRef.current),
-  };
 
-  for (const name in fields) {
+  for (const name in fieldsRef.current) {
     if (
       isUndefined(search) ||
       (isString(search)

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -4,6 +4,7 @@ import isString from '../utils/isString';
 import isArray from '../utils/isArray';
 import isUndefined from '../utils/isUndefined';
 import { InternalFieldName, FieldValues, FieldRefs } from '../types/form';
+import transformToNestObject from './transformToNestObject';
 
 export default <TFieldValues extends FieldValues>(
   fieldsRef: React.MutableRefObject<FieldRefs<TFieldValues>>,
@@ -25,10 +26,12 @@ export default <TFieldValues extends FieldValues>(
       output[name as InternalFieldName<TFieldValues>] = getFieldValue(
         fieldsRef,
         name,
-        unmountFieldsStateRef,
       );
     }
   }
 
-  return output;
+  return {
+    ...(unmountFieldsStateRef || {}).current,
+    ...transformToNestObject(output),
+  };
 };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -557,9 +557,10 @@ export function useForm<
       );
     }
 
-    return transformToNestObject(
-      getFieldsValues(fieldsRef, unmountFieldsStateRef),
-    );
+    return transformToNestObject({
+      ...unmountFieldsStateRef.current,
+      ...getFieldsValues(fieldsRef, unmountFieldsStateRef),
+    });
   }
 
   const validateResolver = React.useCallback(

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -557,10 +557,7 @@ export function useForm<
       );
     }
 
-    return transformToNestObject({
-      ...unmountFieldsStateRef.current,
-      ...getFieldsValues(fieldsRef, unmountFieldsStateRef),
-    });
+    return getFieldsValues(fieldsRef, unmountFieldsStateRef);
   }
 
   const validateResolver = React.useCallback(


### PR DESCRIPTION
@JeromeDeLeon `getFieldsValues` are flat object once merge with unmounted input data which will lead to error, so I just do a merge at getValues function now.

- [ ] follow up a unit test at getValues() at useForm

close #2229