### PR TITLE
don't spread non-primitive values in nested array fields while using `useFieldArray`

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -221,7 +221,7 @@ export const useFieldArray = <
               ? registerFieldArray(value, valueIndex, inputName)
               : (register as UseFormRegister<TFieldValues>)(
                   inputName as Path<TFieldValues>,
-                  { value: isPrimitive(value) ? value : { ...value } },
+                  { value },
                 );
           });
     });


### PR DESCRIPTION
I found a problem when using file fields in nested array. There was that line, that was spreading value if it is was not primitive, which caused `File` object to become just a plain object with one prop `path`. I don't know why this behaviour exists. I think it's a bug. After the change, all tests are passing.