### PR TITLE
Make isWeb work better on react native

### DIFF
--- a/src/utils/isWeb.test.ts
+++ b/src/utils/isWeb.test.ts
@@ -16,6 +16,7 @@ describe('isWeb', () => {
   it('should return true when in a browser', () => {
     expect(isWeb()).toBeTruthy();
   });
+  
   it('should return false when navigator product is ReactNative', () => {
     productGetter.mockReturnValue('ReactNative');
     expect(isWeb()).toBeFalsy();

--- a/src/utils/isWeb.test.ts
+++ b/src/utils/isWeb.test.ts
@@ -1,0 +1,23 @@
+const isWeb = () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const isWeb = require('./isWeb');
+
+  return isWeb.default;
+};
+
+describe('isWeb', () => {
+  let productGetter: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    productGetter = jest.spyOn(window.navigator, 'product', 'get');
+  });
+
+  it('should return true when in a browser', () => {
+    expect(isWeb()).toBeTruthy();
+  });
+  it('should return false when navigator product is ReactNative', () => {
+    productGetter.mockReturnValue('ReactNative');
+    expect(isWeb()).toBeFalsy();
+  });
+});

--- a/src/utils/isWeb.test.ts
+++ b/src/utils/isWeb.test.ts
@@ -16,7 +16,7 @@ describe('isWeb', () => {
   it('should return true when in a browser', () => {
     expect(isWeb()).toBeTruthy();
   });
-  
+
   it('should return false when navigator product is ReactNative', () => {
     productGetter.mockReturnValue('ReactNative');
     expect(isWeb()).toBeFalsy();

--- a/src/utils/isWeb.ts
+++ b/src/utils/isWeb.ts
@@ -1,5 +1,5 @@
 import { UNDEFINED } from '../constants';
 
-export default typeof window !== UNDEFINED &&
-  typeof document !== UNDEFINED &&
-  navigator.product !== 'ReactNative';
+export default typeof window !== UNDEFINED && 
+  window.HTMLElement !== UNDEFINED && 
+  typeof document !== UNDEFINED;;

--- a/src/utils/isWeb.ts
+++ b/src/utils/isWeb.ts
@@ -1,5 +1,5 @@
 import { UNDEFINED } from '../constants';
 
 export default typeof window !== UNDEFINED &&
-  typeof document !== UNDEFINED &&
-  navigator.product !== 'ReactNative';
+  typeof window.HTMLElement !== UNDEFINED &&
+  typeof document !== UNDEFINED;

--- a/src/utils/isWeb.ts
+++ b/src/utils/isWeb.ts
@@ -1,3 +1,5 @@
 import { UNDEFINED } from '../constants';
 
-export default typeof window !== UNDEFINED && typeof document !== UNDEFINED;
+export default typeof window !== UNDEFINED &&
+  typeof document !== UNDEFINED &&
+  navigator.product !== 'ReactNative';

--- a/src/utils/isWeb.ts
+++ b/src/utils/isWeb.ts
@@ -1,5 +1,5 @@
 import { UNDEFINED } from '../constants';
 
 export default typeof window !== UNDEFINED &&
-  typeof window.HTMLElement !== UNDEFINED &&
-  typeof document !== UNDEFINED;
+  typeof document !== UNDEFINED &&
+  navigator.product !== 'ReactNative';

--- a/src/utils/isWeb.ts
+++ b/src/utils/isWeb.ts
@@ -1,5 +1,5 @@
 import { UNDEFINED } from '../constants';
 
-export default typeof window !== UNDEFINED && 
-  window.HTMLElement !== UNDEFINED && 
-  typeof document !== UNDEFINED;;
+export default typeof window !== UNDEFINED &&
+  typeof document !== UNDEFINED &&
+  navigator.product !== 'ReactNative';


### PR DESCRIPTION
# ~blocked on #4297 being merged~

One of the libraries we're using is creating document, so it's not undefined. This adds a more reliable way to check based on https://github.com/facebook/react-native/blob/6e6443afd04a847ef23fb6254a84e48c70b45896/Libraries/Core/setUpNavigator.js#L15


The consequences of this inaccurately reporting is that `useForm` tries to use `MutationObserver` which does not exists outside of the DOM