### PR TITLE
Use yarn for circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,6 @@ jobs:
 
     steps:
       - checkout
-      - run: npm install
-      - run: npm run build
-      - run: npm run bundlesize
+      - run: yarn install
+      - run: yarn build
+      - run: yarn bundlesize


### PR DESCRIPTION
I had a failing build on #4296 . It looks like the lack of `package-lock.json` is causing the problem. Switching to yarn fixes things. 