### PR TITLE
Add constants to exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export * from './controller';
 export * from './logic';
 export * from './types';


### PR DESCRIPTION
Allows for:

```
import { VALIDATION_MODE, useForm } from 'react-hook-form';

const methods = useForm<TFieldValues>({
  mode: VALIDATION_MODE.onTouched
});
```