### PR TITLE
Fix exports for IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     ".": {
       "import": "./dist/index.esm.js",
       "require": "./dist/index.js"
+    },
+    "./dist/index.ie11": {
+      "import": "./dist/index.ie11.js",
+      "require": "./dist/index.ie11.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Problems
- After updating to v6.9.6, I could not build due to `ERR_PACKAGE_PATH_NOT_EXPORTED` with Next.js.

## Causes
- Defined base export path with `.`, so `./dist/index.ie11` is not defined by `exports` in `package.json`.  #3258 

## Fixes
- I've added `exports` paths to  `./dist/index.ie11`.