### PR TITLE
fix: TypeError: e.focus is not a function

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -105,9 +105,9 @@ export function useController<
       ref: (elm) => {
         const field = get(control._fields, name);
 
-        if (elm && field) {
+        if (elm && field && elm.focus) {
           field._f.ref = {
-            focus: () => elm.focus && elm.focus(),
+            focus: () => elm.focus(),
             setCustomValidity: (message: string) =>
               elm.setCustomValidity(message),
             reportValidity: () => elm.reportValidity(),

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -107,7 +107,7 @@ export function useController<
 
         if (elm && field) {
           field._f.ref = {
-            focus: () => elm.focus(),
+            focus: () => elm.focus && elm.focus(),
             setCustomValidity: (message: string) =>
               elm.setCustomValidity(message),
             reportValidity: () => elm.reportValidity(),


### PR DESCRIPTION
`react-hook-form@7.14.0` version shows the type error when I run the jest test.

```
TypeError: e.focus is not a function

    at Object.options [as focus] (node_modules/react-hook-form/src/useController.ts:113:39)
    at next (node_modules/react-hook-form/src/logic/getFocusFieldName.ts:8:3)
    at Object.<anonymous> (node_modules/react-hook-form/src/logic/createFormControl.ts:1081:25)
```

The test passed on `react-hook-form@7.12.2` version, where [this](https://github.com/react-hook-form/react-hook-form/commit/b6ffb6e33a253e13df8f0569ed09be899dcf0174#diff-3f5bdfa7d822b4562b8e1c72dd1996197fe93478b039779bb78853ab3ae2a3feL108) change has not committed. 
I assume that `elm.focus &&` statement has to be added.