### PR TITLE
only register absent fields with shouldUnregister false

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -302,6 +302,36 @@ describe('useForm', () => {
       });
     });
 
+    it('should not register or shallow defaultValues into submission data', () => {
+      let data = {};
+
+      const App = () => {
+        const { handleSubmit } = useForm({
+          defaultValues: {
+            test: 'test',
+          },
+        });
+
+        return (
+          <button
+            onClick={handleSubmit((d) => {
+              data = d;
+            })}
+          >
+            sumbit
+          </button>
+        );
+      };
+
+      render(<App />);
+
+      actComponent(() => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+
+      expect(data).toEqual({});
+    });
+
     it('should keep validation during unmount', async () => {
       function Component() {
         const {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1209,6 +1209,7 @@ export function useForm<
     }
 
     !keepStateOptions.keepDefaultValues &&
+      !shouldUnregister &&
       registerAbsentFields({ ...updatedValues });
 
     resetFromState(keepStateOptions, values);
@@ -1218,7 +1219,8 @@ export function useForm<
     get(fieldsRef.current, name)._f.ref.focus();
 
   React.useEffect(() => {
-    registerAbsentFields(defaultValuesRef.current);
+    !shouldUnregister && registerAbsentFields(defaultValuesRef.current);
+
     const formStateSubscription = formStateSubjectRef.current.subscribe({
       next(formState) {
         if (shouldRenderFormState(formState, readFormStateRef.current, true)) {


### PR DESCRIPTION
<img width="794" alt="Screen Shot 2021-05-30 at 6 49 07 pm" src="https://user-images.githubusercontent.com/10513364/120098167-b95bc400-c177-11eb-8989-83f3de9e6817.png">

> By setting shouldUnregister to true at useForm level, defaultValues will not be merged against submission result.

Reflecting on the doc above for `shouldUnregister: true`, and keep that config as close to native input behavior.