### PR TITLE
Allow Jest VSCode extension to run successfully on startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "name": "vscode-jest-tests",
+      "request": "launch",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "args": ["test", "--runInBand", "--watchAll=false"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
     "source.fixAll.eslint": true
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "jest.jestCommandLine": "yarn test"
+  "jest.jestCommandLine": "yarn test",
+  "jest.autoRun": {
+    "watch": false,
+    "onSave": "test-file",
+    "onStartup": ["all-tests"]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "jest.jestCommandLine": "yarn test"
 }


### PR DESCRIPTION
## Changes

- Latest Jest VSCode extension has great support for the new Testing sidebar - easy detection without having to run the full test suite
- Without this change, the extension simply fails as it hasn't been configured to use the proper jest.config file

Addresses https://github.com/react-hook-form/react-hook-form/issues/6811

To test (which I ran to verify): 
- Install the Jest VSCode extension
- Restart VSCode, the suite will run and pass successfully
- Force one of the tests to fail: the VSCode status bar will show the problem
- Fix the issue: VSCode status bar will show success again

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works (this is dependent on a VSCode extension)
- [x] New and existing tests pass locally with my changes
