### PR TITLE
Fix input defaultValues value type = 'number' causes touched input to show dirty

### DIFF
--- a/app/src/formState.tsx
+++ b/app/src/formState.tsx
@@ -5,14 +5,18 @@ import { withRouter } from 'react-router';
 let renderCounter = 0;
 
 const FormState: React.FC = (props: any) => {
+  const defaultValues = {useFormDefaultValue: 42};
   const { register, handleSubmit, formState, reset } = useForm<{
     firstName: string;
     lastName: string;
     select: string;
     radio: string;
     checkbox: string;
+    useFormDefaultValue: number;
+    inputDefaultValue: number;
   }>({
     mode: props.match.params.mode,
+    defaultValues,
   });
 
   renderCounter++;
@@ -28,6 +32,17 @@ const FormState: React.FC = (props: any) => {
         name="lastName"
         ref={register({ required: true })}
         placeholder="lastName"
+      />
+      <input
+          name="useFormDefaultValue"
+          ref={register}
+          type="number"
+      />
+      <input
+          name="inputDefaultValue"
+          defaultValue={73}
+          ref={register}
+          type="number"
       />
       <div id="state">
         {JSON.stringify({
@@ -52,7 +67,7 @@ const FormState: React.FC = (props: any) => {
         ref={register}
       />
       <button id="submit">Submit</button>
-      <button type="button" onClick={() => reset()} id="resetForm">
+      <button type="button" onClick={() => reset({...defaultValues})} id="resetForm">
         Reset
       </button>
       <div id="renderCount">{renderCounter}</div>

--- a/cypress/integration/formState.ts
+++ b/cypress/integration/formState.ts
@@ -36,7 +36,20 @@ describe('form state', () => {
     cy.get('#state').contains(
       '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName"],"isDirty":true,"isSubmitting":false,"isValid":true}',
     );
-    cy.get('#renderCount').contains('14');
+
+    cy.get('input[name="inputDefaultValue"]').focus();
+    cy.get('input[name="inputDefaultValue"]').blur();
+    cy.get('#state').contains(
+      '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName","inputDefaultValue"],"isDirty":true,"isSubmitting":false,"isValid":true}',
+    );
+
+    cy.get('input[name="useFormDefaultValue"]').focus();
+    cy.get('input[name="useFormDefaultValue"]').blur();
+    cy.get('#state').contains(
+      '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName","inputDefaultValue","useFormDefaultValue"],"isDirty":true,"isSubmitting":false,"isValid":true}',
+    );
+
+    cy.get('#renderCount').contains('16');
   });
 
   it('should return correct form state with onChange mode', () => {
@@ -76,7 +89,20 @@ describe('form state', () => {
     cy.get('#state').contains(
       '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName"],"isDirty":true,"isSubmitting":false,"isValid":true}',
     );
-    cy.get('#renderCount').contains('15');
+
+    cy.get('input[name="inputDefaultValue"]').focus();
+    cy.get('input[name="inputDefaultValue"]').blur();
+    cy.get('#state').contains(
+      '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName","inputDefaultValue"],"isDirty":true,"isSubmitting":false,"isValid":true}',
+    );
+
+    cy.get('input[name="useFormDefaultValue"]').focus();
+    cy.get('input[name="useFormDefaultValue"]').blur();
+    cy.get('#state').contains(
+      '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName","inputDefaultValue","useFormDefaultValue"],"isDirty":true,"isSubmitting":false,"isValid":true}',
+    );
+
+    cy.get('#renderCount').contains('17');
   });
 
   it('should return correct form state with onBlur mode', () => {
@@ -116,7 +142,20 @@ describe('form state', () => {
     cy.get('#state').contains(
       '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName"],"isDirty":true,"isSubmitting":false,"isValid":true}',
     );
-    cy.get('#renderCount').contains('16');
+
+    cy.get('input[name="inputDefaultValue"]').focus();
+    cy.get('input[name="inputDefaultValue"]').blur();
+    cy.get('#state').contains(
+      '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName","inputDefaultValue"],"isDirty":true,"isSubmitting":false,"isValid":true}',
+    );
+
+    cy.get('input[name="useFormDefaultValue"]').focus();
+    cy.get('input[name="useFormDefaultValue"]').blur();
+    cy.get('#state').contains(
+      '{"dirtyFields":["firstName","lastName"],"isSubmitted":true,"submitCount":2,"touched":["firstName","lastName","inputDefaultValue","useFormDefaultValue"],"isDirty":true,"isSubmitting":false,"isValid":true}',
+    );
+
+    cy.get('#renderCount').contains('18');
   });
 
   it('should reset dirty value when inputs reset back to default with onSubmit mode', () => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -247,7 +247,7 @@ export function useForm<
       }
 
       const isFieldDirty =
-        defaultValuesAtRenderRef.current[name] !==
+        defaultValuesAtRenderRef.current[name] !=
         getFieldValue(fieldsRef, name, unmountFieldsStateRef);
       const isDirtyFieldExist = get(dirtyFieldsRef.current, name);
       const isFieldArray = isNameInFieldArray(fieldArrayNamesRef.current, name);


### PR DESCRIPTION
dirtyFields object is populated by a ~number~ input name when nothing changed.

Issue is triggered when an ~number~ input is blurred. This only occurs when the ~number~ input has its default value set via the `useForm` `defaultValues` parameter with type 'number'. 

inputs without defaults and defaults set by the `input` `defaultValue` prop ~, and text inputs~ behave as expected in regards to `dirtyFields`.

#2644