### PR TITLE
7.19.0 Feature/reset field

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-object-literal-type-assertion": "off",
+    "cypress/no-unnecessary-waiting": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
     "react/display-name": "warn",

--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -33,6 +33,8 @@ import UseWatchUseFieldArrayNested from './useWatchUseFieldArrayNested';
 import Test from './test';
 import Welcome from './welcome';
 import { UseFormState } from './useFormState';
+import SetValueAsyncStrictMode from './setValueStrictMode';
+import './style.css';
 
 const App: React.FC = () => {
   return (
@@ -75,6 +77,10 @@ const App: React.FC = () => {
       />
       <Route path="/reset" exact component={Reset} />
       <Route path="/setValue" exact component={SetValue} />
+      <Route
+        path="/setValueAsyncStrictMode"
+        component={SetValueAsyncStrictMode}
+      />
       <Route path="/setValueWithSchema" exact component={SetValueWithSchema} />
       <Route
         path="/SetValueCustomRegister"

--- a/app/src/setValueStrictMode.tsx
+++ b/app/src/setValueStrictMode.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+
+const SetValueAsyncStrictMode = () => {
+  const state = React.useRef(new Set());
+  const [, update] = React.useState({});
+  const { register, setValue, control } = useForm<{
+    firstName: string;
+  }>();
+
+  useEffect(() => {
+    setTimeout(() => {
+      setValue('firstName', 'A');
+    }, 10);
+
+    setTimeout(() => {
+      setValue('firstName', 'B', { shouldDirty: true });
+    }, 20);
+
+    setTimeout(() => {
+      setValue('firstName', 'C', { shouldTouch: true });
+    }, 30);
+
+    setTimeout(() => {
+      setValue('firstName', 'D', { shouldValidate: true });
+    }, 40);
+  }, [register, setValue]);
+
+  return (
+    <React.StrictMode>
+      <form>
+        <Controller
+          defaultValue={'test'}
+          control={control}
+          render={({ field }) => {
+            state.current.add(field.value);
+            return <input id={'input'} {...field} />;
+          }}
+          name={'firstName'}
+        />
+
+        <button id="submit" type={'button'} onClick={() => update({})}>
+          Submit
+        </button>
+
+        <p id="result">{JSON.stringify([...state.current])}</p>
+      </form>
+    </React.StrictMode>
+  );
+};
+
+export default SetValueAsyncStrictMode;

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -1,0 +1,58 @@
+body {
+  padding: 20px;
+  background: #081229;
+  color: white;
+}
+
+select,
+input {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  border-radius: 4px;
+  border: 1px solid white;
+  padding: 10px 15px;
+  margin-bottom: 15px;
+  font-size: 14px;
+  max-width: 600px;
+}
+
+button,
+input[type='submit'],
+.button {
+  position: relative;
+  background: #ec5990;
+  color: white;
+  text-transform: uppercase;
+  border: none;
+  margin-top: 20px;
+  padding: 20px;
+  font-size: 16px;
+  letter-spacing: 10px;
+  display: block;
+  appearance: none;
+  border-radius: 4px;
+  width: 100%;
+  font-weight: lighter;
+  transition: 0.3s all;
+  max-width: 600px;
+}
+
+button[type="button"] {
+  background: #516391;
+  color: white;
+  text-transform: none;
+  padding: 10px;
+  letter-spacing: 2px;
+}
+
+input[type="submit"]:hover,
+button[type="button"]:hover {
+  background: #bf1650;
+  color: white;
+}
+
+input[type="submit"]:active {
+  transition: 0.3s all;
+  top: 2px;
+}

--- a/app/src/welcome/index.tsx
+++ b/app/src/welcome/index.tsx
@@ -121,7 +121,7 @@ const items: Item[] = [
   {
     title: 'SetValue',
     description: 'Should set input value',
-    slugs: ['/setValue'],
+    slugs: ['/setValue', '/setValueAsyncStrictMode'],
   },
   {
     title: 'SetValueCustomRegister',

--- a/app/src/welcome/styles.ts
+++ b/app/src/welcome/styles.ts
@@ -1,5 +1,4 @@
 export const page: object = {
-  background: '#081229',
   minHeight: '100vh',
   color: 'white',
   padding: '1rem',

--- a/cypress/integration/setValueAsyncStrictMode.ts
+++ b/cypress/integration/setValueAsyncStrictMode.ts
@@ -1,0 +1,11 @@
+describe('form setValueAsyncStrictMode', () => {
+  it('should set async input value correctly', () => {
+    cy.visit('http://localhost:3000/setValueAsyncStrictMode');
+
+    cy.wait(10);
+
+    cy.get('#submit').click();
+
+    cy.get('p').contains('["test","A","B","C","D"]');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form",
   "description": "Performant, flexible and extensible forms library for React Hooks",
-  "version": "7.18.0",
+  "version": "7.19.0-next.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "umd:main": "dist/index.umd.js",

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -535,7 +535,7 @@ describe('reset', () => {
         defaultValues: { test: 'test', test1: 'test1' },
       });
       const resetData = () => {
-        reset({}, { keepDefaultValues: true });
+        reset(undefined, { keepDefaultValues: true });
       };
 
       return (

--- a/src/__tests__/useForm/resetField.test.tsx
+++ b/src/__tests__/useForm/resetField.test.tsx
@@ -1,0 +1,396 @@
+import * as React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useForm } from '../../useForm';
+
+describe('resetField', () => {
+  it('should reset input value', () => {
+    const App = () => {
+      const { register, resetField } = useForm({
+        defaultValues: {
+          test: 'test',
+        },
+      });
+
+      return (
+        <form>
+          <input {...register('test')} />
+          <button
+            type={'button'}
+            onClick={() => {
+              resetField('test');
+            }}
+          >
+            reset
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: {
+        value: '1234',
+      },
+    });
+
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
+      '1234',
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
+      'test',
+    );
+  });
+
+  it('should reset input touched field state', async () => {
+    const App = () => {
+      const {
+        register,
+        resetField,
+        formState: { touchedFields },
+      } = useForm({
+        defaultValues: {
+          test: 'test',
+        },
+      });
+
+      return (
+        <form>
+          <input {...register('test')} />
+          <p>{touchedFields.test ? 'touched' : 'noTouched'}</p>
+          <button
+            type={'button'}
+            onClick={() => {
+              resetField('test');
+            }}
+          >
+            reset
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.focus(screen.getByRole('textbox'));
+
+    fireEvent.blur(screen.getByRole('textbox'));
+
+    await waitFor(async () => {
+      screen.getByText('touched');
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(async () => {
+      screen.getByText('noTouched');
+    });
+  });
+
+  it('should reset input dirty field and dirty state', async () => {
+    const App = () => {
+      const {
+        register,
+        resetField,
+        formState: { dirtyFields, isDirty },
+      } = useForm({
+        defaultValues: {
+          test: 'test',
+        },
+      });
+
+      return (
+        <form>
+          <input {...register('test')} />
+          <p>{dirtyFields.test ? 'dirty' : 'notDirty'}</p>
+          <p>{isDirty ? 'formDirty' : 'formNotDirty'}</p>
+          <button
+            type={'button'}
+            onClick={() => {
+              resetField('test');
+            }}
+          >
+            reset
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: {
+        value: '1234',
+      },
+    });
+
+    await waitFor(async () => {
+      screen.getByText('dirty');
+      screen.getByText('formDirty');
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(async () => {
+      screen.getByText('notDirty');
+      screen.getByText('formNotDirty');
+    });
+  });
+
+  it('should reset input error field and isValid state', async () => {
+    const App = () => {
+      const {
+        register,
+        resetField,
+        formState: { errors, isValid },
+      } = useForm({
+        defaultValues: {
+          test: 'test',
+        },
+        mode: 'onChange',
+      });
+
+      return (
+        <form>
+          <input {...register('test', { maxLength: 4 })} />
+          <p>{errors.test ? 'error' : 'noError'}</p>
+          <p>{isValid ? 'valid' : 'NotValid'}</p>
+          <button
+            type={'button'}
+            onClick={() => {
+              resetField('test');
+            }}
+          >
+            reset
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    await waitFor(async () => {
+      screen.getByText('noError');
+      screen.getByText('valid');
+    });
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: {
+        value: 'test12345',
+      },
+    });
+
+    await waitFor(async () => {
+      screen.getByText('error');
+      screen.getByText('NotValid');
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(async () => {
+      screen.getByText('noError');
+      screen.getByText('valid');
+    });
+  });
+
+  describe('when provided with options', () => {
+    it('should update input value and its defaultValue', () => {
+      const App = () => {
+        const { register, resetField } = useForm({
+          defaultValues: {
+            test: 'test',
+          },
+        });
+
+        return (
+          <form>
+            <input {...register('test')} />
+            <button
+              type={'button'}
+              onClick={() => {
+                resetField('test', {
+                  defaultValue: 'test1234',
+                });
+              }}
+            >
+              reset
+            </button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: '1234',
+        },
+      });
+
+      expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
+        '1234',
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
+        'test1234',
+      );
+    });
+
+    it('should keep touched field state', async () => {
+      const App = () => {
+        const {
+          register,
+          resetField,
+          formState: { touchedFields },
+        } = useForm({
+          defaultValues: {
+            test: 'test',
+          },
+        });
+
+        return (
+          <form>
+            <input {...register('test')} />
+            <p>{touchedFields.test ? 'touched' : 'noTouched'}</p>
+            <button
+              type={'button'}
+              onClick={() => {
+                resetField('test', { keepTouch: true });
+              }}
+            >
+              reset
+            </button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.focus(screen.getByRole('textbox'));
+
+      fireEvent.blur(screen.getByRole('textbox'));
+
+      await waitFor(async () => {
+        screen.getByText('touched');
+      });
+
+      fireEvent.click(screen.getByRole('button'));
+
+      await waitFor(async () => {
+        screen.getByText('touched');
+      });
+    });
+
+    it('should keep dirty field and isDirty state', async () => {
+      const App = () => {
+        const {
+          register,
+          resetField,
+          formState: { dirtyFields, isDirty },
+        } = useForm({
+          defaultValues: {
+            test: 'test',
+          },
+        });
+
+        return (
+          <form>
+            <input {...register('test')} />
+            <p>{dirtyFields.test ? 'dirty' : 'notDirty'}</p>
+            <p>{isDirty ? 'formDirty' : 'formNotDirty'}</p>
+            <button
+              type={'button'}
+              onClick={() => {
+                resetField('test', { keepDirty: true });
+              }}
+            >
+              reset
+            </button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: '1234',
+        },
+      });
+
+      await waitFor(async () => {
+        screen.getByText('dirty');
+        screen.getByText('formDirty');
+      });
+
+      fireEvent.click(screen.getByRole('button'));
+
+      await waitFor(async () => {
+        screen.getByText('dirty');
+        screen.getByText('formDirty');
+      });
+    });
+
+    it('should skip reset error field and isValid state', async () => {
+      const App = () => {
+        const {
+          register,
+          resetField,
+          formState: { errors, isValid },
+        } = useForm({
+          defaultValues: {
+            test: 'test',
+          },
+          mode: 'onChange',
+        });
+
+        return (
+          <form>
+            <input {...register('test', { maxLength: 4 })} />
+            <p>{errors.test ? 'error' : 'noError'}</p>
+            <p>{isValid ? 'valid' : 'NotValid'}</p>
+            <button
+              type={'button'}
+              onClick={() => {
+                resetField('test', { keepError: true });
+              }}
+            >
+              reset
+            </button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await waitFor(async () => {
+        screen.getByText('noError');
+        screen.getByText('valid');
+      });
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: 'test12345',
+        },
+      });
+
+      await waitFor(async () => {
+        screen.getByText('error');
+        screen.getByText('NotValid');
+      });
+
+      fireEvent.click(screen.getByRole('button'));
+
+      await waitFor(async () => {
+        screen.getByText('error');
+        screen.getByText('NotValid');
+      });
+    });
+  });
+});

--- a/src/__tests__/useForm/resetField.test.tsx
+++ b/src/__tests__/useForm/resetField.test.tsx
@@ -261,7 +261,7 @@ describe('resetField', () => {
             <button
               type={'button'}
               onClick={() => {
-                resetField('test', { keepTouch: true });
+                resetField('test', { keepTouched: true });
               }}
             >
               reset

--- a/src/__tests__/utils/createSubject.test.ts
+++ b/src/__tests__/utils/createSubject.test.ts
@@ -13,6 +13,8 @@ describe('createSubject', () => {
       next,
     });
 
+    expect(subject.observers.length).toBe(2);
+
     subject.next(2);
 
     expect(next).toBeCalledTimes(2);
@@ -21,19 +23,46 @@ describe('createSubject', () => {
 
   it('should unsubscribe observers', () => {
     const subject = createSubject();
+    const next1 = jest.fn();
+    const next2 = jest.fn();
+
+    const subscription = subject.subscribe({
+      next: next1,
+    });
+
+    subject.subscribe({
+      next: next2,
+    });
+
+    expect(subject.observers.length).toBe(2);
+
+    subscription.unsubscribe();
+
+    expect(subject.observers.length).toBe(1);
+
+    subject.next(2);
+
+    expect(next1).not.toBeCalled();
+    expect(next2).toBeCalledWith(2);
+  });
+
+  it('should unsubscribe all observers', () => {
+    const subject = createSubject();
     const next = jest.fn();
 
-    const tearDown = subject.subscribe({
+    subject.subscribe({
       next,
     });
 
-    const tearDown1 = subject.subscribe({
+    subject.subscribe({
       next,
     });
 
-    tearDown.unsubscribe();
+    expect(subject.observers.length).toBe(2);
 
-    tearDown1.unsubscribe();
+    subject.unsubscribe();
+
+    expect(subject.observers.length).toBe(0);
 
     subject.next(2);
     subject.next(2);

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -30,6 +30,7 @@ import {
   UseFormRegister,
   UseFormRegisterReturn,
   UseFormReset,
+  UseFormResetField,
   UseFormReturn,
   UseFormSetError,
   UseFormSetFocus,
@@ -1047,6 +1048,36 @@ export function createFormControl<
       }
     };
 
+  const resetField: UseFormResetField<TFieldValues> = (name, options = {}) => {
+    if (!options.keepTouch) {
+      unset(_formState.touchedFields, name);
+    }
+
+    if (!options.keepDirty) {
+      unset(_formState.dirtyFields, name);
+      _formState.isDirty = _getDirty(name, get(_defaultValues, name));
+    }
+
+    if (isUndefined(options.defaultValue)) {
+      setValue(name, get(_defaultValues, name));
+    } else {
+      setValue(name, options.defaultValue);
+      set(_defaultValues, name, options.defaultValue);
+    }
+
+    if (!options.keepError) {
+      unset(_formState.errors, name);
+      _updateValid();
+    }
+
+    _subjects.state.next({
+      errors: _formState.errors,
+      touchedFields: _formState.touchedFields,
+      isDirty: _formState.isDirty,
+      dirtyFields: _formState.dirtyFields,
+    });
+  };
+
   const reset: UseFormReset<TFieldValues> = (
     formValues,
     keepStateOptions = {},
@@ -1213,6 +1244,7 @@ export function createFormControl<
     setValue,
     getValues,
     reset,
+    resetField,
     clearErrors,
     unregister,
     setError,

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -621,7 +621,6 @@ export function createFormControl<
     isFieldWatched(name) && _subjects.state.next({});
     _subjects.watch.next({
       name,
-      values: { ..._formValues },
     });
   };
 
@@ -893,7 +892,8 @@ export function createFormControl<
     });
     _names.mount.add(name);
 
-    !isUndefined(options.value) && set(_formValues, name, options.value);
+    !isUndefined(options.value) &&
+      set(_formValues, name, get(_formValues, name, options.value));
 
     field
       ? isBoolean(options.disabled) &&

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1049,6 +1049,13 @@ export function createFormControl<
     };
 
   const resetField: UseFormResetField<TFieldValues> = (name, options = {}) => {
+    if (isUndefined(options.defaultValue)) {
+      setValue(name, get(_defaultValues, name));
+    } else {
+      setValue(name, options.defaultValue);
+      set(_defaultValues, name, options.defaultValue);
+    }
+
     if (!options.keepTouch) {
       unset(_formState.touchedFields, name);
     }
@@ -1058,24 +1065,12 @@ export function createFormControl<
       _formState.isDirty = _getDirty(name, get(_defaultValues, name));
     }
 
-    if (isUndefined(options.defaultValue)) {
-      setValue(name, get(_defaultValues, name));
-    } else {
-      setValue(name, options.defaultValue);
-      set(_defaultValues, name, options.defaultValue);
-    }
-
     if (!options.keepError) {
       unset(_formState.errors, name);
-      _updateValid();
+      _proxyFormState.isValid && _updateValid();
     }
 
-    _subjects.state.next({
-      errors: _formState.errors,
-      touchedFields: _formState.touchedFields,
-      isDirty: _formState.isDirty,
-      dirtyFields: _formState.dirtyFields,
-    });
+    _subjects.state.next({ ..._formState });
   };
 
   const reset: UseFormReset<TFieldValues> = (

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1065,7 +1065,9 @@ export function createFormControl<
 
     if (!options.keepDirty) {
       unset(_formState.dirtyFields, name);
-      _formState.isDirty = _getDirty(name, get(_defaultValues, name));
+      _formState.isDirty = options.defaultValue
+        ? _getDirty(name, get(_defaultValues, name))
+        : _getDirty();
     }
 
     if (!options.keepError) {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1059,7 +1059,7 @@ export function createFormControl<
       set(_defaultValues, name, options.defaultValue);
     }
 
-    if (!options.keepTouch) {
+    if (!options.keepTouched) {
       unset(_formState.touchedFields, name);
     }
 

--- a/src/logic/generateWatchOutput.ts
+++ b/src/logic/generateWatchOutput.ts
@@ -1,6 +1,6 @@
 import { FieldValues, InternalFieldName, Names } from '../types';
-import convertToArrayPayload from '../utils/convertToArrayPayload';
 import get from '../utils/get';
+import isString from '../utils/isString';
 
 export function generateWatchOutput(
   names: string | string[] | undefined,
@@ -8,15 +8,19 @@ export function generateWatchOutput(
   formValues?: FieldValues,
   isGlobal?: boolean,
 ) {
-  if (names) {
-    const result = convertToArrayPayload(names).map(
+  const isArray = Array.isArray(names);
+  if (isString(names)) {
+    _names.watch.add(names as InternalFieldName);
+    return get(formValues, names as InternalFieldName);
+  }
+
+  if (isArray) {
+    return names.map(
       (fieldName) => (
-        isGlobal && _names.watch.add(fieldName as InternalFieldName),
+        _names.watch.add(fieldName as InternalFieldName),
         get(formValues, fieldName as InternalFieldName)
       ),
     );
-
-    return Array.isArray(names) ? result : result[0];
   }
 
   isGlobal && (_names.watchAll = true);

--- a/src/logic/generateWatchOutput.ts
+++ b/src/logic/generateWatchOutput.ts
@@ -10,14 +10,14 @@ export function generateWatchOutput(
 ) {
   const isArray = Array.isArray(names);
   if (isString(names)) {
-    _names.watch.add(names as InternalFieldName);
+    isGlobal && _names.watch.add(names as InternalFieldName);
     return get(formValues, names as InternalFieldName);
   }
 
   if (isArray) {
     return names.map(
       (fieldName) => (
-        _names.watch.add(fieldName as InternalFieldName),
+        isGlobal && _names.watch.add(fieldName as InternalFieldName),
         get(formValues, fieldName as InternalFieldName)
       ),
     );

--- a/src/logic/generateWatchOutput.ts
+++ b/src/logic/generateWatchOutput.ts
@@ -1,0 +1,24 @@
+import { FieldValues, InternalFieldName, Names } from '../types';
+import convertToArrayPayload from '../utils/convertToArrayPayload';
+import get from '../utils/get';
+
+export function generateWatchOutput(
+  names: string | string[] | undefined,
+  _names: Names,
+  formValues?: FieldValues,
+  isGlobal?: boolean,
+) {
+  if (names) {
+    const result = convertToArrayPayload(names).map(
+      (fieldName) => (
+        isGlobal && _names.watch.add(fieldName as InternalFieldName),
+        get(formValues, fieldName as InternalFieldName)
+      ),
+    );
+
+    return Array.isArray(names) ? result : result[0];
+  }
+
+  isGlobal && (_names.watchAll = true);
+  return formValues;
+}

--- a/src/logic/shouldSubscribeByName.ts
+++ b/src/logic/shouldSubscribeByName.ts
@@ -1,8 +1,12 @@
 import convertToArrayPayload from '../utils/convertToArrayPayload';
 
-export default <T>(name?: T, signalName?: string) =>
+export default <T extends string | string[] | undefined>(
+  name?: T,
+  signalName?: string,
+) =>
   !name ||
   !signalName ||
+  name === signalName ||
   convertToArrayPayload(name).some(
     (currentName) =>
       currentName &&

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -251,7 +251,7 @@ export type UseFormResetField<TFieldValues extends FieldValues> = <
   name: TFieldName,
   options?: Partial<{
     keepDirty: boolean;
-    keepTouch: boolean;
+    keepTouched: boolean;
     keepError: boolean;
     defaultValue: any;
   }>,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -286,10 +286,6 @@ export type Subjects<TFieldValues extends FieldValues = FieldValues> = {
     type?: EventType;
     values?: FieldValues;
   }>;
-  control: Subject<{
-    name?: InternalFieldName;
-    values?: FieldValues;
-  }>;
   array: Subject<{
     name?: InternalFieldName;
     values?: FieldValues;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -245,6 +245,18 @@ export type UseFormHandleSubmit<TFieldValues extends FieldValues> = <
   onInvalid?: SubmitErrorHandler<TFieldValues>,
 ) => (e?: React.BaseSyntheticEvent) => Promise<void>;
 
+export type UseFormResetField<TFieldValues extends FieldValues> = <
+  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(
+  name: TFieldName,
+  options?: Partial<{
+    keepDirty: boolean;
+    keepTouch: boolean;
+    keepError: boolean;
+    defaultValue: any;
+  }>,
+) => void;
+
 export type UseFormReset<TFieldValues extends FieldValues> = (
   values?: DefaultValues<TFieldValues>,
   keepStateOptions?: KeepStateOptions,
@@ -365,6 +377,7 @@ export type UseFormReturn<
   setValue: UseFormSetValue<TFieldValues>;
   trigger: UseFormTrigger<TFieldValues>;
   formState: FormState<TFieldValues>;
+  resetField: UseFormResetField<TFieldValues>;
   reset: UseFormReset<TFieldValues>;
   handleSubmit: UseFormHandleSubmit<TFieldValues>;
   unregister: UseFormUnregister<TFieldValues>;

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -79,11 +79,10 @@ export function useController<
 
   return {
     field: {
-      onChange: (event: any) => {
-        const value = getControllerValue(event);
+      onChange: (event) => {
         registerProps.onChange({
           target: {
-            value,
+            value: getControllerValue(event),
             name: name as InternalFieldName,
           },
           type: EVENTS.CHANGE,

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -61,7 +61,6 @@ export const useFieldArray = <
       }
     },
     subject: control._subjects.array,
-    skipEarlySubscription: true,
   });
 
   const updateValues = React.useCallback(

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -35,7 +35,6 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
         ...formState,
       }),
     subject: control._subjects.state,
-    skipEarlySubscription: true,
   });
 
   return getProxyFormState(

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -3,7 +3,12 @@ import * as React from 'react';
 import getProxyFormState from './logic/getProxyFormState';
 import shouldRenderFormState from './logic/shouldRenderFormState';
 import shouldSubscribeByName from './logic/shouldSubscribeByName';
-import { FieldValues, UseFormStateProps, UseFormStateReturn } from './types';
+import {
+  FieldValues,
+  InternalFieldName,
+  UseFormStateProps,
+  UseFormStateReturn,
+} from './types';
 import { useFormContext } from './useFormContext';
 import { useSubscribe } from './useSubscribe';
 
@@ -28,7 +33,10 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
   useSubscribe({
     disabled,
     callback: (formState) =>
-      shouldSubscribeByName(_name.current, formState.name) &&
+      shouldSubscribeByName(
+        _name.current as InternalFieldName,
+        formState.name,
+      ) &&
       shouldRenderFormState(formState, _localProxyFormState.current) &&
       updateFormState({
         ...control._formState,

--- a/src/useSubscribe.ts
+++ b/src/useSubscribe.ts
@@ -23,28 +23,24 @@ const tearDown = (
   }
 };
 
-const updateSubscriptionProps =
-  <T>({ _subscription, props }: Payload<T>) =>
-  () => {
-    if (props.disabled) {
-      tearDown(_subscription);
-    } else if (!_subscription.current) {
-      _subscription.current = props.subject.subscribe({
-        next: props.callback,
-      });
-    }
-  };
+const updateSubscriptionProps = <T>({ _subscription, props }: Payload<T>) => {
+  if (props.disabled) {
+    tearDown(_subscription);
+  } else if (!_subscription.current) {
+    _subscription.current = props.subject.subscribe({
+      next: props.callback,
+    });
+  }
+};
 
 export function useSubscribe<T>(props: Props<T>) {
   const _subscription = React.useRef<Subscription>();
   const _updateSubscription = React.useRef<Noop>(() => {});
 
-  _updateSubscription.current = updateSubscriptionProps({
+  updateSubscriptionProps({
     _subscription,
     props,
   });
-
-  _updateSubscription.current();
 
   React.useEffect(() => {
     _updateSubscription.current();

--- a/src/useSubscribe.ts
+++ b/src/useSubscribe.ts
@@ -7,7 +7,6 @@ type Props<T> = {
   disabled?: boolean;
   subject: Subject<T>;
   callback: (value: T) => void;
-  skipEarlySubscription?: boolean;
 };
 
 type Payload<T> = {
@@ -45,7 +44,7 @@ export function useSubscribe<T>(props: Props<T>) {
     props,
   });
 
-  !props.skipEarlySubscription && _updateSubscription.current();
+  _updateSubscription.current();
 
   React.useEffect(() => {
     _updateSubscription.current();

--- a/src/useSubscribe.ts
+++ b/src/useSubscribe.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Subject, Subscription } from './utils/createSubject';
-import { Noop } from './types';
 
 type Props<T> = {
   disabled?: boolean;
@@ -35,7 +34,6 @@ const updateSubscriptionProps = <T>({ _subscription, props }: Payload<T>) => {
 
 export function useSubscribe<T>(props: Props<T>) {
   const _subscription = React.useRef<Subscription>();
-  const _updateSubscription = React.useRef<Noop>(() => {});
 
   updateSubscriptionProps({
     _subscription,
@@ -43,7 +41,6 @@ export function useSubscribe<T>(props: Props<T>) {
   });
 
   React.useEffect(() => {
-    _updateSubscription.current();
     return () => tearDown(_subscription);
   }, []);
 }

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -68,7 +68,7 @@ export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
         const fieldValues = generateWatchOutput(
           _name.current as InternalFieldName | InternalFieldName[],
           control._names,
-          formState.values || control._formValues,
+          control._formValues,
         );
 
         updateValue(

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { generateWatchOutput } from './logic/generateWatchOutput';
 import shouldSubscribeByName from './logic/shouldSubscribeByName';
 import isObject from './utils/isObject';
 import isUndefined from './utils/isUndefined';
@@ -59,12 +60,10 @@ export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
     subject: control._subjects.watch,
     callback: (formState) => {
       if (shouldSubscribeByName(_name.current, formState.name)) {
-        control._stateFlags.mount = true;
-        const fieldValues = control._getWatch(
-          _name.current as InternalFieldName,
-          defaultValue as UnpackNestedValue<
-            DeepPartialSkipArrayKey<TFieldValues>
-          >,
+        const fieldValues = generateWatchOutput(
+          _name.current as InternalFieldName | InternalFieldName[],
+          control._names,
+          formState.values || control._formValues,
         );
 
         updateValue(

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -59,7 +59,12 @@ export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
     disabled,
     subject: control._subjects.watch,
     callback: (formState) => {
-      if (shouldSubscribeByName(_name.current, formState.name)) {
+      if (
+        shouldSubscribeByName(
+          _name.current as InternalFieldName,
+          formState.name,
+        )
+      ) {
         const fieldValues = generateWatchOutput(
           _name.current as InternalFieldName | InternalFieldName[],
           control._names,

--- a/src/utils/createSubject.ts
+++ b/src/utils/createSubject.ts
@@ -4,59 +4,15 @@ export type Observer<T> = {
   next: (value: T) => void;
 };
 
-export type TearDown = Noop;
-
 export type Subscription = {
-  add: (tearDown: TearDown) => void;
-  unsubscribe: () => void;
+  unsubscribe: Noop;
 };
 
 export type Subject<T> = {
   readonly observers: Observer<T>[];
-  next: (value: T) => void;
-  subscribe: (value: Observer<T>) => {
-    unsubscribe: TearDown;
-  };
+  subscribe: (value: Observer<T>) => Subscription;
   unsubscribe: Noop;
-};
-
-function createSubscription() {
-  let tearDowns: TearDown[] = [];
-
-  const add = (tearDown: TearDown) => {
-    tearDowns.push(tearDown);
-  };
-
-  const unsubscribe = () => {
-    for (const teardown of tearDowns) {
-      teardown();
-    }
-    tearDowns = [];
-  };
-
-  return {
-    add,
-    unsubscribe,
-  };
-}
-
-function createSubscriber<T>(
-  observer: Observer<T>,
-  subscription: Subscription,
-): Observer<T> {
-  let closed = false;
-  subscription.add(() => (closed = true));
-
-  const next = (value: T) => {
-    if (!closed) {
-      observer.next(value);
-    }
-  };
-
-  return {
-    next,
-  };
-}
+} & Observer<T>;
 
 export default function createSubject<T>(): Subject<T> {
   let _observers: Observer<T>[] = [];
@@ -67,11 +23,13 @@ export default function createSubject<T>(): Subject<T> {
     }
   };
 
-  const subscribe = (observer: Observer<T>) => {
-    const subscription = createSubscription();
-    const subscriber = createSubscriber(observer, subscription);
-    _observers.push(subscriber);
-    return subscription;
+  const subscribe = (observer: Observer<T>): Subscription => {
+    _observers.push(observer);
+    return {
+      unsubscribe: () => {
+        _observers = _observers.filter((o) => o !== observer);
+      },
+    };
   };
 
   const unsubscribe = () => {


### PR DESCRIPTION
## `resetField`

RFC: https://github.com/react-hook-form/react-hook-form/discussions/6884

- [x] unit/integration tests
- [x] documentation update
- [x] unit test case for `setValue` with StrictMode
- [x] release beta version

doc: https://react-hook-form-website-git-7190-bluebill1049.vercel.app/api/useform/resetField/

```tsx
const { resetField } = useForm();

resetField('test')

resetField('test', {
  keepError: true,
  keepDirty: true,
  keepTouched: true,
  defaultValue: 'test1',
})
```

- improve `useController` by integrating with `useWatch`
- package size-reduction
- internally removed `skipEarlySubscription`

