### PR TITLE
Handle errors when handleSubmit callback return errors

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -59,10 +59,20 @@ export type ValidationMode = {
 
 export type Mode = keyof ValidationMode;
 
-export type SubmitHandler<TFieldValues extends FieldValues> = (
-  data: UnpackNestedValue<TFieldValues>,
+export type SubmitHandler<
+  TSubmitFieldValues extends FieldValues,
+  TFieldValues extends FieldValues
+> = (
+  data: UnpackNestedValue<TSubmitFieldValues>,
   event?: React.BaseSyntheticEvent,
-) => void | Promise<void>;
+) =>
+  | void
+  | SubmitError<TFieldValues>
+  | Promise<void | SubmitError<TFieldValues>>;
+
+export type SubmitError<TFieldValues extends FieldValues = FieldValues> = {
+  errors: FieldErrors<TFieldValues>;
+};
 
 export type ResolverSuccess<TFieldValues extends FieldValues = FieldValues> = {
   values: UnpackNestedValue<TFieldValues>;
@@ -365,7 +375,7 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
     names: TFieldName[],
   ): UnpackNestedValue<Pick<TFieldValues, TFieldName>>;
   handleSubmit: <TSubmitFieldValues extends FieldValues = TFieldValues>(
-    callback: SubmitHandler<TSubmitFieldValues>,
+    callback: SubmitHandler<TSubmitFieldValues, TFieldValues>,
   ) => (e?: React.BaseSyntheticEvent) => Promise<void>;
   control: Control<TFieldValues>;
 };

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1461,6 +1461,26 @@ describe('useForm', () => {
       expect(callback).toBeCalled();
     });
 
+    it('should set errors when callback return errors', async () => {
+      const { result } = renderHook(() => useForm<{ test: string }>());
+      const callback = jest.fn().mockReturnValue({
+        errors: {
+          test: 'invalid',
+        },
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit(callback)({
+          preventDefault: () => {},
+          persist: () => {},
+        } as React.SyntheticEvent);
+      });
+      expect(result.current.errors).toEqual({
+        test: 'invalid',
+      });
+      expect(result.current.formState.isValid).toBeFalsy();
+    });
+
     it('should pass default value', async () => {
       const { result } = renderHook(() =>
         useForm<{ test: string; deep: { nested: string; values: string } }>({


### PR DESCRIPTION
According to the [handleSubmit documentation](https://react-hook-form.com/api#handleSubmit)

```
Note: You can pass an async function for asynchronous validation. eg:
handleSubmit(async (data) => await fetchAPI(data))
```

But the errors returned from fetchAPI are not being handled yet. 
This merge request will make it work.