### PR TITLE
Simplify controller field state error type

### DIFF
--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1232,7 +1232,7 @@ describe('Controller', () => {
             render={({ field, fieldState }) => (
               <>
                 <input {...field} />
-                <p>{fieldState.error?.[0]?.message}</p>
+                <p>{fieldState.error?.message}</p>
               </>
             )}
             control={control}

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1294,7 +1294,7 @@ describe('Controller', () => {
             render={({ field, fieldState }) => (
               <>
                 <input {...field} />
-                <p>{fieldState.error?.[0]?.message}</p>
+                <p>{fieldState.error?.message}</p>
               </>
             )}
             control={control}

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { RegisterOptions } from './validator';
 import {
   Control,
-  ControllerFieldStateError,
+  FieldError,
   FieldPath,
   FieldPathValue,
   FieldValues,
@@ -13,14 +13,11 @@ import {
   UseFormStateReturn,
 } from './';
 
-export type ControllerFieldState<
-  TFieldValues extends FieldValues = FieldValues,
-  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> = {
+export type ControllerFieldState = {
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;
-  error?: ControllerFieldStateError<FieldPathValue<TFieldValues, TFieldName>>;
+  error?: FieldError;
 };
 
 export type ControllerRenderProps<
@@ -54,7 +51,7 @@ export type UseControllerReturn<
 > = {
   field: ControllerRenderProps<TFieldValues, TName>;
   formState: UseFormStateReturn<TFieldValues>;
-  fieldState: ControllerFieldState<TFieldValues, TName>;
+  fieldState: ControllerFieldState;
 };
 
 export type ControllerProps<
@@ -67,7 +64,7 @@ export type ControllerProps<
     formState,
   }: {
     field: ControllerRenderProps<TFieldValues, TName>;
-    fieldState: ControllerFieldState<TFieldValues, TName>;
+    fieldState: ControllerFieldState;
     formState: UseFormStateReturn<TFieldValues>;
   }) => React.ReactElement;
 } & UseControllerProps<TFieldValues, TName>;

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,12 +1,5 @@
 import { FieldValues, InternalFieldName, Ref } from './fields';
-import {
-  DeepMap,
-  DeepMapImpl,
-  DeepPartial,
-  DeepPartialImpl,
-  LiteralUnion,
-  UnionLike,
-} from './utils';
+import { DeepMap, DeepPartial, LiteralUnion, UnionLike } from './utils';
 import { RegisterOptions, ValidateResult } from './validator';
 
 export type Message = string;
@@ -32,10 +25,6 @@ export type ErrorOption = {
 
 export type FieldErrors<TFieldValues extends FieldValues = FieldValues> =
   DeepMap<DeepPartial<UnionLike<TFieldValues>>, FieldError>;
-
-export type ControllerFieldStateError<
-  TFieldValues extends FieldValues = FieldValues,
-> = DeepMapImpl<DeepPartialImpl<UnionLike<TFieldValues>>, FieldError>;
 
 export type InternalFieldErrors = Partial<
   Record<InternalFieldName, FieldError>


### PR DESCRIPTION
JS: https://codesandbox.io/s/xenodochial-sound-qlqfh?file=/src/App.js
TS: https://codesandbox.io/s/serene-goldstine-4dx4x?file=/src/App.tsx

related #6679

- Controller with array type should still return FieldError instead of an array of errors, this should help with the recursive issue that we are facing right now.
- Controller is always a single unit

![Screen Shot 2021-10-07 at 12 25 18 pm](https://user-images.githubusercontent.com/10513364/136305670-d2b3647e-cc48-424b-be44-bf708c0319ba.png)