### PR TITLE
chore: allow readonly tuple in useWatch generic params

### DIFF
--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -31,7 +31,7 @@ export function useWatch<
 }): FieldPathValue<TFieldValues, TName>;
 export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues>[] = FieldPath<TFieldValues>[],
+  TName extends readonly FieldPath<TFieldValues>[] = FieldPath<TFieldValues>[],
 >(props: {
   name: TName;
   defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>;


### PR DESCRIPTION
Mutatable array is not actually needed here.

Current way of using useWatch:

```ts
const [field1, field2] = useWatch<Schema, ['field1', 'field2']>({name: ['field1', 'field2']});
```

But if there are a lot of fields to watch, it makes sense to infer the type from the actual tuple:

```ts
const fieldsToWatch = ['field1', 'field2'] as const; // typeof fieldsToWatch === readonly ['field1', 'field2']

const [field1, field2] = useWatch<Schema, typeof fieldsToWatch>({name: fieldsToWatch}); // Error! useWatch cannot take readonly tuple as a second generic parameter
```

This PR solves this issue