### PR TITLE
add MutationObserver to interface stubs for React Native

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -9,3 +9,4 @@ If you want type definitions for various properties, you need to add `--lib DOM`
 
 interface HTMLOptionsCollection {}
 interface FileList {}
+interface MutationObserver {}


### PR DESCRIPTION
Resolve Typescript build error in React Native projects by adding stub for MutationObserver interface.

https://github.com/react-hook-form/react-hook-form/discussions/2805