### PR TITLE
accept readonly field path arrays

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -160,11 +160,18 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
   <TFieldNames extends FieldPath<TFieldValues>[]>(
     fieldNames: readonly [...TFieldNames],
   ): [...FieldPathValues<TFieldValues, TFieldNames>];
+  <TFieldNames extends readonly FieldPath<TFieldValues>[]>(
+    fieldNames: readonly [...TFieldNames],
+  ): [...FieldPathValues<TFieldValues, TFieldNames>];
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {
   (): UnpackNestedValue<TFieldValues>;
   <TFieldNames extends FieldPath<TFieldValues>[]>(
+    fieldNames: readonly [...TFieldNames],
+    defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>,
+  ): [...FieldPathValues<TFieldValues, TFieldNames>];
+  <TFieldNames extends readonly FieldPath<TFieldValues>[]>(
     fieldNames: readonly [...TFieldNames],
     defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>,
   ): [...FieldPathValues<TFieldValues, TFieldNames>];
@@ -360,7 +367,11 @@ export type UseFormWatch<TFieldValues extends FieldValues> = {
     fieldName: TFieldName,
     defaultValue?: FieldPathValue<TFieldValues, TFieldName>,
   ): FieldPathValue<TFieldValues, TFieldName>;
-  <TFieldNames extends FieldPath<TFieldValues>[]>(
+  <
+    TFieldNames extends
+      | FieldPath<TFieldValues>[]
+      | readonly FieldPath<TFieldValues>[],
+  >(
     fieldNames: TFieldNames,
     defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>,
   ): FieldPathValues<TFieldValues, TFieldNames>;
@@ -371,11 +382,17 @@ export type UseFormWatch<TFieldValues extends FieldValues> = {
 };
 
 export type UseFormTrigger<TFieldValues extends FieldValues> = (
-  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+  name?:
+    | FieldPath<TFieldValues>
+    | FieldPath<TFieldValues>[]
+    | readonly FieldPath<TFieldValues>[],
 ) => Promise<boolean>;
 
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (
-  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+  name?:
+    | FieldPath<TFieldValues>
+    | FieldPath<TFieldValues>[]
+    | readonly FieldPath<TFieldValues>[],
 ) => void;
 
 export type UseFormSetValue<TFieldValues extends FieldValues> = <
@@ -395,7 +412,10 @@ export type UseFormSetError<TFieldValues extends FieldValues> = (
 ) => void;
 
 export type UseFormUnregister<TFieldValues extends FieldValues> = (
-  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+  name?:
+    | FieldPath<TFieldValues>
+    | FieldPath<TFieldValues>[]
+    | readonly FieldPath<TFieldValues>[],
   options?: Omit<
     KeepStateOptions,
     | 'keepIsSubmitted'
@@ -407,7 +427,10 @@ export type UseFormUnregister<TFieldValues extends FieldValues> = (
 ) => void;
 
 export type UseFormInternalUnregister<TFieldValues extends FieldValues> = (
-  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
+  name?:
+    | FieldPath<TFieldValues>
+    | FieldPath<TFieldValues>[]
+    | readonly FieldPath<TFieldValues>[],
   options?: Omit<
     KeepStateOptions,
     | 'keepIsSubmitted'
@@ -520,14 +543,20 @@ export type UseFormReturn<TFieldValues extends FieldValues = FieldValues> = {
 
 export type UseFormStateProps<TFieldValues> = Partial<{
   control?: Control<TFieldValues>;
-  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[];
+  name?:
+    | FieldPath<TFieldValues>
+    | FieldPath<TFieldValues>[]
+    | readonly FieldPath<TFieldValues>[];
 }>;
 
 export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
 
 export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
   defaultValue?: unknown;
-  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[];
+  name?:
+    | FieldPath<TFieldValues>
+    | FieldPath<TFieldValues>[]
+    | readonly FieldPath<TFieldValues>[];
   control?: Control<TFieldValues>;
 };
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -131,7 +131,7 @@ export type FieldArrayPathValue<
 
 export type FieldPathValues<
   TFieldValues extends FieldValues,
-  TPath extends FieldPath<TFieldValues>[],
+  TPath extends FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[],
 > = {} & {
   [K in keyof TPath]: FieldPathValue<
     TFieldValues,


### PR DESCRIPTION
I was trying to use `trigger` from `UseFormReturn` and found it wouldn't accept a readonly array (due to the array of trigger names being declared with `as const`).

A workaround would be to awkwardly apply a "mutable" type mapping to my array, but instead I've naively widened the signatures for everything that accepted
`FieldPath<TFieldValues>[]`
to now also accept
`readonly FieldPath<TFieldValues>[]`

In some cases that means adding an extra overload signature, in others just a union.

This fixed the issue in my project and, as far as I can tell, should be backwards compatible.
Please let me know if you have any questions!