### PR TITLE
Fix input control checkbox

### DIFF
--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -140,6 +140,37 @@ describe('Controller', () => {
     expect(screen.getByRole('textbox')).toHaveValue('test');
   });
 
+  it('should update checkbox input correctly', () => {
+    let fieldValues: any;
+    const Component = () => {
+      const { control, getValues } = useForm();
+      return (
+        <>
+          <Controller
+            defaultValue={false}
+            name="test"
+            type="checkbox"
+            as={<input type="checkbox" />}
+            control={control}
+          />
+          {/**
+           * We are checking if setValue method is invoked
+           */}
+          <button onClick={() => (fieldValues = getValues())}>getValues</button>
+        </>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    fireEvent.click(screen.getByRole('button', { name: /getValues/ }));
+
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(fieldValues).toEqual({ test: true });
+  });
+
   it("should trigger component's onChange method and invoke setValue method", () => {
     let fieldValues: any;
     const Component = () => {

--- a/src/logic/getInputValue.ts
+++ b/src/logic/getInputValue.ts
@@ -7,6 +7,6 @@ export default (event: any) =>
   !isObject(event.target) ||
   (isObject(event.target) && !event.type)
     ? event
-    : isUndefined(event.target.value)
+    : event.target.type === 'checkbox' || isUndefined(event.target.value)
     ? event.target.checked
     : event.target.value;


### PR DESCRIPTION
I got an issue with checkbox controller:
```js
import React from "react";
import { useForm, Controller } from "react-hook-form";

export default function App() {
  const { handleSubmit, control } = useForm({
    reValidateMode: "onSubmit"
  });

  return (
    <div className="App">
        <div>
          <Controller
            as={<input type="checkbox" />}
            defaultValue={true}
            name="test"
            control={control}
          />
        </div>
    </div>
  );
}
```

It was just OK in previous release.  It seems that https://github.com/react-hook-form/react-hook-form/pull/2140 broke it.

I just made some changes to make it work.

After changing checkbox - I expect that the **test** is **true** but it is **'false'**

I just made small [representation](https://codesandbox.io/s/react-hook-form-issue-bhqor)

Also I expect that the input should be **checked**, if **defaultValue** is **true**