### PR TITLE
make DeepMap type support generic

### DIFF
--- a/src/logic/focusOnErrorField.ts
+++ b/src/logic/focusOnErrorField.ts
@@ -1,8 +1,8 @@
 import get from '../utils/get';
 import isUndefined from '../utils/isUndefined';
-import { FieldErrors, FieldRefs } from '../types';
+import { FieldErrors, FieldRefs, FieldValues } from '../types';
 
-export default <TFieldValues>(
+export default <TFieldValues extends FieldValues>(
   fields: FieldRefs<TFieldValues>,
   fieldErrors: FieldErrors<TFieldValues>,
 ) => {

--- a/src/types/utils.test.ts
+++ b/src/types/utils.test.ts
@@ -1,0 +1,9 @@
+import { DeepMap } from './utils';
+
+// @ts-ignore
+function DeepMapGenericTest<T extends { a: string; b: string; c: string }>() {
+  const a = (null as any) as DeepMap<T, { test: 'A' }>;
+  a.a?.test;
+  a.b?.test;
+  a.c?.test;
+}

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -41,23 +41,25 @@ export type IsAny<T> = boolean extends (T extends never ? true : false)
   ? true
   : false;
 
-export type DeepMap<T, TValue> = {
-  [K in keyof T]?: IsAny<T[K]> extends true
-    ? any
-    : NonUndefined<T[K]> extends NestedValue | Date | FileList
-    ? TValue
-    : NonUndefined<T[K]> extends object
-    ? DeepMap<T[K], TValue>
-    : NonUndefined<T[K]> extends Array<infer U>
-    ? IsAny<U> extends true
-      ? Array<any>
-      : U extends NestedValue | Date | FileList
-      ? Array<TValue>
-      : U extends object
-      ? Array<DeepMap<U, TValue>>
-      : Array<TValue>
-    : TValue;
-};
+export type DeepMap<T, TValue> = T extends T
+  ? {
+      [K in keyof T]?: IsAny<T[K]> extends true
+        ? any
+        : NonUndefined<T[K]> extends NestedValue | Date | FileList
+        ? TValue
+        : NonUndefined<T[K]> extends object
+        ? DeepMap<T[K], TValue>
+        : NonUndefined<T[K]> extends Array<infer U>
+        ? IsAny<U> extends true
+          ? Array<any>
+          : U extends NestedValue | Date | FileList
+          ? Array<TValue>
+          : U extends object
+          ? Array<DeepMap<U, TValue>>
+          : Array<TValue>
+        : TValue;
+    }
+  : never;
 
 export type IsFlatObject<T extends object> = Extract<
   Exclude<T[keyof T], NestedValue | Date | FileList>,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -100,9 +100,9 @@ export function useForm<
   const useWatchRenderFunctionsRef = React.useRef<UseWatchRenderFunctions>({});
   const fieldsWithValidationRef = React.useRef<
     FieldNamesMarkedBoolean<TFieldValues>
-  >({});
+  >({} as FieldNamesMarkedBoolean<TFieldValues>);
   const validFieldsRef = React.useRef<FieldNamesMarkedBoolean<TFieldValues>>(
-    {},
+    {} as FieldNamesMarkedBoolean<TFieldValues>,
   );
   const defaultValuesRef = React.useRef<DefaultValues<TFieldValues>>(
     defaultValues,
@@ -125,14 +125,14 @@ export function useForm<
   const [formState, setFormState] = React.useState<FormState<TFieldValues>>({
     isDirty: false,
     isValidating: false,
-    dirtyFields: {},
+    dirtyFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
     isSubmitted: false,
     submitCount: 0,
-    touched: {},
+    touched: {} as FieldNamesMarkedBoolean<TFieldValues>,
     isSubmitting: false,
     isSubmitSuccessful: false,
     isValid: !isOnSubmit,
-    errors: {},
+    errors: {} as FieldErrors<TFieldValues>,
   });
   const readFormStateRef = React.useRef<ReadFormState>({
     isDirty: !isProxyEnabled,
@@ -419,7 +419,8 @@ export function useForm<
       }
 
       if (Array.isArray(fields)) {
-        !name && (formStateRef.current.errors = {});
+        !name &&
+          (formStateRef.current.errors = {} as FieldErrors<TFieldValues>);
         const result = await Promise.all(
           fields.map(async (data) => await executeValidation(data, null)),
         );
@@ -783,7 +784,9 @@ export function useForm<
       );
 
     updateFormState({
-      errors: name ? formStateRef.current.errors : {},
+      errors: name
+        ? formStateRef.current.errors
+        : ({} as FieldErrors<TFieldValues>),
     });
   }
 
@@ -1082,7 +1085,7 @@ export function useForm<
         e.preventDefault();
         e.persist();
       }
-      let fieldErrors: FieldErrors<TFieldValues> = {};
+      let fieldErrors = {} as FieldErrors<TFieldValues>;
       let fieldValues = setFieldArrayDefaultValues(
         getFieldsValues(
           fieldsRef,
@@ -1104,7 +1107,7 @@ export function useForm<
             contextRef.current,
             isValidateAllFieldCriteria,
           );
-          formStateRef.current.errors = fieldErrors = errors;
+          formStateRef.current.errors = fieldErrors = errors as FieldErrors<TFieldValues>;
           fieldValues = values;
         } else {
           for (const field of Object.values(fieldsRef.current)) {
@@ -1136,7 +1139,7 @@ export function useForm<
           )
         ) {
           updateFormState({
-            errors: {},
+            errors: {} as FieldErrors<TFieldValues>,
             isSubmitting: true,
           });
           await onValid(fieldValues, e);
@@ -1172,8 +1175,8 @@ export function useForm<
     dirtyFields,
   }: OmitResetState) => {
     if (!isValid) {
-      validFieldsRef.current = {};
-      fieldsWithValidationRef.current = {};
+      validFieldsRef.current = {} as FieldNamesMarkedBoolean<TFieldValues>;
+      fieldsWithValidationRef.current = {} as FieldNamesMarkedBoolean<TFieldValues>;
     }
 
     fieldArrayDefaultValuesRef.current = {};
@@ -1185,9 +1188,15 @@ export function useForm<
       isDirty: isDirty ? formStateRef.current.isDirty : false,
       isSubmitted: isSubmitted ? formStateRef.current.isSubmitted : false,
       isValid: isValid ? formStateRef.current.isValid : false,
-      dirtyFields: dirtyFields ? formStateRef.current.dirtyFields : {},
-      touched: touched ? formStateRef.current.touched : {},
-      errors: errors ? formStateRef.current.errors : {},
+      dirtyFields: dirtyFields
+        ? formStateRef.current.dirtyFields
+        : ({} as FieldNamesMarkedBoolean<TFieldValues>),
+      touched: touched
+        ? formStateRef.current.touched
+        : ({} as FieldNamesMarkedBoolean<TFieldValues>),
+      errors: errors
+        ? formStateRef.current.errors
+        : ({} as FieldErrors<TFieldValues>),
       isSubmitting: false,
       isSubmitSuccessful: false,
     });


### PR DESCRIPTION
`DeepMap` related types didn't work with generic. [you can see here](https://codesandbox.io/s/cocky-newton-8wyd5?file=/src/index.tsx)

I solved this with [some little hack](https://bit.ly/35x2FK4).
With this approach, TypeScript cannot infer `{}` as DeepMap type.
I don't know there's better way to solve this.

But I think this is required for dividing interface and separation of concerns.
I don't want my component to know all dependency. (let me know if I divide interface without generic in component)