### PR TITLE
bubble up error when thrown in submitHandler

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1072,8 +1072,9 @@ export function useForm<
               fieldsNamesRef.current,
             );
         }
-      } catch {
+      } catch (err) {
         hasNoPromiseError = false;
+        throw err;
       } finally {
         formStateRef.current.isSubmitted = true;
         formStateSubjectRef.current.next({


### PR DESCRIPTION
This PR is to address an issue where when an error is thrown during the `onValid` parameter passed in to `handleSubmit.

This issue is primarily caused when you want to call `handleSubmit` remotely and also `try/catch` within it.

Currently, if you call it remotely, it swallows the error and the caller has no insight as to what error occurred..

The code didn't use to have a `catch` block, but I believe [this change](https://github.com/react-hook-form/react-hook-form/commit/82f2e4be80a0a4e625b6492ca3df2e8a75707093) plus the modifications I've made here would allow for valid `onSubmitSuccessful` and also handling errors with a remote caller.

I'm open to other ways of doing this as well, possibly such as some kind of prop we pass in that would allow for the behavior to be changed in the event there's no need for the caller to have insight into the error.

Either way, it's mainly a discussion point and I wanted to gather other's thoughts.

Thanks in advance!

