### PR TITLE
useWatch remove default value

### DIFF
--- a/app/src/useFieldArrayUnregister.tsx
+++ b/app/src/useFieldArrayUnregister.tsx
@@ -28,7 +28,6 @@ const ConditionField = <T extends any[]>({
   const output = useWatch<FormInputs>({
     name: 'data',
     control,
-    defaultValue: fields,
   });
 
   React.useEffect(() => {
@@ -40,7 +39,7 @@ const ConditionField = <T extends any[]>({
     };
   }, [unregister, index]);
 
-  return output[index]?.name === 'bill' ? (
+  return output?.[index]?.name === 'bill' ? (
     <input
       {...control.register(`data.${index}.conditional`)}
       defaultValue={fields[index].conditional}

--- a/app/src/useWatch.tsx
+++ b/app/src/useWatch.tsx
@@ -21,7 +21,6 @@ const GrandChild = ({
   const output = useWatch({
     name: 'test',
     control,
-    defaultValue: 'yay! I am watching you :)',
   });
 
   counter1.current++;
@@ -44,7 +43,6 @@ const GrandChild1 = ({
   const output = useWatch<FormInputs>({
     name: ['test', 'test1'],
     control,
-    defaultValue: { test: '', test1: '' },
   });
 
   counter.current++;

--- a/src/__tests__/__snapshots__/useWatch.test.tsx.snap
+++ b/src/__tests__/__snapshots__/useWatch.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useWatch reset with useFieldArray should return current value with radio type 1`] = `
+Array [
+  Object {
+    "options": Array [
+      Object {
+        "option": "test",
+      },
+      Object {
+        "option": "test1",
+      },
+    ],
+  },
+  Object {
+    "options": Array [
+      Object {
+        "option": undefined,
+      },
+      Object {
+        "option": undefined,
+      },
+    ],
+  },
+  Object {
+    "options": Array [
+      Object {
+        "option": null,
+      },
+      Object {
+        "option": null,
+      },
+    ],
+  },
+  Object {
+    "options": Array [
+      Object {
+        "option": null,
+      },
+      Object {
+        "option": null,
+      },
+    ],
+  },
+]
+`;

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -46,7 +46,11 @@ describe('useWatch', () => {
 
     it('should return default value in useWatch', () => {
       const { result } = renderHook(() => {
-        const { control } = useForm<{ test: string }>();
+        const { control } = useForm<{ test: string }>({
+          defaultValues: {
+            test: 'test',
+          },
+        });
         return useWatch({
           control,
           name: 'test',

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -313,7 +313,7 @@ describe('useWatch', () => {
         },
       });
 
-      await wait(() => expect(renderCount.current.Parent).toBeRenderedTimes(2));
+      await wait(() => expect(renderCount.current.Parent).toBeRenderedTimes(1));
     });
 
     it('should not throw error when null or undefined is set', () => {

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -50,7 +50,6 @@ describe('useWatch', () => {
         return useWatch({
           control,
           name: 'test',
-          defaultValue: 'test',
         });
       });
 
@@ -660,7 +659,6 @@ describe('useWatch', () => {
             test: string;
           }>({
             name: 'test',
-            defaultValue: 'test',
             control,
           });
 
@@ -721,7 +719,6 @@ describe('useWatch', () => {
           const { register, reset, control } = useForm<{ test: string }>();
           const test = useWatch<{ test: string }>({
             name: 'test',
-            defaultValue: 'test',
             control,
           });
 

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -91,7 +91,7 @@ describe('useWatch', () => {
         });
       });
 
-      expect(result.current).toEqual({ test: 'test', test1: 'test1' });
+      expect(result.current).toEqual(['test', 'test1']);
     });
 
     it('should return default value when name is undefined', () => {
@@ -110,7 +110,7 @@ describe('useWatch', () => {
       expect(result.current).toEqual({ test: 'test', test1: 'test1' });
     });
 
-    it('should return empty object', () => {
+    it('should return empty array when watch array fields', () => {
       const { result } = renderHook(() => {
         const { control } = useForm<{ test: string }>();
         return useWatch({
@@ -119,7 +119,7 @@ describe('useWatch', () => {
         });
       });
 
-      expect(result.current).toEqual({});
+      expect(result.current).toEqual([undefined]);
     });
 
     it('should return undefined', () => {
@@ -541,15 +541,25 @@ describe('useWatch', () => {
     describe('with useFieldArray', () => {
       // issue: https://github.com/react-hook-form/react-hook-form/issues/2229
       it('should return current value with radio type', async () => {
-        let watchedValue: any;
+        type FormValues = {
+          options: { option: string }[];
+        };
+
+        const watchedValue: object[] = [];
+
+        const Test = ({ control }: { control: Control<FormValues> }) => {
+          watchedValue.push(
+            useWatch({
+              control,
+            }),
+          );
+
+          return null;
+        };
+
         const Component = () => {
-          const { register, reset, control } = useForm<{
-            options: { option: string }[];
-          }>();
+          const { register, reset, control } = useForm<FormValues>();
           const { fields } = useFieldArray({ name: 'options', control });
-          watchedValue = useWatch({
-            control,
-          });
 
           React.useEffect(() => {
             reset({
@@ -578,6 +588,7 @@ describe('useWatch', () => {
                     value="no"
                     {...register(`options.${i}.option` as const)}
                   />
+                  <Test control={control} />
                 </div>
               ))}
             </form>
@@ -588,15 +599,12 @@ describe('useWatch', () => {
 
         fireEvent.change(screen.getAllByRole('radio')[1], {
           target: {
+            value: 'yes',
             checked: true,
           },
         });
 
-        actComponent(() => {
-          expect(watchedValue).toEqual({
-            options: [{ option: 'test' }, { option: 'test1' }],
-          });
-        });
+        expect(watchedValue).toMatchSnapshot();
       });
 
       it("should watch item correctly with useFieldArray's remove method", async () => {
@@ -720,7 +728,11 @@ describe('useWatch', () => {
 
       it('should return default value', async () => {
         const Component = () => {
-          const { register, reset, control } = useForm<{ test: string }>();
+          const { register, reset, control } = useForm<{ test: string }>({
+            defaultValues: {
+              test: 'test',
+            },
+          });
           const test = useWatch<{ test: string }>({
             name: 'test',
             control,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ import { ValidationMode } from './types';
 
 export const EVENTS = {
   BLUR: 'blur',
+  CHANGE: 'change',
 };
 
 export const VALIDATION_MODE: ValidationMode = {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -296,6 +296,7 @@ export type UseFormStateProps<TFieldValues> = Partial<{
 export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
 
 export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
+  defaultValue?: unknown;
   name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[];
   control?: Control<TFieldValues>;
 };

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -296,7 +296,6 @@ export type UseFormStateProps<TFieldValues> = Partial<{
 export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
 
 export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
-  defaultValue?: unknown;
   name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[];
   control?: Control<TFieldValues>;
 };

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -220,6 +220,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = {
     SubjectType<{
       name?: InternalFieldName;
       value?: unknown;
+      type?: EventType;
     }>
   >;
   controllerSubjectRef: React.MutableRefObject<

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -66,6 +66,7 @@ export function useController<TFieldValues extends FieldValues = FieldValues>({
             value,
             name: name as InternalFieldName,
           },
+          type: EVENTS.CHANGE,
         });
       },
       onBlur: () => {

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -48,14 +48,8 @@ export function useWatch<TFieldValues>({
     control || methods.control;
   const [value, updateValue] = React.useState<unknown>(
     Array.isArray(name)
-      ? name.reduce(
-          (previous, inputName) => ({
-            ...previous,
-            [inputName]: getFieldValue(
-              get(fieldsRef.current, inputName as InternalFieldName),
-            ),
-          }),
-          {},
+      ? name.map((inputName) =>
+          getFieldValue(get(fieldsRef.current, inputName as InternalFieldName)),
         )
       : isString(name)
       ? getFieldValue(get(fieldsRef.current, name as InternalFieldName))

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { useFormContext } from './useFormContext';
 import isUndefined from './utils/isUndefined';
 import isString from './utils/isString';
-import get from './utils/get';
-import isObject from './utils/isObject';
+// import get from './utils/get';
+// import isObject from './utils/isObject';
 import {
   DeepPartial,
   UseWatchProps,
@@ -55,13 +55,19 @@ export function useWatch<TFieldValues>({
   React.useEffect(() => {
     const watchSubscription = watchSubjectRef.current.subscribe({
       next: ({ name: inputName, value }) => {
-        updateValue(
-          isString(inputName) && name === inputName && !isUndefined(value)
-            ? value
-            : name && isObject(value)
-            ? get(value, name as InternalFieldName, defaultValue)
-            : watchInternal(name as string, defaultValue),
-        );
+        (!name ||
+          !inputName ||
+          (Array.isArray(name) ? name : [name]).some(
+            (fieldName) =>
+              inputName &&
+              fieldName &&
+              inputName.startsWith(fieldName as InternalFieldName),
+          )) &&
+          updateValue(
+            isString(inputName) && name === inputName && !isUndefined(value)
+              ? value
+              : watchInternal(name as string, defaultValue),
+          );
       },
     });
 

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { useFormContext } from './useFormContext';
 import isUndefined from './utils/isUndefined';
 import isString from './utils/isString';
-// import get from './utils/get';
-// import isObject from './utils/isObject';
 import {
   DeepPartial,
   UseWatchProps,


### PR DESCRIPTION
- `useWatch` no longer need to supply defaultValue, because it was always meant to use in your deep form level instead of at the root.
- `useWatch` array field lookup will return consistent array format instead of an object.