### PR TITLE
Removes redundant dependencies in append and remove of useFieldArray

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -247,7 +247,7 @@ export const useFieldArray = <
         ...get(
           dirtyFields,
           name,
-          fillEmptyArray(new Array(allFields.current.length)),
+          fillEmptyArray(allFields.current),
         ),
         ...filterBooleanArray(value),
       ]);

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -244,11 +244,7 @@ export const useFieldArray = <
       readFormStateRef.current.isDirty
     ) {
       set(dirtyFields, name, [
-        ...get(
-          dirtyFields,
-          name,
-          fillEmptyArray(allFields.current),
-        ),
+        ...get(dirtyFields, name, fillEmptyArray(allFields.current)),
         ...filterBooleanArray(value),
       ]);
       updateFormState({

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -244,7 +244,11 @@ export const useFieldArray = <
       readFormStateRef.current.isDirty
     ) {
       set(dirtyFields, name, [
-        ...get(dirtyFields, name, fillEmptyArray(fields)),
+        ...get(
+          dirtyFields,
+          name,
+          fillEmptyArray(new Array(allFields.current.length)),
+        ),
         ...filterBooleanArray(value),
       ]);
       updateFormState({
@@ -426,8 +430,8 @@ export const useFieldArray = <
     swap: React.useCallback(swap, [name, errors]),
     move: React.useCallback(move, [name, errors]),
     prepend: React.useCallback(prepend, [name, errors]),
-    append: React.useCallback(append, [name, errors, fields]),
-    remove: React.useCallback(remove, [name, errors, fields]),
+    append: React.useCallback(append, [name, errors]),
+    remove: React.useCallback(remove, [name, errors]),
     insert: React.useCallback(insert, [name, errors]),
     fields,
   };


### PR DESCRIPTION
Fixes #2773

In `append` method `fillEmptyArray` cares just about the length of the array, so the `fields` dep was not needed there at all.

In `remove` dependency `fields` was not used.

All tests are still green. Probably we should add some test cases, so these dependencies are not re-added to the methods in `useFieldArray`.