### PR TITLE
submitHandler forwards successful return values

### DIFF
--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1934,7 +1934,7 @@ describe('useForm', () => {
     });
 
     it('should invoke onSubmit callback and reset nested errors when submit with valid form values', async () => {
-      const callback = jest.fn();
+      const callback = jest.fn().mockReturnValue('successValue');
       const { result } = renderHook(() =>
         useForm<{
           test: { firstName: string; lastName: string }[];
@@ -1959,6 +1959,8 @@ describe('useForm', () => {
         validate,
       });
 
+      let returnValue;
+
       await act(async () => {
         await result.current.handleSubmit(callback)({
           preventDefault: () => {},
@@ -1971,13 +1973,14 @@ describe('useForm', () => {
       result.current.setValue('test[0].firstName', 'test');
 
       await act(async () => {
-        await result.current.handleSubmit(callback)({
+        returnValue = await result.current.handleSubmit(callback)({
           preventDefault: () => {},
           persist: () => {},
         } as React.SyntheticEvent);
       });
 
       expect(callback).toBeCalled();
+      expect(returnValue).toBe('successValue');
     });
   });
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1080,7 +1080,7 @@ export function useForm<
     <TSubmitFieldValues extends FieldValues = TFieldValues>(
       onValid: SubmitHandler<TSubmitFieldValues>,
       onInvalid?: SubmitErrorHandler<TFieldValues>,
-    ) => async (e?: React.BaseSyntheticEvent): Promise<void> => {
+    ) => async (e?: React.BaseSyntheticEvent): Promise<any> => {
       if (e && e.preventDefault) {
         e.preventDefault();
         e.persist();
@@ -1099,6 +1099,8 @@ export function useForm<
         updateFormState({
           isSubmitting: true,
         });
+
+      let validReturnValue;
 
       try {
         if (resolverRef.current) {
@@ -1142,7 +1144,7 @@ export function useForm<
             errors: {},
             isSubmitting: true,
           });
-          await onValid(fieldValues, e);
+          validReturnValue = await onValid(fieldValues, e);
         } else {
           formStateRef.current.errors = {
             ...formStateRef.current.errors,
@@ -1160,6 +1162,9 @@ export function useForm<
           isSubmitSuccessful: isEmptyObject(formStateRef.current.errors),
           submitCount: formStateRef.current.submitCount + 1,
         });
+        if (validReturnValue) {
+          return validReturnValue;
+        }
       }
     },
     [shouldFocusError, isValidateAllFieldCriteria],


### PR DESCRIPTION
If a submitHandler's callback function returns a value and there are no errors, return that value.

Why:  I encountered a scenario where I had to invoke the handleSubmit manually.  I needed to know the results of the operation to know how to proceed.

Tests:
Updated existing unit test.
All tests pass & build.
