### PR TITLE
fix use form trigger type

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -368,7 +368,7 @@ export type UseFormWatch<TFieldValues extends FieldValues> = {
 
 export type UseFormTrigger<TFieldValues extends FieldValues> = (
   name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
-) => Promise<Boolean>;
+) => Promise<boolean>;
 
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (
   name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],


### PR DESCRIPTION
To fix this issue:

```
Type 'Boolean' is not assignable to type 'boolean'.
'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.
```