### PR TITLE
Add stale.yml for stale github actions by probot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,65 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 10
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - waiting-up-vote
+  - question
+  - pinned
+  - security
+  - 'Status: under investigation'
+  - 'status: working in progress'
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  Thank you for your contributions! This Pull Request has been automatically marked as stale 
+  because it has not had any recent activity. It will be closed if no further activity occurs.  
+  Best, RHF Team ❤️
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  Thank you for your contributions! This Pull Request is being closed because it has
+  not had any recent activity. Feel free to re-open the issue and begin work again! 
+  Best, RHF Team ❤️
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 10
+
+# Limit to only `issues` or `pulls`
+only: pulls
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
This PR adds some defaults for this github actions: [Stale probot](https://github.com/probot/stale). 

Summary: It will mark a PR as stale if 30 days of inactivity have gone by. 10 days after that it will close the PR. 

Take a look at the defaults (amount of days to stale, days from stale -> close, stale and close messages etc.) and tell me if they look good!

