### PR TITLE
Remove charged terminology

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,6 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "main",
   "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release:
@@ -23,7 +23,7 @@ jobs:
         run: npm i
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
+        uses: changesets/action@main
         with:
           publish: npm run release
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Here is a quick guide to doing code contributions to the library.
 
 1. Fork and clone the repo to your local machine `git clone https://github.com/YOUR_GITHUB_USERNAME/react-hook-form.git`
 
-2. Create a new branch from `master` with a meaningful name for a new feature or an issue you want to work on: `git checkout -b your-meaningful-branch-name`
+2. Create a new branch from `main` with a meaningful name for a new feature or an issue you want to work on: `git checkout -b your-meaningful-branch-name`
 
 3. Install packages by running:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -13,14 +13,14 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 </div>
 
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
 </div>
@@ -47,7 +47,7 @@ English | <a href="./docs/README.zh-CN.md">简体中文</a> | <a href="./docs/RE
 - [Video tutorial](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Get started](https://react-hook-form.com/get-started)
 - [API](https://react-hook-form.com/api)
-- [Examples](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [Examples](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Demo](https://react-hook-form.com)
 - [Form Builder](https://react-hook-form.com/form-builder)
 - [FAQs](https://react-hook-form.com/faqs)

--- a/docs/README.de-DE.md
+++ b/docs/README.de-DE.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Einfache React Formular Eingabeprüfung">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React einstellbare Hook für Formulareingabeprüfung" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React einstellbare Hook für Formulareingabeprüfung" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Einfache React Formular Eingabeprüfung">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React einstellbare Hook für Formulareingabeprüfung" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React einstellbare Hook für Formulareingabeprüfung" width="100%" />
         </a>
     </p>
 </div>
@@ -50,7 +50,7 @@
 - [Video Lehrgang](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Anfangen](https://react-hook-form.com/get-started)
 - [API](https://react-hook-form.com/api)
-- [Beispiele](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [Beispiele](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Demonstration](https://react-hook-form.com)
 - [Formular Ersteller](https://react-hook-form.com/form-builder)
 - [Häufige Fragen](https://react-hook-form.com/faqs)

--- a/docs/README.es-ES.md
+++ b/docs/README.es-ES.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Validación simple de formularios React">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook personalizado para la validación de formularios" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook personalizado para la validación de formularios" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Validación de formularios de reacción simple">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React hook personalizado para la validacion de de formularios" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React hook personalizado para la validacion de de formularios" width="100%" />
         </a>
     </p>
 </div>
@@ -51,7 +51,7 @@
 - [Video tutorial](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Empezar](https://react-hook-form.com/get-started)
 - [API](https://react-hook-form.com/api)
-- [Ejemplos](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [Ejemplos](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Demo](https://react-hook-form.com)
 - [Generador de formularios](https://react-hook-form.com/form-builder)
 - [FAQs](https://react-hook-form.com/faqs)

--- a/docs/README.fr-FR.md
+++ b/docs/README.fr-FR.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
 </div>
@@ -51,7 +51,7 @@
 - [Tutoriel vidéo](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Bien demarrer](https://react-hook-form.com/get-started)
 - [API](https://react-hook-form.com/api)
-- [Exemples](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [Exemples](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Démo](https://react-hook-form.com)
 - [Form Builder](https://react-hook-form.com/form-builder)
 - [FAQs](https://react-hook-form.com/faqs)

--- a/docs/README.it-IT.md
+++ b/docs/README.it-IT.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
 </div>
@@ -51,7 +51,7 @@
 - [Video tutorial](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Primi passi](https://react-hook-form.com/get-started)
 - [API](https://react-hook-form.com/api)
-- [Esempi](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [Esempi](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Demo](https://react-hook-form.com)
 - [Form Builder](https://react-hook-form.com/form-builder)
 - [FAQ](https://react-hook-form.com/faqs)

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com/jp" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com/jp" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
 </div>
@@ -50,7 +50,7 @@
 - [ビデオチュートリアル](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [始める](https://react-hook-form.com/jp/get-started)
 - [API](https://react-hook-form.com/jp/api)
-- [例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [例](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [デモ](https://react-hook-form.com/jp)
 - [Form Builder](https://react-hook-form.com/jp/form-builder)
 - [FAQs](https://react-hook-form.com/jp/faqs)

--- a/docs/README.ko-KR.md
+++ b/docs/README.ko-KR.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
 </div>
@@ -51,7 +51,7 @@
 - [비디오 튜토리얼](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [시작하기](https://react-hook-form.com/get-started)
 - [API](https://react-hook-form.com/api)
-- [예제](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [예제](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [데모](https://react-hook-form.com)
 - [Form Builder](https://react-hook-form.com/form-builder)
 - [FAQs](https://react-hook-form.com/faqs)

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
 </div>
@@ -51,7 +51,7 @@
 - [Video tutorial](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Como iniciar](https://react-hook-form.com/pt/get-started)
 - [API](https://react-hook-form.com/pt/api)
-- [Exemplos](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [Exemplos](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Demonstração](https://react-hook-form.com/pt)
 - [Form Builder](https://react-hook-form.com/pt/form-builder)
 - [FAQs](https://react-hook-form.com/pt/faqs)

--- a/docs/README.ru-RU.md
+++ b/docs/README.ru-RU.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
 </div>
@@ -51,7 +51,7 @@
 - [Видеоурок](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Начать](https://react-hook-form.com/get-started)
 - [АПИ](https://react-hook-form.com/api)
-- [Примеры](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [Примеры](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Демонстрация](https://react-hook-form.com)
 - [Конструктор форм](https://react-hook-form.com/form-builder)
 - [ЧЗВ](https://react-hook-form.com/faqs)

--- a/docs/README.tr-TR.md
+++ b/docs/README.tr-TR.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -13,7 +13,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
@@ -22,7 +22,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
 </div>
@@ -50,7 +50,7 @@
 - [Video eğitimi](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Başlangıç](https://react-hook-form.com/get-started)
 - [API](https://react-hook-form.com/api)
-- [Örnekler](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [Örnekler](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Demo](https://react-hook-form.com)
 - [Form Oluşturucu](https://react-hook-form.com/form-builder)
 - [Sıkça Sorulan Sorular](https://react-hook-form.com/faqs)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
       <a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation">
-        <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - hook custom hook for form validation" width="330px" />
+        <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - hook custom hook for form validation" width="330px" />
       </a>
     </p>
 </div>
@@ -13,13 +13,13 @@
 [![npm downloads](https://img.shields.io/npm/dm/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/npm/dt/react-hook-form.svg?style=for-the-badge)](https://www.npmjs.com/package/react-hook-form)
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
-[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
+[![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/main?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=main)
 
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
 
 </div>
 
-<div align="center"><p align="center"><a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/example.gif" alt="React Hook Form Logo - React hook form validation" width="100%" /></a></p></div>
+<div align="center"><p align="center"><a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/example.gif" alt="React Hook Form Logo - React hook form validation" width="100%" /></a></p></div>
 
 <a href="https://github.com/react-hook-form/react-hook-form">English</a> | 简体中文 | <a href="./README.ja-JP.md">日本語</a> | <a href="./README.ko-KR.md">한국어</a> | <a href="./README.fr-FR.md">Français</a> | <a href="./README.it-IT.md">Italiano</a> | <a href="./README.pt-BR.md">Português</a> | <a href="./README.es-ES.md">Español</a> | <a href="./README.ru-RU.md">Русский</a> | <a href="./README.de-DE.md">Deutsch</a> | <a href="./README.tr-TR.md">Türkçe</a>
 
@@ -44,7 +44,7 @@
 - [动机](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [开始](https://react-hook-form.com/zh/get-started)
 - [API](https://react-hook-form.com/zh/api)
-- [示例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
+- [示例](https://github.com/bluebill1049/react-hook-form/tree/main/examples)
 - [Demo](https://react-hook-form.com/zh)
 - [Form Builder](https://react-hook-form.com/zh/form-builder)
 - [常见问题](https://react-hook-form.com/zh/faqs)


### PR DESCRIPTION
Hi there,

in line with this PR: https://github.com/react-hook-form/documentation/pull/378, I'm opening this PR as a suggestion, to remove racially-charged and marginalizing terminology; according to the Code Of Conduct:

>In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.

I think it would be great to take a step and take the following two (minor) changes:

1. Replace "master" branch with "main" branch as the default branch. (this PR)
2. Add "other" to gender options (perhaps staying away from gender in the docs is even better) (other PR: https://github.com/react-hook-form/react-hook-form/pull/2269)