### PR TITLE
improve dx on control object when hooks are optional inside compoennt

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,3 +22,31 @@ export const INPUT_VALIDATION_RULES = {
   required: 'required',
   validate: 'validate',
 };
+
+const noop = () => {};
+
+const subscribeNoop = {
+  next: noop,
+  subscribe: noop,
+};
+
+export const CONTROL_DEFAULT = {
+  register: noop,
+  _getWatch: noop,
+  _removeUnmounted: noop,
+  _updateFieldArray: noop,
+  _getFieldArray: noop,
+  _subjects: {
+    watch: subscribeNoop,
+    state: subscribeNoop,
+    array: subscribeNoop,
+  },
+  _proxyFormState: {},
+  _formValues: {},
+  _stateFlags: {},
+  _names: {
+    watch: new Set(),
+    array: new Set(),
+  },
+  _options: {},
+};

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -16,7 +16,9 @@ import removeArrayAt from './utils/remove';
 import set from './utils/set';
 import swapArrayAt from './utils/swap';
 import updateAt from './utils/update';
+import { CONTROL_DEFAULT } from './constants';
 import {
+  Control,
   FieldArray,
   FieldArrayMethodProps,
   FieldArrayPath,
@@ -39,7 +41,9 @@ export const useFieldArray = <
 ): UseFieldArrayReturn<TFieldValues, TFieldArrayName, TKeyName> => {
   const methods = useFormContext();
   const {
-    control = methods.control,
+    control = methods
+      ? methods.control
+      : (CONTROL_DEFAULT as unknown as Control<TFieldValues>),
     name,
     keyName = 'id' as TKeyName,
     shouldUnregister,

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -3,7 +3,9 @@ import * as React from 'react';
 import getProxyFormState from './logic/getProxyFormState';
 import shouldRenderFormState from './logic/shouldRenderFormState';
 import shouldSubscribeByName from './logic/shouldSubscribeByName';
+import { CONTROL_DEFAULT } from './constants';
 import {
+  Control,
   FieldValues,
   InternalFieldName,
   UseFormStateProps,
@@ -16,7 +18,13 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
   props?: UseFormStateProps<TFieldValues>,
 ): UseFormStateReturn<TFieldValues> {
   const methods = useFormContext<TFieldValues>();
-  const { control = methods.control, disabled, name } = props || {};
+  const {
+    control = methods
+      ? methods.control
+      : (CONTROL_DEFAULT as unknown as Control<TFieldValues>),
+    disabled,
+    name,
+  } = props || {};
   const [formState, updateFormState] = React.useState(control._formState);
   const _localProxyFormState = React.useRef({
     isDirty: false,

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { generateWatchOutput } from './logic/generateWatchOutput';
 import shouldSubscribeByName from './logic/shouldSubscribeByName';
 import isUndefined from './utils/isUndefined';
+import { CONTROL_DEFAULT } from './constants';
 import {
   Control,
   DeepPartialSkipArrayKey,
@@ -49,7 +50,9 @@ export function useWatch<
 export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
   const methods = useFormContext();
   const {
-    control = methods.control,
+    control = methods
+      ? methods.control
+      : (CONTROL_DEFAULT as unknown as Control),
     name,
     defaultValue,
     disabled,


### PR DESCRIPTION
ref: https://codesandbox.io/s/xenodochial-clarke-kxk1z?file=/src/App.js

related: #4033

## rational

right now control object is a hard lock when used with a component, this could be a problem when using a component in which hooks are optional, this will prevent this sort of error and allow developers to integrate with hooks easier.

- [ ] RFC