### PR TITLE
v7 rename dirtyFields to dirty

### DIFF
--- a/app/src/UseFieldArrayUnregister.tsx
+++ b/app/src/UseFieldArrayUnregister.tsx
@@ -40,7 +40,7 @@ const UseFieldArrayUnregister: React.FC = () => {
     register,
     setValue,
     getValues,
-    formState: { isDirty, touched, dirtyFields, errors },
+    formState: { isDirty, touched, dirty, errors },
   } = useForm<{
     data: { name: string }[];
   }>({
@@ -161,7 +161,7 @@ const UseFieldArrayUnregister: React.FC = () => {
       <div id="renderCount">{renderCount}</div>
       <div id="result">{JSON.stringify(data)}</div>
       <div id="dirty">{isDirty ? 'yes' : 'no'}</div>
-      <div id="dirtyFields">{JSON.stringify(dirtyFields)}</div>
+      <div id="dirtyFields">{JSON.stringify(dirty)}</div>
       <div id="touched">{JSON.stringify(touched.data)}</div>
     </form>
   );

--- a/app/src/conditionalField.tsx
+++ b/app/src/conditionalField.tsx
@@ -9,7 +9,7 @@ const ConditionalField: React.FC = () => {
     handleSubmit,
     watch,
     formState: {
-      dirtyFields,
+      dirty,
       isSubmitted,
       submitCount,
       touched,
@@ -98,7 +98,7 @@ const ConditionalField: React.FC = () => {
           isSubmitSuccessful,
           isValid,
           touched: Object.keys(touched),
-          dirtyFields: Object.keys(dirtyFields),
+          dirty: Object.keys(dirty),
         })}
       </div>
       <div id="result">{JSON.stringify(result)}</div>

--- a/app/src/formState.tsx
+++ b/app/src/formState.tsx
@@ -16,7 +16,7 @@ const FormState = (props: {
     register,
     handleSubmit,
     formState: {
-      dirtyFields,
+      dirty,
       isSubmitted,
       submitCount,
       touched,
@@ -68,7 +68,7 @@ const FormState = (props: {
           isSubmitSuccessful,
           isValid,
           touched: Object.keys(touched),
-          dirtyFields: Object.keys(dirtyFields),
+          dirty: Object.keys(dirty),
         })}
       </div>
       <select name="select" ref={register} defaultValue="test">

--- a/app/src/formStateWithNestedFields.tsx
+++ b/app/src/formStateWithNestedFields.tsx
@@ -9,7 +9,7 @@ const FormStateWithNestedFields: React.FC = (props: any) => {
     register,
     handleSubmit,
     formState: {
-      dirtyFields,
+      dirty,
       isSubmitted,
       submitCount,
       touched,
@@ -82,8 +82,8 @@ const FormStateWithNestedFields: React.FC = (props: any) => {
               (nestedKey) => `${topLevelKey}.${nestedKey}`,
             ),
           ),
-          dirtyFields: Object.keys(dirtyFields).flatMap((topLevelKey) =>
-            Object.keys(dirtyFields[topLevelKey] || {}).map(
+          dirty: Object.keys(dirty).flatMap((topLevelKey) =>
+            Object.keys(dirty[topLevelKey] || {}).map(
               (nestedKey) => `${topLevelKey}.${nestedKey}`,
             ),
           ),

--- a/app/src/formStateWithSchema.tsx
+++ b/app/src/formStateWithSchema.tsx
@@ -18,7 +18,7 @@ const FormStateWithSchema: React.FC = (props: any) => {
     register,
     handleSubmit,
     formState: {
-      dirtyFields,
+      dirty,
       isSubmitted,
       submitCount,
       touched,
@@ -78,7 +78,7 @@ const FormStateWithSchema: React.FC = (props: any) => {
           isSubmitSuccessful,
           isValid,
           touched: Object.keys(touched),
-          dirtyFields: Object.keys(dirtyFields),
+          dirty: Object.keys(dirty),
         })}
       </div>
       <div id="renderCount">{renderCounter}</div>

--- a/app/src/useFieldArray.tsx
+++ b/app/src/useFieldArray.tsx
@@ -9,7 +9,7 @@ const UseFieldArray: React.FC = (props: any) => {
     control,
     handleSubmit,
     register,
-    formState: { isDirty, touched, isValid, dirtyFields, errors },
+    formState: { isDirty, touched, isValid, dirty, errors },
     reset,
   } = useForm<{
     data: { name: string }[];
@@ -137,7 +137,7 @@ const UseFieldArray: React.FC = (props: any) => {
       <div id="result">{JSON.stringify(data)}</div>
       <div id="dirty">{isDirty ? 'yes' : 'no'}</div>
       <div id="isValid">{isValid ? 'yes' : 'no'}</div>
-      <div id="dirtyFields">{JSON.stringify(dirtyFields)}</div>
+      <div id="dirtyFields">{JSON.stringify(dirty)}</div>
       <div id="touched">{JSON.stringify(touched.data)}</div>
     </form>
   );

--- a/app/src/useFormState.tsx
+++ b/app/src/useFormState.tsx
@@ -6,7 +6,7 @@ let renderCounter = 0;
 const SubForm = ({ control }: { control: Control }) => {
   const {
     isDirty,
-    dirtyFields,
+    dirty,
     touched,
     isSubmitted,
     isSubmitSuccessful,
@@ -21,7 +21,7 @@ const SubForm = ({ control }: { control: Control }) => {
       {JSON.stringify({
         isDirty,
         touched: Object.keys(touched),
-        dirtyFields: Object.keys(dirtyFields),
+        dirty: Object.keys(dirty),
         isSubmitted,
         isSubmitSuccessful,
         submitCount,

--- a/cypress/integration/conditionalField.ts
+++ b/cypress/integration/conditionalField.ts
@@ -3,7 +3,7 @@ describe('ConditionalField', () => {
     cy.visit('http://localhost:3000/conditionalField');
     cy.get('#state').should(($state) => {
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -20,7 +20,7 @@ describe('ConditionalField', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['selectNumber', 'firstName', 'lastName'],
+        dirty: ['selectNumber', 'firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['selectNumber', 'firstName', 'lastName'],
@@ -36,7 +36,7 @@ describe('ConditionalField', () => {
     );
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['selectNumber', 'firstName', 'lastName'],
+        dirty: ['selectNumber', 'firstName', 'lastName'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['selectNumber', 'firstName', 'lastName'],
@@ -57,7 +57,7 @@ describe('ConditionalField', () => {
     cy.get('select[name="selectNumber"]').select('2');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['selectNumber', 'firstName', 'lastName'],
+        dirty: ['selectNumber', 'firstName', 'lastName'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['selectNumber', 'firstName', 'lastName'],
@@ -72,7 +72,7 @@ describe('ConditionalField', () => {
     cy.get('input[name="max"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
+        dirty: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
@@ -85,7 +85,7 @@ describe('ConditionalField', () => {
     cy.get('button#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
+        dirty: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
@@ -106,7 +106,7 @@ describe('ConditionalField', () => {
     cy.get('select[name="selectNumber"]').select('3');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
+        dirty: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
@@ -121,7 +121,7 @@ describe('ConditionalField', () => {
     cy.get('input[name="notRequired"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [
+        dirty: [
           'selectNumber',
           'firstName',
           'lastName',

--- a/cypress/integration/formState.ts
+++ b/cypress/integration/formState.ts
@@ -4,7 +4,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -19,7 +19,7 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -33,7 +33,7 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -49,7 +49,7 @@ describe('form state', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -65,7 +65,7 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
@@ -80,7 +80,7 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
@@ -98,7 +98,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -113,7 +113,7 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -127,7 +127,7 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -143,7 +143,7 @@ describe('form state', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -159,7 +159,7 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
@@ -174,7 +174,7 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
@@ -192,7 +192,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -207,7 +207,7 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -221,7 +221,7 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -237,7 +237,7 @@ describe('form state', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -253,7 +253,7 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
@@ -268,7 +268,7 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
@@ -290,7 +290,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -306,7 +306,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -321,7 +321,7 @@ describe('form state', () => {
     cy.get('select[name="select"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['select'],
+        dirty: ['select'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select'],
@@ -334,7 +334,7 @@ describe('form state', () => {
     cy.get('select[name="select"]').select('');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select'],
@@ -349,7 +349,7 @@ describe('form state', () => {
     cy.get('input[name="checkbox"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['checkbox'],
+        dirty: ['checkbox'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select', 'checkbox'],
@@ -363,7 +363,7 @@ describe('form state', () => {
     cy.get('input[name="checkbox"]').uncheck();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select', 'checkbox'],
@@ -378,7 +378,7 @@ describe('form state', () => {
     cy.get('input[name="checkbox-checked"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['checkbox-checked'],
+        dirty: ['checkbox-checked'],
         isSubmitted: false,
         submitCount: 0,
         touched: [
@@ -397,7 +397,7 @@ describe('form state', () => {
     cy.get('input[name="checkbox-checked"]').check();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [
@@ -418,7 +418,7 @@ describe('form state', () => {
     cy.get('input[name="radio"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['radio'],
+        dirty: ['radio'],
         isSubmitted: false,
         submitCount: 0,
         touched: [
@@ -439,7 +439,7 @@ describe('form state', () => {
     cy.get('select[name="select"]').select('');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['radio'],
+        dirty: ['radio'],
         isSubmitted: false,
         submitCount: 0,
         touched: [
@@ -468,7 +468,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -485,7 +485,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -507,7 +507,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -522,7 +522,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -543,7 +543,7 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],

--- a/cypress/integration/formStateWithNestedFields.ts
+++ b/cypress/integration/formStateWithNestedFields.ts
@@ -5,7 +5,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -21,7 +21,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1'],
+        dirty: ['left.1'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1'],
@@ -36,7 +36,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1'],
@@ -52,7 +52,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],
@@ -68,7 +68,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1'],
+        dirty: ['left.1'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['left.1', 'left.2'],
@@ -83,7 +83,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['left.1', 'left.2'],
@@ -101,7 +101,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -116,7 +116,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1'],
+        dirty: ['left.1'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1'],
@@ -130,7 +130,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1'],
@@ -146,7 +146,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],
@@ -162,7 +162,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1'],
+        dirty: ['left.1'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['left.1', 'left.2'],
@@ -177,7 +177,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['left.1', 'left.2'],
@@ -195,7 +195,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -210,7 +210,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1'],
+        dirty: ['left.1'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1'],
@@ -224,7 +224,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1'],
@@ -240,7 +240,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],
@@ -256,7 +256,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1'],
+        dirty: ['left.1'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['left.1', 'left.2'],
@@ -271,7 +271,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['left.1', 'left.2'],
@@ -293,7 +293,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],
@@ -309,7 +309,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],
@@ -332,7 +332,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],
@@ -349,7 +349,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],
@@ -371,7 +371,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: true,
-        dirtyFields: ['left.1', 'left.2'],
+        dirty: ['left.1', 'left.2'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],
@@ -386,7 +386,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -407,7 +407,7 @@ describe('form state with nested fields', () => {
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['left.1', 'left.2'],

--- a/cypress/integration/formStateWithSchema.ts
+++ b/cypress/integration/formStateWithSchema.ts
@@ -4,7 +4,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -19,7 +19,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -33,7 +33,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -49,7 +49,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -65,7 +65,7 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
@@ -80,7 +80,7 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
@@ -99,7 +99,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -114,7 +114,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -128,7 +128,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -144,7 +144,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -160,7 +160,7 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
@@ -175,7 +175,7 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
@@ -193,7 +193,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -208,7 +208,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -222,7 +222,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName'],
@@ -238,7 +238,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -254,7 +254,7 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName'],
+        dirty: ['firstName'],
         isSubmitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
@@ -269,7 +269,7 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
@@ -291,7 +291,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -307,7 +307,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -322,7 +322,7 @@ describe('form state with schema validation', () => {
     cy.get('select[name="select"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['select'],
+        dirty: ['select'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select'],
@@ -335,7 +335,7 @@ describe('form state with schema validation', () => {
     cy.get('select[name="select"]').select('');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select'],
@@ -350,7 +350,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="checkbox"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['checkbox'],
+        dirty: ['checkbox'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select', 'checkbox'],
@@ -363,7 +363,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="checkbox"]').uncheck();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select', 'checkbox'],
@@ -378,7 +378,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="checkbox-checked"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['checkbox-checked'],
+        dirty: ['checkbox-checked'],
         isSubmitted: false,
         submitCount: 0,
         touched: [
@@ -397,7 +397,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="checkbox-checked"]').check();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [
@@ -418,7 +418,7 @@ describe('form state with schema validation', () => {
     cy.get('input[name="radio"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['radio'],
+        dirty: ['radio'],
         isSubmitted: false,
         submitCount: 0,
         touched: [
@@ -439,7 +439,7 @@ describe('form state with schema validation', () => {
     cy.get('select[name="select"]').select('');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['radio'],
+        dirty: ['radio'],
         isSubmitted: false,
         submitCount: 0,
         touched: [
@@ -468,7 +468,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -485,7 +485,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -507,7 +507,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: ['firstName', 'lastName'],
+        dirty: ['firstName', 'lastName'],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
@@ -522,7 +522,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: [],
@@ -543,7 +543,7 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],

--- a/cypress/integration/useFormState.tsx
+++ b/cypress/integration/useFormState.tsx
@@ -34,7 +34,7 @@ describe('useFormState', () => {
           'maxDate',
           'minLength',
         ],
-        dirtyFields: [
+        dirty: [
           'nestItem',
           'firstName',
           'arrayItem',
@@ -79,7 +79,7 @@ describe('useFormState', () => {
           'minLength',
           'minRequiredLength',
         ],
-        dirtyFields: [
+        dirty: [
           'nestItem',
           'firstName',
           'arrayItem',
@@ -119,7 +119,7 @@ describe('useFormState', () => {
           'minLength',
           'minRequiredLength',
         ],
-        dirtyFields: [
+        dirty: [
           'nestItem',
           'firstName',
           'arrayItem',
@@ -146,7 +146,7 @@ describe('useFormState', () => {
       expect(JSON.parse($state.text())).to.be.deep.equal({
         isDirty: false,
         touched: [],
-        dirtyFields: [],
+        dirty: [],
         isSubmitted: false,
         isSubmitSuccessful: false,
         submitCount: 0,

--- a/src/logic/setFieldArrayDirtyFields.test.ts
+++ b/src/logic/setFieldArrayDirtyFields.test.ts
@@ -1,7 +1,7 @@
 import setFieldArrayDirtyFields from './setFieldArrayDirtyFields';
 
 describe('setFieldArrayDirtyFields', () => {
-  it('should set correctly dirtyFields', () => {
+  it('should set correctly dirty', () => {
     expect(
       setFieldArrayDirtyFields(
         [{ data: 'bill' }, { data: 'luo', data1: 'luo1' }],
@@ -87,7 +87,7 @@ describe('setFieldArrayDirtyFields', () => {
     ]);
   });
 
-  it('should set correctly with nested dirtyFields', () => {
+  it('should set correctly with nested dirty', () => {
     expect(
       setFieldArrayDirtyFields(
         [

--- a/src/logic/setFieldArrayDirtyFields.ts
+++ b/src/logic/setFieldArrayDirtyFields.ts
@@ -9,7 +9,7 @@ function setDirtyFields<
 >(
   values: T,
   defaultValues: U,
-  dirtyFields: Record<string, boolean | []>[],
+  dirty: Record<string, boolean | []>[],
   parentNode?: K,
   parentName?: keyof K,
 ) {
@@ -18,39 +18,37 @@ function setDirtyFields<
   while (++index < values.length) {
     for (const key in values[index]) {
       if (Array.isArray(values[index][key])) {
-        !dirtyFields[index] && (dirtyFields[index] = {});
-        dirtyFields[index][key] = [];
+        !dirty[index] && (dirty[index] = {});
+        dirty[index][key] = [];
         setDirtyFields(
           values[index][key] as T,
           get(defaultValues[index] || {}, key, []),
-          dirtyFields[index][key] as [],
-          dirtyFields[index],
+          dirty[index][key] as [],
+          dirty[index],
           key,
         );
       } else {
         get(defaultValues[index] || {}, key) === values[index][key]
-          ? set(dirtyFields[index] || {}, key)
-          : (dirtyFields[index] = {
-              ...dirtyFields[index],
+          ? set(dirty[index] || {}, key)
+          : (dirty[index] = {
+              ...dirty[index],
               [key]: true,
             });
       }
     }
 
-    parentNode &&
-      !dirtyFields.length &&
-      delete parentNode[parentName as keyof K];
+    parentNode && !dirty.length && delete parentNode[parentName as keyof K];
   }
 
-  return dirtyFields;
+  return dirty;
 }
 
 export default <T extends U, U extends Record<string, unknown>[]>(
   values: T,
   defaultValues: U,
-  dirtyFields: Record<string, boolean | []>[],
+  dirty: Record<string, boolean | []>[],
 ) =>
   deepMerge(
-    setDirtyFields(values, defaultValues, dirtyFields),
-    setDirtyFields(defaultValues, values, dirtyFields),
+    setDirtyFields(values, defaultValues, dirty),
+    setDirtyFields(defaultValues, values, dirty),
   );

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -97,7 +97,7 @@ export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<
 export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
   isDirty: boolean;
   isValidating: boolean;
-  dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
+  dirty: FieldNamesMarkedBoolean<TFieldValues>;
   touched: FieldNamesMarkedBoolean<TFieldValues>;
   isSubmitting: boolean;
   errors: boolean;
@@ -108,7 +108,7 @@ export type ReadFormState = { [K in keyof FormStateProxy]: boolean | 'all' };
 
 export type FormState<TFieldValues> = {
   isDirty: boolean;
-  dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
+  dirty: FieldNamesMarkedBoolean<TFieldValues>;
   isSubmitted: boolean;
   isSubmitSuccessful: boolean;
   submitCount: number;
@@ -126,7 +126,7 @@ export type OmitResetState = Partial<{
   touched: boolean;
   isValid: boolean;
   submitCount: boolean;
-  dirtyFields: boolean;
+  dirty: boolean;
 }>;
 
 export type Control<TFieldValues extends FieldValues = FieldValues> = Pick<

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -210,7 +210,7 @@ export function useController<TFieldValues extends FieldValues = FieldValues>({
         },
         isDirty: {
           get() {
-            return !!get(formState.dirtyFields, name);
+            return !!get(formState.dirty, name);
           },
         },
         isTouched: {

--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -773,7 +773,7 @@ describe('useFieldArray', () => {
   });
 
   describe('with setValue', () => {
-    it.each(['isDirty', 'dirtyFields'])(
+    it.each(['isDirty', 'dirty'])(
       'should set name to dirtyFieldRef if array field values are different with default value when formState.%s is defined',
       (property) => {
         let setValue: any;
@@ -829,14 +829,14 @@ describe('useFieldArray', () => {
           );
         });
 
-        expect(formState.dirtyFields).toEqual({
+        expect(formState.dirty).toEqual({
           test: [{ name: true }],
         });
         expect(formState.isDirty).toBeTruthy();
       },
     );
 
-    it.each(['isDirty', 'dirtyFields'])(
+    it.each(['isDirty', 'dirty'])(
       'should unset name from dirtyFieldRef if array field values are not different with default value when formState.%s is defined',
       (property) => {
         let setValue: any;
@@ -890,7 +890,7 @@ describe('useFieldArray', () => {
           );
         });
 
-        expect(formState.dirtyFields).toEqual({
+        expect(formState.dirty).toEqual({
           test: [{ name: true }],
         });
         expect(formState.isDirty).toBeTruthy();
@@ -903,7 +903,7 @@ describe('useFieldArray', () => {
           );
         });
 
-        expect(formState.dirtyFields).toEqual({
+        expect(formState.dirty).toEqual({
           test: [],
         });
         expect(formState.isDirty).toBeFalsy();
@@ -1001,7 +1001,7 @@ describe('useFieldArray', () => {
         const {
           register,
           control,
-          formState: { dirtyFields },
+          formState: { dirty },
         } = useForm<{
           test: { value: string }[];
         }>({
@@ -1018,7 +1018,7 @@ describe('useFieldArray', () => {
           name: 'test',
         });
 
-        dirtyInputs = dirtyFields;
+        dirtyInputs = dirty;
 
         return (
           <form>
@@ -1033,7 +1033,7 @@ describe('useFieldArray', () => {
             <button type="button" onClick={() => append({ value: '' })}>
               append
             </button>
-            {dirtyFields.test?.length && 'dirty'}
+            {dirty.test?.length && 'dirty'}
           </form>
         );
       };
@@ -1143,7 +1143,7 @@ describe('useFieldArray', () => {
         });
 
         result.current.formState.isDirty;
-        result.current.formState.dirtyFields;
+        result.current.formState.dirty;
 
         act(() => {
           result.current.append({ value: 'test' });
@@ -1158,7 +1158,7 @@ describe('useFieldArray', () => {
         });
 
         expect(result.current.formState.isDirty).toBeTruthy();
-        expect(result.current.formState.dirtyFields).toEqual({
+        expect(result.current.formState.dirty).toEqual({
           test: [{ value: true }, { value: true }, { value: true }],
         });
       },
@@ -1424,7 +1424,7 @@ describe('useFieldArray', () => {
         });
 
         result.current.formState.isDirty;
-        result.current.formState.dirtyFields;
+        result.current.formState.dirty;
 
         act(() => {
           result.current.prepend({ value: 'test' });
@@ -1439,7 +1439,7 @@ describe('useFieldArray', () => {
         });
 
         expect(result.current.formState.isDirty).toBeTruthy();
-        expect(result.current.formState.dirtyFields).toEqual({
+        expect(result.current.formState.dirty).toEqual({
           test: [{ value: true }, { value: true }, { value: true }],
         });
       },
@@ -2025,7 +2025,7 @@ describe('useFieldArray', () => {
         });
 
         result.current.formState.isDirty;
-        result.current.formState.dirtyFields;
+        result.current.formState.dirty;
 
         act(() => {
           result.current.append({ value: 'test' });
@@ -2040,7 +2040,7 @@ describe('useFieldArray', () => {
         });
 
         expect(result.current.formState.isDirty).toBeTruthy();
-        expect(result.current.formState.dirtyFields).toEqual({
+        expect(result.current.formState.dirty).toEqual({
           test: [{ value: true }, { value: true }],
         });
 
@@ -2049,7 +2049,7 @@ describe('useFieldArray', () => {
         });
 
         expect(result.current.formState.isDirty).toBeTruthy();
-        expect(result.current.formState.dirtyFields).toEqual({
+        expect(result.current.formState.dirty).toEqual({
           test: [{ value: true }],
         });
       },
@@ -2577,7 +2577,7 @@ describe('useFieldArray', () => {
         return { register, formState, fields, append, remove };
       });
 
-      result.current.formState.dirtyFields as Record<string, any>;
+      result.current.formState.dirty as Record<string, any>;
       result.current.formState.isDirty;
 
       act(() => {
@@ -2585,7 +2585,7 @@ describe('useFieldArray', () => {
       });
 
       expect(result.current.formState.isDirty).toBeTruthy();
-      expect(result.current.formState.dirtyFields).toEqual({
+      expect(result.current.formState.dirty).toEqual({
         test: { data: [undefined, { value: true }] },
       });
 
@@ -2594,7 +2594,7 @@ describe('useFieldArray', () => {
       });
 
       expect(result.current.formState.isDirty).toBeFalsy();
-      expect(result.current.formState.dirtyFields).toEqual({});
+      expect(result.current.formState.dirty).toEqual({});
     });
 
     it('should remove Controller by index without error', () => {
@@ -2854,7 +2854,7 @@ describe('useFieldArray', () => {
         });
 
         result.current.formState.isDirty;
-        result.current.formState.dirtyFields;
+        result.current.formState.dirty;
 
         act(() => {
           result.current.append({ value: '2' });
@@ -2862,7 +2862,7 @@ describe('useFieldArray', () => {
         });
 
         expect(result.current.formState.isDirty).toBeTruthy();
-        expect(result.current.formState.dirtyFields).toEqual({
+        expect(result.current.formState.dirty).toEqual({
           test: [undefined, { value1: true }, { value: true }],
         });
       },
@@ -2884,7 +2884,7 @@ describe('useFieldArray', () => {
         });
 
         result.current.formState.isDirty;
-        result.current.formState.dirtyFields;
+        result.current.formState.dirty;
 
         act(() => {
           result.current.append({ value: '2' });
@@ -2892,7 +2892,7 @@ describe('useFieldArray', () => {
         });
 
         expect(result.current.formState.isDirty).toBeTruthy();
-        expect(result.current.formState.dirtyFields).toEqual({
+        expect(result.current.formState.dirty).toEqual({
           test: [
             undefined,
             { value1: true },
@@ -3412,7 +3412,7 @@ describe('useFieldArray', () => {
         });
 
         result.current.formState.isDirty;
-        result.current.formState.dirtyFields;
+        result.current.formState.dirty;
 
         act(() => {
           result.current.append({ value: '2' });
@@ -3427,7 +3427,7 @@ describe('useFieldArray', () => {
         });
 
         expect(result.current.formState.isDirty).toBeTruthy();
-        expect(result.current.formState.dirtyFields).toEqual({
+        expect(result.current.formState.dirty).toEqual({
           test: [{ value: true }, undefined, { value: true }],
         });
       },
@@ -3780,7 +3780,7 @@ describe('useFieldArray', () => {
         });
 
         result.current.formState.isDirty;
-        result.current.formState.dirtyFields;
+        result.current.formState.dirty;
 
         act(() => {
           result.current.append({ value: '2' });
@@ -3795,7 +3795,7 @@ describe('useFieldArray', () => {
         });
 
         expect(result.current.formState.isDirty).toBeTruthy();
-        expect(result.current.formState.dirtyFields).toEqual({
+        expect(result.current.formState.dirty).toEqual({
           test: [{ value: true }, undefined, { value: true }],
         });
       },

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -194,12 +194,12 @@ export const useFieldArray = <
   ) => {
     if (updatedFieldArrayValues) {
       set(
-        formStateRef.current.dirtyFields,
+        formStateRef.current.dirty,
         name,
         setFieldArrayDirtyFields(
           omitKey(updatedFieldArrayValues),
           get(defaultValuesRef.current, name, []),
-          get(formStateRef.current.dirtyFields, name, []),
+          get(formStateRef.current.dirty, name, []),
         ),
       );
     }
@@ -263,18 +263,15 @@ export const useFieldArray = <
       cleanup(formStateRef.current.touched);
     }
 
-    if (
-      readFormStateRef.current.dirtyFields ||
-      readFormStateRef.current.isDirty
-    ) {
+    if (readFormStateRef.current.dirty || readFormStateRef.current.isDirty) {
       const output = method(
-        get(formStateRef.current.dirtyFields, name, []),
+        get(formStateRef.current.dirty, name, []),
         args.argC,
         args.argD,
       );
-      shouldSet && set(formStateRef.current.dirtyFields, name, output);
+      shouldSet && set(formStateRef.current.dirty, name, output);
       updateDirtyFieldsWithDefaultValues(updatedFieldValues);
-      cleanup(formStateRef.current.dirtyFields);
+      cleanup(formStateRef.current.dirty);
     }
 
     if (shouldUpdateValid && readFormStateRef.current.isValid) {
@@ -311,15 +308,12 @@ export const useFieldArray = <
     ];
     setFieldAndValidState(updateFormValues);
 
-    if (
-      readFormStateRef.current.dirtyFields ||
-      readFormStateRef.current.isDirty
-    ) {
+    if (readFormStateRef.current.dirty || readFormStateRef.current.isDirty) {
       updateDirtyFieldsWithDefaultValues(updateFormValues);
 
       formStateSubjectRef.current.next({
         isDirty: true,
-        dirtyFields: formStateRef.current.dirtyFields,
+        dirty: formStateRef.current.dirty,
       });
     }
 

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -409,7 +409,7 @@ describe('useForm', () => {
       expect(formState.isDirty).toBeFalsy();
     });
 
-    it('should update dirtyFields during unregister', () => {
+    it('should update dirty during unregister', () => {
       let formState: any;
       const Component = () => {
         const { register, formState: tempFormState } = useForm();
@@ -431,12 +431,12 @@ describe('useForm', () => {
         },
       });
 
-      expect(formState.dirtyFields.test).toBeDefined();
+      expect(formState.dirty.test).toBeDefined();
       expect(formState.isDirty).toBeTruthy();
 
       unmount();
 
-      expect(formState.dirtyFields.test).toBeDefined();
+      expect(formState.dirty.test).toBeDefined();
       expect(formState.isDirty).toBeTruthy();
     });
 
@@ -717,7 +717,7 @@ describe('useForm', () => {
             touched: true,
             isValid: true,
             submitCount: true,
-            dirtyFields: true,
+            dirty: true,
           },
         ),
       );
@@ -1147,7 +1147,7 @@ describe('useForm', () => {
           },
         );
 
-        result.current.formState.dirtyFields;
+        result.current.formState.dirty;
 
         await act(async () =>
           result.current.setValue('test', 'abc', {
@@ -1239,7 +1239,7 @@ describe('useForm', () => {
           );
 
           expect(result.current.formState.isDirty).toBeTruthy();
-          expect(result.current.formState.dirtyFields).toEqual({ test: true });
+          expect(result.current.formState.dirty).toEqual({ test: true });
         },
       );
 
@@ -1273,7 +1273,7 @@ describe('useForm', () => {
           );
 
           expect(result.current.formState.isDirty).toBeTruthy();
-          expect(result.current.formState.dirtyFields).toEqual({
+          expect(result.current.formState.dirty).toEqual({
             test: dirtyFields,
           });
         },
@@ -1293,12 +1293,12 @@ describe('useForm', () => {
           );
 
           expect(result.current.formState.isDirty).toBeFalsy();
-          expect(result.current.formState.dirtyFields).toEqual({});
+          expect(result.current.formState.dirty).toEqual({});
         },
       );
 
       it.each(['isDirty', 'dirtyFields'])(
-        'should set name to dirtyFieldRef if field value is different with default value when formState.dirtyFields is defined',
+        'should set name to dirtyFieldRef if field value is different with default value when formState.dirty is defined',
         (property) => {
           const { result } = renderHook(() =>
             useForm<{ test: string }>({
@@ -1315,12 +1315,12 @@ describe('useForm', () => {
           );
 
           expect(result.current.formState.isDirty).toBeTruthy();
-          expect(result.current.formState.dirtyFields.test).toBeTruthy();
+          expect(result.current.formState.dirty.test).toBeTruthy();
         },
       );
 
       it.each(['isDirty', 'dirtyFields'])(
-        'should unset name from dirtyFieldRef if field value is not different with default value when formState.dirtyFields is defined',
+        'should unset name from dirtyFieldRef if field value is not different with default value when formState.dirty is defined',
         (property) => {
           const { result } = renderHook(() =>
             useForm<{ test: string }>({
@@ -1337,14 +1337,14 @@ describe('useForm', () => {
           );
 
           expect(result.current.formState.isDirty).toBeTruthy();
-          expect(result.current.formState.dirtyFields.test).toBeTruthy();
+          expect(result.current.formState.dirty.test).toBeTruthy();
 
           act(() =>
             result.current.setValue('test', 'default', { shouldDirty: true }),
           );
 
           expect(result.current.formState.isDirty).toBeFalsy();
-          expect(result.current.formState.dirtyFields.test).toBeUndefined();
+          expect(result.current.formState.dirty.test).toBeUndefined();
         },
       );
     });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -127,7 +127,7 @@ export function useForm<
   const [formState, setFormState] = React.useState<FormState<TFieldValues>>({
     isDirty: false,
     isValidating: false,
-    dirtyFields: {},
+    dirty: {},
     isSubmitted: false,
     submitCount: 0,
     touched: {},
@@ -138,7 +138,7 @@ export function useForm<
   });
   const readFormStateRef = React.useRef<ReadFormState>({
     isDirty: !isProxyEnabled,
-    dirtyFields: !isProxyEnabled,
+    dirty: !isProxyEnabled,
     touched: !isProxyEnabled || isOnTouch,
     isValidating: !isProxyEnabled,
     isSubmitting: !isProxyEnabled,
@@ -172,7 +172,7 @@ export function useForm<
       error: FieldError | undefined,
       shouldRender: boolean | null = false,
       state: {
-        dirtyFields?: FieldNamesMarkedBoolean<TFieldValues>;
+        dirty?: FieldNamesMarkedBoolean<TFieldValues>;
         isDirty?: boolean;
         touched?: FieldNamesMarkedBoolean<TFieldValues>;
       } = {},
@@ -281,33 +281,30 @@ export function useForm<
       name: InternalFieldName<TFieldValues>,
       shouldRender = true,
     ): Partial<
-      Pick<FormState<TFieldValues>, 'dirtyFields' | 'isDirty' | 'touched'>
+      Pick<FormState<TFieldValues>, 'dirty' | 'isDirty' | 'touched'>
     > => {
-      if (
-        readFormStateRef.current.isDirty ||
-        readFormStateRef.current.dirtyFields
-      ) {
+      if (readFormStateRef.current.isDirty || readFormStateRef.current.dirty) {
         const isFieldDirty = !deepEqual(
           get(defaultValuesRef.current, name),
           getFieldValue(fieldsRef, name, shallowFieldsStateRef),
         );
-        const isDirtyFieldExist = get(formStateRef.current.dirtyFields, name);
+        const isDirtyFieldExist = get(formStateRef.current.dirty, name);
         const previousIsDirty = formStateRef.current.isDirty;
 
         isFieldDirty
-          ? set(formStateRef.current.dirtyFields, name, true)
-          : unset(formStateRef.current.dirtyFields, name);
+          ? set(formStateRef.current.dirty, name, true)
+          : unset(formStateRef.current.dirty, name);
 
         const state = {
           isDirty: isFormDirty(),
-          dirtyFields: formStateRef.current.dirtyFields,
+          dirty: formStateRef.current.dirty,
         };
 
         const isChanged =
           (readFormStateRef.current.isDirty &&
             previousIsDirty !== state.isDirty) ||
-          (readFormStateRef.current.dirtyFields &&
-            isDirtyFieldExist !== get(formStateRef.current.dirtyFields, name));
+          (readFormStateRef.current.dirty &&
+            isDirtyFieldExist !== get(formStateRef.current.dirty, name));
 
         isChanged && shouldRender && formStateSubjectRef.current.next(state);
 
@@ -470,21 +467,21 @@ export function useForm<
 
           if (
             (readFormStateRef.current.isDirty ||
-              readFormStateRef.current.dirtyFields) &&
+              readFormStateRef.current.dirty) &&
             config.shouldDirty
           ) {
             set(
-              formStateRef.current.dirtyFields,
+              formStateRef.current.dirty,
               name,
               setFieldArrayDirtyFields(
                 value,
                 get(defaultValuesRef.current, name, []),
-                get(formStateRef.current.dirtyFields, name, []),
+                get(formStateRef.current.dirty, name, []),
               ),
             );
 
             formStateSubjectRef.current.next({
-              dirtyFields: formStateRef.current.dirtyFields,
+              dirty: formStateRef.current.dirty,
               isDirty: !deepEqual(
                 { ...getValues(), [name]: value },
                 defaultValuesRef.current,
@@ -723,7 +720,7 @@ export function useForm<
           unset(validFieldsRef.current, field.ref.name);
           unset(fieldsWithValidationRef.current, field.ref.name);
           unset(formStateRef.current.errors, field.ref.name);
-          set(formStateRef.current.dirtyFields, field.ref.name, true);
+          set(formStateRef.current.dirty, field.ref.name, true);
 
           formStateSubjectRef.current.next({
             ...formStateRef.current,
@@ -1005,7 +1002,7 @@ export function useForm<
     }
 
     if (!(isFieldArray && isEmptyDefaultValue)) {
-      !isFieldArray && unset(formStateRef.current.dirtyFields, name);
+      !isFieldArray && unset(formStateRef.current.dirty, name);
     }
 
     if (type) {
@@ -1150,7 +1147,7 @@ export function useForm<
     touched,
     isValid,
     submitCount,
-    dirtyFields,
+    dirty,
   }: OmitResetState) => {
     if (!isValid) {
       validFieldsRef.current = {};
@@ -1166,7 +1163,7 @@ export function useForm<
       isDirty: isDirty ? formStateRef.current.isDirty : false,
       isSubmitted: isSubmitted ? formStateRef.current.isSubmitted : false,
       isValid: isValid ? formStateRef.current.isValid : !isOnSubmit,
-      dirtyFields: dirtyFields ? formStateRef.current.dirtyFields : {},
+      dirty: dirty ? formStateRef.current.dirty : {},
       touched: touched ? formStateRef.current.touched : {},
       errors: errors ? formStateRef.current.errors : {},
       isSubmitting: false,

--- a/src/useFormState.test.tsx
+++ b/src/useFormState.test.tsx
@@ -5,17 +5,17 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { Control } from './types';
 
 describe('useFormState', () => {
-  it('should render correct form state with isDirty, dirtyFields, touched', () => {
+  it('should render correct form state with isDirty, dirty, touched', () => {
     let count = 0;
     const Test = ({ control }: { control: Control }) => {
-      const { isDirty, dirtyFields, touched } = useFormState({
+      const { isDirty, dirty, touched } = useFormState({
         control,
       });
 
       return (
         <>
           <div>{isDirty ? 'isDirty' : ''}</div>
-          <div>{dirtyFields['test'] ? 'dirty field' : ''}</div>
+          <div>{dirty['test'] ? 'dirty field' : ''}</div>
           <div>{touched['test'] ? 'isTouched' : ''}</div>
         </>
       );
@@ -117,7 +117,7 @@ describe('useFormState', () => {
     let test1Count = 0;
 
     const Test1 = ({ control }: { control: Control }) => {
-      const { isDirty, dirtyFields } = useFormState({
+      const { isDirty, dirty } = useFormState({
         control,
       });
 
@@ -125,9 +125,7 @@ describe('useFormState', () => {
 
       return (
         <>
-          <div>
-            {dirtyFields['test'] ? 'hasDirtyField' : 'notHasDirtyField'}
-          </div>
+          <div>{dirty['test'] ? 'hasDirtyField' : 'notHasDirtyField'}</div>
           <div>{isDirty ? 'isDirty' : 'notDirty'}</div>
         </>
       );


### PR DESCRIPTION
- `dirtyFields`

rename `dirtyFeilds` to `dirty`, keep it consistent with `touched` formState.

https://github.com/react-hook-form/react-hook-form/issues/2086