### PR TITLE
improve perf with resolver

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -787,14 +787,6 @@ describe('useForm', () => {
               value: 'test',
             },
           },
-          test1: {
-            name: 'test1',
-            ref: {
-              name: 'test1',
-              value: 'test1',
-            },
-            value: 'test1',
-          },
         };
 
         expect(resolver).toHaveBeenCalledWith(defaultValues, undefined, {
@@ -810,7 +802,17 @@ describe('useForm', () => {
 
         expect(resolver).toHaveBeenNthCalledWith(2, defaultValues, undefined, {
           criteriaMode: undefined,
-          fields,
+          fields: {
+            ...fields,
+            test1: {
+              name: 'test1',
+              ref: {
+                name: 'test1',
+                value: 'test1',
+              },
+              value: 'test1',
+            },
+          },
           names: [],
         });
 
@@ -821,7 +823,17 @@ describe('useForm', () => {
 
         expect(resolver).toHaveBeenNthCalledWith(3, defaultValues, undefined, {
           criteriaMode: undefined,
-          fields,
+          fields: {
+            ...fields,
+            test1: {
+              name: 'test1',
+              ref: {
+                name: 'test1',
+                value: 'test1',
+              },
+              value: 'test1',
+            },
+          },
           names: ['test.sub', 'test1'],
         });
       });

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -787,6 +787,14 @@ describe('useForm', () => {
               value: 'test',
             },
           },
+          test1: {
+            name: 'test1',
+            ref: {
+              name: 'test1',
+              value: 'test1',
+            },
+            value: 'test1',
+          },
         };
 
         expect(resolver).toHaveBeenCalledWith(defaultValues, undefined, {
@@ -802,17 +810,7 @@ describe('useForm', () => {
 
         expect(resolver).toHaveBeenNthCalledWith(2, defaultValues, undefined, {
           criteriaMode: undefined,
-          fields: {
-            ...fields,
-            test1: {
-              name: 'test1',
-              ref: {
-                name: 'test1',
-                value: 'test1',
-              },
-              value: 'test1',
-            },
-          },
+          fields,
           names: [],
         });
 
@@ -823,17 +821,7 @@ describe('useForm', () => {
 
         expect(resolver).toHaveBeenNthCalledWith(3, defaultValues, undefined, {
           criteriaMode: undefined,
-          fields: {
-            ...fields,
-            test1: {
-              name: 'test1',
-              ref: {
-                name: 'test1',
-                value: 'test1',
-              },
-              value: 'test1',
-            },
-          },
+          fields,
           names: ['test.sub', 'test1'],
         });
       });

--- a/src/logic/getFields.ts
+++ b/src/logic/getFields.ts
@@ -4,7 +4,7 @@ import isKey from '../utils/isKey';
 import set from '../utils/set';
 
 export default function getFields(
-  fieldsNames: Set<InternalFieldName>,
+  fieldsNames: Set<InternalFieldName> | InternalFieldName[],
   fieldsRefs: FieldRefs,
 ) {
   const currentFields: Record<InternalFieldName, Field['_f']> = {};

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -580,7 +580,7 @@ export function useForm<
             contextRef.current,
             {
               criteriaMode,
-              fields: getFields(fieldsNamesRef.current, fieldsRef.current),
+              fields: getFields([name], fieldsRef.current),
               names: [name as FieldName<TFieldValues>],
             },
           );

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -342,15 +342,18 @@ export function useForm<
   const executeSchemaOrResolverValidation = React.useCallback(
     async (
       names: InternalFieldName[],
-      currentNames: FieldName<TFieldValues>[] = [],
+      currentNames?: FieldName<TFieldValues>[],
     ) => {
       const { errors } = await resolverRef.current!(
         getValues(),
         contextRef.current,
         {
           criteriaMode,
-          names: currentNames,
-          fields: getFields(fieldsNamesRef.current, fieldsRef.current),
+          names: currentNames || [],
+          fields: getFields(
+            currentNames || fieldsNamesRef.current,
+            fieldsRef.current,
+          ),
         },
       );
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -342,18 +342,15 @@ export function useForm<
   const executeSchemaOrResolverValidation = React.useCallback(
     async (
       names: InternalFieldName[],
-      currentNames?: FieldName<TFieldValues>[],
+      currentNames: FieldName<TFieldValues>[] = [],
     ) => {
       const { errors } = await resolverRef.current!(
         getValues(),
         contextRef.current,
         {
           criteriaMode,
-          names: currentNames || [],
-          fields: getFields(
-            currentNames || fieldsNamesRef.current,
-            fieldsRef.current,
-          ),
+          names: currentNames,
+          fields: getFields(fieldsNamesRef.current, fieldsRef.current),
         },
       );
 


### PR DESCRIPTION
I think it's too expensive to call `getFields` onChange, by a loop through the names of the entire fields. This PR I only keep it to the current name or names.