### PR TITLE
Avoiding FormProvider performance implication on library hooks

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -12,7 +12,7 @@ import {
   UseControllerProps,
   UseControllerReturn,
 } from './types';
-import { useFormContext } from './useFormContext';
+import { useFormControl } from './useFormContext';
 import { useFormState } from './useFormState';
 
 export function useController<
@@ -28,7 +28,7 @@ export function useController<
   TFieldValues,
   TName
 > {
-  const methods = useFormContext<TFieldValues>();
+  const controlContext = useFormControl<TFieldValues>();
   const {
     defaultValuesRef,
     register,
@@ -38,7 +38,7 @@ export function useController<
     subjectsRef,
     shouldUnmount,
     inFieldArrayActionRef,
-  } = control || methods.control;
+  } = control || controlContext;
 
   const isFieldArray = isNameInFieldArray(namesRef.current.array, name);
   const field = get(fieldsRef.current, name);
@@ -54,7 +54,7 @@ export function useController<
     value,
   });
   const formState = useFormState({
-    control: control || methods.control,
+    control: control || controlContext,
     name,
   });
 

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -32,7 +32,7 @@ import {
   UseFieldArrayReturn,
   UseFormRegister,
 } from './types';
-import { useFormContext } from './useFormContext';
+import { useFormControl } from './useFormContext';
 
 export const useFieldArray = <
   TFieldValues extends FieldValues = FieldValues,
@@ -48,7 +48,7 @@ export const useFieldArray = <
   TFieldArrayName,
   TKeyName
 >): UseFieldArrayReturn<TFieldValues, TFieldArrayName, TKeyName> => {
-  const methods = useFormContext();
+  const controlContext = useFormControl<TFieldValues>();
   const focusNameRef = React.useRef('');
   const isMountedRef = React.useRef(false);
   const {
@@ -65,7 +65,7 @@ export const useFieldArray = <
     shouldUnmount,
     inFieldArrayActionRef,
     register,
-  } = control || methods.control;
+  } = control || controlContext;
 
   const [fields, setFields] = React.useState<
     Partial<FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>>[]

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,7 +1,21 @@
 import * as React from 'react';
 
 import omit from './utils/omit';
-import { FieldValues, FormProviderProps, UseFormReturn } from './types';
+import {
+  Control,
+  FieldValues,
+  FormProviderProps,
+  UseFormReturn,
+} from './types';
+
+const FormControlContext = React.createContext<Control | null>(null);
+
+FormControlContext.displayName = 'RHFControlContext';
+
+export const useFormControl = <
+  TFieldValues extends FieldValues,
+>(): Control<TFieldValues> =>
+  React.useContext(FormControlContext) as unknown as Control<TFieldValues>;
 
 const FormContext = React.createContext<UseFormReturn | null>(null);
 
@@ -14,10 +28,14 @@ export const useFormContext = <
 
 export const FormProvider = <TFieldValues extends FieldValues>(
   props: FormProviderProps<TFieldValues>,
-) => (
-  <FormContext.Provider
-    value={omit(props, 'children') as unknown as UseFormReturn}
-  >
-    {props.children}
-  </FormContext.Provider>
-);
+) => {
+  return (
+    <FormContext.Provider
+      value={omit(props, 'children') as unknown as UseFormReturn}
+    >
+      <FormControlContext.Provider value={props.control as unknown as Control}>
+        {props.children}
+      </FormControlContext.Provider>
+    </FormContext.Provider>
+  );
+};

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -11,15 +11,15 @@ import {
   UseFormStateProps,
   UseFormStateReturn,
 } from './types';
-import { useFormContext } from './useFormContext';
+import { useFormControl } from './useFormContext';
 
 function useFormState<TFieldValues extends FieldValues = FieldValues>(
   props?: UseFormStateProps<TFieldValues>,
 ): UseFormStateReturn<TFieldValues> {
   const { control, name } = props || {};
-  const methods = useFormContext();
+  const controlContext = useFormControl<TFieldValues>();
   const { formStateRef, subjectsRef, readFormStateRef } =
-    control || methods.control;
+    control || controlContext;
   const nameRef = React.useRef<InternalFieldName>(name as InternalFieldName);
   nameRef.current = name as InternalFieldName;
 

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -13,7 +13,7 @@ import {
   UnpackNestedValue,
   UseWatchProps,
 } from './types';
-import { useFormContext } from './useFormContext';
+import { useFormControl } from './useFormContext';
 
 export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
@@ -39,11 +39,11 @@ export function useWatch<
 }): FieldPathValues<TFieldValues, TName>;
 export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
   const { control, name, defaultValue } = props || {};
-  const methods = useFormContext();
+  const controlContext = useFormControl<TFieldValues>();
   const nameRef = React.useRef(name);
   nameRef.current = name;
 
-  const { watchInternal, subjectsRef } = control || methods.control;
+  const { watchInternal, subjectsRef } = control || controlContext;
   const [value, updateValue] = React.useState<unknown>(
     isUndefined(defaultValue)
       ? watchInternal(name as InternalFieldName)


### PR DESCRIPTION
Current FormProvider implementation brings performance implication to most of the hooks:
`useFormState`
`useController`
`useWatch`
`useFieldArray`

These hooks use `control` internally, either taken from the function property or from `useFormContext` which updates frequently. (whereas these hooks do not use any of `useFormContext` other properties)


The big question is - are there reasons to not split `control` from the other form context properties? It will isolate updates only to necessary ones (I'm assuming the answer is not, due to the fact you can use these hooks without form context)
Because `control` is always the same object reference it will never cause unnecessary render for the component using the needed hook.

Perhaps, it is planned for the future.

Implementation wise - obviously, there are many ways to achieve that. I added the `FormControlProvider` into `FormProvider`, since it will be as seamless as using previous versions, but with the performance improvement :)