### PR TITLE
Fix package names in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
     "dist"
   ],
   "exports": {
-    ".": {
-      "import": "./dist/react-hook-form.es.js"
-    }
+    "import": "./dist/index.esm.js",
+    "require": "./dist/index.js"
   },
   "scripts": {
     "clean": "rimraf dist",


### PR DESCRIPTION
Doh! I forgot to check the new build's file names!

This should be correct now and I added the `require` key as well.