### PR TITLE
update gitignore to include yarn 2 generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@ node_modules/
 app/node_modules/
 example/node_modules/
 example/build/
+.yarn/*
+!.yarn/patches
+!.yarn/releases
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
 
 # Optional npm cache directory
 .npm


### PR DESCRIPTION
This pr updates `gitignore` to include files generated when using yarn 2 as the package manager.