### PR TITLE
Fix set error api consistency

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -163,6 +163,9 @@ export type UseFormSetValue<TFieldValues extends FieldValues> = (
 export type UseFormSetError<TFieldValues extends FieldValues> = (
   name: FieldName<TFieldValues>,
   error: ErrorOption,
+  options?: {
+    shouldFocus: boolean;
+  },
 ) => void;
 
 export type UseFormUnregister<TFieldValues extends FieldValues> = (

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -704,7 +704,7 @@ export function useForm<
     });
   };
 
-  const setError: UseFormSetError<TFieldValues> = (name, error) => {
+  const setError: UseFormSetError<TFieldValues> = (name, error, options) => {
     const ref = ((get(fieldsRef.current, name) as Field) || { _f: {} })._f.ref;
 
     set(formStateRef.current.errors, name, {
@@ -717,7 +717,7 @@ export function useForm<
       isValid: false,
     });
 
-    error.shouldFocus && ref && ref.focus && ref.focus();
+    options && options.shouldFocus && ref && ref.focus && ref.focus();
   };
 
   const watchInternal: WatchInternal = React.useCallback(


### PR DESCRIPTION
Fix API consistency with `setError`

`set(name, value, options)`