### PR TITLE
parseFormatInputValues example fixes

### DIFF
--- a/examples/parseFormatInputValues.tsx
+++ b/examples/parseFormatInputValues.tsx
@@ -7,7 +7,7 @@ const ParseFormatTextarea = ({ value = [], onChange }) => {
   const handleChange = (e) => {
     const value = e.target.value.split('\n');
 
-    setText(value);
+    setText(e.target.value);
     onChange(value);
   };
 
@@ -22,13 +22,24 @@ export default function App() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Controller name="emails" as={ParseFormatTextarea} control={control} />
+      <Controller
+        name="emails"
+        as={ParseFormatTextarea}
+        control={control}
+        defaultValue={[]}
+      />
 
       <Controller
         name="number"
-        as={<input type="number" />}
-        onChange={([e]) => parseInt(e.target.value, 10)}
+        render={({ value, onChange }) => (
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => onChange(parseInt(e.target.value, 10))}
+          />
+        )}
         control={control}
+        defaultValue={0}
       />
 
       <button type="submit">Submit</button>


### PR DESCRIPTION
fixes errors:
- handling new lines on text area - before it added semicolon after convert and didn't work
- number formatting - in the v6 the onChange event was moved to the render method and it didn't work anymore

fixes warnings on the example:
- emails is missing in the 'defaultValue' prop of either its Controller
- number is missing in the 'defaultValue' prop of either its Controller