### PR TITLE
fix reset updateFormState replacing isSubmitting

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1101,7 +1101,7 @@ export function useForm<
     updateFormState({
       isDirty: isDirty ? formStateRef.current.isDirty : false,
       isSubmitted: isSubmitted ? formStateRef.current.isSubmitted : false,
-      isSubmitting: formState.isSubmitting,
+      isSubmitting: false,
       submitCount: submitCount ? formStateRef.current.submitCount : 0,
       isValid: isValid ? formStateRef.current.isValid : true,
       dirtyFields: dirtyFields ? formStateRef.current.dirtyFields : {},

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1101,6 +1101,7 @@ export function useForm<
     updateFormState({
       isDirty: isDirty ? formStateRef.current.isDirty : false,
       isSubmitted: isSubmitted ? formStateRef.current.isSubmitted : false,
+      isSubmitting: formState.isSubmitting,
       submitCount: submitCount ? formStateRef.current.submitCount : 0,
       isValid: isValid ? formStateRef.current.isValid : true,
       dirtyFields: dirtyFields ? formStateRef.current.dirtyFields : {},


### PR DESCRIPTION
Fixes a variant of #2812 when reset gets called before onSubmit finishes.

In this case the proposed solution is for reset to not replace the isSubmitting property, so only handleSubmit controller is the one that manipulates isSubmitting.