### PR TITLE
support register return array value

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -132,11 +132,16 @@ export type SetFieldValue<TFieldValues> = FieldValue<TFieldValues>;
 
 export type RefCallBack = (instance: any) => void;
 
-export type UseFormRegisterReturn = {
+export type UseFormRegisterReturn = [
+  name: InternalFieldName,
+  ref: RefCallBack,
+  onChange: ChangeHandler,
+  onBlur: ChangeHandler,
+] & {
+  name: InternalFieldName;
+  ref: RefCallBack;
   onChange: ChangeHandler;
   onBlur: ChangeHandler;
-  ref: RefCallBack;
-  name: InternalFieldName;
 };
 
 export type UseFormRegister<TFieldValues extends FieldValues> = <

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -982,28 +982,38 @@ export function useForm<
       fieldsNamesRef.current.add(name);
       isInitialRegister && updateValidAndValue(name, options);
 
-      return isWindowUndefined
-        ? ({ name: name as InternalFieldName } as UseFormRegisterReturn)
-        : {
-            name,
-            onChange: handleChange,
-            onBlur: handleChange,
-            ref: (ref: HTMLInputElement | null): void => {
-              if (ref) {
-                registerFieldRef(name, ref, options);
-              } else {
-                const field = get(fieldsRef.current, name) as Field;
-                field && (field._f.mount = false);
+      const callbackRef = (ref: HTMLInputElement | null): void => {
+        if (ref) {
+          registerFieldRef(name, ref, options);
+        } else {
+          const field = get(fieldsRef.current, name) as Field;
+          field && (field._f.mount = false);
 
-                if (
-                  isWeb &&
-                  (shouldUnregister || (options && options.shouldUnregister))
-                ) {
-                  unregisterFieldsNamesRef.current.add(name);
-                }
-              }
-            },
-          };
+          if (
+            isWeb &&
+            (shouldUnregister || (options && options.shouldUnregister))
+          ) {
+            unregisterFieldsNamesRef.current.add(name);
+          }
+        }
+      };
+
+      if (isWindowUndefined) {
+        const result = ([name] as unknown) as UseFormRegisterReturn;
+        result.name = result[0];
+        return result;
+      }
+      const result = [
+        name as InternalFieldName,
+        callbackRef,
+        handleChange,
+        handleChange,
+      ] as UseFormRegisterReturn;
+      result.name = result[0];
+      result.ref = result[1];
+      result.onChange = result[2];
+      result.onBlur = result[3];
+      return result;
     },
     [defaultValuesRef.current],
   );


### PR DESCRIPTION
## Context

make it easy to customize the prop names.

```ts
// object destructing
const { name, ref: inputRef, onChange: onChangeText, onBlur } = register("name");
// array destructing, making it easy to customize the prop names 
const [name, inputRef, onChangeText, onBlur] = register("name"); // <- support!
```

## Feature Request

#5070
#4629