### PR TITLE
Update triggerFieldValidation.tsx example to get rid of `triggerValidation`

### DIFF
--- a/examples/triggerFieldValidation.tsx
+++ b/examples/triggerFieldValidation.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { useForm } from 'react-hook-form';
 
 export default function App() {
-  const { register, errors, triggerValidation } = useForm();
+  const { register, errors, trigger } = useForm();
 
   console.log('errors', errors);
 
@@ -19,14 +18,10 @@ export default function App() {
       <button
         type="button"
         onClick={async () => {
-          console.log(
-            'firstName',
-            await triggerValidation({ name: 'firstName' }),
-          );
-          console.log(
-            'lastName',
-            await triggerValidation({ name: 'lastName', value: 'test' }),
-          );
+          const result = await trigger(['firstName', 'lastName']);
+          if (result) {
+            console.log('Valid input');
+          }
         }}
       >
         Trigger


### PR DESCRIPTION
Trigger validation is not a "thing" anymore. It disappeared from the API and all this example is currently doing is confusing :confused: the daylights out of people.