### PR TITLE
Memoize control so it does not change across renders

### DIFF
--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -40,6 +40,8 @@ type Form = {
   RadioGroup: string;
 };
 
+const PureReactSelect = React.memo(ReactSelect)
+
 export default function Field(props: any) {
   const methods = useForm<Form>({
     defaultValues,
@@ -47,7 +49,10 @@ export default function Field(props: any) {
   });
   const { handleSubmit, errors, reset, control } = methods;
 
+  const [, setRerender] = React.useState(0)
   renderCount++;
+
+  const rerender = () => setRerender(Math.random())
 
   return (
     <form onSubmit={handleSubmit(() => {})}>
@@ -150,7 +155,7 @@ export default function Field(props: any) {
           <label>React Select</label>
           <Controller
             render={(props) => (
-              <ReactSelect isClearable options={options} {...props} />
+              <PureReactSelect isClearable options={options} {...props} />
             )}
             name="ReactSelect"
             control={control}
@@ -162,6 +167,8 @@ export default function Field(props: any) {
       </div>
 
       <span id="renderCount">{renderCount}</span>
+
+      <button type="button" onClick={rerender}>Rerender</button>
 
       <button
         type="button"

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -946,4 +946,35 @@ describe('Controller', () => {
 
     expect(currentErrors.test).toBeUndefined();
   });
+
+  it('does not trigger rerenders for memoized inputs', () => {
+    let renderCount = 0;
+
+    const MemoizedInput = React.memo(
+      React.forwardRef((_props: any, _ref) => {
+        renderCount++;
+        return null;
+      }),
+    );
+
+    const Component = () => {
+      const { control } = useForm();
+      return (
+        <Controller
+          defaultValue=""
+          name="test"
+          render={(props) => <MemoizedInput {...props} />}
+          control={control}
+        />
+      );
+    };
+
+    const { rerender } = render(<Component />);
+
+    expect(renderCount).toEqual(1);
+
+    rerender(<Component />);
+
+    expect(renderCount).toEqual(1);
+  });
 });

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -69,22 +69,32 @@ const Controller = <
   });
   const onFocusRef = React.useRef(onFocus || (() => ref.current.focus()));
 
-  const shouldValidate = (isBlurEvent?: boolean) =>
-    !skipValidation({
-      isBlurEvent,
+  const shouldValidate = React.useCallback(
+    (isBlurEvent?: boolean) =>
+      !skipValidation({
+        isBlurEvent,
+        isReValidateOnBlur,
+        isReValidateOnChange,
+        isSubmitted,
+        isTouched: !!get(touched, name),
+        ...mode,
+      }),
+    [
       isReValidateOnBlur,
       isReValidateOnChange,
       isSubmitted,
-      isTouched: !!get(touched, name),
-      ...mode,
-    });
+      touched,
+      name,
+      mode,
+    ],
+  );
 
-  const commonTask = ([event]: any[]) => {
+  const commonTask = React.useCallback(([event]: any[]) => {
     const data = getInputValue(event);
     setInputStateValue(data);
     valueRef.current = data;
     return data;
-  };
+  }, []);
 
   const registerField = React.useCallback(() => {
     if (process.env.NODE_ENV !== 'production' && !name) {
@@ -159,7 +169,7 @@ const Controller = <
     }
   });
 
-  const onBlur = () => {
+  const onBlur = React.useCallback(() => {
     if (readFormStateRef.current.touched && !get(touched, name)) {
       set(touched, name, true);
       updateFormState({
@@ -170,13 +180,23 @@ const Controller = <
     if (shouldValidate(true)) {
       trigger(name);
     }
-  };
+  }, [
+    name,
+    touched,
+    updateFormState,
+    shouldValidate,
+    trigger,
+    readFormStateRef,
+  ]);
 
-  const onChange = (...event: any[]) =>
-    setValue(name, commonTask(event), {
-      shouldValidate: shouldValidate(),
-      shouldDirty: true,
-    });
+  const onChange = React.useCallback(
+    (...event: any[]) =>
+      setValue(name, commonTask(event), {
+        shouldValidate: shouldValidate(),
+        shouldDirty: true,
+      }),
+    [setValue, commonTask, name, shouldValidate],
+  );
 
   const commonProps = {
     onChange,

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -3387,4 +3387,32 @@ describe('useForm', () => {
       expect(errorsObject).toEqual({});
     });
   });
+
+  describe('control', () => {
+    it('does not change across re-renders', () => {
+      let control;
+
+      const Component = () => {
+        const form = useForm();
+
+        control = form.control;
+
+        return (
+          <>
+            <input type="text" name="test" ref={form.register()} />
+          </>
+        );
+      };
+
+      const { rerender } = render(<Component />);
+
+      const firstRenderControl = control;
+
+      rerender(<Component />);
+
+      const secondRenderControl = control;
+
+      expect(Object.is(firstRenderControl, secondRenderControl)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
This is a big change, but it gives us a stable instance of `control` across re-renders. Most of the diff is moving functions around and wrapping them in `useMemo` or `useCallback`. All original tests pass with only one "hack" (adding a ref value to a dependency list, which shouldn't be necessary but is the way that defaults are dealt as far as I can tell)

I updated the example app `/controller/onSubmit` with a "Rerender" button and memoized the `Select` component. Now, when clicking rerender, the `Select` will not rerender.