### PR TITLE
✨ Add TypeScript support for optional array fields

### DIFF
--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -24,9 +24,10 @@ export type FieldArrayWithId<
 export type FieldArray<
   TFieldValues extends FieldValues = FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
-> = FieldArrayPathValue<TFieldValues, TFieldArrayName> extends ReadonlyArray<
-  infer U
->
+> = FieldArrayPathValue<TFieldValues, TFieldArrayName> extends
+  | ReadonlyArray<infer U>
+  | null
+  | undefined
   ? U
   : never;
 


### PR DESCRIPTION
Fixes https://github.com/react-hook-form/react-hook-form/discussions/5301

This adds TypeScript support for form interfaces that has the entire array as an optional/nullable field. Example:

```ts
import { useFieldArray, useForm } from 'react-hook-form'

interface FormData {
  name: string
  things?: Array<{ name: string }>
}

export default function App () {
  const { control, register } = useForm<FormData>({ defaultValues: { name: 'test' } })
  const { fields, append } = useFieldArray({ control, name: 'things' })

  return (
    <div className="App">
      <h1>useFieldArray demo</h1>
      <input {...register('name')} />
      <br />
      <button onClick={() => append({ name: '' })}>Add</button>
      {fields.map((field, index) => (
        <div key={field.id}>
          <input
            {...register(`things.${index}.name`)}
            defaultValue={field.name}
            placeholder={`Thing ${index + 1}`}
          />
        </div>
      ))}
    </div>
  )
}
```

Before this change the `field` parameter of the `map` function would receive `field` as `never` instead of `{ name: string }` because the `things` array was optional. This change fixes that.

This is my first contribution to this library, so I'm not familiar with the setup. If there is anything else you want me to do, like adding tests, I'd be happy to fix it if you point me in the right direction!
