### PR TITLE
Revert "🔢 fix #7149 Supporting Number Object comparison in deepEqual …

### DIFF
--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -95,10 +95,4 @@ describe('deepEqual', () => {
       deepEqual({ test: new Date('1990') }, { test: new Date('1990') }),
     ).toBeTruthy();
   });
-
-  it('should compare Number object', () => {
-    expect(deepEqual(new Number(10), new Number(10))).toBeTruthy();
-    expect(deepEqual(new Number(10), new Number(20))).toBeFalsy();
-    expect(deepEqual(new Number(10), null)).toBeFalsy();
-  });
 });

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -8,10 +8,6 @@ export default function deepEqual(object1: any, object2: any) {
     return object1 === object2;
   }
 
-  if (!isNaN(object1) || !isNaN(object2)) {
-    return +object1 === +object2;
-  }
-
   if (isDateObject(object1) && isDateObject(object2)) {
     return object1.getTime() === object2.getTime();
   }


### PR DESCRIPTION
…(#7150)"

This reverts commit 1d5059a878c6c870068bcdc3d0258987d80c98c2.