### PR TITLE
do not passing refs to logic functions

### DIFF
--- a/src/logic/findRemovedFieldAndRemoveListener.test.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.test.ts
@@ -19,9 +19,7 @@ describe('findMissDomAndClean', () => {
     it('should return default fields value if nothing matches', () => {
       document.body.contains = jest.fn(() => true);
       const fields = {
-        current: {
-          test: 'test',
-        },
+        test: 'test',
       };
       expect(
         findRemovedFieldAndRemoveListener(
@@ -45,19 +43,17 @@ describe('findMissDomAndClean', () => {
 
       const disconnect = jest.fn();
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            ref,
-            options: [
-              {
-                ref,
-                mutationWatcher: {
-                  disconnect,
-                },
+        test: {
+          name: 'test',
+          ref,
+          options: [
+            {
+              ref,
+              mutationWatcher: {
+                disconnect,
               },
-            ],
-          },
+            },
+          ],
         },
       };
 
@@ -71,9 +67,7 @@ describe('findMissDomAndClean', () => {
         true,
       );
 
-      expect(fields).toEqual({
-        current: {},
-      });
+      expect(fields).toEqual({});
     });
 
     it('should remove none radio field when found', () => {
@@ -83,18 +77,16 @@ describe('findMissDomAndClean', () => {
       document.body.contains = jest.fn(() => false);
       const disconnect = jest.fn();
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            ref: {},
-            mutationWatcher: {
-              disconnect,
-            },
+        test: {
+          name: 'test',
+          ref: {},
+          mutationWatcher: {
+            disconnect,
           },
-          test1: {
-            name: 'test',
-            ref: {},
-          },
+        },
+        test1: {
+          name: 'test',
+          ref: {},
         },
       };
 
@@ -120,19 +112,17 @@ describe('findMissDomAndClean', () => {
       document.body.contains = jest.fn(() => false);
       const disconnect = jest.fn();
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            ref: {},
-            mutationWatcher: {
-              disconnect,
-            },
+        test: {
+          name: 'test',
+          ref: {},
+          mutationWatcher: {
+            disconnect,
           },
-          test1: {
-            name: 'test',
-            ref: {
-              type: 'radio',
-            },
+        },
+        test1: {
+          name: 'test',
+          ref: {
+            type: 'radio',
           },
         },
       };
@@ -160,19 +150,17 @@ describe('findMissDomAndClean', () => {
       document.body.contains = jest.fn(() => false);
       const disconnect = jest.fn();
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            ref: {},
-            mutationWatcher: {
-              disconnect,
-            },
+        test: {
+          name: 'test',
+          ref: {},
+          mutationWatcher: {
+            disconnect,
           },
-          test1: {
-            name: 'test',
-            ref: {
-              type: 'checkbox',
-            },
+        },
+        test1: {
+          name: 'test',
+          ref: {
+            type: 'checkbox',
           },
         },
       };
@@ -199,13 +187,11 @@ describe('findMissDomAndClean', () => {
       });
 
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            type: 'radio',
-            ref: {},
-            options: [{ ref: { name: 'test', type: 'radio' } }],
-          },
+        test: {
+          name: 'test',
+          type: 'radio',
+          ref: {},
+          options: [{ ref: { name: 'test', type: 'radio' } }],
         },
       };
 
@@ -219,13 +205,11 @@ describe('findMissDomAndClean', () => {
       );
 
       expect(fields).toEqual({
-        current: {
-          test: {
-            name: 'test',
-            type: 'radio',
-            ref: {},
-            options: [{ ref: { name: 'test', type: 'radio' } }],
-          },
+        test: {
+          name: 'test',
+          type: 'radio',
+          ref: {},
+          options: [{ ref: { name: 'test', type: 'radio' } }],
         },
       });
     });
@@ -238,20 +222,18 @@ describe('findMissDomAndClean', () => {
 
       const disconnect = jest.fn();
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            type: 'radio',
-            ref: {},
-            options: [
-              {
-                ref: 'test',
-                mutationWatcher: {
-                  disconnect,
-                },
+        test: {
+          name: 'test',
+          type: 'radio',
+          ref: {},
+          options: [
+            {
+              ref: 'test',
+              mutationWatcher: {
+                disconnect,
               },
-            ],
-          },
+            },
+          ],
         },
       };
 
@@ -299,12 +281,10 @@ describe('findMissDomAndClean', () => {
 
       const disconnect = jest.fn();
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            ref: {},
-            options: [],
-          },
+        test: {
+          name: 'test',
+          ref: {},
+          options: [],
         },
       };
       findRemovedFieldAndRemoveListener(
@@ -326,28 +306,24 @@ describe('findMissDomAndClean', () => {
         true,
       );
 
-      expect(fields).toEqual({
-        current: {},
-      });
+      expect(fields).toEqual({});
     });
   });
 
   describe('text', () => {
     it('should delete field if type is text', () => {
       const mockWatcher = jest.fn();
-      const state = { current: {} };
+      const state = {};
       const fields = {
-        current: {
-          test: {
+        test: {
+          name: 'test',
+          ref: {
             name: 'test',
-            ref: {
-              name: 'test',
-              type: 'text',
-              value: 'test',
-            },
-            mutationWatcher: {
-              disconnect: mockWatcher,
-            },
+            type: 'text',
+            value: 'test',
+          },
+          mutationWatcher: {
+            disconnect: mockWatcher,
           },
         },
       };
@@ -360,26 +336,22 @@ describe('findMissDomAndClean', () => {
       );
 
       expect(state).toEqual({
-        current: { test: 'test' },
+        test: 'test',
       });
       expect(mockWatcher).toBeCalled();
-      expect(fields).toEqual({
-        current: {},
-      });
+      expect(fields).toEqual({});
     });
 
     it('should delete field if forceDelete is true', () => {
       (isDetached as any).mockReturnValue(false);
-      const state = { current: {} };
+      const state = {};
       const fields = {
-        current: {
-          test: {
+        test: {
+          name: 'test',
+          ref: {
             name: 'test',
-            ref: {
-              name: 'test',
-              type: 'text',
-              value: 'test',
-            },
+            type: 'text',
+            value: 'test',
           },
         },
       };
@@ -394,23 +366,19 @@ describe('findMissDomAndClean', () => {
       );
 
       expect(state).toEqual({
-        current: { test: 'test' },
+        test: 'test',
       });
       expect(removeAllEventListeners).toBeCalled();
-      expect(fields).toEqual({
-        current: {},
-      });
+      expect(fields).toEqual({});
     });
 
     it('should store state when component is getting unmount', () => {
-      const state = { current: {} };
+      const state = {};
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            ref: {
-              value: 'test',
-            },
+        test: {
+          name: 'test',
+          ref: {
+            value: 'test',
           },
         },
       };
@@ -426,18 +394,16 @@ describe('findMissDomAndClean', () => {
       );
 
       expect(state).toEqual({
-        current: { test: 'test' },
+        test: 'test',
       });
     });
 
     it('should not store state when component is getting unmount and value is return undefined', () => {
-      const state = { current: {} };
+      const state = {};
       const fields = {
-        current: {
-          test: {
-            name: 'test',
-            ref: {},
-          },
+        test: {
+          name: 'test',
+          ref: {},
         },
       };
 
@@ -451,9 +417,7 @@ describe('findMissDomAndClean', () => {
         false,
       );
 
-      expect(state).toEqual({
-        current: {},
-      });
+      expect(state).toEqual({});
     });
   });
 
@@ -465,16 +429,14 @@ describe('findMissDomAndClean', () => {
     ref.setAttribute('type', 'radio');
 
     const fields = {
-      current: {
-        test: {
-          name: 'test',
-          ref,
-          options: [
-            {
-              ref,
-            },
-          ],
-        },
+      test: {
+        name: 'test',
+        ref,
+        options: [
+          {
+            ref,
+          },
+        ],
       },
     };
 

--- a/src/logic/findRemovedFieldAndRemoveListener.ts
+++ b/src/logic/findRemovedFieldAndRemoveListener.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import removeAllEventListeners from './removeAllEventListeners';
 import getFieldValue from './getFieldValue';
 import isRadioInput from '../utils/isRadioInput';
@@ -16,10 +15,10 @@ const isSameRef = (fieldValue: Field, ref: Ref) =>
 export default function findRemovedFieldAndRemoveListener<
   TFieldValues extends FieldValues
 >(
-  fieldsRef: React.MutableRefObject<FieldRefs<TFieldValues>>,
+  fields: FieldRefs<TFieldValues>,
   handleChange: ({ type, target }: Event) => Promise<void | boolean>,
   field: Field,
-  unmountFieldsStateRef: React.MutableRefObject<Record<string, any>>,
+  unmountFieldsState: Record<string, any>,
   shouldUnregister?: boolean,
   forceDelete?: boolean,
 ): void {
@@ -28,18 +27,18 @@ export default function findRemovedFieldAndRemoveListener<
     ref: { name, type },
     mutationWatcher,
   } = field;
-  const fieldRef = fieldsRef.current[name] as Field;
+  const fieldRef = fields[name] as Field;
 
   if (!shouldUnregister) {
-    const value = getFieldValue(fieldsRef, name, unmountFieldsStateRef);
+    const value = getFieldValue(fields, name, unmountFieldsState);
 
     if (!isUndefined(value)) {
-      unmountFieldsStateRef.current[name] = value;
+      unmountFieldsState[name] = value;
     }
   }
 
   if (!type) {
-    delete fieldsRef.current[name];
+    delete fields[name];
     return;
   }
 
@@ -61,10 +60,10 @@ export default function findRemovedFieldAndRemoveListener<
       });
 
       if (options && !unique(options).length) {
-        delete fieldsRef.current[name];
+        delete fields[name];
       }
     } else {
-      delete fieldsRef.current[name];
+      delete fields[name];
     }
   } else if ((isDetached(ref) && isSameRef(fieldRef, ref)) || forceDelete) {
     removeAllEventListeners(ref, handleChange);
@@ -73,6 +72,6 @@ export default function findRemovedFieldAndRemoveListener<
       mutationWatcher.disconnect();
     }
 
-    delete fieldsRef.current[name];
+    delete fields[name];
   }
 }

--- a/src/logic/getFieldValue.test.ts
+++ b/src/logic/getFieldValue.test.ts
@@ -22,11 +22,9 @@ describe('getFieldValue', () => {
     expect(
       getFieldValue(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'radio',
-              },
+          test: {
+            ref: {
+              type: 'radio',
             },
           },
         },
@@ -39,13 +37,11 @@ describe('getFieldValue', () => {
     expect(
       getFieldValue(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'select-multiple',
-                name: 'test',
-                value: 'test',
-              },
+          test: {
+            ref: {
+              type: 'select-multiple',
+              name: 'test',
+              value: 'test',
             },
           },
         },
@@ -58,12 +54,10 @@ describe('getFieldValue', () => {
     expect(
       getFieldValue(
         {
-          current: {
-            test: {
-              ref: {
-                name: 'test',
-                type: 'checkbox',
-              },
+          test: {
+            ref: {
+              name: 'test',
+              type: 'checkbox',
             },
           },
         },
@@ -76,13 +70,11 @@ describe('getFieldValue', () => {
     expect(
       getFieldValue(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'bill',
-                value: 'value',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'bill',
+              value: 'value',
             },
           },
         },
@@ -92,13 +84,13 @@ describe('getFieldValue', () => {
   });
 
   it('should return empty string when radio input value is not found', () => {
-    expect(getFieldValue({ current: {} }, '')).toEqual(undefined);
+    expect(getFieldValue({}, '')).toEqual(undefined);
   });
 
   it('should return false when checkbox input value is not found', () => {
     expect(
       getFieldValue(
-        { current: {} },
+        {},
         {
           type: 'checkbox',
           value: 'value',
@@ -112,13 +104,11 @@ describe('getFieldValue', () => {
     expect(
       getFieldValue(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'file',
-                name: 'test',
-                files: 'files',
-              },
+          test: {
+            ref: {
+              type: 'file',
+              name: 'test',
+              files: 'files',
             },
           },
         },
@@ -131,11 +121,9 @@ describe('getFieldValue', () => {
     expect(
       getFieldValue(
         {
-          current: {
-            test: {
-              ref: {
-                files: 'files',
-              },
+          test: {
+            ref: {
+              files: 'files',
             },
           },
         },
@@ -148,16 +136,14 @@ describe('getFieldValue', () => {
     expect(
       getFieldValue(
         {
-          current: {
-            test: {
-              ref: {
-                files: 'files',
-              },
+          test: {
+            ref: {
+              files: 'files',
             },
           },
         },
         'what',
-        { current: { what: 'data' } },
+        { what: 'data' },
       ),
     ).toEqual('data');
   });

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import getRadioValue from './getRadioValue';
 import getMultipleSelectValue from './getMultipleSelectValue';
 import isRadioInput from '../utils/isRadioInput';
@@ -9,11 +8,11 @@ import getCheckboxValue from './getCheckboxValue';
 import { FieldRefs, FieldValues, InternalFieldName } from '../types/form';
 
 export default function getFieldValue<TFieldValues extends FieldValues>(
-  fieldsRef: React.MutableRefObject<FieldRefs<TFieldValues>>,
+  fields: FieldRefs<TFieldValues>,
   name: InternalFieldName<TFieldValues>,
-  unmountFieldsStateRef?: React.MutableRefObject<Record<string, any>>,
+  unmountFieldsStateRef?: Record<string, any>,
 ) {
-  const field = fieldsRef.current[name]!;
+  const field = fields[name]!;
 
   if (field) {
     const {
@@ -41,6 +40,6 @@ export default function getFieldValue<TFieldValues extends FieldValues>(
   }
 
   if (unmountFieldsStateRef) {
-    return unmountFieldsStateRef.current[name];
+    return unmountFieldsStateRef[name];
   }
 }

--- a/src/logic/getFieldsValues.test.ts
+++ b/src/logic/getFieldsValues.test.ts
@@ -10,16 +10,14 @@ describe('getFieldsValues', () => {
     expect(
       getFieldsValues(
         {
-          current: {
-            test: {
-              ref: { name: 'test' },
-            },
-            test1: {
-              ref: { name: 'test1' },
-            },
+          test: {
+            ref: { name: 'test' },
+          },
+          test1: {
+            ref: { name: 'test1' },
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: 'test',
@@ -31,19 +29,17 @@ describe('getFieldsValues', () => {
     expect(
       getFieldsValues(
         {
-          current: {
-            test: {
-              ref: { name: 'test' },
-            },
-            tex: {
-              ref: { name: 'test1' },
-            },
-            tex123: {
-              ref: { name: 'test1' },
-            },
+          test: {
+            ref: { name: 'test' },
+          },
+          tex: {
+            ref: { name: 'test1' },
+          },
+          tex123: {
+            ref: { name: 'test1' },
           },
         },
-        { current: {} },
+        {},
         'test',
       ),
     ).toEqual({
@@ -55,22 +51,20 @@ describe('getFieldsValues', () => {
     expect(
       getFieldsValues(
         {
-          current: {
-            test: {
-              ref: { name: 'test' },
-            },
-            tex: {
-              ref: { name: 'test1' },
-            },
-            123: {
-              ref: { name: 'test1' },
-            },
-            1456: {
-              ref: { name: 'test1' },
-            },
+          test: {
+            ref: { name: 'test' },
+          },
+          tex: {
+            ref: { name: 'test1' },
+          },
+          123: {
+            ref: { name: 'test1' },
+          },
+          1456: {
+            ref: { name: 'test1' },
           },
         },
-        { current: {} },
+        {},
         ['test', 'tex'],
       ),
     ).toEqual({
@@ -83,16 +77,12 @@ describe('getFieldsValues', () => {
     expect(
       getFieldsValues(
         {
-          current: {
-            test: {
-              ref: { name: 'test' },
-            },
+          test: {
+            ref: { name: 'test' },
           },
         },
         {
-          current: {
-            test1: 'test',
-          },
+          test1: 'test',
         },
       ),
     ).toEqual({

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import getFieldValue from './getFieldValue';
 import isString from '../utils/isString';
 import isArray from '../utils/isArray';
@@ -7,8 +6,8 @@ import { InternalFieldName, FieldValues, FieldRefs } from '../types/form';
 import transformToNestObject from './transformToNestObject';
 
 export default <TFieldValues extends FieldValues>(
-  fieldsRef: React.MutableRefObject<FieldRefs<TFieldValues>>,
-  unmountFieldsStateRef?: React.MutableRefObject<Record<string, any>>,
+  fields: FieldRefs<TFieldValues>,
+  unmountFieldsState?: Record<string, any>,
   search?:
     | InternalFieldName<TFieldValues>
     | InternalFieldName<TFieldValues>[]
@@ -16,7 +15,7 @@ export default <TFieldValues extends FieldValues>(
 ) => {
   const output = {} as TFieldValues;
 
-  for (const name in fieldsRef.current) {
+  for (const name in fields) {
     if (
       isUndefined(search) ||
       (isString(search)
@@ -24,14 +23,14 @@ export default <TFieldValues extends FieldValues>(
         : isArray(search) && search.find((data) => name.startsWith(data)))
     ) {
       output[name as InternalFieldName<TFieldValues>] = getFieldValue(
-        fieldsRef,
+        fields,
         name,
       );
     }
   }
 
   return {
-    ...(unmountFieldsStateRef || {}).current,
+    ...unmountFieldsState,
     ...transformToNestObject(output),
   };
 };

--- a/src/logic/validateField.test.tsx
+++ b/src/logic/validateField.test.tsx
@@ -27,7 +27,7 @@ describe('validateField', () => {
           ref: { type: 'text', value: '', name: 'test' },
           required: true,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -45,7 +45,7 @@ describe('validateField', () => {
           ref: { type: 'text', value: '', name: 'test' },
           required: 'required',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -63,7 +63,7 @@ describe('validateField', () => {
           ref: { type: 'text', value: '', name: 'test' },
           required: 'required',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -84,7 +84,7 @@ describe('validateField', () => {
             message: 'required',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -105,7 +105,7 @@ describe('validateField', () => {
             message: 'required',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -126,22 +126,20 @@ describe('validateField', () => {
             message: 'required',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
 
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {} as any,
-              options: [
-                {
-                  ref: 'test',
-                } as any,
-              ],
-            },
+          test: {
+            ref: {} as any,
+            options: [
+              {
+                ref: 'test',
+              } as any,
+            ],
           },
         },
         false,
@@ -149,7 +147,7 @@ describe('validateField', () => {
           ref: { type: 'radio', name: 'test' },
           required: true,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -167,7 +165,7 @@ describe('validateField', () => {
           ref: { type: 'text', value: '', name: 'test' },
           required: 'test',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -180,15 +178,13 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: 'test' as any,
-              options: [
-                {
-                  ref: 'test',
-                } as any,
-              ],
-            },
+          test: {
+            ref: 'test' as any,
+            options: [
+              {
+                ref: 'test',
+              } as any,
+            ],
           },
         },
         false,
@@ -196,7 +192,7 @@ describe('validateField', () => {
           ref: { type: 'radio', value: '', name: 'test' },
           required: 'test',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -209,15 +205,13 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: 'test' as any,
-              options: [
-                {
-                  ref: 'test',
-                },
-              ] as any,
-            },
+          test: {
+            ref: 'test' as any,
+            options: [
+              {
+                ref: 'test',
+              },
+            ] as any,
           },
         },
         false,
@@ -225,7 +219,7 @@ describe('validateField', () => {
           ref: { type: 'checkbox', name: 'test' },
           required: 'test',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -242,15 +236,13 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: 'test' as any,
-              options: [
-                {
-                  ref: 'test',
-                },
-              ] as any,
-            },
+          test: {
+            ref: 'test' as any,
+            options: [
+              {
+                ref: 'test',
+              },
+            ] as any,
           },
         },
         false,
@@ -258,7 +250,7 @@ describe('validateField', () => {
           ref: { type: 'checkbox', name: 'test' },
           required: 'test',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
   });
@@ -273,7 +265,7 @@ describe('validateField', () => {
           required: true,
           max: 0,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -295,7 +287,7 @@ describe('validateField', () => {
             message: 'max',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -317,7 +309,7 @@ describe('validateField', () => {
             message: 'max',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -336,7 +328,7 @@ describe('validateField', () => {
           required: true,
           max: 8,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
 
@@ -348,7 +340,7 @@ describe('validateField', () => {
           ref: { type: 'number', name: 'test', value: 10, valueAsNumber: 10 },
           max: 8,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -369,7 +361,7 @@ describe('validateField', () => {
           ref: { type: 'custom', name: 'test', value: '', valueAsNumber: NaN },
           required: true,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -392,7 +384,7 @@ describe('validateField', () => {
           },
           required: true,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -420,7 +412,7 @@ describe('validateField', () => {
           },
           required: true,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -438,7 +430,7 @@ describe('validateField', () => {
           ref: { type: 'custom', name: 'test', value: 'ok' },
           required: true,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
 
@@ -455,7 +447,7 @@ describe('validateField', () => {
           required: true,
           max: '2019-1-12',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -480,7 +472,7 @@ describe('validateField', () => {
           required: true,
           min: 0,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -502,7 +494,7 @@ describe('validateField', () => {
             message: 'min',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -524,7 +516,7 @@ describe('validateField', () => {
             message: 'min',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -543,7 +535,7 @@ describe('validateField', () => {
           required: true,
           min: 12,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -567,7 +559,7 @@ describe('validateField', () => {
           required: true,
           min: '2019-3-12',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -598,7 +590,7 @@ describe('validateField', () => {
             message: 'min',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -629,7 +621,7 @@ describe('validateField', () => {
             message: 'min',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -655,7 +647,7 @@ describe('validateField', () => {
           required: true,
           min: '4',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -674,7 +666,7 @@ describe('validateField', () => {
           required: true,
           max: '2',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -698,7 +690,7 @@ describe('validateField', () => {
           required: true,
           max: '2019-1-12',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -728,7 +720,7 @@ describe('validateField', () => {
           required: true,
           maxLength: 12,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -758,7 +750,7 @@ describe('validateField', () => {
             message: 'maxLength',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -788,7 +780,7 @@ describe('validateField', () => {
             message: 'maxLength',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -817,7 +809,7 @@ describe('validateField', () => {
           required: true,
           minLength: 200,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -847,7 +839,7 @@ describe('validateField', () => {
             message: 'minLength',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -877,7 +869,7 @@ describe('validateField', () => {
             message: 'minLength',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -908,7 +900,7 @@ describe('validateField', () => {
           required: true,
           pattern: emailRegex,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -938,7 +930,7 @@ describe('validateField', () => {
             message: 'regex failed',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -968,7 +960,7 @@ describe('validateField', () => {
             message: 'regex failed',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -995,7 +987,7 @@ describe('validateField', () => {
           required: true,
           pattern: emailRegex,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
   });
@@ -1004,13 +996,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'test',
-                value: 'This is a long text input',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'test',
+              value: 'This is a long text input',
             },
           },
         },
@@ -1024,20 +1014,18 @@ describe('validateField', () => {
           required: true,
           validate: (value) => value.toString().length > 3,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
 
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'test',
-                value: 'This is a long text input',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'test',
+              value: 'This is a long text input',
             },
           },
         },
@@ -1051,7 +1039,7 @@ describe('validateField', () => {
           required: true,
           validate: (value) => value.toString().length < 3,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -1068,13 +1056,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'test',
-                value: 'This is a long text input',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'test',
+              value: 'This is a long text input',
             },
           },
         },
@@ -1091,7 +1077,7 @@ describe('validateField', () => {
             test1: (value) => value.toString().length > 10,
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -1115,13 +1101,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'test',
-                value: 'This is a long text input!',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'test',
+              value: 'This is a long text input!',
             },
           },
         },
@@ -1137,7 +1121,7 @@ describe('validateField', () => {
             test1: (value) => value.toString().length > 10,
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -1154,13 +1138,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'radio',
-                name: 'test',
-                value: 'This is a long text input!',
-              },
+          test: {
+            ref: {
+              type: 'radio',
+              name: 'test',
+              value: 'This is a long text input!',
             },
           },
         },
@@ -1181,7 +1163,7 @@ describe('validateField', () => {
             },
           ],
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -1194,13 +1176,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'radio',
-                name: 'test',
-                value: 'This is a long text input!',
-              },
+          test: {
+            ref: {
+              type: 'radio',
+              name: 'test',
+              value: 'This is a long text input!',
             },
           },
         },
@@ -1220,7 +1200,7 @@ describe('validateField', () => {
             },
           ],
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
   });
@@ -1229,13 +1209,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'test',
-                value: 'This is a long text input',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'test',
+              value: 'This is a long text input',
             },
           },
         },
@@ -1255,7 +1233,7 @@ describe('validateField', () => {
             },
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -1272,13 +1250,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'test',
-                value: 'This is a long text input',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'test',
+              value: 'This is a long text input',
             },
           },
         },
@@ -1298,7 +1274,7 @@ describe('validateField', () => {
             },
           },
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -1317,13 +1293,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'test',
-                value: 'This is a long text input',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'test',
+              value: 'This is a long text input',
             },
           },
         },
@@ -1336,7 +1310,7 @@ describe('validateField', () => {
           },
           validate: (value) => value.toString().length < 3 || 'bill',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -1353,13 +1327,11 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {
-                type: 'text',
-                name: 'test',
-                value: 'This is a long text input',
-              },
+          test: {
+            ref: {
+              type: 'text',
+              name: 'test',
+              value: 'This is a long text input',
             },
           },
         },
@@ -1372,7 +1344,7 @@ describe('validateField', () => {
           },
           validate: (value) => value.toString().length < 3 || 'bill',
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({
       test: {
@@ -1391,10 +1363,8 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {} as any,
-            },
+          test: {
+            ref: {} as any,
           },
         },
         false,
@@ -1406,7 +1376,7 @@ describe('validateField', () => {
           },
           validate: () => undefined,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
   });
@@ -1415,10 +1385,8 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: {} as any,
-            },
+          test: {
+            ref: {} as any,
           },
         },
         false,
@@ -1430,7 +1398,7 @@ describe('validateField', () => {
           },
           validate: 'validate' as any,
         },
-        { current: {} },
+        {},
       ),
     ).toEqual({});
   });
@@ -1442,9 +1410,7 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: { ref: { type: 'text', value: '', name: 'test' } },
-          },
+          test: { ref: { type: 'text', value: '', name: 'test' } },
         },
         true,
         {
@@ -1454,13 +1420,13 @@ describe('validateField', () => {
           pattern: /d/i,
           validate: (value) => value === 'test',
         },
-        { current: {} },
+        {},
       ),
     ).toMatchSnapshot();
 
     expect(
       await validateField(
-        { current: {} },
+        {},
         true,
         {
           ref: { type: 'text', value: '123', name: 'test' },
@@ -1469,7 +1435,7 @@ describe('validateField', () => {
           pattern: /d/i,
           validate: (value) => value === 'test',
         },
-        { current: {} },
+        {},
       ),
     ).toMatchSnapshot();
   });
@@ -1481,10 +1447,8 @@ describe('validateField', () => {
     expect(
       await validateField(
         {
-          current: {
-            test: {
-              ref: { type: 'text', value: '', name: 'test' },
-            },
+          test: {
+            ref: { type: 'text', value: '', name: 'test' },
           },
         },
         true,
@@ -1505,13 +1469,13 @@ describe('validateField', () => {
             test2: (value) => value == 'test' || 'Bill',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toMatchSnapshot();
 
     expect(
       await validateField(
-        { current: {} },
+        {},
         true,
         {
           ref: { type: 'text', value: 'bil', name: 'test' },
@@ -1530,13 +1494,13 @@ describe('validateField', () => {
             test2: (value) => value == 'test' || 'Bill',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toMatchSnapshot();
 
     expect(
       await validateField(
-        { current: {} },
+        {},
         true,
         {
           ref: { type: 'text', value: 'bil', name: 'test' },
@@ -1555,7 +1519,7 @@ describe('validateField', () => {
             test2: (value) => value == 'test' || 'Bill',
           },
         },
-        { current: {} },
+        {},
       ),
     ).toMatchSnapshot();
   });

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import getRadioValue from './getRadioValue';
 import getCheckboxValue from './getCheckboxValue';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
@@ -27,7 +26,7 @@ import {
 } from '../types/form';
 
 export default async <TFieldValues extends FieldValues>(
-  fieldsRef: React.MutableRefObject<FieldRefs<TFieldValues>>,
+  fields: FieldRefs<TFieldValues>,
   validateAllFieldCriteria: boolean,
   {
     ref,
@@ -41,9 +40,8 @@ export default async <TFieldValues extends FieldValues>(
     pattern,
     validate,
   }: Field,
-  unmountFieldsStateRef: React.MutableRefObject<Record<string, any>>,
+  unmountFieldsState: Record<string, any>,
 ): Promise<FlatFieldErrors<TFieldValues>> => {
-  const fields = fieldsRef.current;
   const name: InternalFieldName<TFieldValues> = ref.name;
   const error: FlatFieldErrors<TFieldValues> = {};
   const isRadio = isRadioInput(ref);
@@ -184,7 +182,7 @@ export default async <TFieldValues extends FieldValues>(
   }
 
   if (validate) {
-    const fieldValue = getFieldsValue(fieldsRef, name, unmountFieldsStateRef);
+    const fieldValue = getFieldsValue(fields, name, unmountFieldsState);
     const validateRef = isRadioOrCheckbox && options ? options[0].ref : ref;
 
     if (isFunction(validate)) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -245,7 +245,7 @@ export function useForm<
 
       const isFieldDirty =
         defaultValuesAtRenderRef.current[name] !==
-        getFieldValue(fieldsRef, name, unmountFieldsStateRef);
+        getFieldValue(fieldsRef.current, name, unmountFieldsStateRef);
       const isDirtyFieldExist = get(dirtyFieldsRef.current, name);
       const isFieldArray = isNameInFieldArray(fieldArrayNamesRef.current, name);
       const previousIsDirty = isDirtyRef.current;
@@ -279,7 +279,7 @@ export function useForm<
     ): Promise<boolean> => {
       if (fieldsRef.current[name]) {
         const error = await validateField<TFieldValues>(
-          fieldsRef,
+          fieldsRef.current,
           isValidateAllFieldCriteria,
           fieldsRef.current[name] as Field,
           unmountFieldsStateRef,
@@ -521,7 +521,7 @@ export function useForm<
             }
           } else {
             error = await validateField<TFieldValues>(
-              fieldsRef,
+              fieldsRef.current,
               isValidateAllFieldCriteria,
               field,
               unmountFieldsStateRef,
@@ -547,20 +547,20 @@ export function useForm<
   ): UnpackNestedValue<Pick<TFieldValues, TFieldName>>;
   function getValues(payload?: string | string[]): unknown {
     if (isString(payload)) {
-      return getFieldValue(fieldsRef, payload, unmountFieldsStateRef);
+      return getFieldValue(fieldsRef.current, payload, unmountFieldsStateRef);
     }
 
     if (isArray(payload)) {
       return payload.reduce(
         (previous, name) => ({
           ...previous,
-          [name]: getFieldValue(fieldsRef, name, unmountFieldsStateRef),
+          [name]: getFieldValue(fieldsRef.current, name, unmountFieldsStateRef),
         }),
         {},
       );
     }
 
-    return getFieldsValues(fieldsRef, unmountFieldsStateRef);
+    return getFieldsValues(fieldsRef.current, unmountFieldsStateRef);
   }
 
   const validateResolver = React.useCallback(
@@ -588,7 +588,7 @@ export function useForm<
   const removeFieldEventListener = React.useCallback(
     (field: Field, forceDelete?: boolean) =>
       findRemovedFieldAndRemoveListener(
-        fieldsRef,
+        fieldsRef.current,
         handleChangeRef.current!,
         field,
         unmountFieldsStateRef,
@@ -675,7 +675,7 @@ export function useForm<
         ? defaultValuesRef.current
         : defaultValue;
       const fieldValues = getFieldsValues<TFieldValues>(
-        fieldsRef,
+        fieldsRef.current,
         unmountFieldsStateRef,
         fieldNames,
       );
@@ -844,7 +844,7 @@ export function useForm<
 
       if (!isOnSubmit && readFormStateRef.current.isValid) {
         validateField(
-          fieldsRef,
+          fieldsRef.current,
           isValidateAllFieldCriteria,
           field,
           unmountFieldsStateRef,
@@ -867,7 +867,7 @@ export function useForm<
       !(isFieldArray && isEmptyDefaultValue)
     ) {
       defaultValuesAtRenderRef.current[name] = isEmptyDefaultValue
-        ? getFieldValue(fieldsRef, name, unmountFieldsStateRef)
+        ? getFieldValue(fieldsRef.current, name, unmountFieldsStateRef)
         : defaultValue;
     }
 
@@ -952,7 +952,7 @@ export function useForm<
               } = field;
 
               const fieldError = await validateField(
-                fieldsRef,
+                fieldsRef.current,
                 isValidateAllFieldCriteria,
                 field,
                 unmountFieldsStateRef,


### PR DESCRIPTION
logic functions are getting data and calculate depend on it so they don't have callback function which needs to access  latest value in ref in future and it just want to access current value of ref which we can pass it directly 
in another way logic functions should not import React and should not depend on it so we shouldn't use refs in them 

in this PR tests has been changed and remove current creating in them but I do not know what should I do with snapshot , please someone fix snapshots 

thank you