### PR TITLE
improve CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `resolver` supports both async and sync
 - `getValues` will return default values before inputs registration
+  - By this change, handleSubmit has been to pass defaultValues even if the field is not registered
 
 ## [6.0.7] - 2020-07-17
 


### PR DESCRIPTION
Stated that the behavior of `handleSubmit` has changed.

## Example

[CodeSandbox](https://codesandbox.io/s/react-hook-form-useform-template-627yn?file=/src/index.js)

- In version 6.1.0, clicking on the "Submit" button outputs `Object {FirstName: "FirstName", LastName: "LastName", AdditionalInfo: "Additional Info"}` to the console.
- In version 6.0.8, clicking on the "Submit" button outputs `Object {FirstName: "FirstName", LastName: "LastName"}` to the console.