### PR TITLE
fix `TypeError: Cannot read property '_f' of undefined` bug in createFormControl.ts

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -934,6 +934,7 @@ export function createFormControl<
     const isRadioOrCheckbox = isRadioOrCheckboxFunction(ref);
 
     if (
+      field == null ||
       ref === field._f.ref ||
       (isRadioOrCheckbox &&
         compact(field._f.refs || []).find((option) => option === ref))


### PR DESCRIPTION
`get()` in line 926 in `createFormControl.ts` can return `undefined` (making `field` `undefined`), but subsequent lines assume that `field` is never `undefined` - causing the `Cannot read property '_f' of undefined` type error