### PR TITLE
Add `rethrowSubmitErrors` to `useForm`

### DIFF
--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -386,6 +386,47 @@ describe('formState', () => {
     screen.getByText('isNotSubmitSuccessful');
   });
 
+  it('should set isSubmitSuccessful to false and swallow error when rethrowSubmitErrors is false', async () => {
+    const App = () => {
+      const {
+        register,
+        handleSubmit,
+        formState: { isSubmitSuccessful, isSubmitted },
+      } = useForm({ rethrowSubmitErrors: false });
+
+      const rejectPromiseFn = jest
+        .fn()
+        .mockRejectedValue(new Error('this is an error'));
+
+      return (
+        <form>
+          <input {...register('test')} />
+          <p>{isSubmitted ? 'isSubmitted' : 'no'}</p>
+          <p>
+            {isSubmitSuccessful
+              ? 'isSubmitSuccessful'
+              : 'isNotSubmitSuccessful'}
+          </p>
+          <button
+            type={'button'}
+            onClick={handleSubmit(rejectPromiseFn)}
+          >
+            Submit
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    await actComponent(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+
+    screen.getByText('isSubmitted');
+    screen.getByText('isNotSubmitSuccessful');
+  });
+
   it('should update correct isValid formState with dynamic fields', async () => {
     const Component = () => {
       const {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -85,6 +85,7 @@ const defaultOptions = {
   mode: VALIDATION_MODE.onSubmit,
   reValidateMode: VALIDATION_MODE.onChange,
   shouldFocusError: true,
+  rethrowSubmitErrors: true,
 } as const;
 
 const isWindowUndefined = typeof window === 'undefined';
@@ -1075,7 +1076,9 @@ export function createFormControl<
         }
       } catch (err) {
         hasNoPromiseError = false;
-        throw err;
+        if (formOptions.rethrowSubmitErrors) {
+          throw err;
+        }
       } finally {
         _formState.isSubmitted = true;
         _subjects.state.next({

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -100,6 +100,7 @@ export type UseFormProps<
   shouldFocusError: boolean;
   shouldUnregister: boolean;
   shouldUseNativeValidation: boolean;
+  rethrowSubmitErrors: boolean;
   criteriaMode: CriteriaMode;
   delayError: number;
 }>;


### PR DESCRIPTION
Enables rethrown errors to be swallowed by RHF if the intention is just to prevent
`isSubmitSuccessful` from being moved to `true`.

Related to convo on #5391.