### PR TITLE
fix valueAs consistency

### DIFF
--- a/src/__tests__/logic/getFieldValue.test.ts
+++ b/src/__tests__/logic/getFieldValue.test.ts
@@ -114,25 +114,21 @@ describe('getFieldValue', () => {
   });
 
   it('should return unmount field value when field is not found', () => {
-    expect(getFieldValue(undefined, false)).toBeFalsy();
     expect(getFieldValue(undefined)).toBeFalsy();
   });
 
   it('should not return value when the input is disabled', () => {
     expect(
-      getFieldValue(
-        {
-          _f: {
-            name: 'test',
-            ref: {
-              name: 'radio',
-              disabled: true,
-              type: 'radio',
-            },
+      getFieldValue({
+        _f: {
+          name: 'test',
+          ref: {
+            name: 'radio',
+            disabled: true,
+            type: 'radio',
           },
         },
-        true,
-      ),
+      }),
     ).toEqual(undefined);
   });
 });

--- a/src/__tests__/logic/getFieldValue.test.ts
+++ b/src/__tests__/logic/getFieldValue.test.ts
@@ -114,6 +114,7 @@ describe('getFieldValue', () => {
   });
 
   it('should return unmount field value when field is not found', () => {
+    expect(getFieldValue(undefined, false)).toBeFalsy();
     expect(getFieldValue(undefined)).toBeFalsy();
   });
 

--- a/src/__tests__/logic/getFieldValue.test.ts
+++ b/src/__tests__/logic/getFieldValue.test.ts
@@ -114,25 +114,24 @@ describe('getFieldValue', () => {
   });
 
   it('should return unmount field value when field is not found', () => {
-    expect(getFieldValue(undefined, false)).toBeFalsy();
     expect(getFieldValue(undefined)).toBeFalsy();
   });
 
-  it('should not return value when the input is disabled', () => {
-    expect(
-      getFieldValue(
-        {
-          _f: {
-            name: 'test',
-            ref: {
-              name: 'radio',
-              disabled: true,
-              type: 'radio',
-            },
-          },
-        },
-        true,
-      ),
-    ).toEqual(undefined);
-  });
+  // it('should not return value when the input is disabled', () => {
+  //   expect(
+  //     getFieldValue(
+  //       {
+  //         _f: {
+  //           name: 'test',
+  //           ref: {
+  //             name: 'radio',
+  //             disabled: true,
+  //             type: 'radio',
+  //           },
+  //         },
+  //       },
+  //       true,
+  //     ),
+  //   ).toEqual(undefined);
+  // });
 });

--- a/src/__tests__/logic/getFieldValue.test.ts
+++ b/src/__tests__/logic/getFieldValue.test.ts
@@ -117,21 +117,21 @@ describe('getFieldValue', () => {
     expect(getFieldValue(undefined)).toBeFalsy();
   });
 
-  // it('should not return value when the input is disabled', () => {
-  //   expect(
-  //     getFieldValue(
-  //       {
-  //         _f: {
-  //           name: 'test',
-  //           ref: {
-  //             name: 'radio',
-  //             disabled: true,
-  //             type: 'radio',
-  //           },
-  //         },
-  //       },
-  //       true,
-  //     ),
-  //   ).toEqual(undefined);
-  // });
+  it('should not return value when the input is disabled', () => {
+    expect(
+      getFieldValue(
+        {
+          _f: {
+            name: 'test',
+            ref: {
+              name: 'radio',
+              disabled: true,
+              type: 'radio',
+            },
+          },
+        },
+        true,
+      ),
+    ).toEqual(undefined);
+  });
 });

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -10,6 +10,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { VALIDATION_MODE } from '../../constants';
+import isString from '../../utils/isString';
 
 describe('register', () => {
   it('should support register passed to ref', async () => {
@@ -42,53 +43,44 @@ describe('register', () => {
     });
   });
 
-  // test.each([['text'], ['radio'], ['checkbox']])(
-  //   'should register field for %s type',
-  //   async (type) => {
-  //     const mockListener = jest.spyOn(
-  //       findRemovedFieldAndRemoveListener,
-  //       'default',
-  //     );
-  //     jest.spyOn(HTMLInputElement.prototype, 'addEventListener');
-  //
-  //     const Component = () => {
-  //       const {
-  //         register,
-  //         formState: { isDirty },
-  //       } = useForm<{
-  //         test: string;
-  //       }>();
-  //       return (
-  //         <div>
-  //           <input type={type} {...register('test')} />
-  //           <span role="alert">{`${isDirty}`}</span>
-  //         </div>
-  //       );
-  //     };
-  //
-  //     const { renderCount } = perf<{ Component: unknown }>(React);
-  //
-  //     render(<Component />);
-  //
-  //     const ref = screen.getByRole(type === 'text' ? 'textbox' : type);
-  //
-  //     expect(ref.addEventListener).toHaveBeenCalledWith(
-  //       type === 'radio' || type === 'checkbox'
-  //         ? EVENTS.CHANGE
-  //         : EVENTS.INPUT,
-  //       expect.any(Function),
-  //     );
-  //
-  //     // check MutationObserver
-  //     ref.remove();
-  //
-  //     await waitFor(() => expect(mockListener).toHaveBeenCalled());
-  //     expect(screen.getByRole('alert').textContent).toBe('false');
-  //     await wait(() =>
-  //       expect(renderCount.current.Component).toBeRenderedTimes(2),
-  //     );
-  //   },
-  // );
+  test.each([['text'], ['radio'], ['checkbox']])(
+    'should register field for %s type and remain its value after unmount',
+    async (type) => {
+      const Component = () => {
+        const {
+          register,
+          watch,
+          formState: { isDirty },
+        } = useForm<{
+          test: string;
+        }>({
+          defaultValues: {
+            test: 'test',
+          },
+        });
+
+        const test = watch('test');
+
+        return (
+          <form>
+            <input type={type} {...register('test')} />
+            <span role="alert">{`${isDirty}`}</span>
+            {test}
+          </form>
+        );
+      };
+
+      render(<Component />);
+
+      const ref = screen.getByRole(type === 'text' ? 'textbox' : type);
+
+      ref.remove();
+
+      expect(screen.getByRole('alert').textContent).toBe('false');
+
+      screen.getByText('test');
+    },
+  );
 
   test.each([['text'], ['radio'], ['checkbox']])(
     'should not register the same %s input',
@@ -245,6 +237,63 @@ describe('register', () => {
       });
 
       expect(output).toEqual({ test: 12345, test1: true });
+    });
+
+    it('should only validate input before the process', async () => {
+      const Component = () => {
+        const {
+          register,
+          formState: { errors },
+        } = useForm<{
+          test: number;
+          test1: number;
+        }>({
+          mode: 'onChange',
+        });
+
+        return (
+          <>
+            <input
+              {...register('test', {
+                validate: (data) => {
+                  return !isString(data);
+                },
+              })}
+            />
+            <span role="alert">{errors.test && 'Not number'}</span>
+
+            <input
+              {...register('test1', {
+                valueAsNumber: true,
+                min: 20,
+              })}
+            />
+            <span role="alert">{errors.test && 'Number length'}</span>
+          </>
+        );
+      };
+
+      render(<Component />);
+
+      await actComponent(async () => {
+        fireEvent.change(screen.getAllByRole('textbox')[0], {
+          target: {
+            value: '123',
+          },
+        });
+      });
+
+      screen.getByText('Not number');
+
+      await actComponent(async () => {
+        fireEvent.change(screen.getAllByRole('textbox')[1], {
+          target: {
+            value: '12',
+          },
+        });
+      });
+
+      screen.getByText('Number length');
     });
   });
 });

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -239,7 +239,7 @@ describe('register', () => {
       expect(output).toEqual({ test: 12345, test1: true });
     });
 
-    it('should only validate input before the process', async () => {
+    it('should validate input before the valueAs', async () => {
       const Component = () => {
         const {
           register,
@@ -294,6 +294,64 @@ describe('register', () => {
       });
 
       screen.getByText('Number length');
+    });
+
+    it('should send valueAs filed to schema validation', () => {
+      let output: any;
+
+      const Component = () => {
+        const { register, trigger } = useForm<{
+          test: number;
+          test1: any;
+          test2: boolean;
+        }>({
+          resolver: (data) => {
+            output = data;
+            return {
+              values: {
+                test: 1,
+                test1: 2,
+                test2: true,
+              },
+              errors: {},
+            };
+          },
+        });
+
+        return (
+          <form>
+            <input {...register('test', { valueAsNumber: true })} />
+            <input {...register('test1', { valueAsDate: true })} />
+            <input
+              {...register('test2', { setValueAs: (data) => data === 'test' })}
+            />
+            <button type="button" onClick={() => trigger()}>
+              trigger
+            </button>
+          </form>
+        );
+      };
+
+      render(<Component />);
+
+      fireEvent.change(screen.getAllByRole('textbox')[0], {
+        target: { value: 1 },
+      });
+      fireEvent.change(screen.getAllByRole('textbox')[1], {
+        target: { value: '1990' },
+      });
+      fireEvent.change(screen.getAllByRole('textbox')[2], {
+        target: { value: 'test' },
+      });
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(output).toEqual({
+        test: 1,
+
+        test1: new Date('1990'),
+        test2: true,
+      });
     });
   });
 });

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -163,7 +163,7 @@ describe('setValue', () => {
     await act(async () => {
       await result.current.handleSubmit((data) => {
         expect(data).toEqual({
-          test: true,
+          test: ['1'],
         });
       })({
         preventDefault: () => {},

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -163,7 +163,7 @@ describe('setValue', () => {
     await act(async () => {
       await result.current.handleSubmit((data) => {
         expect(data).toEqual({
-          test: ['1'],
+          test: true,
         });
       })({
         preventDefault: () => {},

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -5,8 +5,8 @@ import isFileInput from '../utils/isFileInput';
 import isCheckBox from '../utils/isCheckBoxInput';
 import isMultipleSelect from '../utils/isMultipleSelect';
 import getCheckboxValue from './getCheckboxValue';
-import { Field } from '../types';
 import getFieldValueAs from './getFieldValueAs';
+import { Field } from '../types';
 
 export default function getFieldValue(
   field?: Field,

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -13,7 +13,7 @@ export default function getFieldValue(
   shouldReturnRawValue?: boolean,
 ) {
   if (field && field._f) {
-    const { ref, valueAsNumber, valueAsDate, setValueAs } = field._f;
+    const { ref } = field._f;
 
     if (ref.disabled) {
       return;
@@ -37,6 +37,6 @@ export default function getFieldValue(
 
     return shouldReturnRawValue
       ? ref.value
-      : getFieldValueAs(ref.value, valueAsNumber, valueAsDate, setValueAs);
+      : getFieldValueAs(ref.value, field._f);
   }
 }

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -10,7 +10,7 @@ import { Field } from '../types';
 
 export default function getFieldValue(
   field?: Field,
-  shouldReturnRawValue?: boolean,
+  shouldReturnAsValue?: boolean,
 ) {
   if (field && field._f) {
     const { ref } = field._f;
@@ -35,8 +35,8 @@ export default function getFieldValue(
       return getCheckboxValue(field._f.refs).value;
     }
 
-    return shouldReturnRawValue
-      ? ref.value
-      : getFieldValueAs(ref.value, field._f);
+    return shouldReturnAsValue
+      ? getFieldValueAs(ref.value, field._f)
+      : ref.value;
   }
 }

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -7,14 +7,11 @@ import isMultipleSelect from '../utils/isMultipleSelect';
 import getCheckboxValue from './getCheckboxValue';
 import { Field } from '../types';
 
-export default function getFieldValue(
-  field?: Field,
-  shouldReturnSubmitValue?: boolean,
-) {
+export default function getFieldValue(field?: Field) {
   if (field && field._f) {
     const { ref, valueAsNumber, valueAsDate, setValueAs } = field._f;
 
-    if (ref.disabled && shouldReturnSubmitValue) {
+    if (ref.disabled) {
       return;
     }
 
@@ -34,16 +31,14 @@ export default function getFieldValue(
       return getCheckboxValue(field._f.refs).value;
     }
 
-    return shouldReturnSubmitValue
-      ? valueAsNumber
-        ? ref.value === ''
-          ? NaN
-          : +ref.value
-        : valueAsDate
-        ? (ref as HTMLInputElement).valueAsDate
-        : setValueAs
-        ? setValueAs(ref.value)
-        : ref.value
+    return valueAsNumber
+      ? ref.value === ''
+        ? NaN
+        : +ref.value
+      : valueAsDate
+      ? (ref as HTMLInputElement).valueAsDate
+      : setValueAs
+      ? setValueAs(ref.value)
       : ref.value;
   }
 }

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -6,6 +6,7 @@ import isCheckBox from '../utils/isCheckBoxInput';
 import isMultipleSelect from '../utils/isMultipleSelect';
 import getCheckboxValue from './getCheckboxValue';
 import { Field } from '../types';
+import getFieldValueAs from './getFieldValueAs';
 
 export default function getFieldValue(
   field?: Field,
@@ -36,14 +37,6 @@ export default function getFieldValue(
 
     return shouldReturnRawValue
       ? ref.value
-      : valueAsNumber
-      ? ref.value === ''
-        ? NaN
-        : +ref.value
-      : valueAsDate
-      ? (ref as HTMLInputElement).valueAsDate
-      : setValueAs
-      ? setValueAs(ref.value)
-      : ref.value;
+      : getFieldValueAs(ref.value, valueAsNumber, valueAsDate, setValueAs);
   }
 }

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -7,7 +7,10 @@ import isMultipleSelect from '../utils/isMultipleSelect';
 import getCheckboxValue from './getCheckboxValue';
 import { Field } from '../types';
 
-export default function getFieldValue(field?: Field) {
+export default function getFieldValue(
+  field?: Field,
+  shouldReturnRawValue?: boolean,
+) {
   if (field && field._f) {
     const { ref, valueAsNumber, valueAsDate, setValueAs } = field._f;
 
@@ -31,7 +34,9 @@ export default function getFieldValue(field?: Field) {
       return getCheckboxValue(field._f.refs).value;
     }
 
-    return valueAsNumber
+    return shouldReturnRawValue
+      ? ref.value
+      : valueAsNumber
       ? ref.value === ''
         ? NaN
         : +ref.value

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -9,12 +9,12 @@ import { Field } from '../types';
 
 export default function getFieldValue(
   field?: Field,
-  excludeDisabled?: boolean,
+  shouldReturnSubmitValue?: boolean,
 ) {
   if (field && field._f) {
     const { ref, valueAsNumber, valueAsDate, setValueAs } = field._f;
 
-    if (ref.disabled && excludeDisabled) {
+    if (ref.disabled && shouldReturnSubmitValue) {
       return;
     }
 
@@ -34,14 +34,16 @@ export default function getFieldValue(
       return getCheckboxValue(field._f.refs).value;
     }
 
-    return valueAsNumber
-      ? ref.value === ''
-        ? NaN
-        : +ref.value
-      : valueAsDate
-      ? (ref as HTMLInputElement).valueAsDate
-      : setValueAs
-      ? setValueAs(ref.value)
+    return shouldReturnSubmitValue
+      ? valueAsNumber
+        ? ref.value === ''
+          ? NaN
+          : +ref.value
+        : valueAsDate
+        ? (ref as HTMLInputElement).valueAsDate
+        : setValueAs
+        ? setValueAs(ref.value)
+        : ref.value
       : ref.value;
   }
 }

--- a/src/logic/getFieldValue.ts
+++ b/src/logic/getFieldValue.ts
@@ -35,8 +35,6 @@ export default function getFieldValue(
       return getCheckboxValue(field._f.refs).value;
     }
 
-    return shouldReturnAsValue
-      ? getFieldValueAs(ref.value, field._f)
-      : ref.value;
+    return getFieldValueAs(ref.value, field._f, shouldReturnAsValue);
   }
 }

--- a/src/logic/getFieldValueAs.ts
+++ b/src/logic/getFieldValueAs.ts
@@ -1,8 +1,8 @@
+import { Field } from '../types';
+
 export default (
   value: any,
-  valueAsNumber?: boolean,
-  valueAsDate?: boolean,
-  setValueAs?: any,
+  { valueAsNumber, valueAsDate, setValueAs }: Field['_f'],
 ) =>
   valueAsNumber
     ? value === ''

--- a/src/logic/getFieldValueAs.ts
+++ b/src/logic/getFieldValueAs.ts
@@ -3,13 +3,16 @@ import { Field } from '../types';
 export default (
   value: any,
   { valueAsNumber, valueAsDate, setValueAs }: Field['_f'],
+  shouldReturnAsValue?: boolean,
 ) =>
-  valueAsNumber
-    ? value === ''
-      ? NaN
-      : +value
-    : valueAsDate
-    ? new Date(value)
-    : setValueAs
-    ? setValueAs(value)
+  shouldReturnAsValue
+    ? valueAsNumber
+      ? value === ''
+        ? NaN
+        : +value
+      : valueAsDate
+      ? new Date(value)
+      : setValueAs
+      ? setValueAs(value)
+      : value
     : value;

--- a/src/logic/getFieldValueAs.ts
+++ b/src/logic/getFieldValueAs.ts
@@ -1,0 +1,15 @@
+export default (
+  value: any,
+  valueAsNumber?: boolean,
+  valueAsDate?: boolean,
+  setValueAs?: any,
+) =>
+  valueAsNumber
+    ? value === ''
+      ? NaN
+      : +value
+    : valueAsDate
+    ? new Date(value)
+    : setValueAs
+    ? setValueAs(value)
+    : value;

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -16,7 +16,7 @@ const getFieldsValues = (
       set(
         output,
         name,
-        shouldReturnSubmitValue && _f
+        shouldReturnSubmitValue
           ? getFieldValue(field, shouldReturnSubmitValue)
           : _f
           ? _f.value

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -4,6 +4,7 @@ import { FieldRefs } from '../types';
 
 const getFieldsValues = (
   fieldsRef: React.MutableRefObject<FieldRefs>,
+  shouldReturnSubmitValue?: boolean,
   output: Record<string, any> = {},
 ): any => {
   for (const name in fieldsRef.current) {
@@ -14,7 +15,21 @@ const getFieldsValues = (
       set(
         output,
         name,
-        _f && !_f.ref.disabled ? _f.value : Array.isArray(field) ? [] : {},
+        _f && !_f.ref.disabled
+          ? shouldReturnSubmitValue
+            ? _f.valueAsNumber
+              ? _f.value === ''
+                ? NaN
+                : +_f.value
+              : _f.valueAsDate
+              ? (_f.ref as HTMLInputElement).valueAsDate
+              : _f.setValueAs
+              ? _f.setValueAs(_f.value)
+              : _f.value
+            : _f.value
+          : Array.isArray(field)
+          ? []
+          : {},
       );
 
       if (current) {
@@ -22,6 +37,7 @@ const getFieldsValues = (
           {
             current,
           },
+          shouldReturnSubmitValue,
           output[name],
         );
       }

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -17,9 +17,7 @@ const getFieldsValues = (
         output,
         name,
         _f && !_f.ref.disabled
-          ? shouldReturnAsValue
-            ? getFieldValueAs(_f.value, _f)
-            : _f.value
+          ? getFieldValueAs(_f.value, _f, shouldReturnAsValue)
           : Array.isArray(field)
           ? []
           : {},

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import set from '../utils/set';
+import getFieldValueAs from './getFieldValueAs';
 import { FieldRefs } from '../types';
 
 const getFieldsValues = (
@@ -17,15 +18,12 @@ const getFieldsValues = (
         name,
         _f && !_f.ref.disabled
           ? shouldReturnSubmitValue
-            ? _f.valueAsNumber
-              ? _f.value === ''
-                ? NaN
-                : +_f.value
-              : _f.valueAsDate
-              ? (_f.ref as HTMLInputElement).valueAsDate
-              : _f.setValueAs
-              ? _f.setValueAs(_f.value)
-              : _f.value
+            ? getFieldValueAs(
+                _f.value,
+                _f.valueAsNumber,
+                _f.valueAsDate,
+                _f.setValueAs,
+              )
             : _f.value
           : Array.isArray(field)
           ? []

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import set from '../utils/set';
 import { FieldRefs } from '../types';
-import getFieldValue from './getFieldValue';
 
 const getFieldsValues = (
   fieldsRef: React.MutableRefObject<FieldRefs>,
-  shouldReturnSubmitValue?: boolean,
   output: Record<string, any> = {},
 ): any => {
   for (const name in fieldsRef.current) {
@@ -16,13 +14,7 @@ const getFieldsValues = (
       set(
         output,
         name,
-        shouldReturnSubmitValue
-          ? getFieldValue(field, shouldReturnSubmitValue)
-          : _f
-          ? _f.value
-          : Array.isArray(field)
-          ? []
-          : {},
+        _f && !_f.ref.disabled ? _f.value : Array.isArray(field) ? [] : {},
       );
 
       if (current) {
@@ -30,7 +22,6 @@ const getFieldsValues = (
           {
             current,
           },
-          shouldReturnSubmitValue,
           output[name],
         );
       }

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import set from '../utils/set';
 import { FieldRefs } from '../types';
+import getFieldValue from './getFieldValue';
 
 const getFieldsValues = (
   fieldsRef: React.MutableRefObject<FieldRefs>,
+  shouldReturnSubmitValue?: boolean,
   output: Record<string, any> = {},
 ): any => {
   for (const name in fieldsRef.current) {
@@ -14,7 +16,13 @@ const getFieldsValues = (
       set(
         output,
         name,
-        _f && !_f.ref.disabled ? _f.value : Array.isArray(field) ? [] : {},
+        shouldReturnSubmitValue && _f
+          ? getFieldValue(field, shouldReturnSubmitValue)
+          : _f
+          ? _f.value
+          : Array.isArray(field)
+          ? []
+          : {},
       );
 
       if (current) {
@@ -22,6 +30,7 @@ const getFieldsValues = (
           {
             current,
           },
+          shouldReturnSubmitValue,
           output[name],
         );
       }

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -18,12 +18,7 @@ const getFieldsValues = (
         name,
         _f && !_f.ref.disabled
           ? shouldReturnSubmitValue
-            ? getFieldValueAs(
-                _f.value,
-                _f.valueAsNumber,
-                _f.valueAsDate,
-                _f.setValueAs,
-              )
+            ? getFieldValueAs(_f.value, _f)
             : _f.value
           : Array.isArray(field)
           ? []

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -5,7 +5,7 @@ import { FieldRefs } from '../types';
 
 const getFieldsValues = (
   fieldsRef: React.MutableRefObject<FieldRefs>,
-  shouldReturnSubmitValue?: boolean,
+  shouldReturnAsValue?: boolean,
   output: Record<string, any> = {},
 ): any => {
   for (const name in fieldsRef.current) {
@@ -17,7 +17,7 @@ const getFieldsValues = (
         output,
         name,
         _f && !_f.ref.disabled
-          ? shouldReturnSubmitValue
+          ? shouldReturnAsValue
             ? getFieldValueAs(_f.value, _f)
             : _f.value
           : Array.isArray(field)
@@ -30,7 +30,7 @@ const getFieldsValues = (
           {
             current,
           },
-          shouldReturnSubmitValue,
+          shouldReturnAsValue,
           output[name],
         );
       }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -345,7 +345,7 @@ export function useForm<
       currentNames: FieldName<TFieldValues>[] = [],
     ) => {
       const { errors } = await resolverRef.current!(
-        getValues(),
+        getFieldsValues(fieldsRef, true),
         contextRef.current,
         {
           criteriaMode,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -940,7 +940,7 @@ export function useForm<
         e.preventDefault();
         e.persist();
       }
-      let fieldValues = getFieldsValues(fieldsRef, true);
+      let fieldValues = getFieldsValues(fieldsRef);
 
       formStateSubjectRef.current.next({
         isSubmitting: true,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -523,7 +523,7 @@ export function useForm<
       const field = get(fieldsRef.current, name) as Field;
 
       if (field) {
-        const inputValue = inputType ? getFieldValue(field) : value;
+        const inputValue = inputType ? getFieldValue(field, true) : value;
         const isBlurEvent = type === EVENTS.BLUR;
         const {
           isOnBlur: isReValidateOnBlur,
@@ -576,7 +576,7 @@ export function useForm<
 
         if (resolverRef.current) {
           const { errors } = await resolverRef.current(
-            getValues(),
+            getFieldsValues(fieldsRef, true),
             contextRef.current,
             {
               criteriaMode,
@@ -651,7 +651,7 @@ export function useForm<
       if (resolver) {
         const { errors } = await resolverRef.current!(
           {
-            ...getValues(),
+            ...getFieldsValues(fieldsRef, true),
             ...values,
           },
           contextRef.current,
@@ -879,6 +879,7 @@ export function useForm<
       ) {
         get(fieldsRef.current, name)._f.value = getFieldValue(
           get(fieldsRef.current, name),
+          true,
         );
       }
 
@@ -940,7 +941,7 @@ export function useForm<
         e.preventDefault();
         e.persist();
       }
-      let fieldValues = getFieldsValues(fieldsRef);
+      let fieldValues = getFieldsValues(fieldsRef, true);
 
       formStateSubjectRef.current.next({
         isSubmitting: true,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -290,7 +290,7 @@ export function useForm<
       ) {
         const isFieldDirty = !deepEqual(
           get(defaultValuesRef.current, name),
-          getFieldValue(get(fieldsRef.current, name) as Field),
+          getFieldValue(get(fieldsRef.current, name) as Field, true),
         );
         const isDirtyFieldExist = get(formStateRef.current.dirtyFields, name);
         const previousIsDirty = formStateRef.current.isDirty;
@@ -523,7 +523,7 @@ export function useForm<
       const field = get(fieldsRef.current, name) as Field;
 
       if (field) {
-        const inputValue = inputType ? getFieldValue(field, true) : value;
+        const inputValue = inputType ? getFieldValue(field) : value;
         const isBlurEvent = type === EVENTS.BLUR;
         const {
           isOnBlur: isReValidateOnBlur,
@@ -879,7 +879,6 @@ export function useForm<
       ) {
         get(fieldsRef.current, name)._f.value = getFieldValue(
           get(fieldsRef.current, name),
-          true,
         );
       }
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -940,7 +940,7 @@ export function useForm<
         e.preventDefault();
         e.persist();
       }
-      let fieldValues = getFieldsValues(fieldsRef);
+      let fieldValues = getFieldsValues(fieldsRef, true);
 
       formStateSubjectRef.current.next({
         isSubmitting: true,


### PR DESCRIPTION
- `valueAs` `setValueAs` **will not** invoked before in-build validation.
- `valueAs` `setValueAs` **will be** invoked before schema validation.
- `getValues` and `getFieldValue` will only read whats's in the input value.
- `dirty` will be measured after the `valueAs`