### PR TITLE
fix(Controller): update fieldValues with copy object when Controller …

### DIFF
--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,5 +1,6 @@
 import { FieldValues } from '../types';
 
+import cloneObject from './cloneObject';
 import isKey from './isKey';
 import isObject from './isObject';
 import stringToPath from './stringToPath';
@@ -10,6 +11,7 @@ export default function set(
   value?: unknown,
 ) {
   let index = -1;
+  const tempObject = cloneObject(object);
   const tempPath = isKey(path) ? [path] : stringToPath(path);
   const length = tempPath.length;
   const lastIndex = length - 1;
@@ -27,8 +29,8 @@ export default function set(
           ? []
           : {};
     }
-    object[key] = newValue;
-    object = object[key];
+    tempObject[key] = newValue;
+    object = tempObject[key];
   }
   return object;
 }


### PR DESCRIPTION
The problem is in src/utils/set.ts，when the form data is stored in the immer store，the object: FieldValues is not expandable，

```ts
object[key] = newValue;
```
is wrong, the original object should not be manipulated directly. I'll submit a PR later. Please check and merge it after passing.😄

fix(Controller): update fieldValues with copy object when Controller component rerender，Related [[Bug]: Cannot assign to read only property '0' of object '[object Array]'](https://github.com/react-hook-form/react-hook-form/issues/6121#issuecomment-979698278)