### PR TITLE
remove as prop at Controller

### DIFF
--- a/app/src/UseFieldArrayUnregister.tsx
+++ b/app/src/UseFieldArrayUnregister.tsx
@@ -25,7 +25,11 @@ const ConditionField = <T extends any[]>({
   });
 
   return output[index]?.name === 'bill' ? (
-    <input ref={control.register()} name={`data[${index}].conditional`} defaultValue={output[index].conditional} />
+    <input
+      ref={control.register()}
+      name={`data[${index}].conditional`}
+      defaultValue={output[index].conditional}
+    />
   ) : null;
 };
 
@@ -84,7 +88,9 @@ const UseFieldArrayUnregister: React.FC = () => {
               />
             ) : (
               <Controller
-                render={(props) => <input id={`field${index}`} {...props} />}
+                render={({ field }) => (
+                  <input id={`field${index}`} {...field} />
+                )}
                 control={control}
                 rules={{
                   required: 'This is required',

--- a/app/src/autoUnregister.tsx
+++ b/app/src/autoUnregister.tsx
@@ -21,7 +21,7 @@ export default function AutoUnregister() {
           <Controller
             defaultValue=""
             control={control}
-            as={<input name="test" />}
+            render={({ field }) => <input {...field} />}
             name="test"
           />
           <section id="input-ReactSelect">

--- a/app/src/autoUnregister.tsx
+++ b/app/src/autoUnregister.tsx
@@ -26,8 +26,8 @@ export default function AutoUnregister() {
           />
           <section id="input-ReactSelect">
             <Controller
-              render={(props) => (
-                <ReactSelect isClearable options={options} {...props} />
+              render={({ field}) => (
+                <ReactSelect isClearable options={options} {...field} />
               )}
               name="ReactSelect"
               control={control}

--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -77,8 +77,8 @@ export default function Field(props: any) {
         <section id="input-radio-group">
           <label>Radio Group</label>
           <Controller
-            render={(props) => (
-              <RadioGroup aria-label="gender" {...props} name="gender1">
+            render={({ field }) => (
+              <RadioGroup aria-label="gender" {...field} name="gender1">
                 <FormControlLabel
                   value="female"
                   control={<Radio />}
@@ -119,8 +119,8 @@ export default function Field(props: any) {
         <section id="input-select">
           <label>MUI Select</label>
           <Controller
-            render={(props) => (
-              <Select {...props}>
+            render={({ field }) => (
+              <Select {...field}>
                 <MenuItem value={10}>Ten</MenuItem>
                 <MenuItem value={20}>Twenty</MenuItem>
                 <MenuItem value={30}>Thirty</MenuItem>
@@ -154,8 +154,8 @@ export default function Field(props: any) {
         <section id="input-ReactSelect">
           <label>React Select</label>
           <Controller
-            render={(props) => (
-              <PureReactSelect isClearable options={options} {...props} />
+            render={({ field }) => (
+              <PureReactSelect isClearable options={options} {...field} />
             )}
             name="ReactSelect"
             control={control}

--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -40,7 +40,7 @@ type Form = {
   RadioGroup: string;
 };
 
-const PureReactSelect = React.memo(ReactSelect)
+const PureReactSelect = React.memo(ReactSelect);
 
 export default function Field(props: any) {
   const methods = useForm<Form>({
@@ -49,10 +49,10 @@ export default function Field(props: any) {
   });
   const { handleSubmit, errors, reset, control } = methods;
 
-  const [, setRerender] = React.useState(0)
+  const [, setRerender] = React.useState(0);
   renderCount++;
 
-  const rerender = () => setRerender(Math.random())
+  const rerender = () => setRerender(Math.random());
 
   return (
     <form onSubmit={handleSubmit(() => {})}>
@@ -63,7 +63,7 @@ export default function Field(props: any) {
             name="Checkbox"
             control={control}
             rules={{ required: true }}
-            render={(props) => (
+            render={({ field: props }) => (
               <Checkbox
                 {...props}
                 onChange={(e) => props.onChange(e.target.checked)}
@@ -107,7 +107,7 @@ export default function Field(props: any) {
         <section id="input-textField">
           <label>MUI TextField</label>
           <Controller
-            as={<TextField />}
+            render={({ field }) => <TextField {...field} />}
             name="TextField"
             control={control}
             rules={{ required: true }}
@@ -139,7 +139,7 @@ export default function Field(props: any) {
           <Controller
             name="switch"
             rules={{ required: true }}
-            render={(props) => (
+            render={({ field: props }) => (
               <Switch
                 {...props}
                 onChange={(e) => props.onChange(e.target.checked)}
@@ -168,7 +168,9 @@ export default function Field(props: any) {
 
       <span id="renderCount">{renderCount}</span>
 
-      <button type="button" onClick={rerender}>Rerender</button>
+      <button type="button" onClick={rerender}>
+        Rerender
+      </button>
 
       <button
         type="button"

--- a/app/src/useFieldArray.tsx
+++ b/app/src/useFieldArray.tsx
@@ -68,7 +68,9 @@ const UseFieldArray: React.FC = (props: any) => {
               />
             ) : (
               <Controller
-                render={(props) => <input id={`field${index}`} {...props} />}
+                render={({ field }) => (
+                  <input id={`field${index}`} {...field} />
+                )}
                 control={control}
                 rules={{
                   required: 'This is required',

--- a/app/src/useWatch.tsx
+++ b/app/src/useWatch.tsx
@@ -110,12 +110,12 @@ export default () => {
       <Controller
         name="test1"
         control={control}
-        render={(props) => (
+        render={({ field }) => (
           <input
             placeholder="👀 watching me :)"
             autoComplete="off"
             style={{ fontSize: 20 }}
-            {...props}
+            {...field}
           />
         )}
         defaultValue=""

--- a/cypress/integration/watchUseFieldArray.ts
+++ b/cypress/integration/watchUseFieldArray.ts
@@ -1,5 +1,5 @@
 describe('watchUseFieldArray', () => {
-  it.only('should behaviour correctly when watching the field array', () => {
+  it('should behaviour correctly when watching the field array', () => {
     cy.visit('http://localhost:3000/watch-field-array/normal');
 
     cy.get('#append').click();

--- a/src/controller.native.test.tsx
+++ b/src/controller.native.test.tsx
@@ -25,7 +25,7 @@ describe('Controller with React Native', () => {
             rules={{ minLength: 5 }}
             control={control}
             defaultValue=""
-            render={({ onChange, onBlur, value }) => (
+            render={({ field: { onChange, onBlur, value } }) => (
               <TextInput
                 testID={'input'}
                 onChange={onChange}

--- a/src/controller.server.test.tsx
+++ b/src/controller.server.test.tsx
@@ -16,7 +16,7 @@ describe('Controller with SSR', () => {
         <Controller
           defaultValue="default"
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           control={control}
         />
       );

--- a/src/controller.test.tsx
+++ b/src/controller.test.tsx
@@ -7,7 +7,6 @@ import {
   screen,
 } from '@testing-library/react';
 import { Controller } from './controller';
-import { FormProvider } from './useFormContext';
 import { useFieldArray } from './useFieldArray';
 import { useForm } from './useForm';
 
@@ -27,7 +26,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          as={'input' as const}
+          render={({ field }) => <input {...field} />}
           control={control}
         />
       );
@@ -48,7 +47,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           control={control}
         />
       );
@@ -62,19 +61,6 @@ describe('Controller', () => {
     expect(input?.name).toBe('test');
   });
 
-  it('should be assigned method.control variable if wrap with FormProvider', () => {
-    const Component = () => {
-      const methods = useForm();
-      return (
-        <FormProvider {...methods}>
-          <Controller defaultValue="" name="test" as={'input' as const} />
-        </FormProvider>
-      );
-    };
-
-    expect(() => render(<Component />)).not.toThrow();
-  });
-
   it('should reset value', async () => {
     const Component = () => {
       const { reset, control } = useForm();
@@ -84,7 +70,7 @@ describe('Controller', () => {
           <Controller
             defaultValue="default"
             name="test"
-            as={<input />}
+            render={({ field }) => <input {...field} />}
             control={control}
           />
           <button type="button" onClick={() => reset()}>
@@ -117,7 +103,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           control={control}
         />
       );
@@ -135,7 +121,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           control={control}
         />
       );
@@ -158,7 +144,7 @@ describe('Controller', () => {
           <Controller
             defaultValue=""
             name="test"
-            as={<input />}
+            render={({ field }) => <input {...field} />}
             control={control}
           />
           {/**
@@ -191,7 +177,7 @@ describe('Controller', () => {
         <Controller
           defaultValue="test"
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           control={control}
           rules={{ required: true }}
         />
@@ -220,7 +206,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           control={control}
           rules={{ required: true }}
         />
@@ -249,7 +235,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           control={control}
         />
       );
@@ -275,7 +261,7 @@ describe('Controller', () => {
           <Controller
             defaultValue=""
             name="test"
-            as={<input />}
+            render={({ field }) => <input {...field} />}
             control={control}
             rules={{ required: true }}
           />
@@ -328,7 +314,7 @@ describe('Controller', () => {
           <Controller
             defaultValue=""
             name="test"
-            render={(props) => {
+            render={({ field: props }) => {
               return <input {...props} />;
             }}
             control={control}
@@ -363,7 +349,7 @@ describe('Controller', () => {
           <Controller
             defaultValue=""
             name="test"
-            render={({ onBlur, value }) => {
+            render={({ field: { onBlur, value } }) => {
               return (
                 <Input placeholder="test" {...{ onChange, onBlur, value }} />
               );
@@ -394,7 +380,7 @@ describe('Controller', () => {
           <Controller
             defaultValue=""
             name="test"
-            render={({ onChange, value }) => {
+            render={({ field: { onChange, value } }) => {
               return <Input {...{ onChange, onBlur, value }} />;
             }}
             control={control}
@@ -410,23 +396,6 @@ describe('Controller', () => {
     expect(onBlur).toBeCalled();
   });
 
-  it('should be null if as and render props are not given', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const Component = () => {
-      const { control } = useForm();
-      // @ts-ignore
-      return <Controller defaultValue="" name="test" control={control} />;
-    };
-
-    const { container } = render(<Component />);
-
-    expect(container).toEqual(document.createElement('div'));
-
-    // @ts-ignore
-    console.warn.mockRestore();
-  });
-
   it('should update rules when rules gets updated', () => {
     let fieldsRef: any;
     const Component = ({ required = true }: { required?: boolean }) => {
@@ -436,7 +405,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           rules={{ required }}
           control={control}
         />
@@ -456,7 +425,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          as={<input />}
+          render={({ field }) => <input {...field} />}
           control={control}
         />
       );
@@ -490,7 +459,7 @@ describe('Controller', () => {
               key={field.id}
               defaultValue=""
               name={`test[${i}].value`}
-              as={<input />}
+              render={({ field }) => <input {...field} />}
               control={control}
             />
           ))}
@@ -525,7 +494,13 @@ describe('Controller', () => {
       process.env.NODE_ENV = 'development';
 
       const Component = () => {
-        return <Controller as={'input' as const} name="test" defaultValue="" />;
+        return (
+          <Controller
+            render={({ field }) => <input {...field} />}
+            name="test"
+            defaultValue=""
+          />
+        );
       };
 
       expect(() => render(<Component />)).toThrow(
@@ -545,7 +520,13 @@ describe('Controller', () => {
       process.env.NODE_ENV = 'production';
 
       const Component = () => {
-        return <Controller as={'input' as const} name="test" defaultValue="" />;
+        return (
+          <Controller
+            render={({ field }) => <input {...field} />}
+            name="test"
+            defaultValue=""
+          />
+        );
       };
 
       expect(() => render(<Component />)).toThrow(
@@ -568,7 +549,7 @@ describe('Controller', () => {
         const { control } = useForm();
         return (
           <Controller
-            as={'input' as const}
+            render={({ field }) => <input {...field} />}
             name=""
             control={control}
             defaultValue=""
@@ -596,7 +577,7 @@ describe('Controller', () => {
         const { control } = useForm();
         return (
           <Controller
-            as={'input' as const}
+            render={({ field }) => <input {...field} />}
             name=""
             control={control}
             defaultValue=""
@@ -623,7 +604,11 @@ describe('Controller', () => {
       const Component = () => {
         const { control } = useForm();
         return (
-          <Controller as={'input' as const} name="test" control={control} />
+          <Controller
+            render={({ field }) => <input {...field} />}
+            name="test"
+            control={control}
+          />
         );
       };
 
@@ -646,7 +631,11 @@ describe('Controller', () => {
       const Component = () => {
         const { control } = useForm();
         return (
-          <Controller as={'input' as const} name="test" control={control} />
+          <Controller
+            render={({ field }) => <input {...field} />}
+            name="test"
+            control={control}
+          />
         );
       };
 
@@ -671,8 +660,7 @@ describe('Controller', () => {
         return (
           // @ts-ignore
           <Controller
-            as={'input' as const}
-            render={() => <input />}
+            render={({ field }) => <input {...field} />}
             defaultValue=""
             name="test"
             control={control}
@@ -699,8 +687,12 @@ describe('Controller', () => {
       const Component = () => {
         const { control } = useForm();
         return (
-          // @ts-ignore
-          <Controller defaultValue="" name="test" control={control} />
+          <Controller
+            render={({ field }) => <input {...field} />}
+            defaultValue=""
+            name="test"
+            control={control}
+          />
         );
       };
 
@@ -737,7 +729,7 @@ describe('Controller', () => {
               return (
                 <Controller
                   name={`test[${index}].data`}
-                  as={'input' as const}
+                  render={({ field }) => <input {...field} />}
                   control={control}
                   key={id}
                 />
@@ -778,8 +770,8 @@ describe('Controller', () => {
           <form>
             {fields.map(({ id }, index) => {
               return (
-                // @ts-ignore
                 <Controller
+                  render={({ field }) => <input {...field} />}
                   name={`test[${index}].data`}
                   control={control}
                   key={id}
@@ -814,7 +806,7 @@ describe('Controller', () => {
           {fields.map((field, i) => (
             <div key={field.id}>
               <Controller
-                as="input"
+                render={({ field }) => <input {...field} />}
                 name={`test[${i}].value`}
                 defaultValue={''}
                 control={control}
@@ -873,7 +865,7 @@ describe('Controller', () => {
             control={control}
             defaultValue=""
             rules={{ required: true }}
-            render={(props) => <input {...props} />}
+            render={({ field }) => <input {...field} />}
           />
         </form>
       );
@@ -898,37 +890,6 @@ describe('Controller', () => {
     expect(currentErrors.test).toBeUndefined();
   });
 
-  it('does not trigger rerender for memoized inputs', () => {
-    let renderCount = 0;
-
-    const MemoizedInput = React.memo(
-      React.forwardRef((_props: any, _ref) => {
-        renderCount++;
-        return null;
-      }),
-    );
-
-    const Component = () => {
-      const { control } = useForm();
-      return (
-        <Controller
-          defaultValue=""
-          name="test"
-          render={(props) => <MemoizedInput {...props} />}
-          control={control}
-        />
-      );
-    };
-
-    const { rerender } = render(<Component />);
-
-    expect(renderCount).toEqual(1);
-
-    rerender(<Component />);
-
-    expect(renderCount).toEqual(1);
-  });
-
   it('should show invalid input when there is an error', async () => {
     const Component = () => {
       const { control } = useForm({
@@ -939,7 +900,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          render={(props, meta) => (
+          render={({ field: props, meta }) => (
             <>
               <input {...props} />
               {meta.invalid && <p>Input is invalid.</p>}
@@ -980,7 +941,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          render={(props, meta) => (
+          render={({ field: props, meta }) => (
             <>
               <input {...props} />
               {meta.isTouched && <p>Input is touched.</p>}
@@ -1011,7 +972,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          render={(props, meta) => (
+          render={({ field: props, meta }) => (
             <>
               <input {...props} />
               {meta.isTouched && <p>Input is dirty.</p>}
@@ -1049,7 +1010,7 @@ describe('Controller', () => {
         <Controller
           defaultValue=""
           name="test"
-          render={(props, meta) => (
+          render={({ field: props, meta }) => (
             <>
               <input {...props} />
               {meta.isTouched && <p>Input is dirty.</p>}

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -1,30 +1,12 @@
-import * as React from 'react';
 import { useController } from './useController';
 import { ControllerProps, FieldValues } from './types';
 
-type NativeInputs = 'input' | 'select' | 'textarea';
-
-const Controller = <
-  TAs extends React.ReactElement | React.ComponentType<any> | NativeInputs,
-  TFieldValues extends FieldValues = FieldValues
->(
-  props: ControllerProps<TAs, TFieldValues>,
+const Controller = <TFieldValues extends FieldValues = FieldValues>(
+  props: ControllerProps<TFieldValues>,
 ) => {
-  const { rules, as, render, defaultValue, control, onFocus, ...rest } = props;
   const { field, meta } = useController(props);
 
-  const componentProps = {
-    ...rest,
-    ...field,
-  };
-
-  return as
-    ? React.isValidElement(as)
-      ? React.cloneElement(as, componentProps)
-      : React.createElement(as as NativeInputs, componentProps as any)
-    : render
-    ? render(field, meta)
-    : null;
+  return props.render({ field, meta });
 };
 
 export { Controller };

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -4,7 +4,6 @@ import {
   FieldValues,
   FieldName,
   Control,
-  Assign,
   InputState,
 } from './';
 import { RegisterOptions } from './validator';
@@ -14,16 +13,6 @@ export type FormProviderProps<
 > = {
   children: React.ReactNode;
 } & UseFormMethods<TFieldValues>;
-
-type AsProps<TAs> = TAs extends undefined
-  ? {}
-  : TAs extends React.ReactElement
-  ? Record<string, any>
-  : TAs extends React.ComponentType<infer P>
-  ? P
-  : TAs extends keyof JSX.IntrinsicElements
-  ? JSX.IntrinsicElements[TAs]
-  : never;
 
 export type ControllerRenderProps<
   TFieldValues extends FieldValues = FieldValues
@@ -48,28 +37,12 @@ export type UseControllerOptions<
   control?: Control<TFieldValues>;
 };
 
-export type ControllerProps<
-  TAs extends
-    | React.ReactElement
-    | React.ComponentType<any>
-    | 'input'
-    | 'select'
-    | 'textarea',
-  TFieldValues extends FieldValues = FieldValues
-> = Assign<
-  (
-    | {
-        as: TAs;
-        render?: undefined;
-      }
-    | {
-        as?: undefined;
-        render: (
-          field: ControllerRenderProps<TFieldValues>,
-          state: InputState,
-        ) => React.ReactElement;
-      }
-  ) &
-    UseControllerOptions,
-  AsProps<TAs>
->;
+export type ControllerProps<TFieldValues extends FieldValues = FieldValues> = {
+  render: ({
+    field,
+    meta,
+  }: {
+    field: ControllerRenderProps<TFieldValues>;
+    meta: InputState;
+  }) => React.ReactElement;
+} & UseControllerOptions;

--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -926,7 +926,7 @@ describe('useFieldArray', () => {
             {fields.map((item, index) => (
               <Controller
                 key={item.id}
-                as={<input aria-label={'name'} />}
+                render={({ field }) => <input {...field} aria-label={'name'} />}
                 name={`${name}[${index}].name`}
                 control={control}
                 defaultValue={item.name}
@@ -2612,7 +2612,7 @@ describe('useFieldArray', () => {
                 return (
                   <li key={item.id}>
                     <Controller
-                      as={<input />}
+                      render={({ field }) => <input {...field} />}
                       name={`test[${index}].firstName`}
                       control={control}
                       defaultValue={item.firstName} // make sure to set up defaultValue


### PR DESCRIPTION
- `Controller`

remove `as` prop and provide a single solution with `render` prop, `as` works well with standard controlled input which exposed `onChange`, `onBlur` and `value`, however, there are cases which are not going to work well and it's confusing to give users too many options. 

```diff
- <Controller as={<input />} />
+ <Controller render={(props) => <input {...props} />} />
```

change `render`'s `props` to align with `useController`