### PR TITLE
fix-missing-register-options-generic-type

### DIFF
--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -35,7 +35,10 @@ export type UseControllerProps<
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
   name: TName;
-  rules?: Omit<RegisterOptions, 'valueAsNumber' | 'valueAsDate' | 'setValueAs'>;
+  rules?: Omit<
+    RegisterOptions<TFieldValues, TName>,
+    'valueAsNumber' | 'valueAsDate' | 'setValueAs'
+  >;
   shouldUnregister?: boolean;
   defaultValue?: unknown;
   control?: Control<TFieldValues>;


### PR DESCRIPTION
## Currently

I am using Controller and Typescript. I found the `validate` function in props `rules` is not typed (`any`).

![image](https://user-images.githubusercontent.com/16717793/118664196-db724f80-b823-11eb-87b3-3b59d230a279.png)

## Now

It has type.

![image](https://user-images.githubusercontent.com/16717793/118664461-12486580-b824-11eb-8402-8900915df10a.png)

## What's changed

I am using Controller and Typescript. I found the `validate` function in props `rules` is not typed (`any`).

![image](https://user-images.githubusercontent.com/16717793/118664196-db724f80-b823-11eb-87b3-3b59d230a279.png)

And I trace the type definition and add types in `UseControllerProps`

![image](https://user-images.githubusercontent.com/16717793/118664309-efb64c80-b823-11eb-8d87-34e03621e22e.png)
(before)
![image](https://user-images.githubusercontent.com/16717793/118662355-81bd5580-b822-11eb-9726-2c4c2911b050.png)
(after)

And it works:

![image](https://user-images.githubusercontent.com/16717793/118664461-12486580-b824-11eb-8402-8900915df10a.png)

I am not sure it is correct to add it. If it is not need, please close this PR.

## Note

The type is correct (not `any`) in `register`. 

![image](https://user-images.githubusercontent.com/16717793/118663092-1c1d9900-b823-11eb-9cbf-0163e5d5a6e5.png)

I also check that definition in `register`

<https://github.com/react-hook-form/react-hook-form/blob/102a60d3e0ed93142e7d863c3bab88ac283868a4/src/types/form.ts#L146>