### PR TITLE
rename methods to formCtx/data to ctx

### DIFF
--- a/examples/formProvider.tsx
+++ b/examples/formProvider.tsx
@@ -3,10 +3,10 @@ import ReactDOM from 'react-dom';
 import { useForm, FormProvider, useFormContext } from 'react-hook-form';
 
 export default function App() {
-  const methods = useForm();
-  const { register, handleSubmit } = methods;
+  const formCtx = useForm();
+  const { register, handleSubmit } = formCtx;
   return (
-    <FormProvider {...methods}>
+    <FormProvider {...formCtx}>
       <form onSubmit={handleSubmit((data) => console.log(data))}>
         <label>Test</label>
         <input name="test" ref={register({ required: true })} />
@@ -19,6 +19,6 @@ export default function App() {
 }
 
 function Test() {
-  const data = useFormContext();
-  return <input name="bill" ref={data.register} />;
+  const ctx = useFormContext();
+  return <input name="bill" ref={ctx.register} />;
 }


### PR DESCRIPTION
Hello,

I think calling it `formCtx`/`ctx` better describes the value it holds since it holds other types/primitives like `formState` and `isValid` which are not methods (but objects & booleans)