### PR TITLE
fix Mapped types for defined value type with interface

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -29,15 +29,11 @@ export type NestedValue<TValue extends object = object> = {
   [$NestedValue]: never;
 } & TValue;
 
-type UnpackNestedValueImpl<T> = T extends NestedValue<infer U>
+export type UnpackNestedValue<T> = T extends NestedValue<infer U>
   ? U
   : T extends ReadonlyArray<any> | Record<any, unknown>
-  ? UnpackNestedValue<T>
+  ? { [K in keyof T]: UnpackNestedValue<T[K]> }
   : T;
-
-export type UnpackNestedValue<T> = {
-  [K in keyof T]: UnpackNestedValueImpl<T[K]>;
-};
 
 export type DefaultValues<TFieldValues> = UnpackNestedValue<
   DeepPartial<TFieldValues>

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -29,11 +29,15 @@ export type NestedValue<TValue extends object = object> = {
   [$NestedValue]: never;
 } & TValue;
 
-export type UnpackNestedValue<T> = T extends NestedValue<infer U>
+type UnpackNestedValueImpl<T> = T extends NestedValue<infer U>
   ? U
   : T extends ReadonlyArray<any> | Record<any, unknown>
-  ? { [K in keyof T]: UnpackNestedValue<T[K]> }
+  ? UnpackNestedValue<T>
   : T;
+
+export type UnpackNestedValue<T> = {
+  [K in keyof T]: UnpackNestedValueImpl<T[K]>;
+};
 
 export type DefaultValues<TFieldValues> = UnpackNestedValue<
   DeepPartial<TFieldValues>

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -31,9 +31,7 @@ export type NestedValue<TValue extends object = object> = {
 
 export type UnpackNestedValue<T> = T extends NestedValue<infer U>
   ? U
-  : T extends Date | FileList | File
-  ? T
-  : T extends object
+  : T extends ReadonlyArray<any> | Record<any, unknown>
   ? { [K in keyof T]: UnpackNestedValue<T[K]> }
   : T;
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,26 +1,6 @@
 import { FieldValues } from './fields';
 import { NestedValue } from './form';
 
-/*
-Projects that React Hook Form installed don't include the DOM library need these interfaces to compile.
-React Native applications is no DOM available. The JavaScript runtime is ES6/ES2015 only.
-These definitions allow such projects to compile with only --lib ES6.
-
-Warning: all of these interfaces are empty.
-If you want type definitions for various properties, you need to add `--lib DOM` (via command line or tsconfig.json).
-*/
-
-interface File extends Blob {
-  readonly lastModified: number;
-  readonly name: string;
-}
-
-interface FileList {
-  readonly length: number;
-  item(index: number): File | null;
-  [index: number]: File;
-}
-
 export type Primitive =
   | null
   | undefined
@@ -38,9 +18,11 @@ export type LiteralUnion<T extends U, U extends Primitive> =
   | T
   | (U & { _?: never });
 
-export type DeepPartial<T> = T extends Date | FileList | File | NestedValue
+export type DeepPartial<T> = T extends NestedValue
   ? T
-  : { [K in keyof T]?: DeepPartial<T[K]> };
+  : T extends ReadonlyArray<any> | Record<any, unknown>
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : T;
 
 export type IsAny<T> = boolean extends (T extends never ? true : false)
   ? true
@@ -48,9 +30,9 @@ export type IsAny<T> = boolean extends (T extends never ? true : false)
 
 export type DeepMap<T, TValue> = IsAny<T> extends true
   ? any
-  : T extends Date | FileList | File | NestedValue
+  : T extends NestedValue
   ? TValue
-  : T extends object
+  : T extends ReadonlyArray<any> | Record<any, unknown>
   ? { [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue> }
   : TValue;
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -152,7 +152,7 @@ export type UnionLike<T> = [T] extends [Date | FileList | File | NestedValue]
   ? T
   : [T] extends [ReadonlyArray<any>]
   ? { [K in keyof T]: UnionLike<T[K]> }
-  : [T] extends [object]
+  : [T] extends [Record<any, unknown>]
   ? PartialBy<
       {
         [K in UnionKeys<T>]: UnionLike<UnionValues<T, K>>;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -18,23 +18,31 @@ export type LiteralUnion<T extends U, U extends Primitive> =
   | T
   | (U & { _?: never });
 
-export type DeepPartial<T> = T extends NestedValue
+type DeepPartialImpl<T> = T extends NestedValue
   ? T
   : T extends ReadonlyArray<any> | Record<any, unknown>
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  ? DeepPartial<T>
   : T;
+
+export type DeepPartial<T> = {
+  [K in keyof T]?: DeepPartialImpl<T[K]>;
+};
 
 export type IsAny<T> = boolean extends (T extends never ? true : false)
   ? true
   : false;
 
-export type DeepMap<T, TValue> = IsAny<T> extends true
+type DeepMapImpl<T, TValue> = IsAny<T> extends true
   ? any
   : T extends NestedValue
   ? TValue
   : T extends ReadonlyArray<any> | Record<any, unknown>
-  ? { [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue> }
+  ? DeepMap<T, TValue>
   : TValue;
+
+export type DeepMap<T, TValue> = {
+  [K in keyof T]: DeepMapImpl<NonUndefined<T[K]>, TValue>;
+};
 
 export type IsFlatObject<T extends object> = Extract<
   Exclude<T[keyof T], NestedValue | Date | FileList>,


### PR DESCRIPTION
## Overview

Improved to not map types defined with `interface`.
We can determine the type defined with `interface` as follows:

```ts
interface Interface {
    test: string;
}
type TypeAlias = {
    test: string;
}

type IsInterface<T> = T extends Record<any, unknown> ? false : true;

type Result1 = IsInterface<Interface>; // true
type Result2 = IsInterface<TypeAlias> // false
```

[TypeScript Playground](https://www.typescriptlang.org/play?ts=4.4.0-beta&ssl=11&ssc=47&pln=1&pc=1#code/JYOwLgpgTgZghgYwgAgJLmvJyDeAoZQ5SAZzAC5kypQBzAbjwF88wBPABxQBVOIBBADbA4JZAF5cBIqQpUwNEA2Z5WfNCXSRYiCAB5uAPgnJuyCAA9IIACZiAShAQB7KDb1wQbADTIAriAA1iDOAO4gxgD8yPCCJCiUCn4QjGpcyI4kfoJgAIwmqJoYOkh6Wpi6hvTIAPQ1xFDJaSiZ2WAATAVF2lj6vFxCIiTGdTFwcRDNGRBZOQDMXeUl+gAicJAj9UmT7OmtOQAsi8W9egBiwIIQmw1Nuy0zbQCsxz2655cQADLAZDfbU32YAA7K8KqUABQASgkxhwTH+jR26iBAA4wctzgEEGBgM4IrUtkjAY8cgBODGnACycA4emodF8DKUhkRdxRpLyAAZKe8AMoQMD0hR0VmE24QIA)

if a field value is a nested value (object), users only needs to define the field value type with `interface` instead of using the `NestedValue` type.

using `NestedValue`:

```ts
import { useForm, NestedValue } from "react-hook-form";

type FormValues = {
  fieldName: NestedValue<{ custom: string }>;
};

const { formState: errors } = useForm<FormValues>({
  defaultValues: { fieldName: { custom: "value" }}
});

// `defaultValues` type:
// {
//   fieldName?: { custom: string } | undefined;
// }
// `errors` type:
// {
//   fieldName?: FieldError | undefined;
// }
```

using `interface`:

```ts
import { useForm } from "react-hook-form";

interface CustomValue {
  custom: string;
}

type FormValues = {
  fieldName: CustomValue
};

const { formState: errors } = useForm<FormValues>({
  defaultValues: { fieldName: { custom: "value" }}
});

// `defaultValues` type:
// {
//   fieldName?: CustomValue | undefined;
// }
// `errors` type:
// {
//   fieldName?: FieldError | undefined;
// }
```

If users like the nested value type definition by `interface`, we can eventually deprecate the `NestedValue` type.

## Resolve Issue

resolve #6523

## Resolved CSB

- https://codesandbox.io/s/eloquent-bas-dp1fe?file=/src/App.tsx
- https://codesandbox.io/s/adoring-flower-xteqx?file=/src/App.tsx