### PR TITLE
Cast checkbox value to string explicitly

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -227,7 +227,7 @@ export function useForm<
               ({ ref: checkboxRef }) =>
                 (checkboxRef.checked = (value as string | boolean)
                   .toString()
-                  .includes(checkboxRef.value))
+                  .includes(checkboxRef.value)),
             )
           : (options[0].ref.checked = !!value);
       } else {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -225,8 +225,9 @@ export function useForm<
         options.length > 1
           ? options.forEach(
               ({ ref: checkboxRef }) =>
-                (checkboxRef.checked = String(value as string | boolean)
-                  .includes(checkboxRef.value)),
+                (checkboxRef.checked = String(
+                  value as string | boolean,
+                ).includes(checkboxRef.value)),
             )
           : (options[0].ref.checked = !!value);
       } else {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -225,7 +225,7 @@ export function useForm<
         options.length > 1
           ? options.forEach(
               ({ ref: checkboxRef }) =>
-                (checkboxRef.checked = value.toString().includes(
+                (checkboxRef.checked = (value as boolean | string).toString().includes(
                   checkboxRef.value,
                 )),
             )

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -223,11 +223,11 @@ export function useForm<
         );
       } else if (isCheckBoxInput(ref) && options) {
         options.length > 1
-          ? options.forEach(
+          ? options.forEachoptions.forEach(
               ({ ref: checkboxRef }) =>
-                (checkboxRef.checked = (value as boolean | string).toString().includes(
-                  checkboxRef.value,
-                )),
+                (checkboxRef.checked = (value as string | boolean)
+                  .toString()
+                  .includes(checkboxRef.value))
             )
           : (options[0].ref.checked = !!value);
       } else {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -223,7 +223,7 @@ export function useForm<
         );
       } else if (isCheckBoxInput(ref) && options) {
         options.length > 1
-          ? options.forEachoptions.forEach(
+          ? options.forEach(
               ({ ref: checkboxRef }) =>
                 (checkboxRef.checked = (value as string | boolean)
                   .toString()

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -225,8 +225,7 @@ export function useForm<
         options.length > 1
           ? options.forEach(
               ({ ref: checkboxRef }) =>
-                (checkboxRef.checked = (value as string | boolean)
-                  .toString()
+                (checkboxRef.checked = String(value as string | boolean)
                   .includes(checkboxRef.value)),
             )
           : (options[0].ref.checked = !!value);

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -225,7 +225,7 @@ export function useForm<
         options.length > 1
           ? options.forEach(
               ({ ref: checkboxRef }) =>
-                (checkboxRef.checked = (value as string).includes(
+                (checkboxRef.checked = value.toString().includes(
                   checkboxRef.value,
                 )),
             )


### PR DESCRIPTION
Fix rare error 'value.includes is not a function', that appears on controlled form with checkboxes array resetting, if fields order was changed.

**Steps to reproduce the behavior:**
1. Go to https://codesandbox.io/s/clever-pond-zjequ
2. Add few fields
3. Click on any checkbox but last

**Expected behavior**
Value of checkbox should change after click

![image](https://user-images.githubusercontent.com/31159587/89718605-87028f80-d9c8-11ea-8ff4-69a993559716.png)
