### PR TITLE
improve errors types to enable auto-complete

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -6,6 +6,7 @@ import {
   DeepPartial,
   DeepMap,
   IsFlatObject,
+  LiteralUnion,
 } from './utils';
 
 declare const $NestedValue: unique symbol;
@@ -136,10 +137,14 @@ export type ValidationRules = Partial<{
   validate: Validate | Record<string, Validate>;
 }>;
 
-export type MultipleFieldErrors = Record<string, ValidateResult>;
+export type MultipleFieldErrors = {
+  [K in keyof ValidationRules]?: ValidateResult;
+} & {
+  [key: string]: ValidateResult;
+};
 
 export type FieldError = {
-  type: keyof ValidationRules | string;
+  type: LiteralUnion<keyof ValidationRules, string>;
   ref?: Ref;
   types?: MultipleFieldErrors;
   message?: Message;
@@ -151,7 +156,7 @@ export type ErrorOption =
     }
   | {
       message?: Message;
-      type: string;
+      type: LiteralUnion<keyof ValidationRules, string>;
     };
 
 export type Field = {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -14,6 +14,10 @@ export type LiteralToPrimitive<T extends any> = T extends string
   ? boolean
   : T;
 
+export type LiteralUnion<T extends U, U extends Primitive> =
+  | T
+  | (U & { _?: never });
+
 export type Assign<T extends object, U extends object> = T & Omit<U, keyof T>;
 
 export type DeepPartial<T> = {


### PR DESCRIPTION
Improved `type` and `types` field in errors type.
As shown below, auto-complete is enabled and DX is improved!!

<img width="500" alt="スクリーンショット 2020-08-18 12 22 28" src="https://user-images.githubusercontent.com/12913947/90467082-3f110480-e14e-11ea-9c5a-a32e785f3148.png">
<img width="500" alt="スクリーンショット 2020-08-18 12 20 14" src="https://user-images.githubusercontent.com/12913947/90467086-40dac800-e14e-11ea-97dc-6dcfc5b2bc1b.png">
<img width="250" alt="スクリーンショット 2020-08-18 12 40 54" src="https://user-images.githubusercontent.com/12913947/90467839-23a6f900-e150-11ea-9995-1fcd23c244ba.png">

Of course, as before, we can use keys other than completion suggestions.

<img width="250" alt="スクリーンショット 2020-08-18 12 24 47" src="https://user-images.githubusercontent.com/12913947/90467079-3d474100-e14e-11ea-9fb9-557c663a37e7.png">
<img width="250" alt="スクリーンショット 2020-08-18 12 41 08" src="https://user-images.githubusercontent.com/12913947/90467856-299cda00-e150-11ea-9f0c-0e1824130ce9.png">
