### PR TITLE
Implement option `shouldRegisterAbsentFields`

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -104,6 +104,7 @@ export type UseFormProps<
   shouldFocusError: boolean;
   shouldUnregister: boolean;
   shouldUseNativeValidation: boolean;
+  shouldRegisterAbsentFields: boolean;
   criteriaMode: CriteriaMode;
   delayError: number;
 }>;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -98,6 +98,7 @@ export function useForm<
   delayError,
   shouldUseNativeValidation,
   shouldUnregister,
+  shouldRegisterAbsentFields,
   criteriaMode,
 }: UseFormProps<TFieldValues, TContext> = {}): UseFormReturn<TFieldValues> {
   const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
@@ -1227,7 +1228,9 @@ export function useForm<
     if (!isMountedRef.current) {
       isMountedRef.current = true;
       readFormStateRef.current.isValid && updateIsValid();
-      !shouldUnregister && registerAbsentFields(defaultValuesRef.current);
+      !shouldUnregister &&
+        shouldRegisterAbsentFields &&
+        registerAbsentFields(defaultValuesRef.current);
     }
 
     for (const name of namesRef.current.unMount) {


### PR DESCRIPTION
Hello all

This PR is related to the following discussion https://github.com/react-hook-form/react-hook-form/discussions/6240

The `registerAbsentFields` feature is giving us troubles. Adding a simple option to enable/disable it, gives developers more freedom on how to work with react-hook-form.

This PR acts as a base for the above mentioned discussion. Of course we could add documentation and tests if this will be considered a viable way to go. It's currently based on version 7.12.2, not sure where to add for 7.13.x