### PR TITLE
🐛 fix can not reuse a regexp with g flag as pattern

### DIFF
--- a/src/__tests__/logic/__snapshots__/validateField.test.tsx.snap
+++ b/src/__tests__/logic/__snapshots__/validateField.test.tsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`validateField should handle pattern with g flag 1`] = `
+Object {
+  "test": Object {
+    "message": "",
+    "ref": Object {
+      "name": "test",
+      "type": "text",
+    },
+    "type": "minLength",
+    "types": Object {
+      "minLength": true,
+      "validate": true,
+    },
+  },
+}
+`;
+
+exports[`validateField should handle pattern with g flag 2`] = `
+Object {
+  "test": Object {
+    "message": "",
+    "ref": Object {
+      "name": "test",
+      "type": "text",
+    },
+    "type": "minLength",
+    "types": Object {
+      "minLength": true,
+      "validate": true,
+    },
+  },
+}
+`;
+
 exports[`validateField should return all validation error messages 1`] = `
 Object {
   "test": Object {

--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -1438,6 +1438,46 @@ describe('validateField', () => {
     ).toMatchSnapshot();
   });
 
+  const reusedRe = /a/g;
+  it('should handle pattern with g flag', async () => {
+    (getRadioValue as jest.Mock<any>).mockImplementation(() => ({
+      value: '',
+    }));
+    expect(
+      await validateField(
+        {
+          _f: {
+            name: 'test',
+            ref: { type: 'text', name: 'test' },
+            value: 'a',
+            required: true,
+            minLength: 10,
+            pattern: reusedRe,
+            validate: (value) => value === 'test',
+          },
+        },
+        true,
+      ),
+    ).toMatchSnapshot();
+
+    expect(
+      await validateField(
+        {
+          _f: {
+            name: 'test',
+            ref: { type: 'text', name: 'test' },
+            value: 'a',
+            required: true,
+            minLength: 10,
+            pattern: reusedRe,
+            validate: (value) => value === 'test',
+          },
+        },
+        true,
+      ),
+    ).toMatchSnapshot();
+  });
+
   it('should return all validation error messages', async () => {
     (getRadioValue as jest.Mock<any>).mockImplementation(() => ({
       value: '',

--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -1438,8 +1438,9 @@ describe('validateField', () => {
     ).toMatchSnapshot();
   });
 
-  const reusedRe = /a/g;
   it('should handle pattern with g flag', async () => {
+    const reusedRe = /a/g;
+    
     (getRadioValue as jest.Mock<any>).mockImplementation(() => ({
       value: '',
     }));

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -159,7 +159,7 @@ export default async (
   if (isString(inputValue) && pattern && !isEmpty) {
     const { value: patternValue, message } = getValueAndMessage(pattern);
 
-    if (isRegex(patternValue) && !patternValue.test(inputValue)) {
+    if (isRegex(patternValue) && !inputValue.match(patternValue)) {
       error[name] = {
         type: INPUT_VALIDATION_RULES.pattern,
         message,


### PR DESCRIPTION
reproduce demo, try inputing `a` and repeat hitting <kbd>enter</kbd> in the form:

https://codesandbox.io/s/react-hook-form-get-started-forked-y8q3x