### PR TITLE
Fixing Field Array's remove function

### DIFF
--- a/src/utils/remove.test.ts
+++ b/src/utils/remove.test.ts
@@ -49,6 +49,13 @@ describe('remove', () => {
 
     expect(remove([true, true, true], [1])).toEqual([true, true]);
     expect(remove([true, true, true], [0])).toEqual([true, true]);
+
+    expect(
+      remove([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], [6, 7, 8, 9, 10, 11]),
+    ).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(
+      remove([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], [11, 10, 9, 8, 7, 6]),
+    ).toEqual([0, 1, 2, 3, 4, 5]);
   });
 
   it('should remove correctly with indexes which contains gap', () => {

--- a/src/utils/remove.ts
+++ b/src/utils/remove.ts
@@ -16,4 +16,4 @@ function removeAtIndexes<T>(data: T[], indexes: number[]): T[] {
 export default <T>(data: T[], index?: number | number[]): T[] =>
   isUndefined(index)
     ? []
-    : removeAtIndexes(data, (Array.isArray(index) ? index : [index]).sort());
+    : removeAtIndexes(data, (Array.isArray(index) ? index : [index]).sort((a, b) => a - b));

--- a/src/utils/remove.ts
+++ b/src/utils/remove.ts
@@ -16,4 +16,7 @@ function removeAtIndexes<T>(data: T[], indexes: number[]): T[] {
 export default <T>(data: T[], index?: number | number[]): T[] =>
   isUndefined(index)
     ? []
-    : removeAtIndexes(data, (Array.isArray(index) ? index : [index]).sort((a, b) => a - b));
+    : removeAtIndexes(
+        data,
+        (Array.isArray(index) ? index : [index]).sort((a, b) => a - b),
+      );


### PR DESCRIPTION
Since JavaScript's sort function sorts elements alphabetically if compareFunction is omitted, we need to give it by hand. This leads to wrong result when Field Array's length is larger then 10 and `remove()` was given array containing indexes larger than 10.

This PR fixes it by giving compareFunction explicitly.

cf. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#parameters