### PR TITLE
Enable sharing form sections between forms in typescript

### DIFF
--- a/src/__tests__/type.test.tsx
+++ b/src/__tests__/type.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Path } from '../types';
+import { Path, UseFormReturn } from '../types';
 import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 
@@ -23,6 +23,28 @@ test('should not throw type error with path name', () => {
   ];
 
   test;
+});
+
+test('all APIs except watch are compatible with a superset of FormFields', () => {
+  type FormFieldsSmall = {
+    gender: 'female' | 'male';
+    firstName: string;
+    lastName: string;
+  };
+
+  type FormFieldsBig = {
+    foo: string;
+    bar: 'test1' | 'test2';
+    test2: boolean;
+  } & FormFieldsSmall;
+
+  function App() {
+    const form = useForm<FormFieldsBig>();
+    const test: Omit<UseFormReturn<FormFieldsSmall>, 'watch'> = form;
+    test;
+    return null;
+  }
+  App;
 });
 
 test('should not throw type error with optional array fields', () => {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -325,7 +325,7 @@ export type Control<
     action: boolean;
     watch: boolean;
   };
-  _options: UseFormProps<TFieldValues, TContext>;
+  _options: Pick<UseFormProps<TFieldValues, TContext>, 'shouldUnregister'>;
   _getDirty: GetIsDirty;
   _formState: FormState<TFieldValues>;
   _updateValid: Noop;


### PR DESCRIPTION
Hi, 

thanks for your work on this library. We are enjoying it a lot, especially the good typescript support and the API design.

This PR fixes an [issue](https://github.com/react-hook-form/react-hook-form/issues/5038) which prevented sharing parts of a form between forms when using typescript. I created an issue for this in the past: https://github.com/react-hook-form/react-hook-form/issues/5038. However, back then neither I nor the maintainers were able to tackle this, and the issue was closed as design limitation (good choice). 

Since my team now has a need to share parts of a form between forms, I took a second take at the issue, and managed to debug it and to come up with a proposed solution.

This PR is meant to gather feedback on whether you'd be willing to accept it. If yes, I'd properly document it, and add examples to the documentation of the library.

## Problem Description

Intuitively, it should be possible to create components which contain form fields, and use this component in different forms. 
I have created a codesandbox which demonstrates this: https://codesandbox.io/s/hook-form-subform-1qfwg. 

One can do this by passing the `UseFormReturn` value as a prop to this component, and then using it inside the component to register the fields. However, when using typescript, and therefore defining which fields are available in the `UseFormReturn` value, we run into a problem here:

```typescript
type FormValuesBig = { foo: string, bar: string }
type FormValuesSmall = { foo: string } // those fields should be inside a shared component

const formMethods = useForm<FormValuesBig>()
// now, pass this value as a prop to a component, which knows only abouts the fields defined in FormValuesSmall
const formMethodsSmall: UseFormReturn<FormValuesSmall> = formMethods // <-- typescript error! not possible to assign
```

Hence, it was not possible to make the shared form component only aware of the fields which it actually used, hence preventing the creation of such a component. 



## Analysis

The root cause was that the `UseFormReturn` type includes two functions, which are not compatible (where compatible means that one is a subtype of the other) when initializing `UseFormReturn` as shown above. One is the `watch` method, the other is part of the `resolver` option, which is contained in the `_options` key of the `UseFormReturn` value.

This is due to the way how typescript (correctly) checks whether a function is a subtype of another function. It does this by comparing the parameters *contravariantly*, and the return type *covariantly*. In a nutshell for a function to be a subtype of another function, the parameters have to be supertypes of the original paramters and the return type has to be a subtype of the original return type. For background, see these two links:
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html#strict-function-types
- https://www.stephanboyer.com/post/132/what-are-covariance-and-contravariance

This was not the case for the two functions: They included the `FormField` as a parameter - and  `FormValuesSmall` is certainly not a supertype of `FormValuesBig` (it's the other way around).

### Proposed Solution

I fixed the problem by relaxing the interface of the `Controller` and the `FieldArray` components such that they don't require those functions anymore (they don't use them anyways), and by introducing a third template parameter `TExcludeSubtypeIncompatibleData` on the `UseFormReturn` type which excludes those functions:

```typescript
const formMethods = useForm<FormValuesBig>()
const formMethodsSmall: UseFormReturn<FormValuesSmall, object, true> = formMethods // <-- works now
```

This is a non-breaking change, and does not change existing behavior. There are other ways of getting the same result - for example by introducing a new type instead of adding a new template parameter - I'm happy to discuss them with you.

Thank you for taking the time to look at this PR/issue. You may use [my codesandbox](https://codesandbox.io/s/hook-form-subform-1qfwg) to test my proposed fix - you will probably have to download it, so you can use my PR as a base.