### PR TITLE
Return value from onValid in handleSubmit

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1021,7 +1021,7 @@ export function createFormControl<
             errors: {} as FieldErrors<TFieldValues>,
             isSubmitting: true,
           });
-          await onValid(fieldValues, e);
+          return await onValid(fieldValues, e);
         } else {
           onInvalid && (await onInvalid(_formState.errors, e));
           _options.shouldFocusError &&


### PR DESCRIPTION
Returning the value from `onValid` in `handleSubmit` allows higher order functions to easily work with data returned from a successful submit without passing in extra callbacks or having to save the state with additional hooks (ie. `setState`). This will allow us to pass the callback created from `handleSubmit` back to a parent component or as a callback in another hook so they can inspect the data from a successful submit.

Example use case:

- passing in data of a newly created resource to an `onSuccess` callback in a modal