### PR TITLE
Return type of trigger should be Promise<void>

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -367,7 +367,7 @@ export type UseFormWatch<TFieldValues extends FieldValues> = {
 
 export type UseFormTrigger<TFieldValues extends FieldValues> = (
   name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
-) => void;
+) => Promise<void>;
 
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (
   name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],


### PR DESCRIPTION
Currently Typescript says that `await` is not necessary. But in order to wait for validation to have kicked in, we need to `await`. This makes Typescript aware that `trigger` returns a `Promise`.

This is necessary to handle the case mentioned in #4793 where we trigger validation and then check the errors object.