### PR TITLE
Add Example for Dirty Field Only Submission

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ You can view the source code for most examples within their folder, or visit Cod
 | DefaultValues                          | https://codesandbox.io/s/react-hook-form-defaultvalues-wv8c4                            |
 | Default/Initial Form Value             | https://codesandbox.io/s/react-hook-form-defaultinitial-form-value-cujvt                |
 | Dirty/Touched/Submitted                | https://codesandbox.io/s/react-hook-form-formstate-dirty-touched-submitted-forked-wjk0k |
+| Dirty Fields Only Submitted            | https://codesandbox.io/s/react-hook-form-submit-only-dirty-fields-ol5d2                 |
 | Disable Native Validation              | https://codesandbox.io/s/purple-glitter-4pgqq                                           |
 | Field Array Min Length                 | https://codesandbox.io/s/react-hook-form-fieldsarray-yup-validation-min-length-k87iy    |
 | FormProvider                           | https://codesandbox.io/s/react-hook-form-form-context-2703c                             |
@@ -45,9 +46,9 @@ You can view the source code for most examples within their folder, or visit Cod
 
 ## React Native
 
-| Type Name   | Link                                                                |
-| ----------- | ------------------------------------------------------------------- |
-| Controller  | https://snack.expo.io/@bluebill1049/react-hook-form-v7---controller |
+| Type Name  | Link                                                                |
+| ---------- | ------------------------------------------------------------------- |
+| Controller | https://snack.expo.io/@bluebill1049/react-hook-form-v7---controller |
 
 ## Types
 

--- a/examples/V7/dirtyFieldsOnlySubmitted.tsx
+++ b/examples/V7/dirtyFieldsOnlySubmitted.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { useForm } from 'react-hook-form';
+
+type UnknownArrayOrObject = unknown[] | Record<string, unknown>;
+
+// https://github.com/react-hook-form/react-hook-form/discussions/1991#discussioncomment-351784
+export const dirtyValues = (
+  dirtyFields: UnknownArrayOrObject | boolean,
+  allValues: UnknownArrayOrObject,
+): UnknownArrayOrObject => {
+  // NOTE: Recursive function.
+
+  // If *any* item in an array was modified, the entire array must be submitted, because there's no
+  // way to indicate "placeholders" for unchanged elements. `dirtyFields` is `true` for leaves.
+  if (dirtyFields === true || Array.isArray(dirtyFields)) {
+    return allValues;
+  }
+
+  // Here, we have an object.
+  return Object.fromEntries(
+    Object.keys(dirtyFields).map((key) => [
+      key,
+      dirtyValues(dirtyFields[key], allValues[key]),
+    ]),
+  );
+};
+
+export default function App() {
+  const { register, handleSubmit, formState } = useForm({
+    mode: 'onChange',
+  });
+  const onSubmit = (data) => {
+    alert(JSON.stringify(dirtyValues(formState.dirtyFields, data)));
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <label>First name</label>
+        <input type="text" {...register('firstName')} />
+      </div>
+      <div>
+        <label>Last name</label>
+        <input type="text" {...register('lastName')} />
+      </div>
+      <div>
+        <label>Email</label>
+        <input type="text" {...register('email')} />
+      </div>
+      <div>
+        <label>Mobile number</label>
+        <input type="tel" {...register('mobileNumber')} />
+      </div>
+      <div>
+        <label>Title</label>
+        <select {...register('title')}>
+          <option value="Mr">Mr</option>
+          <option value="Mrs">Mrs</option>
+          <option value="Miss">Miss</option>
+          <option value="Dr">Dr</option>
+        </select>
+      </div>
+
+      <div>
+        <label>Are you a developer?</label>
+        <input type="radio" value="Yes" {...register('developer')} />
+        <input type="radio" value="No" {...register('developer')} />
+      </div>
+
+      <pre>{JSON.stringify(formState, null, 2)}</pre>
+
+      <input type="submit" />
+    </form>
+  );
+}
+
+const rootElement = document.getElementById('root');
+
+ReactDOM.render(<App />, rootElement);


### PR DESCRIPTION
I found this to be a helpful example for a common use-case - interacting with a PUT endpoint which only wants changed fields. Credit for utility goes to @dandv and others here: https://github.com/react-hook-form/react-hook-form/discussions/1991#discussioncomment-1393156