### PR TITLE
improve rollup config to support IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@babel/plugin-transform-runtime": "^7.10.4",
     "@changesets/changelog-github": "^0.2.6",
     "@changesets/cli": "^2.9.2",
-    "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-replace": "^2.3.3",

--- a/rollup/rollup.ie11.config.js
+++ b/rollup/rollup.ie11.config.js
@@ -1,5 +1,4 @@
 import { createRollupConfig } from './createRollupConfig';
-import { getBabelOutputPlugin } from '@rollup/plugin-babel';
 import pkg from '../package.json';
 
 const name = 'index';
@@ -23,28 +22,4 @@ const options = [
   },
 ];
 
-export default options.map((option) =>
-  createRollupConfig(option, (config) => ({
-    ...config,
-    plugins: config.plugins
-      .reduce(
-        (previous, current) => [
-          ...previous,
-          current,
-          current.name === 'rpt2' &&
-            getBabelOutputPlugin({
-              plugins: [
-                [
-                  '@babel/plugin-transform-runtime',
-                  {
-                    corejs: 3,
-                  },
-                ],
-              ],
-            }),
-        ],
-        [],
-      )
-      .filter(Boolean),
-  })),
-);
+export default options.map((option) => createRollupConfig(option));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,14 +1622,6 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@rollup/plugin-babel@^5.1.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.2.0.tgz#b87556d61ed108b4eaf9d18b5323965adf8d9bee"
-  integrity sha512-CPABsajaKjINgBQ3it+yMnfVO3ibsrMBxRzbUOUw2cL1hsZJ7aogU8mgglQm3S2hHJgjnAmxPz0Rq7DVdmHsTw==
-  dependencies:
-    "@babel/helper-module-imports" "^7.10.4"
-    "@rollup/pluginutils" "^3.1.0"
-
 "@rollup/plugin-commonjs@^13.0.0":
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-13.0.2.tgz#b7783f0db049450c72d60bc06cf48d4951515e58"


### PR DESCRIPTION
The problem seems to have caused after transpiling with Babel.
Probably I think it's enough to transpile with es5 to support IE11.

close #2583 