### PR TITLE
close #3066 improve resolver at input registration

### DIFF
--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -127,7 +127,7 @@ describe('useFieldArray', () => {
       expect(screen.getAllByRole('textbox').length).toEqual(1);
     });
 
-    it.only('should show errors during mount when mode is set to onChange', async () => {
+    it('should show errors during mount when mode is set to onChange', async () => {
       const Component = () => {
         const {
           register,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -936,9 +936,7 @@ export function useForm<
       }
     }
 
-    if (resolver && readFormStateRef.current.isValid) {
-      validateResolver();
-    } else if (!isEmptyObject(validateOptions)) {
+    if (!isEmptyObject(validateOptions)) {
       set(fieldsWithValidationRef.current, name, true);
 
       if (!isOnSubmit && readFormStateRef.current.isValid) {
@@ -1189,6 +1187,7 @@ export function useForm<
 
   React.useEffect(() => {
     isUnMount.current = false;
+    resolver && readFormStateRef.current.isValid && validateResolver();
 
     return () => {
       isUnMount.current = true;


### PR DESCRIPTION
invoke resolver inValid at useEffect instead during registration.