### PR TITLE
Add example of persisted input cache after unmount

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ You can view the source code for most examples within their folder, or visit Cod
 | Field Array Min Length                  | https://codesandbox.io/s/react-hook-form-fieldsarray-yup-validation-min-length-57qtb |
 | FormProvider                            | https://codesandbox.io/s/react-hook-form-form-context-dkvjz                          |
 | Parse and format input value            | https://codesandbox.io/s/react-hook-form-parse-and-format-textarea-furtc             |
+| Persist input value on onUnmount        | https://codesandbox.io/s/headless-sound-wgetb                                        |
 | Modal/Toggle input                      | https://codesandbox.io/s/react-hook-form-conditional-inputs-c7n0r                    |
 | Nested Fields                           | https://codesandbox.io/s/react-hook-form-nested-fields-mv1bb                         |
 | Normalize/Format/Mask Field             | https://codesandbox.io/s/react-hook-form-normalize-field-forked-01lgs                |

--- a/examples/persistInputOnUnmount.tsx
+++ b/examples/persistInputOnUnmount.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { useForm, useWatch } from "react-hook-form";
+
+function useInputCache(values, causeField, effectField, callback) {
+  const [effectCache, setEffectCache] = React.useState(values[effectField]);
+
+  const evaluateRegStatus = (vals, currentState) => {
+    // check if field is registered (naive implementation for demonstration)
+    const isRegistered = !!vals[causeField];
+    return {
+      isRegistered,
+      registrationStatusChanged: isRegistered !== currentState,
+      hasValue: vals[effectField] !== undefined
+    };
+  };
+
+  // use ref to track registration state across renders
+  const currentRegState = React.useRef(false);
+
+  React.useEffect(() => {
+    const {
+      isRegistered,
+      registrationStatusChanged,
+      hasValue
+    } = evaluateRegStatus(values, currentRegState.current);
+
+    if (registrationStatusChanged && hasValue) {
+      if (isRegistered && !!effectCache) {
+        console.debug("Deploying cache");
+        callback(effectField, effectCache);
+      } else if (!isRegistered) {
+        console.debug("Caching before unmount");
+        setEffectCache(values[effectField]);
+      }
+      currentRegState.current = !!isRegistered;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values, causeField, effectField, callback]);
+}
+
+export default function App() {
+  const { register, handleSubmit, setValue, control } = useForm({
+    mode: "onChange",
+    defaultValues: {
+      name: "",
+      check: false,
+      optionalText: ""
+    }
+  });
+
+  const values = useWatch({
+    control
+  });
+  useInputCache(values, "check", "optionalText", setValue);
+
+  return (
+    <div className="App">
+      <h1>Here's a form with conditional fields.</h1>
+      <form onSubmit={handleSubmit(console.log)}>
+        <input
+          name={"name"}
+          type={"text"}
+          ref={register({ required: true, min: 3 })}
+          placeholder={"Enter a name"}
+        />
+        <br />
+        <label htmlFor={"check"}>
+          toggle field:
+          <input
+            name={"check"}
+            type={"checkbox"}
+            ref={register({ required: true })}
+          />
+        </label>
+        <br />
+        {values.check && (
+          <input
+            name={"optionalText"}
+            ref={register({ required: false })}
+            placeholder={"Mandatory when check=true"}
+          />
+        )}
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
[Re: This Discussion](https://github.com/react-hook-form/react-hook-form/discussions/3470)

Added a simple example for the `useInputCache` hook as discussed above.

Example provides a form with a checkbox which will cause the mount/unmount of a neighbouring form element. The hook will track the value of the checkbox, and use it to either store or dispatch the cached value of the effected element.