### PR TITLE
Access input from CustomElement

### DIFF
--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -25,6 +25,7 @@ export type CustomElement<TFieldValues extends FieldValues> = {
   options?: HTMLOptionsCollection;
   files?: FileList | null;
   focus?: () => void;
+  input?: any;
 };
 
 export type FieldValue<

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -126,6 +126,7 @@ export function useController<TFieldValues extends FieldValues = FieldValues>({
             {
               name,
               focus: onFocusRef.current,
+              input: ref.current,
             },
             {
               value: {


### PR DESCRIPTION
With this change, user can implement custom logic to manually focus on the first error input instead of using Controller for all inputs. See #5981 

In order to determine the focus order for error inputs, 'ref' from Controller render prop is required in the CustomElement, so that it can be accessible from FieldErrors.