### PR TITLE
Make `Path` carry the expected result type to allow fully typed generic components

### DIFF
--- a/app/src/setError.tsx
+++ b/app/src/setError.tsx
@@ -45,7 +45,7 @@ const SetError: React.FC = () => {
         message: 'Minlength is 10',
       },
     ].forEach(({ name, type, message }) =>
-      setError(name as FieldPath<FormInputs>, { type, message }),
+      setError(name as FieldPath<FormInputs, any>, { type, message }),
     );
     setError('username', {
       types: {

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@testing-library/react';
 
 import { Controller } from '../controller';
-import { Control } from '../types';
+import { Control, FieldPath, FieldValues } from '../types';
 import { useController } from '../useController';
 import { useForm } from '../useForm';
 
@@ -27,6 +27,37 @@ describe('useController', () => {
       });
 
       return null;
+    };
+
+    render(<Component />);
+  });
+
+  it('should render generic component correctly', () => {
+    type ExpectedType = { test: string };
+
+    const Generic = <FormValues extends FieldValues>({
+      name,
+      control,
+    }: {
+      name: FieldPath<FormValues, ExpectedType>;
+      control: Control<FormValues>;
+    }) => {
+      useController({
+        name,
+        control,
+        defaultValue: { test: 'test' },
+      });
+
+      return null;
+    };
+
+    const Component = () => {
+      const { control } = useForm<{
+        test: string;
+        key: ExpectedType[];
+      }>();
+
+      return <Generic name="key.0" control={control} />;
     };
 
     render(<Component />);
@@ -482,7 +513,7 @@ describe('useController', () => {
   it('should update with inline defaultValue', async () => {
     const onSubmit = jest.fn();
     const App = () => {
-      const { control, handleSubmit } = useForm();
+      const { control, handleSubmit } = useForm<{ test: string }>();
       useController({ control, defaultValue: 'test', name: 'test' });
 
       return (

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -3,9 +3,13 @@ import { useController } from './useController';
 
 const Controller = <
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TResult = unknown,
+  TName extends FieldPath<TFieldValues, TResult> = FieldPath<
+    TFieldValues,
+    TResult
+  >,
 >(
-  props: ControllerProps<TFieldValues, TName>,
-) => props.render(useController<TFieldValues, TName>(props));
+  props: ControllerProps<TFieldValues, TResult, TName>,
+) => props.render(useController<TFieldValues, TResult, TName>(props));
 
 export { Controller };

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -2,7 +2,6 @@ import { EVENTS, VALIDATION_MODE } from '../constants';
 import {
   BatchFieldArrayUpdate,
   ChangeHandler,
-  DeepPartial,
   DelayCallback,
   Field,
   FieldError,
@@ -597,7 +596,7 @@ export function createFormControl<
           );
     });
 
-  const _getWatch: WatchInternal<TFieldValues> = (
+  const _getWatch: WatchInternal<TFieldValues, any> = (
     fieldNames,
     defaultValue,
     isMounted,
@@ -859,25 +858,14 @@ export function createFormControl<
       | FieldPath<TFieldValues, TResult>
       | ReadonlyArray<FieldPath<TFieldValues, TResult>>
       | WatchObserver<TFieldValues, TResult>,
-    defaultValue?: unknown,
+    defaultValue?: TResult,
   ) =>
     isFunction(fieldName)
       ? _subjects.watch.subscribe({
           next: (info: any) =>
-            fieldName(
-              _getWatch(
-                undefined,
-                defaultValue as UnpackNestedValue<DeepPartial<TFieldValues>>,
-              ),
-              info,
-            ),
+            fieldName(_getWatch(undefined, defaultValue), info),
         })
-      : _getWatch(
-          fieldName as InternalFieldName | InternalFieldName[],
-          defaultValue as UnpackNestedValue<DeepPartial<TFieldValues>>,
-          false,
-          true,
-        );
+      : _getWatch(fieldName, defaultValue, false, true);
 
   const unregister: UseFormUnregister<TFieldValues> = (name, options = {}) => {
     for (const inputName of name ? convertToArrayPayload(name) : _names.mount) {

--- a/src/logic/mapId.ts
+++ b/src/logic/mapId.ts
@@ -1,21 +1,16 @@
-import { FieldArrayPath, FieldArrayWithId, FieldValues } from '../types';
+import { FieldArrayWithId, FieldValues } from '../types';
 
 import generateId from './generateId';
 
 export default <
   TFieldArrayValues extends FieldValues = FieldValues,
   TResult = unknown,
-  TFieldName extends FieldArrayPath<TFieldArrayValues> = FieldArrayPath<TFieldArrayValues>,
   TKeyName extends string = 'id',
 >(
   values: Partial<TFieldArrayValues>[] = [],
   keyName: TKeyName,
-): Partial<
-  FieldArrayWithId<TFieldArrayValues, TResult, TFieldName, TKeyName>
->[] =>
+): Partial<FieldArrayWithId<TResult, TKeyName>>[] =>
   values.map((value: Partial<TFieldArrayValues>) => ({
     ...(value[keyName] ? {} : { [keyName]: generateId() }),
     ...value,
-  })) as Partial<
-    FieldArrayWithId<TFieldArrayValues, TResult, TFieldName, TKeyName>
-  >[];
+  })) as Partial<FieldArrayWithId<TResult, TKeyName>>[];

--- a/src/logic/mapId.ts
+++ b/src/logic/mapId.ts
@@ -4,13 +4,18 @@ import generateId from './generateId';
 
 export default <
   TFieldArrayValues extends FieldValues = FieldValues,
+  TResult = unknown,
   TFieldName extends FieldArrayPath<TFieldArrayValues> = FieldArrayPath<TFieldArrayValues>,
   TKeyName extends string = 'id',
 >(
   values: Partial<TFieldArrayValues>[] = [],
   keyName: TKeyName,
-): Partial<FieldArrayWithId<TFieldArrayValues, TFieldName, TKeyName>>[] =>
+): Partial<
+  FieldArrayWithId<TFieldArrayValues, TResult, TFieldName, TKeyName>
+>[] =>
   values.map((value: Partial<TFieldArrayValues>) => ({
     ...(value[keyName] ? {} : { [keyName]: generateId() }),
     ...value,
-  })) as Partial<FieldArrayWithId<TFieldArrayValues, TFieldName, TKeyName>>[];
+  })) as Partial<
+    FieldArrayWithId<TFieldArrayValues, TResult, TFieldName, TKeyName>
+  >[];

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -8,7 +8,6 @@ import {
   FieldPathValue,
   FieldValues,
   RefCallBack,
-  UnpackNestedValue,
   UseFormStateReturn,
 } from './';
 
@@ -35,14 +34,14 @@ export type ControllerRenderProps<
 > = {
   onChange: (...event: any[]) => void;
   onBlur: () => void;
-  value: UnpackNestedValue<FieldPathValue<TFieldValues, TName>>;
+  value: TResult;
   name: TName;
   ref: RefCallBack;
 };
 
 export type UseControllerProps<
   TFieldValues extends FieldValues,
-  TResult,
+  TResult = unknown,
   TName extends FieldPath<TFieldValues, TResult> = FieldPath<
     TFieldValues,
     TResult

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -14,7 +14,10 @@ import {
 
 export type ControllerFieldState<
   TFieldValues extends FieldValues = FieldValues,
-  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldName extends FieldPath<TFieldValues, any> = FieldPath<
+    TFieldValues,
+    any
+  >,
 > = {
   invalid: boolean;
   isTouched: boolean;
@@ -24,7 +27,11 @@ export type ControllerFieldState<
 
 export type ControllerRenderProps<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TResult = unknown,
+  TName extends FieldPath<TFieldValues, TResult> = FieldPath<
+    TFieldValues,
+    TResult
+  >,
 > = {
   onChange: (...event: any[]) => void;
   onBlur: () => void;
@@ -34,8 +41,12 @@ export type ControllerRenderProps<
 };
 
 export type UseControllerProps<
-  TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldValues extends FieldValues,
+  TResult,
+  TName extends FieldPath<TFieldValues, TResult> = FieldPath<
+    TFieldValues,
+    TResult
+  >,
 > = {
   name: TName;
   rules?: Omit<
@@ -43,30 +54,38 @@ export type UseControllerProps<
     'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'
   >;
   shouldUnregister?: boolean;
-  defaultValue?: UnpackNestedValue<FieldPathValue<TFieldValues, TName>>;
+  defaultValue?: TResult;
   control?: Control<TFieldValues>;
 };
 
 export type UseControllerReturn<
-  TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldValues extends FieldValues,
+  TResult,
+  TName extends FieldPath<TFieldValues, TResult> = FieldPath<
+    TFieldValues,
+    TResult
+  >,
 > = {
-  field: ControllerRenderProps<TFieldValues, TName>;
+  field: ControllerRenderProps<TFieldValues, TResult, TName>;
   formState: UseFormStateReturn<TFieldValues>;
   fieldState: ControllerFieldState<TFieldValues, TName>;
 };
 
 export type ControllerProps<
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TResult = unknown,
+  TName extends FieldPath<TFieldValues, TResult> = FieldPath<
+    TFieldValues,
+    TResult
+  >,
 > = {
   render: ({
     field,
     fieldState,
     formState,
   }: {
-    field: ControllerRenderProps<TFieldValues, TName>;
+    field: ControllerRenderProps<TFieldValues, TResult, TName>;
     fieldState: ControllerFieldState<TFieldValues, TName>;
     formState: UseFormStateReturn<TFieldValues>;
   }) => React.ReactElement;
-} & UseControllerProps<TFieldValues, TName>;
+} & UseControllerProps<TFieldValues, TResult, TName>;

--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -17,16 +17,21 @@ export type UseFieldArrayProps<
 
 export type FieldArrayWithId<
   TFieldValues extends FieldValues = FieldValues,
+  TResult = unknown,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',
-> = FieldArray<TFieldValues, TFieldArrayName> & Record<TKeyName, string>;
+> = FieldArray<TFieldValues, TResult, TFieldArrayName> &
+  Record<TKeyName, string>;
 
 export type FieldArray<
   TFieldValues extends FieldValues = FieldValues,
+  TResult = unknown,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
-> = FieldArrayPathValue<TFieldValues, TFieldArrayName> extends ReadonlyArray<
-  infer U
->
+> = FieldArrayPathValue<
+  TFieldValues,
+  TResult,
+  TFieldArrayName
+> extends ReadonlyArray<infer U>
   ? U
   : never;
 
@@ -38,6 +43,7 @@ export type FieldArrayMethodProps = {
 
 export type UseFieldArrayReturn<
   TFieldValues extends FieldValues = FieldValues,
+  TResult = unknown,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',
 > = {
@@ -72,5 +78,5 @@ export type UseFieldArrayReturn<
       | Partial<FieldArray<TFieldValues, TFieldArrayName>>
       | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
   ) => void;
-  fields: FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>[];
+  fields: FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>[];
 };

--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -1,12 +1,16 @@
 import { FieldValues } from './fields';
 import { Control } from './form';
-import { FieldArrayPath, FieldArrayPathValue } from './utils';
+import { FieldArrayPath } from './utils';
 
 export type FieldArrayName = string;
 
 export type UseFieldArrayProps<
   TFieldValues extends FieldValues = FieldValues,
-  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
+  TResult = unknown,
+  TFieldArrayName extends FieldArrayPath<
+    TFieldValues,
+    TResult
+  > = FieldArrayPath<TFieldValues, TResult>,
   TKeyName extends string = 'id',
 > = {
   name: TFieldArrayName;
@@ -16,24 +20,9 @@ export type UseFieldArrayProps<
 };
 
 export type FieldArrayWithId<
-  TFieldValues extends FieldValues = FieldValues,
   TResult = unknown,
-  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',
-> = FieldArray<TFieldValues, TResult, TFieldArrayName> &
-  Record<TKeyName, string>;
-
-export type FieldArray<
-  TFieldValues extends FieldValues = FieldValues,
-  TResult = unknown,
-  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
-> = FieldArrayPathValue<
-  TFieldValues,
-  TResult,
-  TFieldArrayName
-> extends ReadonlyArray<infer U>
-  ? U
-  : never;
+> = TResult & Record<TKeyName, string>;
 
 export type FieldArrayMethodProps = {
   shouldFocus?: boolean;
@@ -42,41 +31,26 @@ export type FieldArrayMethodProps = {
 };
 
 export type UseFieldArrayReturn<
-  TFieldValues extends FieldValues = FieldValues,
   TResult = unknown,
-  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',
 > = {
   swap: (indexA: number, indexB: number) => void;
   move: (indexA: number, indexB: number) => void;
   prepend: (
-    value:
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
+    value: Partial<TResult> | Partial<TResult>[],
     options?: FieldArrayMethodProps,
   ) => void;
   append: (
-    value:
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
+    value: Partial<TResult> | Partial<TResult>[],
     options?: FieldArrayMethodProps,
   ) => void;
   remove: (index?: number | number[]) => void;
   insert: (
     index: number,
-    value:
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
+    value: Partial<TResult> | Partial<TResult>[],
     options?: FieldArrayMethodProps,
   ) => void;
-  update: (
-    index: number,
-    value: Partial<FieldArray<TFieldValues, TFieldArrayName>>,
-  ) => void;
-  replace: (
-    value:
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
-  ) => void;
-  fields: FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>[];
+  update: (index: number, value: Partial<TResult>) => void;
+  replace: (value: Partial<TResult> | Partial<TResult>[]) => void;
+  fields: FieldArrayWithId<TResult, TKeyName>[];
 };

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -153,69 +153,79 @@ export type UseFormRegisterReturn = {
 };
 
 export type UseFormRegister<TFieldValues extends FieldValues> = <
-  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldName extends FieldPath<TFieldValues, any> = FieldPath<
+    TFieldValues,
+    any
+  >,
 >(
   name: TFieldName,
   options?: RegisterOptions<TFieldValues, TFieldName>,
 ) => UseFormRegisterReturn;
 
 export type UseFormSetFocus<TFieldValues extends FieldValues> = <
-  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldName extends FieldPath<TFieldValues, any> = FieldPath<
+    TFieldValues,
+    any
+  >,
 >(
   name: TFieldName,
 ) => void;
 
 export type UseFormGetValues<TFieldValues extends FieldValues> = {
   (): UnpackNestedValue<TFieldValues>;
-  <TFieldName extends FieldPath<TFieldValues>>(
+  <TFieldName extends FieldPath<TFieldValues, any>>(
     name: TFieldName,
   ): FieldPathValue<TFieldValues, TFieldName>;
-  <TFieldNames extends FieldPath<TFieldValues>[]>(
+  <TFieldNames extends FieldPath<TFieldValues, any>[]>(
     names: readonly [...TFieldNames],
   ): [...FieldPathValues<TFieldValues, TFieldNames>];
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {
   (): UnpackNestedValue<TFieldValues>;
-  <TFieldName extends FieldPath<TFieldValues>>(
+  <TResult, TFieldName extends FieldPath<TFieldValues, TResult>>(
     name: TFieldName,
-    defaultValue?: FieldPathValue<TFieldValues, TFieldName>,
+    defaultValue?: TResult,
   ): FieldPathValue<TFieldValues, TFieldName>;
-  <TFieldNames extends readonly FieldPath<TFieldValues>[]>(
+  <TResult, TFieldNames extends readonly FieldPath<TFieldValues, TResult>[]>(
     names: readonly [...TFieldNames],
-    defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>,
+    defaultValue?: TResult,
   ): FieldPathValues<TFieldValues, TFieldNames>;
-  (
-    callback: WatchObserver<TFieldValues>,
+  <TResult>(
+    callback: WatchObserver<TFieldValues, TResult>,
     defaultValues?: UnpackNestedValue<DeepPartial<TFieldValues>>,
   ): Subscription;
 };
 
 export type UseFormTrigger<TFieldValues extends FieldValues> = (
   name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[],
+    | FieldPath<TFieldValues, any>
+    | FieldPath<TFieldValues, any>[]
+    | readonly FieldPath<TFieldValues, any>[],
   options?: TriggerConfig,
 ) => Promise<boolean>;
 
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (
   name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[],
+    | FieldPath<TFieldValues, any>
+    | FieldPath<TFieldValues, any>[]
+    | readonly FieldPath<TFieldValues, any>[],
 ) => void;
 
 export type UseFormSetValue<TFieldValues extends FieldValues> = <
-  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TResult,
+  TFieldName extends FieldPath<TFieldValues, TResult> = FieldPath<
+    TFieldValues,
+    TResult
+  >,
 >(
   name: TFieldName,
-  value: UnpackNestedValue<FieldPathValue<TFieldValues, TFieldName>>,
+  value: TResult,
   options?: SetValueConfig,
 ) => void;
 
 export type UseFormSetError<TFieldValues extends FieldValues> = (
-  name: FieldPath<TFieldValues>,
+  name: FieldPath<TFieldValues, any>,
   error: ErrorOption,
   options?: {
     shouldFocus: boolean;
@@ -224,9 +234,9 @@ export type UseFormSetError<TFieldValues extends FieldValues> = (
 
 export type UseFormUnregister<TFieldValues extends FieldValues> = (
   name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[],
+    | FieldPath<TFieldValues, any>
+    | FieldPath<TFieldValues, any>[]
+    | readonly FieldPath<TFieldValues, any>[],
   options?: Omit<
     KeepStateOptions,
     | 'keepIsSubmitted'
@@ -296,6 +306,7 @@ export type Names = {
 export type BatchFieldArrayUpdate = <
   T extends Function,
   TFieldValues,
+  TResult = unknown,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',
 >(
@@ -307,7 +318,7 @@ export type BatchFieldArrayUpdate = <
     argB?: unknown;
   },
   updatedFieldArrayValues?: Partial<
-    FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
+    FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>
   >[],
   shouldSetValue?: boolean,
   shouldSetFields?: boolean,
@@ -340,10 +351,10 @@ export type Control<
   unregister: UseFormUnregister<TFieldValues>;
 };
 
-export type WatchObserver<TFieldValues> = (
-  value: UnpackNestedValue<TFieldValues>,
+export type WatchObserver<TFieldValues, TResult> = (
+  value: TResult,
   info: {
-    name?: FieldPath<TFieldValues>;
+    name?: FieldPath<TFieldValues, TResult>;
     type?: EventType;
     value?: unknown;
   },
@@ -368,24 +379,27 @@ export type UseFormReturn<
   setFocus: UseFormSetFocus<TFieldValues>;
 };
 
-export type UseFormStateProps<TFieldValues> = Partial<{
+export type UseFormStateProps<TFieldValues, TResult> = Partial<{
   control?: Control<TFieldValues>;
   disabled?: boolean;
   name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[];
+    | FieldPath<TFieldValues, TResult>
+    | FieldPath<TFieldValues, TResult>[]
+    | readonly FieldPath<TFieldValues, TResult>[];
 }>;
 
 export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
 
-export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
+export type UseWatchProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TResult = unknown,
+> = {
   defaultValue?: unknown;
   disabled?: boolean;
   name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[];
+    | FieldPath<TFieldValues, TResult>
+    | FieldPath<TFieldValues, TResult>[]
+    | readonly FieldPath<TFieldValues, TResult>[];
   control?: Control<TFieldValues>;
 };
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -15,7 +15,6 @@ import { Resolver } from './resolvers';
 import {
   DeepMap,
   DeepPartial,
-  FieldArrayPath,
   FieldPath,
   FieldPathValue,
   FieldPathValues,
@@ -259,9 +258,12 @@ export type UseFormReset<TFieldValues extends FieldValues> = (
   keepStateOptions?: KeepStateOptions,
 ) => void;
 
-export type WatchInternal<TFieldValues> = (
-  fieldNames?: InternalFieldName | InternalFieldName[],
-  defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>,
+export type WatchInternal<TFieldValues, TResult> = (
+  fieldNames?:
+    | FieldPath<TFieldValues, TResult>
+    | ReadonlyArray<FieldPath<TFieldValues, TResult>>
+    | WatchObserver<TFieldValues, TResult>,
+  defaultValue?: TResult,
   isMounted?: boolean,
   isGlobal?: boolean,
 ) =>
@@ -305,9 +307,7 @@ export type Names = {
 
 export type BatchFieldArrayUpdate = <
   T extends Function,
-  TFieldValues,
   TResult = unknown,
-  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',
 >(
   keyName: TKeyName,
@@ -317,9 +317,7 @@ export type BatchFieldArrayUpdate = <
     argA?: unknown;
     argB?: unknown;
   },
-  updatedFieldArrayValues?: Partial<
-    FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>
-  >[],
+  updatedFieldArrayValues?: Partial<FieldArrayWithId<TResult, TKeyName>>[],
   shouldSetValue?: boolean,
   shouldSetFields?: boolean,
 ) => void;
@@ -342,7 +340,7 @@ export type Control<
   _formValues: FieldValues;
   _proxyFormState: ReadFormState;
   _defaultValues: Partial<DefaultValues<TFieldValues>>;
-  _getWatch: WatchInternal<TFieldValues>;
+  _getWatch: WatchInternal<TFieldValues, any>;
   register: UseFormRegister<TFieldValues>;
   _updateFieldArray: BatchFieldArrayUpdate;
   _getFieldArrayValue: <TFieldArrayValues>(

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -115,16 +115,12 @@ export type PathValue<T, P extends Path<T, any> | ArrayPath<T>> = T extends any
       ? R extends Path<T[K], any>
         ? PathValue<T[K], R>
         : never
-      : K extends `${ArrayKey}`
+      : P extends keyof T
+      ? T[P]
+      : P extends `${ArrayKey}`
       ? T extends ReadonlyArray<infer V>
         ? PathValue<V, R & Path<V, any>>
         : never
-      : never
-    : P extends keyof T
-    ? T[P]
-    : P extends `${ArrayKey}`
-    ? T extends ReadonlyArray<infer V>
-      ? V
       : never
     : never
   : never;

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -23,7 +23,10 @@ export type Validate<TFieldValue> = (
 
 export type RegisterOptions<
   TFieldValues extends FieldValues = FieldValues,
-  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldName extends FieldPath<TFieldValues, any> = FieldPath<
+    TFieldValues,
+    any
+  >,
 > = Partial<{
   required: Message | ValidationRule<boolean>;
   min: ValidationRule<number | string>;

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -123,7 +123,7 @@ export function useController<
       invalid: !!get(formState.errors, name),
       isDirty: !!get(formState.dirtyFields, name),
       isTouched: !!get(formState.touchedFields, name),
-      error: get(formState.errors, name),
+      error: get(formState.errors, name) as any,
     },
   };
 }

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -16,11 +16,15 @@ import { useFormContext } from './useFormContext';
 import { useFormState } from './useFormState';
 
 export function useController<
-  TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TFieldValues extends FieldValues,
+  TResult,
+  TName extends FieldPath<TFieldValues, TResult> = FieldPath<
+    TFieldValues,
+    TResult
+  >,
 >(
-  props: UseControllerProps<TFieldValues, TName>,
-): UseControllerReturn<TFieldValues, TName> {
+  props: UseControllerProps<TFieldValues, TResult, TName>,
+): UseControllerReturn<TFieldValues, TResult, TName> {
   const methods = useFormContext<TFieldValues>();
   const { name, control = methods.control, shouldUnregister } = props;
   const [value, setInputStateValue] = React.useState(
@@ -30,7 +34,7 @@ export function useController<
       get(control._defaultValues, name, props.defaultValue),
     ),
   );
-  const formState = useFormState({
+  const formState = useFormState<TFieldValues, TResult>({
     control: control || methods.control,
     name,
   });

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -16,7 +16,6 @@ import set from './utils/set';
 import swapArrayAt from './utils/swap';
 import updateAt from './utils/update';
 import {
-  FieldArray,
   FieldArrayMethodProps,
   FieldArrayPath,
   FieldArrayWithId,
@@ -30,11 +29,14 @@ import { useFormContext } from './useFormContext';
 export const useFieldArray = <
   TFieldValues extends FieldValues = FieldValues,
   TResult = unknown,
-  TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
+  TFieldArrayName extends FieldArrayPath<
+    TFieldValues,
+    TResult
+  > = FieldArrayPath<TFieldValues, TResult>,
   TKeyName extends string = 'id',
 >(
-  props: UseFieldArrayProps<TFieldValues, TFieldArrayName, TKeyName>,
-): UseFieldArrayReturn<TFieldValues, TResult, TFieldArrayName, TKeyName> => {
+  props: UseFieldArrayProps<TFieldValues, TResult, TFieldArrayName, TKeyName>,
+): UseFieldArrayReturn<TResult, TKeyName> => {
   const methods = useFormContext();
   const {
     control = methods.control,
@@ -43,9 +45,7 @@ export const useFieldArray = <
     shouldUnregister,
   } = props;
   const [fields, setFields] = React.useState<
-    Partial<
-      FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>
-    >[]
+    Partial<FieldArrayWithId<TResult, TKeyName>>[]
   >(mapIds(control._getFieldArrayValue(name), keyName));
   const _fieldIds = React.useRef(fields);
 
@@ -53,9 +53,7 @@ export const useFieldArray = <
   control._names.array.add(name);
 
   const append = (
-    value:
-      | Partial<FieldArray<TFieldValues, TResult, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TResult, TFieldArrayName>>[],
+    value: Partial<TResult> | Partial<TResult>[],
     options?: FieldArrayMethodProps,
   ) => {
     const appendValue = convertToArrayPayload(value);
@@ -82,9 +80,7 @@ export const useFieldArray = <
   };
 
   const prepend = (
-    value:
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
+    value: Partial<TResult> | Partial<TResult>[],
     options?: FieldArrayMethodProps,
   ) => {
     const updatedFieldArrayValuesWithKey = prependAt(
@@ -107,7 +103,7 @@ export const useFieldArray = <
 
   const remove = (index?: number | number[]) => {
     const updatedFieldArrayValuesWithKey: Partial<
-      FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>
+      FieldArrayWithId<TResult, TKeyName>
     >[] = removeArrayAt(
       mapCurrentIds(control._getFieldArrayValue(name), _fieldIds, keyName),
       index,
@@ -126,9 +122,7 @@ export const useFieldArray = <
 
   const insert = (
     index: number,
-    value:
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
+    value: Partial<TResult> | Partial<TResult>[],
     options?: FieldArrayMethodProps,
   ) => {
     const updatedFieldArrayValuesWithKey = insertAt(
@@ -193,10 +187,7 @@ export const useFieldArray = <
     );
   };
 
-  const update = (
-    index: number,
-    value: Partial<FieldArray<TFieldValues, TFieldArrayName>>,
-  ) => {
+  const update = (index: number, value: Partial<TResult>) => {
     const updatedFieldArrayValuesWithKey = mapCurrentIds(
       control._getFieldArrayValue(name),
       _fieldIds,
@@ -223,17 +214,9 @@ export const useFieldArray = <
     );
   };
 
-  const replace = (
-    value:
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
-  ) => {
+  const replace = (value: Partial<TResult> | Partial<TResult>[]) => {
     const values = mapIds(convertToArrayPayload(value), keyName);
-    setFields(
-      values as Partial<
-        FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>
-      >[],
-    );
+    setFields(values as Partial<FieldArrayWithId<TResult, TKeyName>>[]);
     control._updateFieldArray(
       keyName,
       name,
@@ -302,11 +285,6 @@ export const useFieldArray = <
     insert: React.useCallback(insert, [name, control, keyName]),
     update: React.useCallback(update, [name, control, keyName]),
     replace: React.useCallback(replace, [name, control, keyName]),
-    fields: fields as FieldArrayWithId<
-      TFieldValues,
-      TResult,
-      TFieldArrayName,
-      TKeyName
-    >[],
+    fields: fields as FieldArrayWithId<TResult, TKeyName>[],
   };
 };

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -29,11 +29,12 @@ import { useFormContext } from './useFormContext';
 
 export const useFieldArray = <
   TFieldValues extends FieldValues = FieldValues,
+  TResult = unknown,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',
 >(
   props: UseFieldArrayProps<TFieldValues, TFieldArrayName, TKeyName>,
-): UseFieldArrayReturn<TFieldValues, TFieldArrayName, TKeyName> => {
+): UseFieldArrayReturn<TFieldValues, TResult, TFieldArrayName, TKeyName> => {
   const methods = useFormContext();
   const {
     control = methods.control,
@@ -42,7 +43,9 @@ export const useFieldArray = <
     shouldUnregister,
   } = props;
   const [fields, setFields] = React.useState<
-    Partial<FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>>[]
+    Partial<
+      FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>
+    >[]
   >(mapIds(control._getFieldArrayValue(name), keyName));
   const _fieldIds = React.useRef(fields);
 
@@ -51,8 +54,8 @@ export const useFieldArray = <
 
   const append = (
     value:
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>
-      | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
+      | Partial<FieldArray<TFieldValues, TResult, TFieldArrayName>>
+      | Partial<FieldArray<TFieldValues, TResult, TFieldArrayName>>[],
     options?: FieldArrayMethodProps,
   ) => {
     const appendValue = convertToArrayPayload(value);
@@ -104,7 +107,7 @@ export const useFieldArray = <
 
   const remove = (index?: number | number[]) => {
     const updatedFieldArrayValuesWithKey: Partial<
-      FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
+      FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>
     >[] = removeArrayAt(
       mapCurrentIds(control._getFieldArrayValue(name), _fieldIds, keyName),
       index,
@@ -228,7 +231,7 @@ export const useFieldArray = <
     const values = mapIds(convertToArrayPayload(value), keyName);
     setFields(
       values as Partial<
-        FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
+        FieldArrayWithId<TFieldValues, TResult, TFieldArrayName, TKeyName>
       >[],
     );
     control._updateFieldArray(
@@ -285,7 +288,7 @@ export const useFieldArray = <
     return () => {
       fieldArraySubscription.unsubscribe();
       if (control._shouldUnregister || shouldUnregister) {
-        control.unregister(name as FieldPath<TFieldValues>);
+        control.unregister(name as FieldPath<TFieldValues, any>);
       }
     };
   }, [name, control, keyName, shouldUnregister]);
@@ -301,6 +304,7 @@ export const useFieldArray = <
     replace: React.useCallback(replace, [name, control, keyName]),
     fields: fields as FieldArrayWithId<
       TFieldValues,
+      TResult,
       TFieldArrayName,
       TKeyName
     >[],

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -11,8 +11,11 @@ import {
 } from './types';
 import { useFormContext } from './useFormContext';
 
-function useFormState<TFieldValues extends FieldValues = FieldValues>(
-  props?: UseFormStateProps<TFieldValues>,
+function useFormState<
+  TFieldValues extends FieldValues = FieldValues,
+  TResult = unknown,
+>(
+  props?: UseFormStateProps<TFieldValues, TResult>,
 ): UseFormStateReturn<TFieldValues> {
   const methods = useFormContext<TFieldValues>();
   const { control = methods.control, disabled, name } = props || {};

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -25,7 +25,11 @@ export function useWatch<
 }): UnpackNestedValue<DeepPartial<TFieldValues>>;
 export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
-  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TResult = unknown,
+  TFieldName extends FieldPath<TFieldValues, TResult> = FieldPath<
+    TFieldValues,
+    TResult
+  >,
 >(props: {
   name: TFieldName;
   defaultValue?: FieldPathValue<TFieldValues, TFieldName>;
@@ -34,7 +38,11 @@ export function useWatch<
 }): FieldPathValue<TFieldValues, TFieldName>;
 export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
-  TFieldNames extends FieldPath<TFieldValues>[] = FieldPath<TFieldValues>[],
+  TResult = unknown,
+  TFieldNames extends FieldPath<TFieldValues, TResult>[] = FieldPath<
+    TFieldValues,
+    TResult
+  >[],
 >(props: {
   name: readonly [...TFieldNames];
   defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>;

--- a/src/utils/convertToArrayPayload.ts
+++ b/src/utils/convertToArrayPayload.ts
@@ -1,2 +1,2 @@
-export default <T extends unknown>(value: T) =>
-  Array.isArray(value) ? value : [value];
+export default <T>(value: Array<T> | ReadonlyArray<T> | T): Array<T> =>
+  Array.isArray(value) ? (value as Array<T>) : ([value] as Array<T>);


### PR DESCRIPTION
I'm in no way a Typescript expert but I wanted to be able to create generic form components.
The way I thought it could work was if the `Path` type returns all paths for a compatible type instead of all possible paths.

So you can write components like this (where expected type would actually be infered from a yup/zod/iots... schema)

```typescript
type ExpectedType = { fileName: string; url: string };

const GenericFileUpload = <FormValues extends FieldValues>({
  name,
  control,
}: {
  name: FieldPath<FormValues, ExpectedType>;
  control: Control<FormValues>;
}) => {
  useController({
    name,
    control,
    defaultValue: { fileName: 'My test file', url: 'https://localhost/image.jpg' }, // this is typed and will fail if you pass it something that does not extend ExpectedType
  });

  return null;
};
```

Used like this:

```typescript
interface FormValues {
  invalid: { 
    subpath: string;
  };
  file: {
    fileName: string;
    url: string;
  };
}

const { control } = useForm<FormValues>();

// this will pass
<GenericFileUpload name="file" control={control} />
// while this will not, as expected
<GenericFileUpload name="invalid" control={control} />
```

⚠️ This does not handle all use cases yet and I may have went a little overboard where I put it but I wanted to check if you thought this could be a good idea before continuing?