### PR TITLE
refactor watch, setError and clearErrors signatures in UseFormMethods to arrow functions

### DIFF
--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -5,6 +5,7 @@ import { FormProvider } from './useFormContext';
 import { useFieldArray } from './useFieldArray';
 import { useForm } from './useForm';
 import { Control } from './types';
+import { renderHook } from '@testing-library/react-hooks';
 
 const Input = ({ onChange, onBlur, placeholder }: any) => (
   <input
@@ -949,55 +950,19 @@ describe('Controller', () => {
   });
 
   it('should allow assignment of strictly typed control to a more generic one control', () => {
-    const NestedComponentWithTypedControl = ({
-      control,
-    }: {
-      control: Control<{ lessStrict: string }>;
-    }) => (
-      <Controller
-        data-testid="less-strict"
-        name="lessStrict"
-        defaultValue=""
-        as={<input />}
-        control={control}
-      />
-    );
+    const { result: looseResult } = renderHook(() => {
+      const { control } = useForm<{ test: string }>();
+      const looseControl: Control = control;
+      return looseControl;
+    });
 
-    const NestedComponentWithGenericControl = ({
-      control,
-    }: {
-      control: Control;
-    }) => (
-      <Controller
-        data-testid="loose"
-        defaultValue=""
-        name="loose"
-        as={<input />}
-        control={control}
-      />
-    );
+    const { result: lessStrict } = renderHook(() => {
+      const { control } = useForm<{ test: string; example: string }>();
+      const looseControl: Control<{ test: string }> = control;
+      return looseControl;
+    });
 
-    const Component = () => {
-      const { control } = useForm<{ lessStrict: string; loose: string }>();
-
-      return (
-        <>
-          <NestedComponentWithGenericControl control={control} />
-          <NestedComponentWithTypedControl control={control} />
-        </>
-      );
-    };
-
-    render(<Component />);
-
-    const lessStrict = screen.queryByTestId(
-      'less-strict',
-    ) as HTMLInputElement | null;
-    const loose = screen.queryByTestId('loose') as HTMLInputElement | null;
-
-    expect(lessStrict).toBeInTheDocument();
-    expect(loose).toBeInTheDocument();
-    expect(lessStrict?.name).toBe('lessStrict');
-    expect(loose?.name).toBe('loose');
+    expect(looseResult.current).toBeTruthy();
+    expect(lessStrict.current).toBeTruthy();
   });
 });

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -4,6 +4,7 @@ import { Controller } from './controller';
 import { FormProvider } from './useFormContext';
 import { useFieldArray } from './useFieldArray';
 import { useForm } from './useForm';
+import { Control } from './types';
 
 const Input = ({ onChange, onBlur, placeholder }: any) => (
   <input
@@ -945,5 +946,58 @@ describe('Controller', () => {
     });
 
     expect(currentErrors.test).toBeUndefined();
+  });
+
+  it('should allow assignment of strictly typed control to a more generic one control', () => {
+    const NestedComponentWithTypedControl = ({
+      control,
+    }: {
+      control: Control<{ lessStrict: string }>;
+    }) => (
+      <Controller
+        data-testid="less-strict"
+        name="lessStrict"
+        defaultValue=""
+        as={<input />}
+        control={control}
+      />
+    );
+
+    const NestedComponentWithGenericControl = ({
+      control,
+    }: {
+      control: Control;
+    }) => (
+      <Controller
+        data-testid="loose"
+        defaultValue=""
+        name="loose"
+        as={<input />}
+        control={control}
+      />
+    );
+
+    const Component = () => {
+      const { control } = useForm<{ lessStrict: string; loose: string }>();
+
+      return (
+        <>
+          <NestedComponentWithGenericControl control={control} />
+          <NestedComponentWithTypedControl control={control} />
+        </>
+      );
+    };
+
+    render(<Component />);
+
+    const lessStrict = screen.queryByTestId(
+      'less-strict',
+    ) as HTMLInputElement | null;
+    const loose = screen.queryByTestId('loose') as HTMLInputElement | null;
+
+    expect(lessStrict).toBeInTheDocument();
+    expect(loose).toBeInTheDocument();
+    expect(lessStrict?.name).toBe('lessStrict');
+    expect(loose?.name).toBe('loose');
   });
 });

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -4,8 +4,6 @@ import { Controller } from './controller';
 import { FormProvider } from './useFormContext';
 import { useFieldArray } from './useFieldArray';
 import { useForm } from './useForm';
-import { Control } from './types';
-import { renderHook } from '@testing-library/react-hooks';
 
 const Input = ({ onChange, onBlur, placeholder }: any) => (
   <input
@@ -947,22 +945,5 @@ describe('Controller', () => {
     });
 
     expect(currentErrors.test).toBeUndefined();
-  });
-
-  it('should allow assignment of strictly typed control to a more generic one control', () => {
-    const { result: looseResult } = renderHook(() => {
-      const { control } = useForm<{ test: string }>();
-      const looseControl: Control = control;
-      return looseControl;
-    });
-
-    const { result: lessStrict } = renderHook(() => {
-      const { control } = useForm<{ test: string; example: string }>();
-      const looseControl: Control<{ test: string }> = control;
-      return looseControl;
-    });
-
-    expect(looseResult.current).toBeTruthy();
-    expect(lessStrict.current).toBeTruthy();
   });
 });

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -213,8 +213,10 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
       defaultValues?: UnpackNestedValue<DeepPartial<TFieldValues>>,
     ): UnpackNestedValue<DeepPartial<TFieldValues>>;
   };
-  setError(name: FieldName<TFieldValues>, error: ErrorOption): void;
-  clearErrors(name?: FieldName<TFieldValues> | FieldName<TFieldValues>[]): void;
+  setError: (name: FieldName<TFieldValues>, error: ErrorOption) => void;
+  clearErrors: (
+    name?: FieldName<TFieldValues> | FieldName<TFieldValues>[],
+  ) => void;
   setValue<
     TFieldName extends string,
     TFieldValue extends TFieldValues[TFieldName]

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -192,25 +192,27 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
     rules?: ValidationRules,
   ): void;
   unregister(name: FieldName<TFieldValues> | FieldName<TFieldValues>[]): void;
-  watch(): UnpackNestedValue<TFieldValues>;
-  watch<TFieldName extends string, TFieldValue>(
-    name: TFieldName,
-    defaultValue?: TFieldName extends keyof TFieldValues
+  watch: {
+    (): UnpackNestedValue<TFieldValues>;
+    <TFieldName extends string, TFieldValue>(
+      name: TFieldName,
+      defaultValue?: TFieldName extends keyof TFieldValues
+        ? UnpackNestedValue<TFieldValues[TFieldName]>
+        : UnpackNestedValue<LiteralToPrimitive<TFieldValue>>,
+    ): TFieldName extends keyof TFieldValues
       ? UnpackNestedValue<TFieldValues[TFieldName]>
-      : UnpackNestedValue<LiteralToPrimitive<TFieldValue>>,
-  ): TFieldName extends keyof TFieldValues
-    ? UnpackNestedValue<TFieldValues[TFieldName]>
-    : UnpackNestedValue<LiteralToPrimitive<TFieldValue>>;
-  watch<TFieldName extends keyof TFieldValues>(
-    names: TFieldName[],
-    defaultValues?: UnpackNestedValue<
-      DeepPartial<Pick<TFieldValues, TFieldName>>
-    >,
-  ): UnpackNestedValue<Pick<TFieldValues, TFieldName>>;
-  watch(
-    names: string[],
-    defaultValues?: UnpackNestedValue<DeepPartial<TFieldValues>>,
-  ): UnpackNestedValue<DeepPartial<TFieldValues>>;
+      : UnpackNestedValue<LiteralToPrimitive<TFieldValue>>;
+    <TFieldName extends keyof TFieldValues>(
+      names: TFieldName[],
+      defaultValues?: UnpackNestedValue<
+        DeepPartial<Pick<TFieldValues, TFieldName>>
+      >,
+    ): UnpackNestedValue<Pick<TFieldValues, TFieldName>>;
+    (
+      names: string[],
+      defaultValues?: UnpackNestedValue<DeepPartial<TFieldValues>>,
+    ): UnpackNestedValue<DeepPartial<TFieldValues>>;
+  };
   setError(name: FieldName<TFieldValues>, error: ErrorOption): void;
   clearErrors(name?: FieldName<TFieldValues> | FieldName<TFieldValues>[]): void;
   setValue<

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -17,6 +17,7 @@ import {
   FieldError,
   ValidationRules,
   DeepMap,
+  Control,
 } from './types';
 import { perf, wait, PerfTools } from 'react-performance-testing';
 import 'jest-performance-testing';
@@ -3180,6 +3181,25 @@ describe('useForm', () => {
       });
 
       expect(screen.queryByText('This is required.')).toBeInTheDocument();
+    });
+  });
+
+  describe('control', () => {
+    it('should allow assignment of strictly typed control to a more generic one control', () => {
+      const { result: looseResult } = renderHook(() => {
+        const { control } = useForm<{ test: string }>();
+        const looseControl: Control = control;
+        return looseControl;
+      });
+
+      const { result: lessStrict } = renderHook(() => {
+        const { control } = useForm<{ test: string; example: string }>();
+        const looseControl: Control<{ test: string }> = control;
+        return looseControl;
+      });
+
+      expect(looseResult.current).toBeTruthy();
+      expect(lessStrict.current).toBeTruthy();
     });
   });
 });

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -6,15 +6,17 @@ const FormContext = React.createContext<UseFormMethods | null>(null);
 FormContext.displayName = 'RHFContext';
 
 export const useFormContext = <
-  TFieldValues extends FieldValues
+  TFieldValues extends FieldValues = FieldValues
 >(): UseFormMethods<TFieldValues> =>
   React.useContext(FormContext) as UseFormMethods<TFieldValues>;
 
-export const FormProvider = <TFieldValues extends FieldValues>({
+export const FormProvider = <TFieldValues extends FieldValues = FieldValues>({
   children,
   ...props
-}: FormProviderProps<TFieldValues>) => (
-  <FormContext.Provider value={{ ...props } as UseFormMethods}>
-    {children}
-  </FormContext.Provider>
-);
+}: FormProviderProps<TFieldValues>) => {
+  const Context = FormContext as React.Context<UseFormMethods<
+    TFieldValues
+  > | null>;
+
+  return <Context.Provider value={{ ...props }}>{children}</Context.Provider>;
+};


### PR DESCRIPTION
Part of the solution for #2887

Refactor for only methods unrelated to `Control` type + test for a bug in v6.8.5 from #3002