### PR TITLE
refactor formMethods and control object (use more js and less react for performance reasons)

### DIFF
--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@testing-library/react';
 
 import { Controller } from '../controller';
-import { ControllerRenderProps } from '../types';
+import { Control, ControllerRenderProps } from '../types';
 import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 
@@ -414,10 +414,9 @@ describe('Controller', () => {
   });
 
   it('should update rules when rules gets updated', () => {
-    let fieldsRef: any;
+    let control: Control;
     const Component = ({ required = true }: { required?: boolean }) => {
-      const { control } = useForm();
-      fieldsRef = control.fieldsRef;
+      ({ control } = useForm());
       return (
         <Controller
           defaultValue=""
@@ -432,7 +431,7 @@ describe('Controller', () => {
 
     rerender(<Component required={false} />);
 
-    expect(fieldsRef.current.test.required).toBeFalsy();
+    expect(control!.fieldsRef.test!._f.required).toBeFalsy();
   });
 
   it('should set initial state from unmount state', () => {

--- a/src/__tests__/logic/getFieldsValues.test.ts
+++ b/src/__tests__/logic/getFieldsValues.test.ts
@@ -4,20 +4,18 @@ describe('getFieldsValues', () => {
   it('should return all fields value', () => {
     expect(
       getFieldsValues({
-        current: {
-          test: {
-            _f: {
-              name: 'test',
-              ref: { name: 'test' },
-              value: 'test',
-            },
+        test: {
+          _f: {
+            name: 'test',
+            ref: { name: 'test' },
+            value: 'test',
           },
-          test1: {
-            _f: {
-              name: 'test1',
-              ref: { name: 'test1' },
-              value: 'test',
-            },
+        },
+        test1: {
+          _f: {
+            name: 'test1',
+            ref: { name: 'test1' },
+            value: 'test',
           },
         },
       }),
@@ -30,27 +28,25 @@ describe('getFieldsValues', () => {
   it('should return searched string with fields value', () => {
     expect(
       getFieldsValues({
-        current: {
-          test: {
-            _f: {
-              name: 'test',
-              ref: { name: 'test' },
-              value: 'test',
-            },
+        test: {
+          _f: {
+            name: 'test',
+            ref: { name: 'test' },
+            value: 'test',
           },
-          tex: {
-            _f: {
-              name: 'test1',
-              ref: { name: 'test1' },
-              value: 'test',
-            },
+        },
+        tex: {
+          _f: {
+            name: 'test1',
+            ref: { name: 'test1' },
+            value: 'test',
           },
-          tex123: {
-            _f: {
-              name: 'test123',
-              ref: { name: 'test123' },
-              value: 'test',
-            },
+        },
+        tex123: {
+          _f: {
+            name: 'test123',
+            ref: { name: 'test123' },
+            value: 'test',
           },
         },
       }),
@@ -64,34 +60,32 @@ describe('getFieldsValues', () => {
   it('should return searched array string with fields value', () => {
     expect(
       getFieldsValues({
-        current: {
-          test: {
-            _f: {
-              name: 'test',
-              ref: { name: 'test' },
-              value: 'test',
-            },
+        test: {
+          _f: {
+            name: 'test',
+            ref: { name: 'test' },
+            value: 'test',
           },
-          tex: {
-            _f: {
-              name: 'tex',
-              ref: { name: 'tex' },
-              value: 'test',
-            },
+        },
+        tex: {
+          _f: {
+            name: 'tex',
+            ref: { name: 'tex' },
+            value: 'test',
           },
-          whattest123: {
-            _f: {
-              name: 'whattest123',
-              ref: { name: 'test123' },
-              value: 'test',
-            },
+        },
+        whattest123: {
+          _f: {
+            name: 'whattest123',
+            ref: { name: 'test123' },
+            value: 'test',
           },
-          156: {
-            _f: {
-              name: '156',
-              ref: { name: 'test1456s' },
-              value: 'test',
-            },
+        },
+        156: {
+          _f: {
+            name: '156',
+            ref: { name: 'test1456s' },
+            value: 'test',
           },
         },
       }),
@@ -106,22 +100,20 @@ describe('getFieldsValues', () => {
   it('should return unmounted values', () => {
     expect(
       getFieldsValues({
-        current: {
-          test: {
-            _f: {
-              name: 'test',
-              ref: { name: 'test' },
-              value: 'test',
-            },
+        test: {
+          _f: {
+            name: 'test',
+            ref: { name: 'test' },
+            value: 'test',
           },
-          test1: {
-            _f: {
+        },
+        test1: {
+          _f: {
+            name: 'test1',
+            ref: {
               name: 'test1',
-              ref: {
-                name: 'test1',
-              },
-              value: 'test',
             },
+            value: 'test',
           },
         },
       }),
@@ -134,20 +126,18 @@ describe('getFieldsValues', () => {
   it('should return nested value', () => {
     expect(
       getFieldsValues({
-        current: {
-          ['test.test']: {
-            _f: {
-              name: 'test',
-              ref: { name: 'test' },
-              value: 'test',
-            },
+        ['test.test']: {
+          _f: {
+            name: 'test',
+            ref: { name: 'test' },
+            value: 'test',
           },
-          ['test.test1']: {
-            _f: {
-              name: 'test',
-              ref: { name: 'test' },
-              value: 'test',
-            },
+        },
+        ['test.test1']: {
+          _f: {
+            name: 'test',
+            ref: { name: 'test' },
+            value: 'test',
           },
         },
       }),
@@ -160,32 +150,30 @@ describe('getFieldsValues', () => {
 
     expect(
       getFieldsValues({
-        current: {
-          users: [
-            {
-              name: {
-                _f: {
-                  ref: {
-                    name: 'users.0.name',
-                  },
+        users: [
+          {
+            name: {
+              _f: {
+                ref: {
                   name: 'users.0.name',
-                  value: '1',
                 },
+                name: 'users.0.name',
+                value: '1',
               },
-              company: {
-                _f: {
-                  ref: {
-                    name: 'users.0.company',
-                  },
+            },
+            company: {
+              _f: {
+                ref: {
                   name: 'users.0.company',
-                  value: {
-                    name: '2',
-                  },
+                },
+                name: 'users.0.company',
+                value: {
+                  name: '2',
                 },
               },
             },
-          ] as any,
-        },
+          },
+        ] as any,
       }),
     ).toEqual({
       users: [
@@ -203,22 +191,20 @@ describe('getFieldsValues', () => {
     expect(
       getFieldsValues(
         {
-          current: {
-            test2: {
-              // @ts-ignore
-              test: {
-                _f: {
-                  name: 'test.test',
-                  ref: { name: 'test.test' },
-                  value: 'test',
-                },
+          test2: {
+            // @ts-ignore
+            test: {
+              _f: {
+                name: 'test.test',
+                ref: { name: 'test.test' },
+                value: 'test',
               },
-              test1: {
-                _f: {
-                  name: 'test.test1',
-                  ref: { name: 'test.test1' },
-                  value: 'test',
-                },
+            },
+            test1: {
+              _f: {
+                name: 'test.test1',
+                ref: { name: 'test.test1' },
+                value: 'test',
               },
             },
           },
@@ -237,25 +223,23 @@ describe('getFieldsValues', () => {
     expect(
       getFieldsValues(
         {
-          current: {
-            // @ts-ignore
-            test2: [
-              {
-                _f: {
-                  name: 'test.test',
-                  ref: { name: 'test.test' },
-                  value: 'test',
-                },
+          // @ts-ignore
+          test2: [
+            {
+              _f: {
+                name: 'test.test',
+                ref: { name: 'test.test' },
+                value: 'test',
               },
-              {
-                _f: {
-                  name: 'test.test1',
-                  ref: { name: 'test.test1' },
-                  value: 'test',
-                },
+            },
+            {
+              _f: {
+                name: 'test.test1',
+                ref: { name: 'test.test1' },
+                value: 'test',
               },
-            ],
-          },
+            },
+          ],
         },
         {},
       ),
@@ -267,13 +251,11 @@ describe('getFieldsValues', () => {
   it('should return undefined for disabled input', () => {
     expect(
       getFieldsValues({
-        current: {
-          test1: {
-            _f: {
-              name: 'test.test',
-              ref: { name: 'test.test', disabled: true },
-              value: 'test',
-            },
+        test1: {
+          _f: {
+            name: 'test.test',
+            ref: { name: 'test.test', disabled: true },
+            value: 'test',
           },
         },
       }),

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -473,9 +473,7 @@ describe('useFieldArray', () => {
         { id: '0', value: 'default' },
         { id: '1', value: 'test' },
       ]);
-      expect(result.current.control.namesRef.current.array).toEqual(
-        new Set(['test']),
-      );
+      expect(result.current.control.namesRef.array).toEqual(new Set(['test']));
     });
 
     it('should unset field array values correctly on DOM removing', async () => {

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -10,7 +10,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 
 import { VALIDATION_MODE } from '../../constants';
 import { Controller } from '../../controller';
-import { ControllerRenderProps } from '../../types';
+import { Control, ControllerRenderProps } from '../../types';
 import { useForm } from '../../useForm';
 import isFunction from '../../utils/isFunction';
 import isString from '../../utils/isString';
@@ -898,7 +898,7 @@ describe('register', () => {
 
   it('should not register nested input', () => {
     const watchedValue: unknown[] = [];
-    let inputs: unknown;
+    let control: Control<any>;
 
     const Checkboxes = ({
       value,
@@ -934,13 +934,13 @@ describe('register', () => {
     };
 
     function App() {
-      const { control, watch } = useForm({
+      const methods = useForm({
         defaultValues: {
           test: [true, false, false],
         },
       });
-      inputs = control.fieldsRef;
-      watchedValue.push(watch());
+      control = methods.control;
+      watchedValue.push(methods.watch());
 
       return (
         <form>
@@ -965,7 +965,7 @@ describe('register', () => {
       { test: [false, false, false] },
     ]);
 
-    expect(inputs).toMatchSnapshot();
+    expect({ current: control!.fieldsRef }).toMatchSnapshot();
   });
 
   it('should validate value after toggling enabled/disabled on input', async () => {

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -138,7 +138,7 @@ describe('reset', () => {
 
     act(() => result.current.reset({ test: 'test' }));
 
-    expect(result.current.control.defaultValuesRef.current).toEqual({
+    expect(result.current.control.defaultValuesRef).toEqual({
       test: 'test',
     });
   });

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -10,7 +10,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 
 import { VALIDATION_MODE } from '../../constants';
 import { Controller } from '../../controller';
-import { NestedValue } from '../../types';
+import { Control, NestedValue } from '../../types';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
 import get from '../../utils/get';
@@ -262,7 +262,7 @@ describe('setValue', () => {
       ]);
     });
 
-    expect(result.current.control.fieldsRef.current['test1']).toEqual({
+    expect(result.current.control.fieldsRef['test1']).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test1', value: ['1', '2', '3'] },
@@ -270,7 +270,7 @@ describe('setValue', () => {
         value: ['1', '2', '3'],
       },
     });
-    expect(result.current.control.fieldsRef.current['test2']).toEqual({
+    expect(result.current.control.fieldsRef['test2']).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test2', value: { key1: '1', key2: 2 } },
@@ -278,7 +278,7 @@ describe('setValue', () => {
         value: { key1: '1', key2: 2 },
       },
     });
-    expect(result.current.control.fieldsRef.current['test3']).toEqual({
+    expect(result.current.control.fieldsRef['test3']).toEqual({
       _f: {
         mount: true,
         ref: {
@@ -314,7 +314,7 @@ describe('setValue', () => {
 
     act(() => result.current.setValue('test', ['1', '2', '3']));
 
-    expect(get(result.current.control.fieldsRef.current, 'test.0')).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.0')).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test.0', value: '1' },
@@ -322,7 +322,7 @@ describe('setValue', () => {
         value: '1',
       },
     });
-    expect(get(result.current.control.fieldsRef.current, 'test.1')).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.1')).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test.1', value: '2' },
@@ -330,7 +330,7 @@ describe('setValue', () => {
         value: '2',
       },
     });
-    expect(get(result.current.control.fieldsRef.current, 'test.2')).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.2')).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test.2', value: '3' },
@@ -361,9 +361,7 @@ describe('setValue', () => {
       ]),
     );
 
-    expect(
-      get(result.current.control.fieldsRef.current, 'test.0.test'),
-    ).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.0.test')).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test.0.test', value: '1' },
@@ -371,9 +369,7 @@ describe('setValue', () => {
         value: '1',
       },
     });
-    expect(
-      get(result.current.control.fieldsRef.current, 'test.1.test'),
-    ).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.1.test')).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test.1.test', value: '2' },
@@ -381,9 +377,7 @@ describe('setValue', () => {
         value: '2',
       },
     });
-    expect(
-      get(result.current.control.fieldsRef.current, 'test.2.test'),
-    ).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.2.test')).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test.2.test', value: '3' },
@@ -415,7 +409,7 @@ describe('setValue', () => {
     act(() =>
       result.current.setValue('test', { bill: '1', luo: '2', test: '3' }),
     );
-    expect(get(result.current.control.fieldsRef.current, 'test.bill')).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.bill')).toEqual({
       _f: {
         ref: { name: 'test.bill', value: '1' },
         mount: true,
@@ -423,7 +417,7 @@ describe('setValue', () => {
         value: '1',
       },
     });
-    expect(get(result.current.control.fieldsRef.current, 'test.luo')).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.luo')).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test.luo', value: '2' },
@@ -431,7 +425,7 @@ describe('setValue', () => {
         value: '2',
       },
     });
-    expect(get(result.current.control.fieldsRef.current, 'test.test')).toEqual({
+    expect(get(result.current.control.fieldsRef, 'test.test')).toEqual({
       _f: {
         mount: true,
         ref: { name: 'test.test', value: '3' },
@@ -448,7 +442,7 @@ describe('setValue', () => {
       result.current.setValue('test', '1');
     });
 
-    expect(result.current.control.fieldsRef.current['test']).toEqual({
+    expect(result.current.control.fieldsRef['test']).toEqual({
       _f: {
         name: 'test',
         mount: true,
@@ -472,7 +466,7 @@ describe('setValue', () => {
       });
     });
 
-    expect(result.current.control.fieldsRef.current['test']).toEqual({
+    expect(result.current.control.fieldsRef['test']).toEqual({
       test: {
         _f: {
           mount: true,
@@ -941,20 +935,20 @@ describe('setValue', () => {
   });
 
   it('should register deeply nested inputs correctly', () => {
-    let fields: unknown;
+    let control: Control<any>;
     const App = () => {
-      const { setValue, control } = useForm();
+      const methods = useForm();
+      control = methods.control;
       useFieldArray({
         control,
         name: 'test',
       });
       const [, setShow] = React.useState(false);
-      fields = control.fieldsRef.current;
 
       return (
         <button
           onClick={() => {
-            setValue('test', [
+            methods.setValue('test', [
               {
                 name: 'append',
                 nestedArray: [{ field1: 'append', field2: 'append' }],
@@ -971,7 +965,7 @@ describe('setValue', () => {
     render(<App />);
 
     fireEvent.click(screen.getByRole('button'));
-    expect(fields).toMatchSnapshot();
+    expect(control!.fieldsRef).toMatchSnapshot();
   });
 
   describe('when set field to null', () => {

--- a/src/logic/getFieldsValues.ts
+++ b/src/logic/getFieldsValues.ts
@@ -1,16 +1,14 @@
-import * as React from 'react';
-
 import { FieldRefs, FieldValues } from '../types';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
 import omit from '../utils/omit';
 import set from '../utils/set';
 
 const getFieldsValues = (
-  fieldsRef: React.MutableRefObject<FieldRefs>,
+  fieldsRef: FieldRefs,
   output: FieldValues = {},
 ): any => {
-  for (const name in fieldsRef.current) {
-    const field = fieldsRef.current[name];
+  for (const name in fieldsRef) {
+    const field = fieldsRef[name];
 
     if (field && !isNullOrUndefined(output)) {
       const _f = field._f;
@@ -28,13 +26,7 @@ const getFieldsValues = (
           : {},
       );
 
-      current &&
-        getFieldsValues(
-          {
-            current,
-          },
-          output[name],
-        );
+      current && getFieldsValues(current, output[name]);
     }
   }
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -479,24 +479,23 @@ export type FormStateSubjectRef<TFieldValues> = SubjectType<
   Partial<FormState<TFieldValues>> & { name?: InternalFieldName }
 >;
 
-export type Subjects<TFieldValues extends FieldValues = FieldValues> =
-  React.MutableRefObject<{
-    watch: SubjectType<{
-      name?: InternalFieldName;
-      type?: EventType;
-      values?: FieldValues;
-    }>;
-    control: SubjectType<{
-      name?: InternalFieldName;
-      values?: FieldValues;
-    }>;
-    array: SubjectType<{
-      name?: InternalFieldName;
-      values?: FieldValues;
-      isReset?: boolean;
-    }>;
-    state: FormStateSubjectRef<TFieldValues>;
+export type Subjects<TFieldValues extends FieldValues = FieldValues> = {
+  watch: SubjectType<{
+    name?: InternalFieldName;
+    type?: EventType;
+    values?: FieldValues;
   }>;
+  control: SubjectType<{
+    name?: InternalFieldName;
+    values?: FieldValues;
+  }>;
+  array: SubjectType<{
+    name?: InternalFieldName;
+    values?: FieldValues;
+    isReset?: boolean;
+  }>;
+  state: FormStateSubjectRef<TFieldValues>;
+};
 
 export type Names = {
   mount: InternalNameSet;
@@ -508,7 +507,7 @@ export type Names = {
 
 export type Control<TFieldValues extends FieldValues = FieldValues> = {
   shouldUnmount?: boolean;
-  subjectsRef: Subjects<TFieldValues>;
+  subjectsRef: React.MutableRefObject<Subjects<TFieldValues>>;
   namesRef: React.MutableRefObject<Names>;
   inFieldArrayActionRef: React.MutableRefObject<boolean>;
   getIsDirty: GetIsDirty;
@@ -521,6 +520,11 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = {
   watchInternal: WatchInternal<TFieldValues>;
   register: UseFormRegister<TFieldValues>;
   unregister: UseFormUnregister<TFieldValues>;
+  registerAbsentFields: <T extends DefaultValues<TFieldValues>>(
+    defaultValues: T,
+    name?: string,
+  ) => void;
+  isMountedRef: React.MutableRefObject<boolean>;
 };
 
 export type WatchObserver<TFieldValues> = (
@@ -546,6 +550,7 @@ export type UseFormReturn<TFieldValues extends FieldValues = FieldValues> = {
   control: Control<TFieldValues>;
   register: UseFormRegister<TFieldValues>;
   setFocus: UseFormSetFocus<TFieldValues>;
+  setOptions: (options: UseFormProps<TFieldValues, any>) => void;
 };
 
 export type UseFormStateProps<TFieldValues> = Partial<{

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -507,16 +507,16 @@ export type Names = {
 
 export type Control<TFieldValues extends FieldValues = FieldValues> = {
   shouldUnmount?: boolean;
-  subjectsRef: React.MutableRefObject<Subjects<TFieldValues>>;
-  namesRef: React.MutableRefObject<Names>;
-  inFieldArrayActionRef: React.MutableRefObject<boolean>;
+  subjectsRef: Subjects<TFieldValues>;
+  namesRef: Names;
+  inFieldArrayActionRef: boolean;
   getIsDirty: GetIsDirty;
   fieldArrayDefaultValuesRef: FieldArrayDefaultValues;
-  formStateRef: React.MutableRefObject<FormState<TFieldValues>>;
+  formStateRef: FormState<TFieldValues>;
   updateIsValid: <T extends FieldValues>(payload?: T) => void;
-  fieldsRef: React.MutableRefObject<FieldRefs>;
-  readFormStateRef: React.MutableRefObject<ReadFormState>;
-  defaultValuesRef: React.MutableRefObject<DefaultValues<TFieldValues>>;
+  fieldsRef: FieldRefs;
+  readFormStateRef: ReadFormState;
+  defaultValuesRef: DefaultValues<TFieldValues>;
   watchInternal: WatchInternal<TFieldValues>;
   register: UseFormRegister<TFieldValues>;
   unregister: UseFormUnregister<TFieldValues>;
@@ -524,7 +524,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues> = {
     defaultValues: T,
     name?: string,
   ) => void;
-  isMountedRef: React.MutableRefObject<boolean>;
+  isMountedRef: boolean;
 };
 
 export type WatchObserver<TFieldValues> = (

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -73,7 +73,7 @@ export const useFieldArray = <
   >(
     mapIds(
       (get(fieldsRef.current, name) && isMountedRef.current
-        ? get(getFieldsValues(fieldsRef), name)
+        ? get(getFieldsValues(fieldsRef.current), name)
         : get(fieldArrayDefaultValuesRef.current, getFieldArrayParentName(name))
         ? get(fieldArrayDefaultValuesRef.current, name)
         : get(defaultValuesRef.current, name)) || [],
@@ -94,7 +94,7 @@ export const useFieldArray = <
     fields.map((field = {}) => omit(field as Record<TKeyName, any>, keyName));
 
   const getCurrentFieldsValues = () => {
-    const values = get(getFieldsValues(fieldsRef), name, []);
+    const values = get(getFieldsValues(fieldsRef.current), name, []);
 
     return mapIds<TFieldValues, TKeyName>(
       get(fieldArrayDefaultValuesRef.current, name, []).map(
@@ -383,7 +383,7 @@ export const useFieldArray = <
 
     subjectsRef.current.watch.next({
       name,
-      values: getFieldsValues(fieldsRef),
+      values: getFieldsValues(fieldsRef.current),
     });
 
     focusNameRef.current &&
@@ -428,7 +428,7 @@ export const useFieldArray = <
         unregister(name as FieldPath<TFieldValues>);
         unset(fieldArrayDefaultValuesRef.current, name);
       } else {
-        const fieldArrayValues = get(getFieldsValues(fieldsRef), name);
+        const fieldArrayValues = get(getFieldsValues(fieldsRef.current), name);
         fieldArrayValues &&
           set(fieldArrayDefaultValuesRef.current, name, fieldArrayValues);
       }

--- a/src/useForm.native.test.tsx
+++ b/src/useForm.native.test.tsx
@@ -22,7 +22,7 @@ describe('useForm with React Native', () => {
 
     render(<Component />);
 
-    expect(control.fieldsRef.current.test).toBeDefined();
+    expect(control.fieldsRef.test).toBeDefined();
   });
 
   it('should invoke focus with RN', async () => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1095,84 +1095,70 @@ export function createForm<
     },
   };
 
-  const formControl = {
+  const formControl: UseFormReturn<TFieldValues> = {
     control: {
       register,
-      inFieldArrayActionRef: {
-        get current() {
-          return inFieldArrayActionRef;
-        },
-        set current(v) {
-          inFieldArrayActionRef = v;
-        },
+      get inFieldArrayActionRef() {
+        return inFieldArrayActionRef;
+      },
+      set inFieldArrayActionRef(v) {
+        inFieldArrayActionRef = v;
       },
       getIsDirty,
-      subjectsRef: {
-        get current() {
-          return subjectsRef;
-        },
-        set current(v) {
-          subjectsRef = v;
-        },
+      get subjectsRef() {
+        return subjectsRef;
+      },
+      set subjectsRef(v) {
+        subjectsRef = v;
       },
       watchInternal,
-      fieldsRef: {
-        get current() {
-          return fieldsRef;
-        },
-        set current(v) {
-          fieldsRef = v;
-        },
+      get fieldsRef() {
+        return fieldsRef;
+      },
+      set fieldsRef(v) {
+        fieldsRef = v;
       },
       updateIsValid,
-      namesRef: {
-        get current() {
-          return namesRef;
-        },
-        set current(v) {
-          namesRef = v;
-        },
+      get namesRef() {
+        return namesRef;
       },
-      readFormStateRef: readFormStateRefControl,
-      formStateRef: {
-        get current() {
-          return formStateRef;
-        },
-        set current(v) {
-          formStateRef = v;
-          formControl.formState = getProxyFormState<TFieldValues>(
-            isProxyEnabled,
-            formStateRef,
-            readFormStateRefControl,
-          );
-        },
+      set namesRef(v) {
+        namesRef = v;
       },
-      defaultValuesRef: {
-        get current() {
-          return defaultValues;
-        },
-        set current(v) {
-          defaultValues = v;
-        },
+      get readFormStateRef() {
+        return readFormStateRef;
       },
-      fieldArrayDefaultValuesRef: {
-        get current() {
-          return fieldArrayDefaultValuesRef;
-        },
-        set current(v) {
-          fieldArrayDefaultValuesRef = v;
-        },
+      get formStateRef() {
+        return formStateRef;
+      },
+      set formStateRef(v) {
+        formStateRef = v;
+        formControl.formState = getProxyFormState<TFieldValues>(
+          isProxyEnabled,
+          formStateRef,
+          readFormStateRefControl,
+        );
+      },
+      get defaultValuesRef() {
+        return defaultValues;
+      },
+      set defaultValuesRef(v) {
+        defaultValues = v;
+      },
+      get fieldArrayDefaultValuesRef() {
+        return fieldArrayDefaultValuesRef;
+      },
+      set fieldArrayDefaultValuesRef(v) {
+        fieldArrayDefaultValuesRef = v;
       },
       unregister,
       shouldUnmount: formOptions.shouldUnregister,
       registerAbsentFields,
-      isMountedRef: {
-        get current() {
-          return isMountedRef;
-        },
-        set current(v) {
-          isMountedRef = v;
-        },
+      get isMountedRef() {
+        return isMountedRef;
+      },
+      set isMountedRef(v) {
+        isMountedRef = v;
       },
     },
     formState: getProxyFormState<TFieldValues>(
@@ -1216,17 +1202,11 @@ export function useForm<
   const control = formControlRef.current!.control;
 
   useEffect(() => {
-    const formStateSubscription = control.subjectsRef.current.state.subscribe({
+    const formStateSubscription = control.subjectsRef.state.subscribe({
       next(formState) {
-        if (
-          shouldRenderFormState(
-            formState,
-            control.readFormStateRef.current,
-            true,
-          )
-        ) {
-          control.formStateRef.current = {
-            ...control.formStateRef.current,
+        if (shouldRenderFormState(formState, control.readFormStateRef, true)) {
+          control.formStateRef = {
+            ...control.formStateRef,
             ...formState,
           };
           forceUpdate({});
@@ -1234,20 +1214,15 @@ export function useForm<
       },
     });
 
-    const useFieldArraySubscription =
-      control.subjectsRef.current.array.subscribe({
-        next(state) {
-          if (
-            state.values &&
-            state.name &&
-            control.readFormStateRef.current.isValid
-          ) {
-            const values = getFieldsValues(control.fieldsRef.current);
-            set(values, state.name, state.values);
-            control.updateIsValid(values);
-          }
-        },
-      });
+    const useFieldArraySubscription = control.subjectsRef.array.subscribe({
+      next(state) {
+        if (state.values && state.name && control.readFormStateRef.isValid) {
+          const values = getFieldsValues(control.fieldsRef);
+          set(values, state.name, state.values);
+          control.updateIsValid(values);
+        }
+      },
+    });
 
     return () => {
       formStateSubscription.unsubscribe();
@@ -1259,15 +1234,15 @@ export function useForm<
     const isLiveInDom = (ref: Ref) =>
       !isHTMLElement(ref) || !document.contains(ref);
 
-    if (!control.isMountedRef.current) {
-      control.isMountedRef.current = true;
-      control.readFormStateRef.current.isValid && control.updateIsValid();
+    if (!control.isMountedRef) {
+      control.isMountedRef = true;
+      control.readFormStateRef.isValid && control.updateIsValid();
       !control.shouldUnmount &&
-        control.registerAbsentFields(control.defaultValuesRef.current);
+        control.registerAbsentFields(control.defaultValuesRef);
     }
 
-    for (const name of control.namesRef.current.unMount) {
-      const field = get(control.fieldsRef.current, name) as Field;
+    for (const name of control.namesRef.unMount) {
+      const field = get(control.fieldsRef, name) as Field;
 
       field &&
         (field._f.refs
@@ -1276,7 +1251,7 @@ export function useForm<
         control.unregister(name as FieldPath<TFieldValues>);
     }
 
-    control.namesRef.current.unMount = new Set();
+    control.namesRef.unMount = new Set();
   });
 
   return formControlRef.current!;

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -16,14 +16,12 @@ import { useFormContext } from './useFormContext';
 function useFormState<TFieldValues extends FieldValues = FieldValues>(
   props?: UseFormStateProps<TFieldValues>,
 ): UseFormStateReturn<TFieldValues> {
-  const { control, name } = props || {};
   const methods = useFormContext();
-  const { formStateRef, subjectsRef, readFormStateRef } =
-    control || methods.control;
+  const { control = methods.control, name } = props || {};
   const nameRef = React.useRef<InternalFieldName>(name as InternalFieldName);
   nameRef.current = name as InternalFieldName;
 
-  const [formState, updateFormState] = React.useState(formStateRef.current);
+  const [formState, updateFormState] = React.useState(control.formStateRef);
   const readFormState = React.useRef({
     isDirty: false,
     dirtyFields: false,
@@ -34,14 +32,14 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
   });
 
   React.useEffect(() => {
-    const formStateSubscription = subjectsRef.current.state.subscribe({
+    const formStateSubscription = control.subjectsRef.state.subscribe({
       next: (formState) =>
         (!nameRef.current ||
           !formState.name ||
           convertToArrayPayload(nameRef.current).includes(formState.name)) &&
         shouldRenderFormState(formState, readFormState.current) &&
         updateFormState({
-          ...formStateRef.current,
+          ...control.formStateRef,
           ...formState,
         }),
     });
@@ -52,7 +50,11 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
   return getProxyFormState<TFieldValues>(
     isProxyEnabled,
     formState as FormState<TFieldValues>,
-    readFormStateRef,
+    {
+      get current() {
+        return control.readFormStateRef;
+      },
+    },
     readFormState,
     false,
   );

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -38,22 +38,21 @@ export function useWatch<
   control?: Control<TFieldValues>;
 }): FieldPathValues<TFieldValues, TName>;
 export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
-  const { control, name, defaultValue } = props || {};
   const methods = useFormContext();
+  const { control = methods.control, name, defaultValue } = props || {};
   const nameRef = React.useRef(name);
   nameRef.current = name;
 
-  const { watchInternal, subjectsRef } = control || methods.control;
   const [value, updateValue] = React.useState<unknown>(
     isUndefined(defaultValue)
-      ? watchInternal(name as InternalFieldName)
+      ? control.watchInternal(name as InternalFieldName)
       : defaultValue,
   );
 
   React.useEffect(() => {
-    watchInternal(name as InternalFieldName);
+    control.watchInternal(name as InternalFieldName);
 
-    const watchSubscription = subjectsRef.current.watch.subscribe({
+    const watchSubscription = control.subjectsRef.watch.subscribe({
       next: ({ name: inputName, values }) =>
         (!nameRef.current ||
           !inputName ||
@@ -65,7 +64,7 @@ export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
                 inputName.startsWith(fieldName as InternalFieldName)),
           )) &&
         updateValue(
-          watchInternal(
+          control.watchInternal(
             nameRef.current as string,
             defaultValue as UnpackNestedValue<DeepPartial<TFieldValues>>,
             false,


### PR DESCRIPTION
split one of custom hook logics and use pure-js for better performance and better control of breaking logics down

next changes will be split all logics and move core logics to a single file and other hooks could be wrappers around it 
and also writing less `.current` for refs will decrease bundle size 
even it could be possible to completely break logic into separate repo named `@hookform/core` and some hook utilities around core named `@hookform/react`

also in future maybe we could export `createForm` function to be used out of react components 