### PR TITLE
throw warning when watched input is not found

### DIFF
--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -2653,7 +2653,6 @@ describe('useForm', () => {
       it('should not output error message when formState.isValid is called', () => {
         jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-        const env = process.env.NODE_ENV;
         process.env.NODE_ENV = 'development';
 
         const { result } = renderHook(() =>

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -2583,7 +2583,6 @@ describe('useForm', () => {
       it('should output error message when formState.isValid is called in development environment', () => {
         jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-        const env = process.env.NODE_ENV;
         process.env.NODE_ENV = 'development';
 
         const { result } = renderHook(() => useForm());
@@ -2592,8 +2591,6 @@ describe('useForm', () => {
 
         expect(console.warn).toBeCalledTimes(1);
 
-        process.env.NODE_ENV = env;
-
         // @ts-ignore
         console.warn.mockRestore();
       });
@@ -2601,7 +2598,6 @@ describe('useForm', () => {
       it('should not output error message when formState.isValid is called in production environment', () => {
         jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-        const env = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';
 
         const { result } = renderHook(() => useForm());
@@ -2609,8 +2605,6 @@ describe('useForm', () => {
         result.current.formState.isValid;
 
         expect(console.warn).not.toBeCalled();
-
-        process.env.NODE_ENV = env;
 
         // @ts-ignore
         console.warn.mockRestore();
@@ -2670,8 +2664,6 @@ describe('useForm', () => {
 
         expect(console.warn).not.toBeCalled();
 
-        process.env.NODE_ENV = env;
-
         // @ts-ignore
         console.warn.mockRestore();
       });
@@ -2719,7 +2711,6 @@ describe('useForm', () => {
       it('should not output error message when formState.isValid is called', () => {
         jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-        const env = process.env.NODE_ENV;
         process.env.NODE_ENV = 'development';
 
         const { result } = renderHook(() =>
@@ -2729,8 +2720,6 @@ describe('useForm', () => {
         result.current.formState.isValid;
 
         expect(console.warn).not.toBeCalled();
-
-        process.env.NODE_ENV = env;
 
         // @ts-ignore
         console.warn.mockRestore();

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -415,6 +415,24 @@ describe('useForm', () => {
       expect(result.current.watch('test')).toBe('data');
     });
 
+    it('should throw warning when watched input is not found', () => {
+      process.env.NODE_ENV = 'development';
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const { result } = renderHook(() => useForm());
+
+      result.current.register('test');
+      result.current.register('test.data');
+
+      result.current.watch('whatever');
+      expect(console.warn).toBeCalledTimes(1);
+
+      result.current.watch('test');
+      expect(console.warn).toBeCalledTimes(1);
+
+      // @ts-ignore
+      console.warn.mockRestore();
+    });
+
     it('should return default value if field is undefined', () => {
       const { result } = renderHook(() =>
         useForm<{ test: string }>({ defaultValues: { test: 'test' } }),

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -748,6 +748,26 @@ export function useForm<
         fieldNames,
       );
 
+      if (process.env.NODE_ENV !== 'production') {
+        if (fieldNames) {
+          const fieldRefNames = Object.keys(fieldsRef.current);
+
+          if (fieldRefNames.length) {
+            (isArray(fieldNames) ? fieldNames : [fieldNames]).forEach(
+              (name) => {
+                if (
+                  !fieldRefNames.find((fieldName) => fieldName.startsWith(name))
+                ) {
+                  console.warn(
+                    `📋 watched fields: ${fieldNames} are not found.`,
+                  );
+                }
+              },
+            );
+          }
+        }
+      }
+
       if (isString(fieldNames)) {
         return assignWatchFields<TFieldValues>(
           fieldValues,


### PR DESCRIPTION
improve `watch` API's DX by including a warning when field name is not found.