### PR TITLE
useWatch method should watch form values when defaultValue has a value.

### DIFF
--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -44,10 +44,10 @@ export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
   nameRef.current = name;
 
   const { watchInternal, watchSubjectRef } = control || methods.control;
+
+  const firstValue = watchInternal(name as InternalFieldName);
   const [value, updateValue] = React.useState<unknown>(
-    isUndefined(defaultValue)
-      ? watchInternal(name as InternalFieldName)
-      : defaultValue,
+    isUndefined(firstValue) ? defaultValue : firstValue,
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
This pr is for this [issue ](https://github.com/react-hook-form/react-hook-form/issues/4837)

https://github.com/react-hook-form/react-hook-form/blob/770f7240158ce7e544ead553702648488118b7a5/src/useWatch.ts#L49

When `useWatch` has `defaultValue` property, `defaultValue` is used for the first value of `useState`, not values in a form.
I changed its behavior to use the return value of watchInternal as the first value.
