### PR TITLE
improve WatchObserver type

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -357,7 +357,10 @@ export type Control<
 export type WatchObserver<TFieldValues> = (
   value: UnpackNestedValue<TFieldValues>,
   info: {
-    name?: string;
+    name?:
+      | FieldPath<TFieldValues>
+      | FieldPath<TFieldValues>[]
+      | readonly FieldPath<TFieldValues>[];
     type?: EventType;
     value?: unknown;
   },


### PR DESCRIPTION
fix type of `name` to correctly infer return type
