### PR TITLE
V7 - improve unregister and with extra option

### DIFF
--- a/app/src/useFieldArrayUnregister.tsx
+++ b/app/src/useFieldArrayUnregister.tsx
@@ -31,7 +31,10 @@ const ConditionField = <T extends any[]>({
 
   React.useEffect(() => {
     return () => {
-      control.unregister(`data[${index}].conditional` as any);
+      control.unregister(`data[${index}].conditional` as any, {
+        keepDirty: true,
+        keepTouched: true,
+      });
     };
   }, [control, index]);
 

--- a/cypress/integration/isValid.ts
+++ b/cypress/integration/isValid.ts
@@ -7,7 +7,7 @@ describe('isValid', () => {
     cy.get('#isValid').contains('false');
     cy.get('input[name="lastName"]').type('test');
     cy.get('#isValid').contains('true');
-    cy.get('#renderCount').contains('4');
+    cy.get('#renderCount').contains('5');
     cy.get('#toggle').click();
     cy.get('#isValid').contains('false');
     cy.get('#toggle').click();
@@ -20,7 +20,7 @@ describe('isValid', () => {
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#isValid').contains('false');
-    cy.get('#renderCount').contains('2');
+    cy.get('#renderCount').contains('3');
     cy.get('#toggle').click();
     cy.get('#isValid').contains('false');
   });
@@ -39,7 +39,7 @@ describe('isValid', () => {
     cy.get('#toggle').click();
     cy.get('input[name="firstName"]').type('test');
     cy.get('#isValid').contains('true');
-    cy.get('#renderCount').contains('7');
+    cy.get('#renderCount').contains('8');
   });
 
   it('should showing valid correctly with schema validation and default value supplied', () => {

--- a/cypress/integration/isValid.ts
+++ b/cypress/integration/isValid.ts
@@ -20,7 +20,7 @@ describe('isValid', () => {
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#isValid').contains('false');
-    cy.get('#renderCount').contains('2');
+    cy.get('#renderCount').contains('3');
     cy.get('#toggle').click();
     cy.get('#isValid').contains('false');
   });
@@ -39,7 +39,7 @@ describe('isValid', () => {
     cy.get('#toggle').click();
     cy.get('input[name="firstName"]').type('test');
     cy.get('#isValid').contains('true');
-    cy.get('#renderCount').contains('7');
+    cy.get('#renderCount').contains('8');
   });
 
   it('should showing valid correctly with schema validation and default value supplied', () => {

--- a/cypress/integration/isValid.ts
+++ b/cypress/integration/isValid.ts
@@ -7,7 +7,7 @@ describe('isValid', () => {
     cy.get('#isValid').contains('false');
     cy.get('input[name="lastName"]').type('test');
     cy.get('#isValid').contains('true');
-    cy.get('#renderCount').contains('5');
+    cy.get('#renderCount').contains('4');
     cy.get('#toggle').click();
     cy.get('#isValid').contains('false');
     cy.get('#toggle').click();
@@ -20,7 +20,7 @@ describe('isValid', () => {
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#isValid').contains('false');
-    cy.get('#renderCount').contains('3');
+    cy.get('#renderCount').contains('2');
     cy.get('#toggle').click();
     cy.get('#isValid').contains('false');
   });
@@ -39,7 +39,7 @@ describe('isValid', () => {
     cy.get('#toggle').click();
     cy.get('input[name="firstName"]').type('test');
     cy.get('#isValid').contains('true');
-    cy.get('#renderCount').contains('8');
+    cy.get('#renderCount').contains('7');
   });
 
   it('should showing valid correctly with schema validation and default value supplied', () => {

--- a/cypress/integration/useFieldArrayUnregister.ts
+++ b/cypress/integration/useFieldArrayUnregister.ts
@@ -176,6 +176,6 @@ describe('useFieldArrayUnregister', () => {
       }),
     );
 
-    cy.get('#renderCount').contains('31');
+    cy.get('#renderCount').contains('32');
   });
 });

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -480,7 +480,7 @@ describe('setValue', () => {
       expect(result.current.formState.errors?.test?.message).toBe('min');
     });
 
-    it('should not be called trigger method if config is empty', async () => {
+    it('should not be called trigger method if options is empty', async () => {
       const { result } = renderHook(() => useForm<{ test: string }>());
 
       result.current.register('test', {
@@ -524,7 +524,7 @@ describe('setValue', () => {
       expect(result.current.formState.errors?.test?.[2]?.message).toBe('min');
     });
 
-    it('should not be called trigger method if config is empty and field value is array', async () => {
+    it('should not be called trigger method if options is empty and field value is array', async () => {
       const { result } = renderHook(() =>
         useForm<{
           test: string[];

--- a/src/__tests__/useForm/unregister.test.tsx
+++ b/src/__tests__/useForm/unregister.test.tsx
@@ -32,4 +32,23 @@ describe('unregister', () => {
 
     expect(result.current.getValues()).toEqual({});
   });
+
+  it('should unregister all inputs', async () => {
+    const { result } = renderHook(() =>
+      useForm<{
+        input: string;
+        input2: string;
+      }>(),
+    );
+
+    result.current.register('input');
+    result.current.register('input');
+    result.current.register('input2');
+
+    await act(async () => {
+      await result.current.unregister();
+    });
+
+    expect(result.current.getValues()).toEqual({});
+  });
 });

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -175,6 +175,10 @@ type UseFormCommonMethods<TFieldValues extends FieldValues = FieldValues> = {
   ) => RegisterMethods;
   unregister: (
     name: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+    options?: Pick<
+      KeepStateOptions,
+      'keepErrors' | 'keepTouched' | 'keepDirty'
+    >,
   ) => void;
 };
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -174,7 +174,7 @@ type UseFormCommonMethods<TFieldValues extends FieldValues = FieldValues> = {
     options?: RegisterOptions,
   ) => RegisterMethods;
   unregister: (
-    name: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+    name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
     options?: Pick<KeepStateOptions, 'keepTouched' | 'keepDirty'>,
   ) => void;
 };
@@ -264,7 +264,7 @@ export type UseFormMethods<TFieldValues extends FieldValues = FieldValues> = {
   setValue: (
     name: FieldName<TFieldValues>,
     value: SetFieldValue<TFieldValues>,
-    config?: SetValueConfig,
+    options?: SetValueConfig,
   ) => void;
   trigger: (name?: FieldName<TFieldValues> | FieldName<TFieldValues>[]) => void;
   formState: FormState<TFieldValues>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -175,10 +175,7 @@ type UseFormCommonMethods<TFieldValues extends FieldValues = FieldValues> = {
   ) => RegisterMethods;
   unregister: (
     name: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
-    options?: Pick<
-      KeepStateOptions,
-      'keepErrors' | 'keepTouched' | 'keepDirty'
-    >,
+    options?: Pick<KeepStateOptions, 'keepTouched' | 'keepDirty'>,
   ) => void;
 };
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -778,10 +778,7 @@ export function useForm<
 
   function unregister(
     name: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
-    optinos?: Pick<
-      KeepStateOptions,
-      'keepErrors' | 'keepTouched' | 'keepDirty'
-    >,
+    options?: Pick<KeepStateOptions, 'keepTouched' | 'keepDirty'>,
   ): void {
     for (const inputName of Array.isArray(name) ? name : [name]) {
       const field = get(fieldsRef.current, inputName) as Field;
@@ -790,16 +787,13 @@ export function useForm<
         unset(validFieldsRef.current, inputName);
         unset(fieldsWithValidationRef.current, inputName);
         unset(fieldsRef.current, inputName);
+        unset(formStateRef.current.errors, inputName);
         unset(
-          optinos && optinos.keepErrors ? {} : formStateRef.current.errors,
+          options && options.keepDirty ? {} : formStateRef.current.dirtyFields,
           inputName,
         );
         unset(
-          optinos && optinos.keepDirty ? {} : formStateRef.current.dirtyFields,
-          inputName,
-        );
-        unset(
-          optinos && optinos.keepTouched
+          options && options.keepTouched
             ? {}
             : formStateRef.current.touchedFields,
           inputName,
@@ -807,7 +801,6 @@ export function useForm<
 
         watchSubjectRef.current.next({
           name: inputName,
-          value: null,
         });
       }
     }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -808,10 +808,8 @@ export function useForm<
     formStateSubjectRef.current.next({
       ...formStateRef.current,
       isDirty: isFormDirty(),
-      isValid: getIsValid(),
+      isValid: !!updateIsValid(),
     });
-
-    readFormStateRef.current.isValid && resolverRef.current && updateIsValid();
   }
 
   function updateValueAndGetDefault(name: InternalFieldName) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -458,16 +458,16 @@ export function useForm<
     (
       name: FieldName<TFieldValues>,
       value: SetFieldValue<TFieldValues>,
-      config: SetValueConfig,
+      options: SetValueConfig,
     ) => {
       const field = get(fieldsRef.current, name);
 
       if (field && field.__field) {
         setFieldValue(name, value);
-        config.shouldDirty && updateAndGetDirtyState(name);
-        config.shouldValidate && trigger(name as FieldName<TFieldValues>);
+        options.shouldDirty && updateAndGetDirtyState(name);
+        options.shouldValidate && trigger(name as FieldName<TFieldValues>);
       } else {
-        setInternalValues(name, value, config);
+        setInternalValues(name, value, options);
 
         if (fieldArrayNamesRef.current.has(name)) {
           fieldArraySubjectRef.current.next({
@@ -479,7 +479,7 @@ export function useForm<
           if (
             (readFormStateRef.current.isDirty ||
               readFormStateRef.current.dirtyFields) &&
-            config.shouldDirty
+            options.shouldDirty
           ) {
             set(
               formStateRef.current.dirtyFields,
@@ -513,9 +513,9 @@ export function useForm<
   function setValue(
     name: FieldName<TFieldValues>,
     value: SetFieldValue<TFieldValues>,
-    config?: SetValueConfig,
+    options?: SetValueConfig,
   ): void {
-    setInternalValue(name, value, config || {});
+    setInternalValue(name, value, options || {});
     isFieldWatched(name) && formStateSubjectRef.current.next({});
     watchSubjectRef.current.next({ name, value });
   }
@@ -777,10 +777,14 @@ export function useForm<
   }
 
   function unregister(
-    name: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+    name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
     options?: Pick<KeepStateOptions, 'keepTouched' | 'keepDirty'>,
   ): void {
-    for (const inputName of Array.isArray(name) ? name : [name]) {
+    for (const inputName of name
+      ? Array.isArray(name)
+        ? name
+        : [name]
+      : Object.keys(fieldsNamesRef.current)) {
       const field = get(fieldsRef.current, inputName) as Field;
 
       if (field) {
@@ -1015,7 +1019,7 @@ export function useForm<
     [shouldFocusError, isValidateAllFieldCriteria],
   );
 
-  const resetRefs = ({
+  const resetFromState = ({
     keepErrors,
     keepIsDirty,
     keepIsSubmitted,
@@ -1090,7 +1094,7 @@ export function useForm<
       });
     }
 
-    resetRefs(keepStateOptions);
+    resetFromState(keepStateOptions);
   };
 
   React.useEffect(() => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -808,8 +808,10 @@ export function useForm<
     formStateSubjectRef.current.next({
       ...formStateRef.current,
       isDirty: isFormDirty(),
-      isValid: !!updateIsValid(),
+      ...(resolver ? {} : { isValid: getIsValid() }),
     });
+
+    updateIsValid();
   }
 
   function updateValueAndGetDefault(name: InternalFieldName) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -778,6 +778,10 @@ export function useForm<
 
   function unregister(
     name: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+    optinos?: Pick<
+      KeepStateOptions,
+      'keepErrors' | 'keepTouched' | 'keepDirty'
+    >,
   ): void {
     for (const inputName of Array.isArray(name) ? name : [name]) {
       const field = get(fieldsRef.current, inputName) as Field;
@@ -785,25 +789,36 @@ export function useForm<
       if (field) {
         unset(validFieldsRef.current, inputName);
         unset(fieldsWithValidationRef.current, inputName);
-        unset(formStateRef.current.errors, inputName);
         unset(fieldsRef.current, inputName);
-
-        formStateSubjectRef.current.next({
-          ...formStateRef.current,
-          isDirty: isFormDirty(),
-          isValid: getIsValid(),
-        });
-
-        readFormStateRef.current.isValid &&
-          resolverRef.current &&
-          updateIsValid();
+        unset(
+          optinos && optinos.keepErrors ? {} : formStateRef.current.errors,
+          inputName,
+        );
+        unset(
+          optinos && optinos.keepDirty ? {} : formStateRef.current.dirtyFields,
+          inputName,
+        );
+        unset(
+          optinos && optinos.keepTouched
+            ? {}
+            : formStateRef.current.touchedFields,
+          inputName,
+        );
 
         watchSubjectRef.current.next({
           name: inputName,
-          value: '',
+          value: null,
         });
       }
     }
+
+    formStateSubjectRef.current.next({
+      ...formStateRef.current,
+      isDirty: isFormDirty(),
+      isValid: getIsValid(),
+    });
+
+    readFormStateRef.current.isValid && resolverRef.current && updateIsValid();
   }
 
   function updateValueAndGetDefault(name: InternalFieldName) {


### PR DESCRIPTION
## `unregister` method to have better options

```tsx
  unregister: (
    name: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
    options?: Pick<
      KeepStateOptions,
      'keepTouched' | 'keepDirty'
    >,
  ) => void
```
close https://github.com/react-hook-form/react-hook-form/issues/3155
close https://github.com/react-hook-form/react-hook-form/issues/3045