### PR TITLE
Message can be ReactElement or string

### DIFF
--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,8 +1,10 @@
+import { ReactElement } from 'react';
+
 import { FieldValues, InternalFieldName, Ref } from './fields';
 import { DeepMap, LiteralUnion } from './utils';
 import { RegisterOptions, ValidateResult } from './validator';
 
-export type Message = string;
+export type Message = string | ReactElement;
 
 export type MultipleFieldErrors = {
   [K in keyof RegisterOptions]?: ValidateResult;


### PR DESCRIPTION
**Currently**
Error messages can only be `string`

-----

**Now**
Error messages can also be `ReactElement`.
This is useful when you want to include (for example) a link inside your message.

-----

**Example**
![example](https://user-images.githubusercontent.com/3116720/118152242-c442f480-b414-11eb-99c2-e1794df9e759.png)

where the "£5,000" can trigger a modal opening with more information, or automatically fill the input with the maximum amount.

```
<Controller
  ...
  rules={{
    max: {
      value: 5000,
      message: (
        <Trans components={[<Link as="a" onClick={() => console.log('action')} />]}>
          {"You cannot withdraw this amount. You can withdraw a maximum of <0>£5,000.00</0>"}
        </Trans>
      )
    }
  }}
/>
```

Note: `Trans` is a `react-i18next` component (see details [here](https://react.i18next.com/latest/trans-component))