### PR TITLE
Adds types for no supplied props argument

### DIFF
--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -42,6 +42,10 @@ export function useWatch<
   control?: Control<TFieldValues>;
   disabled?: boolean;
 }): FieldPathValues<TFieldValues, TFieldNames>;
+export function useWatch<
+  TFieldValues extends FieldValues = FieldValues,
+  TFieldNames extends FieldPath<TFieldValues>[] = FieldPath<TFieldValues>[],
+>(): FieldPathValues<TFieldValues, TFieldNames>;
 export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
   const methods = useFormContext();
   const {


### PR DESCRIPTION
## Issue 
The `useWatch` hook's documentation has an object with all optional parameters on the `props`, and the code sets a default value for the same, but the type checking does not allow it to be used without a `props` argument even though the function implementation marks the parameter as optional.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/15187179/141119408-2abebd78-d501-48de-9b06-63ebd27554d5.png">

## Solution

This MR adds a function overload signature without the `props` parameter to avoid this error.