### PR TITLE
Update package.json - fix exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
I am having an issue with 7.0.6, where 7.0.5 works fine. Getting the following error:

```
Error: Cannot find module 'MY_PATH/node_modules/react-hook-form/dist/index.js'
```

Hope it is going resolve the issue.