### PR TITLE
Fixing issue of unmounted component trying to set state after reset for field arrays

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -480,6 +480,7 @@ export const useFieldArray = <
   }, [fields, name]);
 
   React.useEffect(() => {
+    let isMounted = true;
     const resetFunctions = resetFieldArrayFunctionRef.current;
     const fieldArrayNames = fieldArrayNamesRef.current;
 
@@ -494,11 +495,15 @@ export const useFieldArray = <
           data || defaultValuesRef.current,
           name,
         );
-        setFields(mapIds(memoizedDefaultValues.current, keyName));
+        if (isMounted) {
+          setFields(mapIds(memoizedDefaultValues.current, keyName));
+        }
       };
     }
 
     return () => {
+      isMounted = false;
+
       if (process.env.NODE_ENV !== 'production') {
         return;
       }

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -295,9 +295,11 @@ export const useFieldArray = <
       cleanup(fieldsWithValidationRef.current);
     }
 
-    updateFormState({
-      isDirty: isFormDirty(name, omitKey(updatedFormValues)),
-    });
+    if (!isUnMount.current && readFormStateRef.current.isDirty) {
+      updateFormState({
+        isDirty: isFormDirty(name, omitKey(updatedFormValues)),
+      });
+    }
   };
 
   const append = (
@@ -503,9 +505,6 @@ export const useFieldArray = <
 
     return () => {
       isUnMount.current = false;
-      if (process.env.NODE_ENV !== 'production') {
-        return;
-      }
       shouldUnregister && remove();
       resetFields();
       delete resetFunctions[name];


### PR DESCRIPTION
Fixes an issue where a component that contains a fieldArrray is unmounted and the `useEffect` hook is run, then tries to set state (via `setFields`), and creates an unmounted set state error.