### PR TITLE
Type Cleanup Initial Step - Remove Readonly types (for now)

### DIFF
--- a/src/__tests__/type.test.tsx
+++ b/src/__tests__/type.test.tsx
@@ -12,7 +12,6 @@ type ComplexTestType = {
     }[];
     testName: string;
     innerTuple: [{ test: string }[], '2', 100];
-    simpleTupleDoesntMatch: [123, 'test', 234];
   };
   objArray: { test: string }[];
   tuple: ['test', { innerTest: string }[], 123];
@@ -29,13 +28,15 @@ test('should not throw type error with path name (Path<T> validation)', () => {
     'test.testArray.99999',
     'test.testArray.0.name',
     'test.testArray.99999.name',
+    'tupleOfTuples.0.0',
+    'tupleOfTuples.1.0',
     'tuple.2',
   ];
 
   test;
 });
 
-test('validates PathValue scenarios', () => {
+test('validate PathValue scenarios', () => {
   const pathVal: PathValue<ComplexTestType, 'test.testArray'> = [
     { name: 'foo' },
   ];
@@ -51,6 +52,12 @@ test('validates PathValue scenarios', () => {
   };
   pathValTest12345;
 
+  const pathValTest12345Value: PathValue<
+    ComplexTestType,
+    'test.testArray.12345.name'
+  > = 'foo';
+  pathValTest12345Value;
+
   const pathValTestFull: PathValue<ComplexTestType, 'test'> = {
     testArray: [
       {
@@ -59,7 +66,6 @@ test('validates PathValue scenarios', () => {
     ],
     testName: '234',
     innerTuple: [[{ test: '123' }, { test: '345' }], '2', 100],
-    simpleTupleDoesntMatch: [123, 'test', 234],
   };
   pathValTestFull;
 
@@ -69,11 +75,15 @@ test('validates PathValue scenarios', () => {
   ];
   pathValTestObjArray;
 
-  const pathValTupleMatch: PathValue<
-    ComplexTestType,
-    'test.simpleTupleDoesntMatch.0'
-  > = 123;
+  const pathValTupleMatch: PathValue<ComplexTestType, 'test.innerTuple.1'> =
+    '2';
   pathValTupleMatch;
+
+  const pathValTupleOfTuples: PathValue<
+    ComplexTestType,
+    'tupleOfTuples.1.1'
+  > = 333;
+  pathValTupleOfTuples;
 });
 
 test('all APIs except watch are compatible with a superset of FormFields', () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -779,9 +779,7 @@ export function createFormControl<
   };
 
   const getValues: UseFormGetValues<TFieldValues> = (
-    fieldNames?:
-      | FieldPath<TFieldValues>
-      | ReadonlyArray<FieldPath<TFieldValues>>,
+    fieldNames?: FieldPath<TFieldValues> | Array<FieldPath<TFieldValues>>,
   ) => {
     const values = {
       ..._defaultValues,
@@ -828,7 +826,7 @@ export function createFormControl<
   const watch: UseFormWatch<TFieldValues> = (
     name?:
       | FieldPath<TFieldValues>
-      | ReadonlyArray<FieldPath<TFieldValues>>
+      | Array<FieldPath<TFieldValues>>
       | WatchObserver<TFieldValues>,
     defaultValue?: unknown,
   ) =>

--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -25,7 +25,7 @@ export type FieldArray<
   TFieldValues extends FieldValues = FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = FieldArrayPathValue<TFieldValues, TFieldArrayName> extends
-  | ReadonlyArray<infer U>
+  | Array<infer U>
   | null
   | undefined
   ? U

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -171,9 +171,9 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
   <TFieldName extends FieldPath<TFieldValues>>(
     name: TFieldName,
   ): FieldPathValue<TFieldValues, TFieldName>;
-  <TFieldNames extends FieldPath<TFieldValues>[]>(
-    names: readonly [...TFieldNames],
-  ): [...FieldPathValues<TFieldValues, TFieldNames>];
+  <TFieldNames extends FieldPath<TFieldValues>[]>(names: [...TFieldNames]): [
+    ...FieldPathValues<TFieldValues, TFieldNames>
+  ];
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {
@@ -182,8 +182,8 @@ export type UseFormWatch<TFieldValues extends FieldValues> = {
     name: TFieldName,
     defaultValue?: FieldPathValue<TFieldValues, TFieldName>,
   ): FieldPathValue<TFieldValues, TFieldName>;
-  <TFieldNames extends readonly FieldPath<TFieldValues>[]>(
-    names: readonly [...TFieldNames],
+  <TFieldNames extends FieldPath<TFieldValues>[]>(
+    names: [...TFieldNames],
     defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>,
   ): FieldPathValues<TFieldValues, TFieldNames>;
   (
@@ -193,18 +193,12 @@ export type UseFormWatch<TFieldValues extends FieldValues> = {
 };
 
 export type UseFormTrigger<TFieldValues extends FieldValues> = (
-  name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[],
+  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
   options?: TriggerConfig,
 ) => Promise<boolean>;
 
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (
-  name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[],
+  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
 ) => void;
 
 export type UseFormSetValue<TFieldValues extends FieldValues> = <
@@ -224,10 +218,7 @@ export type UseFormSetError<TFieldValues extends FieldValues> = (
 ) => void;
 
 export type UseFormUnregister<TFieldValues extends FieldValues> = (
-  name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[],
+  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[],
   options?: Omit<
     KeepStateOptions,
     | 'keepIsSubmitted'
@@ -385,10 +376,7 @@ export type UseFormReturn<
 export type UseFormStateProps<TFieldValues> = Partial<{
   control?: Control<TFieldValues>;
   disabled?: boolean;
-  name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[];
+  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[];
 }>;
 
 export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
@@ -396,10 +384,7 @@ export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
 export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
   defaultValue?: unknown;
   disabled?: boolean;
-  name?:
-    | FieldPath<TFieldValues>
-    | FieldPath<TFieldValues>[]
-    | readonly FieldPath<TFieldValues>[];
+  name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[];
   control?: Control<TFieldValues>;
 };
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -68,7 +68,7 @@ export type DeepMap<T, TValue> = IsAny<T> extends true
   ? { [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue> }
   : TValue;
 
-/** Is object greater than 1 level deep? */
+/** Is object greater than 1 level deep (not counting NestedValues)? */
 export type IsFlatObject<T extends object> = Extract<
   Exclude<T[keyof T], NestedValue | Date | FileList>,
   Array<unknown> | object
@@ -92,7 +92,7 @@ type PathImpl<K extends string | number, V> = V extends Primitive
   ? `${K}`
   : `${K}` | `${K}.${Path<V>}`;
 
-/** Union of all possible object paths for given type, including Arrays (that's what ArrayKey is for)  */
+/** All dot-notation paths for a given type, including Array indexing */
 export type Path<T> = T extends Array<infer V>
   ? IsTuple<T> extends true
     ? {
@@ -103,10 +103,10 @@ export type Path<T> = T extends Array<infer V>
       [K in keyof T]-?: PathImpl<K & string, T[K]>;
     }[keyof T];
 
-/** Path based on RHF FieldValues  */
+/** Path<T> for RHF FieldValues  */
 export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
 
-/** Similar to PathImpl, but only allow string literal paths to array sub-elements */
+/** Same concept as PathImpl, but only allow string literal paths to array sub-elements */
 type ArrayPathImpl<K extends string | number, V> = V extends Primitive
   ? never
   : V extends Array<infer U>
@@ -115,7 +115,7 @@ type ArrayPathImpl<K extends string | number, V> = V extends Primitive
     : `${K}` | `${K}.${ArrayPath<V>}`
   : `${K}.${ArrayPath<V>}`;
 
-/** Union of all possible array paths for given type  */
+/** All paths for arrays and tuples  */
 export type ArrayPath<T> = T extends Array<infer V>
   ? IsTuple<T> extends true
     ? {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -50,7 +50,7 @@ export type DeepPartialSkipArrayKey<T> = T extends
   | File
   | NestedValue
   ? T
-  : T extends ReadonlyArray<any>
+  : T extends Array<any>
   ? { [K in keyof T]: DeepPartialSkipArrayKey<T[K]> }
   : { [K in keyof T]?: DeepPartialSkipArrayKey<T[K]> };
 
@@ -73,17 +73,15 @@ export type IsFlatObject<T extends object> = Extract<
   ? true
   : false;
 
-type IsTuple<T extends ReadonlyArray<any>> = number extends T['length']
-  ? false
-  : true;
-type TupleKey<T extends ReadonlyArray<any>> = Exclude<keyof T, keyof any[]>;
+type IsTuple<T extends Array<any>> = number extends T['length'] ? false : true;
+type TupleKey<T extends Array<any>> = Exclude<keyof T, keyof any[]>;
 type ArrayKey = number;
 
 type PathImpl<K extends string | number, V> = V extends Primitive
   ? `${K}`
   : `${K}` | `${K}.${Path<V>}`;
 
-export type Path<T> = T extends ReadonlyArray<infer V>
+export type Path<T> = T extends Array<infer V>
   ? IsTuple<T> extends true
     ? {
         [K in TupleKey<T>]-?: PathImpl<K & string, T[K]>;
@@ -97,13 +95,13 @@ export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
 
 type ArrayPathImpl<K extends string | number, V> = V extends Primitive
   ? never
-  : V extends ReadonlyArray<infer U>
+  : V extends Array<infer U>
   ? U extends Primitive
     ? never
     : `${K}` | `${K}.${ArrayPath<V>}`
   : `${K}.${ArrayPath<V>}`;
 
-export type ArrayPath<T> = T extends ReadonlyArray<infer V>
+export type ArrayPath<T> = T extends Array<infer V>
   ? IsTuple<T> extends true
     ? {
         [K in TupleKey<T>]-?: ArrayPathImpl<K & string, T[K]>;
@@ -123,14 +121,14 @@ export type PathValue<T, P extends Path<T> | ArrayPath<T>> = T extends any
         ? PathValue<T[K], R>
         : never
       : K extends `${ArrayKey}`
-      ? T extends ReadonlyArray<infer V>
+      ? T extends Array<infer V>
         ? PathValue<V, R & Path<V>>
         : never
       : never
     : P extends keyof T
     ? T[P]
     : P extends `${ArrayKey}`
-    ? T extends ReadonlyArray<infer V>
+    ? T extends Array<infer V>
       ? V
       : never
     : never
@@ -148,7 +146,7 @@ export type FieldArrayPathValue<
 
 export type FieldPathValues<
   TFieldValues extends FieldValues,
-  TPath extends FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[],
+  TPath extends FieldPath<TFieldValues>[],
 > = {} & {
   [K in keyof TPath]: FieldPathValue<
     TFieldValues,
@@ -172,7 +170,7 @@ type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 export type UnionLike<T> = [T] extends [Date | FileList | File | NestedValue]
   ? T
-  : [T] extends [ReadonlyArray<any>]
+  : [T] extends [Array<any>]
   ? { [K in keyof T]: UnionLike<T[K]> }
   : [T] extends [object]
   ? PartialBy<

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -12,7 +12,6 @@ import {
   FieldPathValue,
   FieldPathValues,
   FieldValues,
-  InternalFieldName,
   UnpackNestedValue,
   UseWatchProps,
 } from './types';
@@ -40,7 +39,7 @@ export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
   TFieldNames extends FieldPath<TFieldValues>[] = FieldPath<TFieldValues>[],
 >(props: {
-  name: readonly [...TFieldNames];
+  name: [...TFieldNames];
   defaultValue?: UnpackNestedValue<DeepPartialSkipArrayKey<TFieldValues>>;
   control?: Control<TFieldValues>;
   disabled?: boolean;
@@ -61,14 +60,9 @@ export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
     disabled,
     subject: control._subjects.watch,
     callback: (formState) => {
-      if (
-        shouldSubscribeByName(
-          _name.current as InternalFieldName,
-          formState.name,
-        )
-      ) {
+      if (shouldSubscribeByName(_name.current, formState.name)) {
         const fieldValues = generateWatchOutput(
-          _name.current as InternalFieldName | InternalFieldName[],
+          _name.current,
           control._names,
           control._formValues,
         );
@@ -77,7 +71,7 @@ export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
           isObject(fieldValues) &&
             !(
               isString(_name.current) &&
-              get(control._fields, _name.current as InternalFieldName, {})._f
+              get(control._fields, _name.current, {})._f
             )
             ? { ...fieldValues }
             : Array.isArray(fieldValues)
@@ -89,9 +83,7 @@ export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
   });
 
   const [value, updateValue] = React.useState<unknown>(
-    isUndefined(defaultValue)
-      ? control._getWatch(name as InternalFieldName)
-      : defaultValue,
+    isUndefined(defaultValue) ? control._getWatch(name) : defaultValue,
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
This PR removes all ReadonlyArray usage (moved to Array) and removes the readonly keyword.

- Start initial steps through removing the 'as' keyword, which was getting caught on the readonl\y nature of the types
- While readonly definitely has a good meaning in TS, I feel we need to have clear meaning and better names to all our types we're applying before using it.
- I want to start being more rigorous about avoiding the 'as' keyword except when absolutely required.  I generally find that it can be somewhat helpful when dealing with a 3rd party library (particularly one with poor types), but when dealing with something that's our own codebase, it's can be an overused hack and should have a comment (next to the code) explaining why we needed it (or else we'll forget)

If we have use cases that NEED a readonly type, let's discuss it, but we have no tests that require it.