### PR TITLE
Allow resolver to be sync or async

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -85,7 +85,7 @@ export type Resolver<
   values: TFieldValues,
   context?: TContext,
   validateAllFieldCriteria?: boolean,
-) => Promise<ResolverResult<TFieldValues>>;
+) => Promise<ResolverResult<TFieldValues>> | ResolverResult<TFieldValues>;
 
 export type UseFormOptions<
   TFieldValues extends FieldValues = FieldValues,

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -2427,6 +2427,46 @@ describe('useForm', () => {
         expect(renderCount).toBe(2);
       });
 
+      it('with sync resolver it should contain error if value is invalid with resolver', async () => {
+        const mockResolver = jest.fn();
+        const resolver = (data: any) => {
+          if (data.test) {
+            return { values: data, errors: {} };
+          }
+          mockResolver();
+          return {
+            values: data,
+            errors: {
+              test: {
+                message: 'resolver error',
+              },
+            },
+          };
+        };
+
+        render(<Component resolver={resolver} mode="onChange" />);
+
+        methods.formState.isValid;
+
+        await actComponent(async () => {
+          await fireEvent.input(screen.getByRole('textbox'), {
+            target: { name: 'test', value: 'test' },
+          });
+        });
+
+        expect(screen.getByRole('alert').textContent).toBe('');
+        expect(methods.formState.isValid).toBeTruthy();
+
+        fireEvent.input(screen.getByRole('textbox'), {
+          target: { name: 'test', value: '' },
+        });
+
+        await waitFor(() => expect(mockResolver).toHaveBeenCalled());
+        expect(screen.getByRole('alert').textContent).toBe('resolver error');
+        expect(methods.formState.isValid).toBeFalsy();
+        expect(renderCount).toBe(2);
+      });
+
       it('should make isValid change to false if it contain error that is not related name with onChange mode', async () => {
         const mockResolver = jest.fn();
         const resolver = async (data: any) => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -557,8 +557,8 @@ export function useForm<
   }
 
   const validateResolver = React.useCallback(
-    (values = {}) => {
-      resolverRef.current!(
+    async (values = {}) => {
+      const { errors } = await resolverRef.current!(
         {
           ...defaultValuesRef.current,
           ...getValues(),
@@ -566,14 +566,13 @@ export function useForm<
         },
         contextRef.current,
         isValidateAllFieldCriteria,
-      ).then(({ errors }) => {
-        const previousFormIsValid = isValidRef.current;
-        isValidRef.current = isEmptyObject(errors);
+      );
+      const previousFormIsValid = isValidRef.current;
+      isValidRef.current = isEmptyObject(errors);
 
-        if (previousFormIsValid !== isValidRef.current) {
-          reRender();
-        }
-      });
+      if (previousFormIsValid !== isValidRef.current) {
+        reRender();
+      }
     },
     [isValidateAllFieldCriteria],
   );


### PR DESCRIPTION
Resolver may now return an object with `values` and `errors` objects
or a Promise returning the same object.

Commit contains a copy of an existing resolver test with the resolver function changed to synchronous. It fails with v6.0.8 but now passes.  
I also changed the type definition for `Resolver` so that it now returns a `ResolverResult` besides a `Promise<ResolverResult>`