### PR TITLE
improve useFieldArray name type to be more strict 

### DIFF
--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -1,6 +1,6 @@
 import { Control } from './form';
 import { FieldValues } from './fields';
-import { FieldPath, FieldPathValue } from './utils';
+import { FieldArrayPath, FieldArrayPathValue } from './utils';
 
 export type FieldArrayName = string;
 
@@ -8,10 +8,10 @@ export type FieldArrayDefaultValues = Partial<Record<FieldArrayName, any>>;
 
 export type UseFieldArrayProps<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id'
 > = {
-  name: TName;
+  name: TFieldArrayName;
   keyName?: TKeyName;
   control?: Control<TFieldValues>;
 };
@@ -20,15 +20,15 @@ type InferArrayType<T> = T extends (infer U)[] ? U : never;
 
 export type FieldArrayWithId<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id'
-> = InferArrayType<FieldPathValue<TFieldValues, TName>> &
+> = InferArrayType<FieldArrayPathValue<TFieldValues, TFieldArrayName>> &
   Record<TKeyName, string>;
 
 export type FieldArray<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
-> = InferArrayType<FieldPathValue<TFieldValues, TName>>;
+  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>
+> = InferArrayType<FieldArrayPathValue<TFieldValues, TFieldArrayName>>;
 
 export type FieldArrayMethodProps = {
   shouldFocus?: boolean;
@@ -38,30 +38,30 @@ export type FieldArrayMethodProps = {
 
 export type UseFieldArrayReturn<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id'
 > = {
   swap: (indexA: number, indexB: number) => void;
   move: (indexA: number, indexB: number) => void;
   prepend: (
     value:
-      | Partial<FieldArray<TFieldValues, TName>>
-      | Partial<FieldArray<TFieldValues, TName>>[],
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
     options?: FieldArrayMethodProps,
   ) => void;
   append: (
     value:
-      | Partial<FieldArray<TFieldValues, TName>>
-      | Partial<FieldArray<TFieldValues, TName>>[],
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
     options?: FieldArrayMethodProps,
   ) => void;
   remove: (index?: number | number[]) => void;
   insert: (
     index: number,
     value:
-      | Partial<FieldArray<TFieldValues, TName>>
-      | Partial<FieldArray<TFieldValues, TName>>[],
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
     options?: FieldArrayMethodProps,
   ) => void;
-  fields: FieldArrayWithId<TFieldValues, TName, TKeyName>[];
+  fields: FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>[];
 };

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -21,27 +21,27 @@ import getFieldsValues from './logic/getFieldsValues';
 import {
   FieldValues,
   UseFieldArrayProps,
-  FieldPath,
   FieldArrayWithId,
   UseFieldArrayReturn,
   FieldArray,
   FieldArrayMethodProps,
   FieldErrors,
+  FieldArrayPath,
 } from './types';
 
 export const useFieldArray = <
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id'
 >({
   control,
   name,
   keyName = 'id' as TKeyName,
-}: UseFieldArrayProps<TFieldValues, TName, TKeyName>): UseFieldArrayReturn<
+}: UseFieldArrayProps<
   TFieldValues,
-  TName,
+  TFieldArrayName,
   TKeyName
-> => {
+>): UseFieldArrayReturn<TFieldValues, TFieldArrayName, TKeyName> => {
   const methods = useFormContext();
   const focusNameRef = React.useRef('');
   const {
@@ -62,7 +62,7 @@ export const useFieldArray = <
   } = control || methods.control;
 
   const [fields, setFields] = React.useState<
-    Partial<FieldArrayWithId<TFieldValues, TName, TKeyName>>[]
+    Partial<FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>>[]
   >(
     mapIds(
       get(fieldArrayDefaultValuesRef.current, getFieldArrayParentName(name))
@@ -97,7 +97,9 @@ export const useFieldArray = <
   };
 
   const omitKey = <
-    T extends Partial<FieldArrayWithId<TFieldValues, TName, TKeyName>>[]
+    T extends Partial<
+      FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
+    >[]
   >(
     fields: T,
   ) => fields.map(({ [keyName]: omitted, ...rest } = {}) => rest);
@@ -145,7 +147,7 @@ export const useFieldArray = <
 
   const setFieldsAndNotify = (
     fieldsValues: Partial<
-      FieldArrayWithId<TFieldValues, TName, TKeyName>
+      FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
     >[] = [],
   ) => {
     setFields(mapIds(fieldsValues, keyName));
@@ -159,7 +161,9 @@ export const useFieldArray = <
     !compact(get(ref, name, [])).length && unset(ref, name);
 
   const updateDirtyFieldsWithDefaultValues = <
-    T extends Partial<FieldArrayWithId<TFieldValues, TName, TKeyName>>[]
+    T extends Partial<
+      FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
+    >[]
   >(
     updatedFieldArrayValues?: T,
   ) =>
@@ -181,7 +185,7 @@ export const useFieldArray = <
       argB?: unknown;
     },
     updatedFieldArrayValues: Partial<
-      FieldArrayWithId<TFieldValues, TName, TKeyName>
+      FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
     >[] = [],
     shouldSet = true,
   ) => {
@@ -255,8 +259,8 @@ export const useFieldArray = <
 
   const append = (
     value:
-      | Partial<FieldArray<TFieldValues, TName>>
-      | Partial<FieldArray<TFieldValues, TName>>[],
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
     options?: FieldArrayMethodProps,
   ) => {
     const appendValue = Array.isArray(value) ? value : [value];
@@ -280,8 +284,8 @@ export const useFieldArray = <
 
   const prepend = (
     value:
-      | Partial<FieldArray<TFieldValues, TName>>
-      | Partial<FieldArray<TFieldValues, TName>>[],
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
     options?: FieldArrayMethodProps,
   ) => {
     const prependValue = Array.isArray(value) ? value : [value];
@@ -304,7 +308,7 @@ export const useFieldArray = <
 
   const remove = (index?: number | number[]) => {
     const updatedFieldArrayValues: Partial<
-      FieldArrayWithId<TFieldValues, TName, TKeyName>
+      FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
     >[] = removeArrayAt(getCurrentFieldsValues(), index);
     resetFields(index);
     batchStateUpdate(
@@ -320,8 +324,8 @@ export const useFieldArray = <
   const insert = (
     index: number,
     value:
-      | Partial<FieldArray<TFieldValues, TName>>
-      | Partial<FieldArray<TFieldValues, TName>>[],
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
     options?: FieldArrayMethodProps,
   ) => {
     const insertValue = Array.isArray(value) ? value : [value];
@@ -408,12 +412,16 @@ export const useFieldArray = <
 
   React.useEffect(() => {
     const fieldArraySubscription = fieldArraySubjectRef.current.subscribe({
-      next({ name: inputName, fields, isReset }) {
+      next({ name: inpuTFieldArrayName, fields, isReset }) {
         if (isReset) {
-          unset(fieldsRef.current, inputName || name);
+          unset(fieldsRef.current, inpuTFieldArrayName || name);
 
-          if (inputName) {
-            set(fieldArrayDefaultValuesRef.current, inputName, fields);
+          if (inpuTFieldArrayName) {
+            set(
+              fieldArrayDefaultValuesRef.current,
+              inpuTFieldArrayName,
+              fields,
+            );
             setFieldsAndNotify(get(fieldArrayDefaultValuesRef.current, name));
           } else {
             fieldArrayDefaultValuesRef.current = fields;
@@ -437,6 +445,6 @@ export const useFieldArray = <
     append: React.useCallback(append, [name]),
     remove: React.useCallback(remove, [name]),
     insert: React.useCallback(insert, [name]),
-    fields: fields as FieldArrayWithId<TFieldValues, TName, TKeyName>,
+    fields: fields as FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>,
   };
 };


### PR DESCRIPTION
## Overview

I think DX could be improved by fixing the `name` type specified in `useFieldArray` to be **more strict**.

```tsx
type FormValues = {
  str: string;
  num: number;
  tuple1: [string, number];
  tuple2: [
    {
      name: string;
      contributors: number;
    },
    {
      name: string;
      contributors: number;
    }
  ];
  array1: string[];
  array2: {
    name: string;
    contributors: number;
  }[];
  object: {
    name: string;
    contributors: number;
    array1: string[];
    array2: {
      name: string;
      contributors: number;
      object: {
        nested: {
          name: string;
          contributors: number;
          array1: string[];
          array2: {
            name: string;
            contributors: number;
          }[];
        };
      };
    }[];
  };
};

const { register, control } = useForm<FormValues>();
const { fields } = useFieldArray({
  name: "", // expected type: "tuple2" | "array2" | "object.array2" | `object.array2.${number}.object.nested.array2`
  control
});
```

## Actual behavior

![スクリーンショット 2021-03-04 1 32 38](https://user-images.githubusercontent.com/12913947/109838532-98bfc300-7c89-11eb-8ef0-13d7264dca1c.png)

## Expected behavior

![スクリーンショット 2021-03-04 1 32 06](https://user-images.githubusercontent.com/12913947/109838563-9fe6d100-7c89-11eb-9d74-98106c0255bd.png)

## Ref

- [CodeSandbox](https://codesandbox.io/s/react-hook-form-4340-270ll?file=/src/App.tsx)
- [TypeScript Playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcAKUCWBbTNMBuqAvAFBxwA+cAdgK4A2D5VcdNAJsAGaY3AcW1AM4wsNAOZDadbACNgUaXIgQGwAIY1pwxPLXLMEvjADcpJCjgBJYQBU6YdQB47cUDGCdhcLYgDaALoAfHDEMvKK7iCe3nB2-gBE6pIwABaJgXAA-HDcGgzCqABcCFB0wOaWqACCUFAaiADSwIhhEQpQVcioDk7ALYiu0bEcPn5BoeEAoiAAxgx0XM4A1q0Q3PEANHBriBu+NAEhFj02whg4eITArlPxI15j6Fi4+EQ5ZRVwpfmFlacrLYAGIMDQwADycgAVsA5jBhh4nj4IDC4TB7rMxBp4c4WLMFktbgk9gc7IEdtQACLg1DUYGYdQAGUwomCWxYEyy1FRsPhpFCSLi-CISgouTEFRYvwKRXMpFAkFgCDOdQaiDQ4LSd3abiFzwASpoOBAaAxEGrGs4+NwogA1YIsXK2PouNwAMkOx0FMWRX2ALHFcAABgASADeroGrWGnq5oU9onEEgAvgA6COWjVa5wOlPBwM-EOZ+qNQbpkvqzXpXPBfPSuDhwsUfxNOB8XbrTbk0q2S5vG6uVshR5xSUBiiTye5EWKZuT0oJJpZfU+I0aE1mi2loY2+2OqdT50XV7XIi10fPcfzo+0YCim8L86g8FQvkIu1wT289E+0Y+a9D0PXI20TMQ+CkICp1KAAKUC4CTCCAEpWDDcN4MQyQK3DLNq21JcQnrKCizQjDwKwjMcJ3PCh2XOtg3MKcU38Ulu0CeVFWgeBqjgXCtTtAoKjxCg7A5Cg0EvHw+JrOxHXuCTV2LcM9ygOAmmwlS4ANIjPjbRTWPiQtcgNSTeOonMCIPYCzKrfjBOJYcdgNKzoLvB9XPgrNBlMgy7CMmzGjwgTFgczyd0GCktK-ALsxk1toq81oQhcotZzFIsFN9OJfKdeJ-DQQIGwkz1ErafSu0MoMEmKmKIobNL5S4BYNCgVBuHYeFMFNOAJGABFRPQUzpPw4Jghg3lFx2MAtVKNAkNKYbgqEga0GCeUeLfdomwoJNSkwiRGIiUp6EiLoWBgRx1AARlKfx9p2E7OnY87LuAAAmW7tsnGgNGwYA9vIg7CzmU1wLkOgYGgYRjtkTpDpTHYvooH6-oB5NDooEGaDBiGoZh074eeigWvVG6EMBoJDpJxoPsbQsUf+8n0eB0GsHByGoGhjpFHhymWB-eFSiR2hfsZ-aMbgLGcY5rnHp5wtqcQMn9r5qdFdp4XkdFtGIIlzHWcwdm8e5s6gIFmAhcffhRAES3iK11Gmd1x99extncc5-G4Zd3wd2Vimift9W7fth2xcBvWoKl92Za9+XQ+YwOgJTSOU8LRP4fMNPSCx0Q4HN0pNvCcMU18cYjnWs4JPCYbnDfR1SHUeATvaK75V6mBxrReEdkSGgIBgWZWRgYREiQ8wO6799e4u-orrTAAGMeJ76qf0Rn1756u5fSEn82N7ntM3p3vfu5gA-1DexeT9X-e4ESWfL7Tefo8Nj3R-H3fb7Pi-3qPm-O530SIrLeC8F7H0-qfaeIYQGUROvmMuktTSiEgd-aBwCdxXwXmmV+RtOYALXj3e+6s0wAFYABsOCDZ4I-ivQBP9iGYOfmAgALGmBmBC77BhIRGeBVC3ZvxlsGRBucYCoPoeg82-DpZQ04Qwh+r0IF0MIefRh6olFfwkeve+Uj1ZyMkWfNMJCWEAGZKFSOtp4DgRjMH6O0cGXRTDeGyHTBY4ANtrHq2ERoHwojx5AA)
