### PR TITLE
exclude submission data with disabled

### DIFF
--- a/src/__tests__/logic/getFieldsValues.test.ts
+++ b/src/__tests__/logic/getFieldsValues.test.ts
@@ -289,6 +289,6 @@ describe('getFieldsValues', () => {
           },
         },
       ),
-    ).toEqual({ test1: undefined, test: 'data' });
+    ).toEqual({ test: 'data' });
   });
 });

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -14,17 +14,18 @@ const getFieldsValues = (
 
     if (field) {
       const { _f, ...current } = field;
-      set(
-        output,
-        name,
-        _f
-          ? _f.ref.disabled
-            ? undefined
-            : getFieldValueAs(_f.value, _f, shouldReturnAsValue)
-          : Array.isArray(field)
-          ? []
-          : {},
-      );
+
+      if (!_f || (_f && !_f.ref.disabled)) {
+        set(
+          output,
+          name,
+          _f
+            ? getFieldValueAs(_f.value, _f, shouldReturnAsValue)
+            : Array.isArray(field)
+            ? []
+            : {},
+        );
+      }
 
       if (current) {
         getFieldsValues(


### PR DESCRIPTION
disabled input will be excluded from submission data.  I think it's made sense to follow the HTML standard for input disabled. https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute