### PR TITLE
Add support for extended generics in path type

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -73,15 +73,17 @@ type PathImpl<K extends string | number, V> = V extends Primitive
   ? `${K}`
   : `${K}` | `${K}.${Path<V>}`;
 
-export type Path<T> = T extends ReadonlyArray<infer V>
-  ? IsTuple<T> extends true
-    ? {
-        [K in TupleKey<T>]-?: PathImpl<K & string, T[K]>;
-      }[TupleKey<T>]
-    : PathImpl<ArrayKey, V>
-  : {
-      [K in keyof T]-?: PathImpl<K & string, T[K]>;
-    }[keyof T];
+export type Path<T> =
+  | (T extends ReadonlyArray<infer V>
+      ? IsTuple<T> extends true
+        ? {
+            [K in TupleKey<T>]-?: PathImpl<K & string, T[K]>;
+          }[TupleKey<T>]
+        : PathImpl<ArrayKey, V>
+      : {
+          [K in keyof T]-?: PathImpl<K & string, T[K]>;
+        }[keyof T])
+  | { [K in keyof T]-?: K & string }[keyof T];
 
 export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
 


### PR DESCRIPTION
With this change the `Path<T>` type can take a generic as `T` and honors the existing keys on said generic. This solution does not support nested generic shapes though.

Fixes #6726