### PR TITLE
improve useController to only return focus method from ref

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -108,7 +108,7 @@ export function useController<
       ref: (elm) =>
         elm &&
         ref({
-          focus: () => elm.focus(),
+          focus: () => elm.focus && elm.focus(),
         }),
     },
     formState,

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -106,9 +106,9 @@ export function useController<
       name,
       value,
       ref: (elm) =>
-        elm &&
+        elm.focus &&
         ref({
-          focus: () => elm.focus && elm.focus(),
+          focus: () => elm.focus(),
         }),
     },
     formState,

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -105,7 +105,11 @@ export function useController<
       },
       name,
       value,
-      ref: (elm) => elm && ref(elm),
+      ref: (elm) =>
+        elm &&
+        ref({
+          focus: () => elm.focus(),
+        }),
     },
     formState,
     fieldState: {

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -106,9 +106,9 @@ export function useController<
       name,
       value,
       ref: (elm) =>
-        elm.focus &&
+        elm &&
         ref({
-          focus: () => elm.focus(),
+          focus: () => elm.focus && elm.focus(),
         }),
     },
     formState,


### PR DESCRIPTION
## change

no longer access ref input's value from `useController`

## Related issues:

https://github.com/react-hook-form/react-hook-form/issues/5559
https://github.com/react-hook-form/react-hook-form/discussions/5360
https://github.com/react-hook-form/react-hook-form/discussions/5548