### PR TITLE
Update watch observer types

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -358,10 +358,7 @@ export type Control<
 export type WatchObserver<TFieldValues> = (
   value: UnpackNestedValue<TFieldValues>,
   info: {
-    name?:
-      | FieldPath<TFieldValues>
-      | FieldPath<TFieldValues>[]
-      | readonly FieldPath<TFieldValues>[];
+    name?: FieldPath<TFieldValues>;
     type?: EventType;
     value?: unknown;
   },


### PR DESCRIPTION
The watch callback is only invoked with one field at a time.  See https://github.com/react-hook-form/react-hook-form/discussions/6392