### PR TITLE
Typing for watch & getValues

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -158,13 +158,13 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
     fieldName: TFieldName,
   ): FieldPathValue<TFieldValues, TFieldName>;
   <TFieldNames extends FieldPath<TFieldValues>[]>(
-    fieldNames: TFieldNames,
-  ): FieldPathValues<TFieldValues, TFieldNames>;
+    fieldNames: readonly [...TFieldNames],
+  ): [...FieldPathValues<TFieldValues, TFieldNames>];
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {
   (): UnpackNestedValue<TFieldValues>;
-  <TFieldNames extends Array<FieldPath<TFieldValues>>>(
+  <TFieldNames extends FieldPath<TFieldValues>[]>(
     fieldNames: readonly [...TFieldNames],
     defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>,
   ): [...FieldPathValues<TFieldValues, TFieldNames>];

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -164,6 +164,10 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {
   (): UnpackNestedValue<TFieldValues>;
+  <TFieldNames extends Array<FieldPath<TFieldValues>>>(
+    fieldNames: readonly [...TFieldNames],
+    defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>,
+  ): [...FieldPathValues<TFieldValues, TFieldNames>];
   <
     T1 extends FieldPath<TFieldValues>,
     T2 extends FieldPath<TFieldValues>,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -724,7 +724,9 @@ export function useForm<
   );
 
   const getValues: UseFormGetValues<TFieldValues> = (
-    fieldNames?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+    fieldNames?:
+      | FieldPath<TFieldValues>
+      | ReadonlyArray<FieldPath<TFieldValues>>,
   ) => {
     const values = isMountedRef.current
       ? getFieldsValues(


### PR DESCRIPTION
Fix #4994

For reference, [here is the sandbox that shows the issue](https://codesandbox.io/s/cranky-kapitsa-3sd8m?file=/src/App.tsx:500-549)

As explained in the issue mentioned above, this PR make use of [TS variadic tuple types](https://github.com/microsoft/TypeScript/pull/39094) to extract the proper type of the tuple returned by `watch` & `getValues` 

To avoid any potential breaking changes on `watch` type definition, I've kept the [previously defined signatures](https://github.com/react-hook-form/react-hook-form/pull/4721).
____

#### The behaviour if this gets merged would be as follow

- `getValues`:
```ts
type MyFormValues = {
    k1: string;
    ...,
    kN: number;
}

// Previously resolved to (string | ... | number)[]
const ['k1', ..., 'kN'] = getValues(['k1', ..., 'kN']);

// With this PR, resolved to [string, ..., number]
const ['k1', ..., 'kN'] = getValues(['k1', ..., 'kN']);

``` 

- `watch`:
```ts
type MyFormValues = {
    k1: string;
    ...,
    k10: boolean,
    ...,
    kN: number;
}

// Previously resolved to (string | number | ...)[]
const [k1, ..., kN] = watch(['k1', ..., 'kN']);

// With this PR, all of the following calls resolved to [string, ..., number]
const [k1, ..., kN] = watch(['k1', ..., 'kN']);
const [k1, ..., kN] = watch<['k1', ..., 'kN']>(['k1', ..., 'kN']);

// To avoid any breaking changes, this call resolved to [string, ..., boolean] as prior to this PR
// The limit for this syntax still being at 10 keys
const [k1, ..., k10] = watch<'k1', ..., 'k10'>(['k1', ..., 'k10']);
``` 
____

**_Ps_**: First time contributing to an open source project, happy to take any advices :)