### PR TITLE
Correct array like object keys manipulating

### DIFF
--- a/src/__tests__/utils/set.test.ts
+++ b/src/__tests__/utils/set.test.ts
@@ -56,5 +56,19 @@ describe('set', () => {
         ],
       },
     });
+
+    const test7 = { a: { 1: { 2: true, 3: false }, 4: { 5: true } } };
+    expect(set(test7, 'a.1.2', false)).toEqual(false);
+    expect(test7).toEqual({
+      a: {
+        1: {
+          2: false,
+          3: false,
+        },
+        4: {
+          5: true,
+        },
+      },
+    });
   });
 });

--- a/src/__tests__/utils/stringToPath.test.ts
+++ b/src/__tests__/utils/stringToPath.test.ts
@@ -4,26 +4,26 @@ describe('stringToPath', () => {
   it('should convert string to path', () => {
     expect(stringToPath('test')).toEqual(['test']);
 
-    expect(stringToPath('[test]]')).toEqual(['test']);
+    expect(stringToPath('[test]]')).toEqual(['[test']);
 
     expect(stringToPath('test.test[2].data')).toEqual([
       'test',
       'test',
-      '2',
+      '[2',
       'data',
     ]);
 
     expect(stringToPath('test.test["2"].data')).toEqual([
       'test',
       'test',
-      '2',
+      '[2',
       'data',
     ]);
 
     expect(stringToPath("test.test['test'].data")).toEqual([
       'test',
       'test',
-      'test',
+      '[test',
       'data',
     ]);
 

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -15,7 +15,7 @@ export default function set(
   const lastIndex = length - 1;
 
   while (++index < length) {
-    const key = tempPath[index];
+    const key = tempPath[index].replace(/^\[/, '');
     let newValue = value;
 
     if (index !== lastIndex) {
@@ -23,7 +23,9 @@ export default function set(
       newValue =
         isObject(objValue) || Array.isArray(objValue)
           ? objValue
-          : !isNaN(+tempPath[index + 1])
+          : (tempPath[index + 1].startsWith('[') &&
+              !isNaN(+tempPath[index + 1].slice(1))) ||
+            !isNaN(+tempPath[index + 1])
           ? []
           : {};
     }

--- a/src/utils/stringToPath.ts
+++ b/src/utils/stringToPath.ts
@@ -1,4 +1,4 @@
 import compact from './compact';
 
 export default (input: string): string[] =>
-  compact(input.replace(/["|']|\]/g, '').split(/\.|\[/));
+  compact(input.replace(/["|']|\]/g, '').split(/\.|\s?(?=\[)/g));

--- a/src/utils/unset.ts
+++ b/src/utils/unset.ts
@@ -5,12 +5,14 @@ import isObject from './isObject';
 import isUndefined from './isUndefined';
 import stringToPath from './stringToPath';
 
-function baseGet(object: any, updatePath: (string | number)[]) {
+function baseGet(object: any, updatePath: string[]) {
   const length = updatePath.slice(0, -1).length;
   let index = 0;
 
   while (index < length) {
-    object = isUndefined(object) ? index++ : object[updatePath[index++]];
+    object = isUndefined(object)
+      ? index++
+      : object[updatePath[index++].replace(/^\[/, '')];
   }
 
   return object;
@@ -20,7 +22,7 @@ export default function unset(object: any, path: string) {
   const updatePath = isKey(path) ? [path] : stringToPath(path);
   const childObject =
     updatePath.length == 1 ? object : baseGet(object, updatePath);
-  const key = updatePath[updatePath.length - 1];
+  const key = updatePath[updatePath.length - 1].replace(/^\[/, '');
   let previousObjRef;
 
   if (childObject) {
@@ -38,7 +40,7 @@ export default function unset(object: any, path: string) {
     }
 
     while (++index < currentPaths.length) {
-      const item = currentPaths[index];
+      const item = currentPaths[index].replace(/^\[/, '');
       objectRef = objectRef ? objectRef[item] : object[item];
 
       if (


### PR DESCRIPTION
### Context

To allow preserving initial array-like objects state.
At the current moment, the library handles array-like object an unexpected way.

Given this object as an example default value (where object keys are numbers):
```javascript
{ a: { 1: { 2: true }, 4: { 182: false } } }
```
any changes applied to, for example, checkbox named `"a.4.182"`, will transform the whole object model to an array, saving empty space between "indexes". This will look something like:
```javascript
{ a: [empty, [empty x 2, true], empty x 2, [empty x 182, false] ] }
```

### Expected behaviour

```tsx
// pseudo-code

const { register, watch } = useForm({
  defaultValues: {
    a: {
      1: {
        8: true,
        108: false,
      },
      4: {
        615: false,
      },
    },
});

render(<input type="checkbox" {...register("a.1.108")}  />);

watch(); // { a: { 1: { 8: true, 108: false }, 4: { 615: false } } }

checkbox.click();

watch(); // { a: { 1: { 8: true, 108: true }, 4: { 615: false } } }
```

_P.S._ I wasn't able to find proper solution for this case, neither in "Issues" tab, nor StackOverflow, nor the documentation, so  I decided to extend the library's existing code a little bit.