### PR TITLE
refactor: let SubmitHandler return any instead of void

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -54,12 +54,12 @@ export type Mode = keyof ValidationMode;
 export type SubmitHandler<TFieldValues extends FieldValues> = (
   data: UnpackNestedValue<TFieldValues>,
   event?: React.BaseSyntheticEvent,
-) => void | Promise<void>;
+) => any | Promise<any>;
 
 export type SubmitErrorHandler<TFieldValues extends FieldValues> = (
   errors: FieldErrors<TFieldValues>,
   event?: React.BaseSyntheticEvent,
-) => void | Promise<void>;
+) => any | Promise<any>;
 
 export type SetValueConfig = Partial<{
   shouldValidate: boolean;


### PR DESCRIPTION
This helps in code situations where your handler returns a promise with a non-void value.

## Before

```ts
onSubmit(data) {
  return updateUser(data).then(() => undefined)
}
```

## After

```ts
onSubmit(data) {
  return updateUser(data)
}
```