### PR TITLE
#4219 Add default values when validating by using resolver

### DIFF
--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -3323,6 +3323,62 @@ describe('useForm', () => {
 
       expect(resolverData).toEqual({ test: 'value' });
     });
+
+    it('should have formState.isValid equals true with defined default values after executing resolver', async () => {
+      const Toggle = () => {
+        const [toggle, setToggle] = React.useState(false);
+
+        const { register, formState } = useForm({
+          defaultValues: { test: 'Test' },
+          mode: 'onChange',
+          resolver: async (values) => {
+            if (!values.test) {
+              const result = {
+                values: {},
+                errors: {
+                  test: {
+                    type: 'required',
+                  },
+                },
+              };
+              return result;
+            }
+
+            return {
+              values,
+              errors: {},
+            };
+          },
+        });
+
+        return (
+          <>
+            <button onClick={() => setToggle(!toggle)}>Toggle</button>
+            {toggle && <input id="test" name="test" ref={register} />}
+            <button disabled={!formState.isValid}>Submit</button>
+          </>
+        );
+      };
+
+      render(<Toggle />);
+
+      const toggle = async () =>
+        await actComponent(async () => {
+          await screen.getByText('Toggle').click();
+        });
+
+      // Show input and Submit button
+      await toggle();
+
+      expect(screen.getByText('Submit')).toBeEnabled();
+
+      // Hide input and Submit button
+      await toggle();
+      // Show input and Submit button again
+      await toggle();
+
+      expect(screen.getByText('Submit')).toBeEnabled();
+    });
   });
 
   describe('mode with onTouched', () => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -704,6 +704,7 @@ export function useForm<
       const { errors } =
         (await resolverRef.current!(
           {
+            ...defaultValuesRef.current,
             ...getValues(),
             ...values,
           },

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -701,12 +701,14 @@ export function useForm<
 
   const validateResolver = React.useCallback(
     async (values = {}) => {
+      const newDefaultValues = isEmptyObject(fieldsRef.current)
+        ? defaultValuesRef.current
+        : {};
+
       const { errors } =
         (await resolverRef.current!(
           {
-            ...(isEmptyObject(fieldsRef.current)
-              ? { ...defaultValuesRef.current }
-              : {}),
+            ...newDefaultValues,
             ...getValues(),
             ...values,
           },

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -704,7 +704,9 @@ export function useForm<
       const { errors } =
         (await resolverRef.current!(
           {
-            ...defaultValuesRef.current,
+            ...(isEmptyObject(fieldsRef.current)
+              ? { ...defaultValuesRef.current }
+              : {}),
             ...getValues(),
             ...values,
           },


### PR DESCRIPTION
- Add default values to resolver validation in order to solve issue formState.isValid is set to false even default values exist.
- Write unit test for the specific case.

Related issue: https://github.com/react-hook-form/react-hook-form/issues/4219