### PR TITLE
fix: adjust isFormDirty function and set to exclude undefined

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -273,13 +273,7 @@ export function useForm<
     [],
   );
 
-  const isFormDirty = () =>
-    !deepEqual(
-      getValues(),
-      isEmptyObject(defaultValuesRef.current)
-        ? defaultValuesAtRenderRef.current
-        : defaultValuesRef.current,
-    ) || !isEmptyObject(formStateRef.current.dirtyFields);
+  const isFormDirty = () => !isEmptyObject(formStateRef.current.dirtyFields);
 
   const updateAndGetDirtyState = React.useCallback(
     (
@@ -483,10 +477,7 @@ export function useForm<
             );
 
             updateFormState({
-              isDirty: !deepEqual(
-                { ...getValues(), [name]: value },
-                defaultValuesRef.current,
-              ),
+              isDirty: isFormDirty(),
               dirtyFields: formStateRef.current.dirtyFields,
             });
           }

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -27,8 +27,12 @@ export default function set(
           ? []
           : {};
     }
-    object[key] = newValue;
-    object = object[key];
+    if (newValue === undefined) {
+      delete object[key];
+    } else {
+      object[key] = newValue;
+      object = object[key];
+    }
   }
   return object;
 }


### PR DESCRIPTION
If setting undefined is indeed a valid value, then ```isFormDirty``` needs to use another function, since ```isEmptyObject``` returns false when the ```dirtyFields``` is in the format ```{"field": undefined}``` (as seen in two useFieldArray tests)