### PR TITLE
🐞make it works with tarojs

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -954,9 +954,9 @@ export function useForm<
 
   const handleSubmit: UseFormHandleSubmit<TFieldValues> = React.useCallback(
     (onValid, onInvalid) => async (e) => {
-      if (e && e.preventDefault) {
-        e.preventDefault();
-        e.persist();
+      if (e) {
+        e.preventDefault && e.preventDefault();
+        e.persist && e.persist();
       }
       let fieldValues = {
         ...defaultValuesRef.current,


### PR DESCRIPTION
Background:

Tarojs is a framework for [WeChat mini-program](https://en.wikipedia.org/wiki/WeChat#WeChat_Mini_Program), it enable you to write code in React then transform those react code to WeChat mini-program code(Like html but is not html, no window, navigator object etc). 

The issue:

I want to use this cool form library in Tarojs, but an error pop up: `TypeError: e.persist is not a function`, it is because the component that I use is not html native element and the component's onClick event argument doesn't have this `persist` property.

