### PR TITLE
Make cloneObject work in both Node & browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form",
   "description": "Performant, flexible and extensible forms library for React Hooks",
-  "version": "6.12.1",
+  "version": "6.12.2-beta.1",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "umd:main": "dist/index.umd.production.min.js",

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -159,7 +159,7 @@ export function useForm<
   shallowFieldsStateRef.current = shouldUnregister
     ? {}
     : isEmptyObject(shallowFieldsStateRef.current)
-    ? cloneObject(defaultValues, isWeb)
+    ? cloneObject(defaultValues)
     : shallowFieldsStateRef.current;
 
   const updateFormState = React.useCallback(
@@ -639,7 +639,7 @@ export function useForm<
 
   function setFieldArrayDefaultValues<T extends FieldValues>(data: T): T {
     if (!shouldUnregister) {
-      let copy = cloneObject(data, isWeb);
+      let copy = cloneObject(data);
 
       for (const value of fieldArrayNamesRef.current) {
         if (isKey(value) && !copy[value]) {
@@ -682,7 +682,7 @@ export function useForm<
     return setFieldArrayDefaultValues(
       getFieldsValues(
         fieldsRef,
-        cloneObject(shallowFieldsStateRef.current, isWeb),
+        cloneObject(shallowFieldsStateRef.current),
         shouldUnregister,
       ),
     );
@@ -799,7 +799,7 @@ export function useForm<
         : watchFieldsRef.current;
       let fieldValues = getFieldsValues<TFieldValues>(
         fieldsRef,
-        cloneObject(shallowFieldsStateRef.current, isWeb),
+        cloneObject(shallowFieldsStateRef.current),
         shouldUnregister,
         false,
         fieldNames,
@@ -1089,7 +1089,7 @@ export function useForm<
       let fieldValues = setFieldArrayDefaultValues(
         getFieldsValues(
           fieldsRef,
-          cloneObject(shallowFieldsStateRef.current, isWeb),
+          cloneObject(shallowFieldsStateRef.current),
           shouldUnregister,
           true,
         ),
@@ -1221,10 +1221,7 @@ export function useForm<
     }
 
     fieldsRef.current = {};
-    defaultValuesRef.current = cloneObject(
-      values || defaultValuesRef.current,
-      isWeb,
-    );
+    defaultValuesRef.current = cloneObject(values || defaultValuesRef.current);
     values && renderWatchedInputs('');
 
     Object.values(resetFieldArrayFunctionRef.current).forEach(
@@ -1233,7 +1230,7 @@ export function useForm<
 
     shallowFieldsStateRef.current = shouldUnregister
       ? {}
-      : cloneObject(values, isWeb) || {};
+      : cloneObject(values) || {};
 
     resetRefs(omitResetState);
   };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -35,6 +35,7 @@ import isMultipleSelect from './utils/isMultipleSelect';
 import compact from './utils/compact';
 import isNullOrUndefined from './utils/isNullOrUndefined';
 import isRadioOrCheckboxFunction from './utils/isRadioOrCheckbox';
+import isWeb from './utils/isWeb';
 import isHTMLElement from './utils/isHTMLElement';
 import { EVENTS, UNDEFINED, VALIDATION_MODE } from './constants';
 import {
@@ -74,10 +75,6 @@ import {
 } from './types';
 
 const isWindowUndefined = typeof window === UNDEFINED;
-const isWeb =
-  typeof document !== UNDEFINED &&
-  !isWindowUndefined &&
-  !isUndefined(HTMLElement);
 const isProxyEnabled = isWeb ? 'Proxy' in window : typeof Proxy !== UNDEFINED;
 
 export function useForm<

--- a/src/utils/cloneObject.test.ts
+++ b/src/utils/cloneObject.test.ts
@@ -35,8 +35,8 @@ describe('clone', () => {
       ]),
     };
 
-    const copy = cloneObject(data, true);
-    expect(cloneObject(data, true)).toEqual(copy);
+    const copy = cloneObject(data);
+    expect(cloneObject(data)).toEqual(copy);
 
     // @ts-ignore
     copy.test.what = '1243';

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -1,8 +1,5 @@
 import isPrimitive from './isPrimitive';
-import { UNDEFINED } from '../constants';
-import isUndefined from '../utils/isUndefined';
-
-const isWeb = typeof window !== UNDEFINED && !isUndefined(HTMLElement);
+import isWeb from './isWeb';
 
 export default function cloneObject<T extends unknown>(data: T): T {
   let copy: any;

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -9,7 +9,7 @@ export default function cloneObject<T extends unknown>(
   if (
     isPrimitive(data) ||
     (isWeb && typeof File === 'function' && data instanceof File)
-    ) {
+  ) {
     return data;
   }
 

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -6,7 +6,10 @@ export default function cloneObject<T extends unknown>(
 ): T {
   let copy: any;
 
-  if (isPrimitive(data) || (isWeb && typeof File === 'function' && data instanceof File)) {
+  if (
+    isPrimitive(data) ||
+    (isWeb && typeof File === 'function' && data instanceof File)
+    ) {
     return data;
   }
 

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -1,15 +1,12 @@
 import isPrimitive from './isPrimitive';
+import { UNDEFINED } from '../constants';
 
-export default function cloneObject<T extends unknown>(
-  data: T,
-  isWeb = true,
-): T {
+const isWeb = typeof window !== UNDEFINED;
+
+export default function cloneObject<T extends unknown>(data: T): T {
   let copy: any;
 
-  if (
-    isPrimitive(data) ||
-    (isWeb && typeof File === 'function' && data instanceof File)
-  ) {
+  if (isPrimitive(data) || (isWeb && data instanceof File)) {
     return data;
   }
 
@@ -29,7 +26,7 @@ export default function cloneObject<T extends unknown>(
   if (data instanceof Map) {
     copy = new Map();
     for (const key of data.keys()) {
-      copy.set(key, cloneObject(data.get(key), isWeb));
+      copy.set(key, cloneObject(data.get(key)));
     }
     return copy;
   }
@@ -37,7 +34,7 @@ export default function cloneObject<T extends unknown>(
   copy = Array.isArray(data) ? [] : {};
 
   for (const key in data) {
-    copy[key] = cloneObject(data[key], isWeb);
+    copy[key] = cloneObject(data[key]);
   }
 
   return copy;

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -1,7 +1,7 @@
 import isPrimitive from './isPrimitive';
 import { UNDEFINED } from '../constants';
 
-const isWeb = typeof window !== UNDEFINED;
+const isWeb = typeof window !== UNDEFINED && !isUndefined(HTMLElement);
 
 export default function cloneObject<T extends unknown>(data: T): T {
   let copy: any;

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -6,7 +6,7 @@ export default function cloneObject<T extends unknown>(
 ): T {
   let copy: any;
 
-  if (isPrimitive(data) || (isWeb && data instanceof File)) {
+  if (isPrimitive(data) || (isWeb && typeof File === 'function' && data instanceof File)) {
     return data;
   }
 

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -1,5 +1,6 @@
 import isPrimitive from './isPrimitive';
 import { UNDEFINED } from '../constants';
+import isUndefined from '../utils/isUndefined';
 
 const isWeb = typeof window !== UNDEFINED && !isUndefined(HTMLElement);
 

--- a/src/utils/isWeb.ts
+++ b/src/utils/isWeb.ts
@@ -1,0 +1,3 @@
+import { UNDEFINED } from '../constants';
+
+export default typeof window !== UNDEFINED && typeof document !== UNDEFINED;


### PR DESCRIPTION
This fixes #3570 by ensuring we check for `File` to be available as a global before we do an instance check. This is required as `File` isn't available on Node.js environments.

@bluebill1049 I'm not sure how to test for this, so any help there is appreciated.