### PR TITLE
fix #6646

### DIFF
--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1238,6 +1238,6 @@ describe('Controller', () => {
 
     render(<App />);
 
-    expect(screen.getAllByRole('textbox'));
+    expect(screen.getAllByRole('textbox').length).toEqual(3);
   });
 });

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1189,6 +1189,9 @@ describe('Controller', () => {
   it('should not throw type error with field state', () => {
     type FormValues = {
       firstName: string;
+      deepNested: {
+        test: string;
+      };
     };
 
     function App() {
@@ -1208,12 +1211,22 @@ describe('Controller', () => {
             control={control}
             name="firstName"
           />
+          <Controller
+            render={({ field, fieldState }) => (
+              <>
+                <input {...field} />
+                <p>{fieldState.error?.message}</p>
+              </>
+            )}
+            control={control}
+            name="deepNested.test"
+          />
         </form>
       );
     }
 
     render(<App />);
 
-    expect(screen.getByRole('textbox'));
+    expect(screen.getAllByRole('textbox'));
   });
 });

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1196,7 +1196,7 @@ describe('Controller', () => {
 
     function App() {
       const { control } = useForm<FormValues>({
-        defaultValues: { firstName: '' },
+        defaultValues: { firstName: '', deepNested: { test: '' } },
       });
 
       return (

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1192,11 +1192,12 @@ describe('Controller', () => {
       deepNested: {
         test: string;
       };
+      todos: string[];
     };
 
     function App() {
       const { control } = useForm<FormValues>({
-        defaultValues: { firstName: '', deepNested: { test: '' } },
+        defaultValues: { firstName: '', deepNested: { test: '' }, todos: [] },
       });
 
       return (
@@ -1220,6 +1221,16 @@ describe('Controller', () => {
             )}
             control={control}
             name="deepNested.test"
+          />
+          <Controller
+            render={({ field, fieldState }) => (
+              <>
+                <input {...field} />
+                <p>{fieldState.error?.[0]?.message}</p>
+              </>
+            )}
+            control={control}
+            name="todos"
           />
         </form>
       );

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1200,7 +1200,10 @@ describe('Controller', () => {
         <form>
           <Controller
             render={({ field, fieldState }) => (
-              <input {...field} helperText={fieldState.error.message} />
+              <>
+                <input {...field} />
+                <p>{fieldState.error?.message}</p>
+              </>
             )}
             control={control}
             name="firstName"

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1185,4 +1185,32 @@ describe('Controller', () => {
 
     screen.getByText('error');
   });
+
+  it('should not throw type error with field state', () => {
+    type FormValues = {
+      firstName: string;
+    };
+
+    function App() {
+      const { control } = useForm<FormValues>({
+        defaultValues: { firstName: '' },
+      });
+
+      return (
+        <form>
+          <Controller
+            render={({ field, fieldState }) => (
+              <input {...field} helperText={fieldState.error.message} />
+            )}
+            control={control}
+            name="firstName"
+          />
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    expect(screen.getByRole('textbox'));
+  });
 });

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { RegisterOptions } from './validator';
 import {
   Control,
+  FieldError,
   FieldErrors,
   FieldPath,
   FieldPathValue,
@@ -19,7 +20,9 @@ export type ControllerFieldState<
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;
-  error?: FieldErrors<FieldPathValue<TFieldValues, TFieldName>>;
+  error?: FieldErrors<FieldPathValue<TFieldValues, TFieldName>> extends any[]
+    ? FieldErrors<FieldPathValue<TFieldValues, TFieldName>>
+    : FieldError;
 };
 
 export type ControllerRenderProps<

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -3,12 +3,10 @@ import * as React from 'react';
 import { RegisterOptions } from './validator';
 import {
   Control,
-  FieldError,
   FieldErrors,
   FieldPath,
   FieldPathValue,
   FieldValues,
-  isNested,
   RefCallBack,
   UnpackNestedValue,
   UseFormStateReturn,
@@ -21,9 +19,7 @@ export type ControllerFieldState<
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;
-  error?: isNested<TFieldName> extends true
-    ? FieldErrors<FieldPathValue<TFieldValues, TFieldName>>
-    : FieldError;
+  error?: FieldErrors<FieldPathValue<TFieldValues, TFieldName>>;
 };
 
 export type ControllerRenderProps<

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -3,15 +3,22 @@ import * as React from 'react';
 import { RegisterOptions } from './validator';
 import {
   Control,
+  DeepMapImpl,
+  DeepPartial,
   FieldError,
-  FieldErrors,
   FieldPath,
   FieldPathValue,
   FieldValues,
   RefCallBack,
+  UnionLike,
   UnpackNestedValue,
   UseFormStateReturn,
 } from './';
+
+type ControllerFieldError<T> = DeepMapImpl<
+  DeepPartial<UnionLike<T>>,
+  FieldError
+>;
 
 export type ControllerFieldState<
   TFieldValues extends FieldValues = FieldValues,
@@ -20,9 +27,7 @@ export type ControllerFieldState<
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;
-  error?: FieldErrors<FieldPathValue<TFieldValues, TFieldName>> extends any[]
-    ? FieldErrors<FieldPathValue<TFieldValues, TFieldName>>
-    : FieldError;
+  error?: ControllerFieldError<FieldPathValue<TFieldValues, TFieldName>>;
 };
 
 export type ControllerRenderProps<

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { RegisterOptions } from './validator';
 import {
   Control,
-  FieldError,
+  FieldErrors,
   FieldPath,
   FieldPathValue,
   FieldValues,
@@ -12,11 +12,14 @@ import {
   UseFormStateReturn,
 } from './';
 
-export type ControllerFieldState = {
+export type ControllerFieldState<
+  TFieldValues extends FieldValues = FieldValues,
+  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;
-  error?: FieldError;
+  error?: FieldErrors<FieldPathValue<TFieldValues, TFieldName>>;
 };
 
 export type ControllerRenderProps<
@@ -50,7 +53,7 @@ export type UseControllerReturn<
 > = {
   field: ControllerRenderProps<TFieldValues, TName>;
   formState: UseFormStateReturn<TFieldValues>;
-  fieldState: ControllerFieldState;
+  fieldState: ControllerFieldState<TFieldValues, TName>;
 };
 
 export type ControllerProps<
@@ -63,7 +66,7 @@ export type ControllerProps<
     formState,
   }: {
     field: ControllerRenderProps<TFieldValues, TName>;
-    fieldState: ControllerFieldState;
+    fieldState: ControllerFieldState<TFieldValues, TName>;
     formState: UseFormStateReturn<TFieldValues>;
   }) => React.ReactElement;
 } & UseControllerProps<TFieldValues, TName>;

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { RegisterOptions } from './validator';
 import {
   Control,
-  FieldErrors,
+  FieldError,
   FieldPath,
   FieldPathValue,
   FieldValues,
@@ -12,14 +12,11 @@ import {
   UseFormStateReturn,
 } from './';
 
-export type ControllerFieldState<
-  TFieldValues extends FieldValues = FieldValues,
-  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> = {
+export type ControllerFieldState = {
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;
-  error?: FieldErrors<FieldPathValue<TFieldValues, TFieldName>>;
+  error?: FieldError;
 };
 
 export type ControllerRenderProps<
@@ -53,7 +50,7 @@ export type UseControllerReturn<
 > = {
   field: ControllerRenderProps<TFieldValues, TName>;
   formState: UseFormStateReturn<TFieldValues>;
-  fieldState: ControllerFieldState<TFieldValues, TName>;
+  fieldState: ControllerFieldState;
 };
 
 export type ControllerProps<
@@ -66,7 +63,7 @@ export type ControllerProps<
     formState,
   }: {
     field: ControllerRenderProps<TFieldValues, TName>;
-    fieldState: ControllerFieldState<TFieldValues, TName>;
+    fieldState: ControllerFieldState;
     formState: UseFormStateReturn<TFieldValues>;
   }) => React.ReactElement;
 } & UseControllerProps<TFieldValues, TName>;

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -3,10 +3,12 @@ import * as React from 'react';
 import { RegisterOptions } from './validator';
 import {
   Control,
+  FieldError,
   FieldErrors,
   FieldPath,
   FieldPathValue,
   FieldValues,
+  isNested,
   RefCallBack,
   UnpackNestedValue,
   UseFormStateReturn,
@@ -19,7 +21,9 @@ export type ControllerFieldState<
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;
-  error?: FieldErrors<FieldPathValue<TFieldValues, TFieldName>>;
+  error?: isNested<TFieldName> extends true
+    ? FieldErrors<FieldPathValue<TFieldValues, TFieldName>>
+    : FieldError;
 };
 
 export type ControllerRenderProps<

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -32,7 +32,7 @@ export type IsAny<T> = boolean extends (T extends never ? true : false)
   ? true
   : false;
 
-type DeepMapImpl<T, TValue> = IsAny<T> extends true
+export type DeepMapImpl<T, TValue> = IsAny<T> extends true
   ? any
   : T extends NestedValue
   ? TValue

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -32,6 +32,8 @@ export type IsAny<T> = boolean extends (T extends never ? true : false)
   ? true
   : false;
 
+export type isNested<T> = T extends `${string}.${string}` ? true : false;
+
 type DeepMapImpl<T, TValue> = IsAny<T> extends true
   ? any
   : T extends NestedValue

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -32,8 +32,6 @@ export type IsAny<T> = boolean extends (T extends never ? true : false)
   ? true
   : false;
 
-export type isNested<T> = T extends `${string}.${string}` ? true : false;
-
 type DeepMapImpl<T, TValue> = IsAny<T> extends true
   ? any
   : T extends NestedValue


### PR DESCRIPTION
`fieldState`'s error is not all errors, only contains errors related to the field. I believe the fix was introduced last time was due to the union object.

close #6646

related: https://github.com/react-hook-form/react-hook-form/issues/6498