### PR TITLE
improve Mapped types

### DIFF
--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -1188,7 +1188,7 @@ describe('register', () => {
 
       const App = () => {
         const { register, handleSubmit } = useForm<{
-          test: Date;
+          test: Date | string;
         }>({
           defaultValues: {
             test: '2020-10-10',

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -6,6 +6,7 @@ import {
   DelayCallback,
   Field,
   FieldError,
+  FieldErrors,
   FieldNamesMarkedBoolean,
   FieldPath,
   FieldRefs,
@@ -101,17 +102,17 @@ export function createFormControl<
     ...props,
   };
   let _delayCallback: DelayCallback;
-  let _formState = {
+  let _formState: FormState<TFieldValues> = {
     isDirty: false,
     isValidating: false,
-    dirtyFields: {},
+    dirtyFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
     isSubmitted: false,
     submitCount: 0,
-    touchedFields: {},
+    touchedFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
     isSubmitting: false,
     isSubmitSuccessful: false,
     isValid: false,
-    errors: {},
+    errors: {} as FieldErrors<TFieldValues>,
   };
   let _fields = {};
   let _formValues = {};
@@ -350,7 +351,7 @@ export function createFormControl<
             formOptions.shouldUseNativeValidation,
           ),
         )
-      : ({} as ResolverResult);
+      : ({} as ResolverResult<TFieldValues>);
   };
 
   const executeResolverValidation = async (names?: InternalFieldName[]) => {
@@ -364,7 +365,7 @@ export function createFormControl<
           : unset(_formState.errors, name);
       }
     } else {
-      _formState.errors = errors;
+      _formState.errors = errors as FieldErrors<TFieldValues>;
     }
 
     return errors;
@@ -841,7 +842,7 @@ export function createFormControl<
       ? convertToArrayPayload(name).forEach((inputName) =>
           unset(_formState.errors, inputName),
         )
-      : (_formState.errors = {});
+      : (_formState.errors = {} as FieldErrors<TFieldValues>);
 
     _subjects.state.next({
       errors: _formState.errors,
@@ -1040,7 +1041,7 @@ export function createFormControl<
       try {
         if (formOptions.resolver) {
           const { errors, values } = await executeResolver();
-          _formState.errors = errors;
+          _formState.errors = errors as FieldErrors<TFieldValues>;
           fieldValues = values;
         } else {
           await validateForm(_fields);
@@ -1051,7 +1052,7 @@ export function createFormControl<
           Object.keys(_formState.errors).every((name) => get(fieldValues, name))
         ) {
           _subjects.state.next({
-            errors: {},
+            errors: {} as FieldErrors<TFieldValues>,
             isSubmitting: true,
           });
           await onValid(fieldValues, e);
@@ -1146,11 +1147,15 @@ export function createFormControl<
       isSubmitted: keepStateOptions.keepIsSubmitted
         ? _formState.isSubmitted
         : false,
-      dirtyFields: keepStateOptions.keepDirty ? _formState.dirtyFields : {},
+      dirtyFields: keepStateOptions.keepDirty
+        ? _formState.dirtyFields
+        : ({} as FieldNamesMarkedBoolean<TFieldValues>),
       touchedFields: keepStateOptions.keepTouched
         ? _formState.touchedFields
-        : {},
-      errors: keepStateOptions.keepErrors ? _formState.errors : {},
+        : ({} as FieldNamesMarkedBoolean<TFieldValues>),
+      errors: keepStateOptions.keepErrors
+        ? _formState.errors
+        : ({} as FieldErrors<TFieldValues>),
       isSubmitting: false,
       isSubmitSuccessful: false,
     });

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,5 +1,5 @@
 import { FieldValues, InternalFieldName, Ref } from './fields';
-import { DeepMap, LiteralUnion } from './utils';
+import { DeepMap, DeepPartial, LiteralUnion } from './utils';
 import { RegisterOptions, ValidateResult } from './validator';
 
 export type Message = string;
@@ -24,7 +24,7 @@ export type ErrorOption = {
 };
 
 export type FieldErrors<TFieldValues extends FieldValues = FieldValues> =
-  DeepMap<TFieldValues, FieldError>;
+  DeepMap<DeepPartial<TFieldValues>, FieldError>;
 
 export type InternalFieldErrors = Partial<
   Record<InternalFieldName, FieldError>

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -101,7 +101,7 @@ export type UseFormProps<
 }>;
 
 export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<
-  TFieldValues,
+  DeepPartial<TFieldValues>,
   true
 >;
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -18,37 +18,23 @@ export type LiteralUnion<T extends U, U extends Primitive> =
   | T
   | (U & { _?: never });
 
-export type DeepPartial<T> = T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends { [key in keyof T]: T[key] }
-  ? {
-      [K in keyof T]?: DeepPartial<T[K]>;
-    }
-  : T;
+export type DeepPartial<T> = T extends Date | FileList | File | NestedValue
+  ? T
+  : { [K in keyof T]?: DeepPartial<T[K]> };
 
 export type IsAny<T> = boolean extends (T extends never ? true : false)
   ? true
   : false;
 
-export type DeepMap<T, TValue> = {
-  [K in keyof T]?: IsAny<T[K]> extends true
-    ? any
-    : NonNullable<T[K]> extends NestedValue | Date | FileList | File
-    ? TValue
-    : NonUndefined<T[K]> extends object | null
-    ? DeepMap<T[K], TValue>
-    : NonUndefined<T[K]> extends Array<infer U>
-    ? IsAny<U> extends true
-      ? Array<any>
-      : U extends NestedValue | Date | FileList
-      ? Array<TValue>
-      : U extends object
-      ? Array<DeepMap<U, TValue>>
-      : Array<TValue>
-    : TValue;
-};
+export type DeepMap<T, TValue> = IsAny<T> extends true
+  ? any
+  : T extends null | undefined
+  ? T
+  : T extends Date | FileList | File | NestedValue
+  ? TValue
+  : T extends object
+  ? { [K in keyof T]: DeepMap<T[K], TValue> }
+  : TValue;
 
 export type IsFlatObject<T extends object> = Extract<
   Exclude<T[keyof T], NestedValue | Date | FileList>,

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -28,12 +28,10 @@ export type IsAny<T> = boolean extends (T extends never ? true : false)
 
 export type DeepMap<T, TValue> = IsAny<T> extends true
   ? any
-  : T extends null | undefined
-  ? T
   : T extends Date | FileList | File | NestedValue
   ? TValue
   : T extends object
-  ? { [K in keyof T]: DeepMap<T[K], TValue> }
+  ? { [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue> }
   : TValue;
 
 export type IsFlatObject<T extends object> = Extract<

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -3,7 +3,14 @@ import * as React from 'react';
 import { createFormControl } from './logic/createFormControl';
 import getProxyFormState from './logic/getProxyFormState';
 import shouldRenderFormState from './logic/shouldRenderFormState';
-import { FieldValues, FormState, UseFormProps, UseFormReturn } from './types';
+import {
+  FieldErrors,
+  FieldNamesMarkedBoolean,
+  FieldValues,
+  FormState,
+  UseFormProps,
+  UseFormReturn,
+} from './types';
 
 export function useForm<
   TFieldValues extends FieldValues = FieldValues,
@@ -17,14 +24,14 @@ export function useForm<
   const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
     isDirty: false,
     isValidating: false,
-    dirtyFields: {},
+    dirtyFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
     isSubmitted: false,
     submitCount: 0,
-    touchedFields: {},
+    touchedFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
     isSubmitting: false,
     isSubmitSuccessful: false,
     isValid: false,
-    errors: {},
+    errors: {} as FieldErrors<TFieldValues>,
   });
 
   if (_formControl.current) {


### PR DESCRIPTION
## Overview

cleaned up `DeepMap` and `DeepPartial` type.
When using `valueAs` option, the users needs to define the union type.

## Related PR comment

https://github.com/react-hook-form/react-hook-form/pull/6381/files#r700349048
