### PR TITLE
Fix typings in watch and useWatch to allow string literals

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -309,13 +309,14 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
   ): void;
   unregister(name: FieldName<TFieldValues> | FieldName<TFieldValues>[]): void;
   watch(): UnpackNestedValue<TFieldValues>;
-  watch<
-    TFieldName extends string,
-    TFieldValue extends TFieldValues[TFieldName]
-  >(
+  watch<TFieldName extends string, TFieldValue>(
     name: TFieldName,
-    defaultValue?: UnpackNestedValue<LiteralToPrimitive<TFieldValue>>,
-  ): UnpackNestedValue<LiteralToPrimitive<TFieldValue>>;
+    defaultValue?: TFieldName extends keyof TFieldValues
+      ? UnpackNestedValue<TFieldValues[TFieldName]>
+      : LiteralToPrimitive<TFieldValue>,
+  ): TFieldName extends keyof TFieldValues
+    ? UnpackNestedValue<TFieldValues[TFieldName]>
+    : LiteralToPrimitive<TFieldValue>;
   watch<TFieldName extends keyof TFieldValues>(
     names: TFieldName[],
     defaultValues?: UnpackNestedValue<

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -313,10 +313,10 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
     name: TFieldName,
     defaultValue?: TFieldName extends keyof TFieldValues
       ? UnpackNestedValue<TFieldValues[TFieldName]>
-      : LiteralToPrimitive<TFieldValue>,
+      : UnpackNestedValue<LiteralToPrimitive<TFieldValue>>,
   ): TFieldName extends keyof TFieldValues
     ? UnpackNestedValue<TFieldValues[TFieldName]>
-    : LiteralToPrimitive<TFieldValue>;
+    : UnpackNestedValue<LiteralToPrimitive<TFieldValue>>;
   watch<TFieldName extends keyof TFieldValues>(
     names: TFieldName[],
     defaultValues?: UnpackNestedValue<

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -11,7 +11,7 @@ import {
   UnpackNestedValue,
   Control,
 } from './types/form';
-import { LiteralToPrimitive, DeepPartial } from './types/utils';
+import { DeepPartial } from './types/utils';
 
 export function useWatch<TWatchFieldValues extends FieldValues>(props: {
   defaultValue?: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;
@@ -20,12 +20,12 @@ export function useWatch<TWatchFieldValues extends FieldValues>(props: {
 export function useWatch<TWatchFieldValue extends any>(props: {
   name: string;
   control?: Control;
-}): undefined | UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
+}): undefined | UnpackNestedValue<TWatchFieldValue>;
 export function useWatch<TWatchFieldValue extends any>(props: {
   name: string;
-  defaultValue: UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
+  defaultValue: UnpackNestedValue<TWatchFieldValue>;
   control?: Control;
-}): UnpackNestedValue<LiteralToPrimitive<TWatchFieldValue>>;
+}): UnpackNestedValue<TWatchFieldValue>;
 export function useWatch<TWatchFieldValues extends FieldValues>(props: {
   name: string[];
   defaultValue?: UnpackNestedValue<DeepPartial<TWatchFieldValues>>;


### PR DESCRIPTION
All changes should be backwards compatible with existing typings. 

Doesn't fix the case when you are trying to specify the return type of a nested value manually - it will always be changed to a primitive rather than the literal. I don't think this can be fixed with backwards compatibility.

[TypeScript Playground ](https://www.typescriptlang.org/play?#code/C4TwDgpgBAYg9gJwLYDUCGAbArhAzlAXigG8AoKKAawhAEYAuKXYBASwDsBzAbnKpoBMjdliQAjCAl4VqIAMyMyFGTQZQR4ydOWyhUMXDgYIadtpXzGAcjRWoAHyhWxV7QF9tsgCzXbDpy6eNACsjLT+ArwepKSgkFAAMqzAkpgAKnAACmxIyawAbhAAPGlQEAAeKewAJvimIAB8hFClFVW1TCwcnHwA-J1sXHyMrZUQNfgaEgh96qLTwy1lYxP6hsamswZGJuyLabykFWCIwFBx0AAiEBBgmWgIwKyYJU1ESlAA2gDSUBz8IDgADMWgBdXojH6g5btfAAQQQCDQICKHCBkigAFUGnwKP0EUiUddbvdHs8MEVsTjlFBId9oW1xh0AEomapwdgYEAE5Go9johBY6nKfqstDszncxG84l3B5PF5U3G0lpQmFM-CsgDGiGqRWYg04ABooFh2JR2HAAO7sYV4qCy0kKilpKF2lWu+lRQ7VCBajAPaA69jMKAAEgAcngUtV0NgIIwzawAI44JggcRGQ7HU7ncDQKPMCCxzA4EpxtOM1b1T7QxxwMQAKz9ZyINbrUAbza1wDeJD4n0j0eLFYgoOEEEKUlIbigADIWqPs+UTo88-EIxzMTUIECOMXXs1RrDTTu9+xi1B+hepx7l6uzhcsewwGgtZRCzHR4eiJv2NvfXPA80iaKsOk-EdS2KNEMWxWZMUWP8AN3fc9RA9VVkuNAUn8GBWGMJJmFmNJEK3M9UMPMD8C7FtZmIL5fn+WRgTBRht1fd8IJLeMSjdKA3H2H0-QDBBoCBM0e1YDkoCtbCtQACwACgASjYl83w-YduLLeBkFHXAGl4X1-UDKBxPYSTpNk4AFJKPCIAwaoIzQJBoCogZuhNNJ7Mc0cGkUvh2BchMWh8pzgqNPhALQLAMGAUcIVC1gHPC1yMI6ZiQV01AoNwZV+nYjSuO-bL9M+bzksc5zXNBd1GCSFIkQwDJslYXInkKOzKu0iAGki1SkpS6q3JWDKaBY0rcvg9TOK0krEBy+NcHKsLhtqxYGtSZqshyPJOoqlK-KM4TTPMyz2BkuT5K6obgvS-BMtgBb9P8wLgtwEZVuC2tIooaLYvi3LEsK2aix6oplUdeVySKTJWHfIpJqWryvtchphT60gBpBzSwe-OGEaRnBcBR7rhvR46TNEsyJKeKyroCiggtcj6PK4H6ot3GK4v04GZtxr8oKKKGyReIm8HR-q1I4gXIJ4kXnUR57copmJSGshSVN4AB6bWaYsumLo1pSBvFvLjcUqxZFoKxlNIXX9fOy6bOugAia3Xf8vcUsYd3VFdk1-p5qDEoNbp-DNQDUIGsOhgtq3VCsE0rBSZhbftvWzsN53bL9uhPcU73HN9j3A65gGEsYWPOAj8iL2qGOujjhmE7oJPzgQHA7YdwAZckYJ9JAQRB1Zb2Q5AAOmt9OHazqSjauoozQta1bUL7qq6b40oCDwH40SpfLRtAaD5XkeXctsfJ8Tk1aGUnXM9puec+u2gvfXtmt53yuoHCRxI5Q+uA0piSDPprVuE8p7J1TsAW299HbZ2NkUPOED-YmldtAguRdqglxoCg-OZcgTc13jgUOm9a5R0ARvQ0oClLgKviAAQ7cWBdzgbPemLsijMN6mvH2H8CFEO-lw8hADiwDW2BsPYFtPitxtsnXQVhQTdwfgbJ+iC860Fdv4POAhMHdVZopdRmjHDaNdspH629y7ByWolBWMMCaUCVnpXKaCPZaN0J7Jof866iMYPYxxi1iYuP9m4wQnsaGKWkZApw8jQQmnotbaw0C7BuCUfA1RC9DEhIYbolK+jMnGPcWY2JFjCEVyBowWxLw-FmyCfnLJOj0bCKAg3Xx8MHE1KgPkzp7icRSJke3VujDinxNUIk6M7ddD907tAFJGcoB93XG5REw8+lRLoVPYZAI1BWGrsk1JbD57nywazau5iv7lIdDcOUosKRm08aeChPjLkkmhmLZWS1ekM0idfaJuD6E202dA6wuz+KpIWQPZZMxwmty8AM+SDkMBwFgXM8F+YyiQuhZfNZ8KMCIuRQ7aumK-lRNvnA4BMx45Yp+YQjAuAIB3zmeI3YRKQCwoZQ7V2aAjGdLEK7FlsLk62HZXrTl3LXa8pZcEfFetf5QAEJK9uchhXzP7miwew85kAGUni4qgFqUwlozi4EgFqVgQIQBQCQKYLAmAuQ0P1JvE0ZtvnyAUS6uQCj-LrNwbAqAczq60gCkcFcuYnyYjpQAdSugAeTAIbfA7xOalKsSQxM5pD5mDeq5Uhhp-CnNBNoYMLAjCJXqN6GIOY1xPjCvpZo2pdQOsNCaeohkYjGREmJR+0ksCRoXmkKNLsa25XurAbqL1FJgCHmAVmHxzl72lkVOaQtKkugHQpIdHzW0UCLUPDApb2AgCiNjfmxVl1XKdDDftV0N3E1Vu206XaLo9ogGu66V7B1jqgiOltE6p0zqzSFauhaOTFr3YwMtM5j7eOqP4HGp6eLvvXZ++Mrb73UwOaaXtHDEPyRvSNE8P7J1wGnYoADVDujaDnTgBdoNBYIdfXhrdeqQO7v3YeyDNHZbgxw4xymHa0ndqw7ZHjyHiYjrwwZX9xH-1M2CuR9mBak0CJDpx+DZYV0lAY6JiWTGd0lvAweo9qml3y3Pa81d17tMGVQyddDj7MMvr7Vpw6KtFIfD0xgX66gIpKbKfGSKbg2JCfkrG+NA0RMuaWjEZ9r63PedcsCuArlgDyW6Hs7gfqHYnxtKQGLC8bB2EcM4Kw-l6LMxCjspLEAUtpdBRluZoqtESryxw6upX4sVaSXVzLetCUtc1mVuTThcBVZq1wduVGKt+BSfVglm9cvBaKAV-wxX2vlcS8l1L43+F+eo04abd8eudK5U1vl-XrrLaKy4NbQ3KubbSztlNFWcV4u6yi1V8R1UzHO0UWVAgbsJeG6NrbnAJuWOISFLwb3e4faWUPb7i2-sA4qyN+722SnKfjGEOrcy-sLcc+fQbgO7vVZB2D5NEPsczbmeS0gQA) 

```ts
type FormValues = {
  key1: string;
  key2: number;
  key3: {
    key1: number;
    key2: boolean;
    key3: 'a' | 'b';
  };
  key4: 'a' | 'b';
  key5: 1 | 2;
};
```

```ts
watch();
// function watch(): FormValues
watch('key1')
// function watch<"key1">(field: "key1", defaultValue?: string | undefined): string
watch('key1', 'test')
// function watch<"key1">(field: "key1", defaultValue?: string | undefined): string
watch('key1', true)
// ❌: type error
watch('key3.key1')
// function watch<unknown>(field: string, defaultValue?: unknown): unknown
watch('key3.key1', 1);
// function watch<1>(field: string, defaultValue?: 1 | undefined): number
watch('key3.key1', 'test');
// function watch<"key3.key1", "test">(field: "key3.key1", defaultValue?: string | undefined): string
watch('key3.key2', true);
// function watch<true>(field: string, defaultValue?: true | undefined): boolean
watch(['key1', 'key2'])
// function watch<"key1" | "key2">(fields: ("key1" | "key2")[], defaultValues?: DeepPartial<Pick<FormValues, "key1" | "key2">> | undefined): Pick<FormValues, "key1" | "key2">
watch(['key1', 'key2'], { key1: 'test' })
// function watch<"key1" | "key2">(fields: ("key1" | "key2")[], defaultValues?: DeepPartial<Pick<FormValues, "key1" | "key2">> | undefined): Pick<FormValues, "key1" | "key2">
watch(['key1', 'key2'], { key1: 'test', key2: true })
// ❌: type error
watch(['key1', 'key3.key1'], { key1: 'string' })
// function watch(fields: string[], defaultValues?: DeepPartial<FormValues> | undefined): DeepPartial<FormValues>
watch(['key1', 'key3.key1'], { test: 'string' })
// ❌: type error

watch('key4', 'hello');
// ❌: type error
watch('key3.key1', 'hello');
// string
watch('key3.key1', 1);
// number
watch('key3.key1', false);
// boolean
watch('key4');
// "a" | "b"
watch('key4', 'a');
// "a" | "b"
watch('key5');
// 1 | 2
watch('key5', 3);
// ❌: type error

// Still cannot specify manually
watch<string, FormValues['key3']['key3']>('key3.key3'); 
// string :(
```

```ts
useWatch({ name: 'something' }); 
// unknown
useWatch<'a' | 'b'>({ name: 'something' }); 
// "a" | "b"
useWatch<string>({ name: 'test' }); 
// string
useWatch({ name: 'something', defaultValue: 'a' }); 
// string
useWatch<'a' | 'b'>({ name: 'something', defaultValue: 'a' }); 
// "a" | "b"
useWatch<'a' | 'b'>({ name: 'something', defaultValue: 'hello' }); 
// ❌: type error
useWatch<1 | 2>({ name: 'something', defaultValue: 4 }); 
// ❌: type error
useWatch<1 | 2>({ name: 'something', defaultValue: 1 });
// 1 | 2
useWatch({ name: 'something', defaultValue: 1 });
// number
```

close #2126