### PR TITLE
Fixed dirty bugs with useFieldArray

### DIFF
--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -354,16 +354,14 @@ describe('useFieldArray', () => {
   describe('append', () => {
     it('should append data into the fields', () => {
       const { result } = renderHook(() => {
-        const { register, formState, control } = useForm();
+        const { register, control } = useForm();
         const { fields, append } = useFieldArray({
           control,
           name: 'test',
         });
 
-        return { register, formState, fields, append };
+        return { register, fields, append };
       });
-
-      result.current.formState.dirtyFields;
 
       act(() => {
         result.current.append({ test: 'test' });
@@ -401,26 +399,41 @@ describe('useFieldArray', () => {
         { id: '3', test: 'test2' },
         { id: '4', test: 'test3' },
       ]);
-
-      expect(result.current.formState.isDirty).toBeTruthy();
-      expect(result.current.formState.dirtyFields).toEqual({
-        test: [
-          {
-            test: true,
-          },
-          {
-            test: true,
-          },
-          {},
-          {
-            test: true,
-          },
-          {
-            test: true,
-          },
-        ],
-      });
     });
+
+    it.each(['isDirty', 'dirtyFields'])(
+      'should be dirty when value is appended with %s',
+      (property) => {
+        const { result } = renderHook(() => {
+          const { register, formState, control } = useForm();
+          const { fields, append } = useFieldArray({
+            control,
+            name: 'test',
+          });
+
+          return { register, formState, fields, append };
+        });
+
+        (result.current.formState as Record<string, any>)[property];
+
+        act(() => {
+          result.current.append({ value: 'test' });
+        });
+
+        act(() => {
+          result.current.append({ value: 'test1' });
+        });
+
+        act(() => {
+          result.current.append({ value: 'test2' });
+        });
+
+        expect(result.current.formState.isDirty).toBeTruthy();
+        expect(result.current.formState.dirtyFields).toEqual({
+          test: [{ value: true }, { value: true }, { value: true }],
+        });
+      },
+    );
 
     it('should trigger reRender when user is watching the all field array', () => {
       let watched: any;

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -140,7 +140,10 @@ export const useFieldArray = <
   const resetFields = (
     flagOrFields?: (Partial<TFieldArrayValues> | undefined)[],
   ) => {
-    if (readFormStateRef.current.isDirty) {
+    if (
+      readFormStateRef.current.isDirty ||
+      readFormStateRef.current.dirtyFields
+    ) {
       isDirtyRef.current =
         isUndefined(flagOrFields) ||
         getIsFieldsDifferent(
@@ -216,12 +219,11 @@ export const useFieldArray = <
     }
 
     if (
-      (readFormStateRef.current.dirtyFields ||
-        readFormStateRef.current.isDirty) &&
-      dirtyFieldsRef.current[name]
+      readFormStateRef.current.dirtyFields ||
+      readFormStateRef.current.isDirty
     ) {
       dirtyFieldsRef.current[name] = prependAt(
-        dirtyFieldsRef.current[name],
+        dirtyFieldsRef.current[name] || [],
         filterBooleanArray(value),
       );
       shouldRender = true;

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -168,7 +168,10 @@ export const useFieldArray = <
         : [appendId(value, keyName)]),
     ]);
 
-    if (readFormStateRef.current.dirtyFields) {
+    if (
+      readFormStateRef.current.dirtyFields ||
+      readFormStateRef.current.isDirty
+    ) {
       dirtyFieldsRef.current[name] = [
         ...(dirtyFieldsRef.current[name] || fillEmptyArray(fields.slice(0, 1))),
         ...filterBooleanArray(value),


### PR DESCRIPTION
I found features that have no consistence. 

- `append` should change `isDirty` and `dirtyFields` when `formState.isDirty` or `formState.dirtyFields` is defined
- `prepend` should change `isDirty` and `dirtyFields` at first `prepend` when `formState.isDirty` or `formState.dirtyFields` is defined
- All `useFieldArray`'s methods should change `isDirty` when `formState.isDirty` or `formState.dirtyFields` is defined