### PR TITLE
Allow Form reset on elements with form attribute

### DIFF
--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -86,8 +86,8 @@ describe('reset', () => {
       methods = useForm<{ test: string }>();
       return (
         <>
-          <form id="formWithId" />
-          <input form={'formWithId'} {...methods.register('test')} />
+          <form id="exampleFormId" />
+          <input form="exampleFormId" {...methods.register('test')} />
         </>
       );
     };

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -79,6 +79,25 @@ describe('reset', () => {
     expect(mockReset).toHaveBeenCalled();
   });
 
+  it('should reset the form if ref is HTMLElement and form is referenced by a form attribute', async () => {
+    const mockReset = jest.spyOn(window.HTMLFormElement.prototype, 'reset');
+    let methods: UseFormReturn<{ test: string }>;
+    const Component = () => {
+      methods = useForm<{ test: string }>();
+      return (
+        <>
+          <form id="formWithId" />
+          <input form={'formWithId'} {...methods.register('test')} />
+        </>
+      );
+    };
+    render(<Component />);
+
+    actComponent(() => methods.reset());
+
+    expect(mockReset).toHaveBeenCalled();
+  });
+
   it('should set array value of multiple checkbox inputs correctly', async () => {
     const Component = () => {
       const { register } = useForm<{

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1069,10 +1069,8 @@ export function useForm<
             try {
               const formId = inputRef.getAttribute('form');
               if (formId) {
-                const formForField = document.getElementById(
-                  formId,
-                ) as HTMLFormElement | null;
-                if (formForField) {
+                const formForField = document.getElementById(formId);
+                if (formForField instanceof HTMLFormElement) {
                   formForField.reset();
                   break;
                 }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1067,6 +1067,16 @@ export function useForm<
 
           if (isHTMLElement(inputRef)) {
             try {
+              const formId = inputRef.getAttribute('form');
+              if (formId) {
+                const formForField = document.getElementById(
+                  formId,
+                ) as HTMLFormElement | null;
+                if (formForField) {
+                  formForField.reset();
+                  break;
+                }
+              }
               inputRef.closest('form')!.reset();
               break;
             } catch {}


### PR DESCRIPTION
This PR:

- [x] allows to reset forms where the element itself isn't placed inside an enclosed `form` tag

`form`-Attribute
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#htmlattrdefform