### PR TITLE
[Feature Request] Make useController save to return undefined if no c…

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -29,6 +29,9 @@ export function useController<
   TName
 > {
   const methods = useFormContext<TFieldValues>();
+  if(!methods && !control) {
+    return undefined;
+  }
   const {
     defaultValuesRef,
     register,


### PR DESCRIPTION
…ontext or control present

Skip initialization of useController if no control or context is present. This is an attempt to solve https://github.com/react-hook-form/react-hook-form/issues/4033

The main use case would be, that users can use the hook inside of their custom component and the functionality will be silently ignored in case its not needed.