### PR TITLE
build(esm): Use explicit .mjs extension for ESM, with CJS interop

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "description": "Performant, flexible and extensible forms library for React Hooks",
   "version": "7.21.2",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.esm.mjs",
   "umd:main": "dist/index.umd.js",
   "unpkg": "dist/index.umd.js",
   "jsdelivr": "dist/index.umd.js",
-  "jsnext:main": "dist/index.esm.js",
+  "jsnext:main": "dist/index.esm.mjs",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": true,
@@ -18,7 +18,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js"
     }
   },
@@ -26,7 +26,7 @@
     "clean": "rimraf dist",
     "prebuild": "yarn clean",
     "build": "yarn build:modern",
-    "postbuild": "rimraf dist/__tests__",
+    "postbuild": "rimraf dist/__tests__; node ./scripts/rollup/assert-esm-exports.mjs && node ./scripts/rollup/assert-cjs-exports.cjs",
     "build:modern": "rollup -c ./scripts/rollup/rollup.config.js",
     "build:esm": "rollup -c ./scripts/rollup/rollup.esm.config.js",
     "prettier:fix": "prettier --config .prettierrc --write \"**/*.{ts,tsx}\"",
@@ -135,6 +135,6 @@
     "url": "https://opencollective.com/react-hook-form"
   },
   "engines": {
-    "node": ">=12.0"
+    "node": ">=12.22.0"
   }
 }

--- a/scripts/rollup/all-exports.json
+++ b/scripts/rollup/all-exports.json
@@ -1,0 +1,13 @@
+[
+  "Controller",
+  "FormProvider",
+  "appendErrors",
+  "get",
+  "set",
+  "useController",
+  "useFieldArray",
+  "useForm",
+  "useFormContext",
+  "useFormState",
+  "useWatch"
+]

--- a/scripts/rollup/assert-cjs-exports.cjs
+++ b/scripts/rollup/assert-cjs-exports.cjs
@@ -1,0 +1,22 @@
+/**
+ * This file, when executed in the postbuild lifecycle, ensures that
+ * the CJS output is valid CJS according to the package.json spec.
+ *
+ * @see https://nodejs.org/docs/latest/api/packages.html#packages_determining_module_system
+ */
+/* eslint-disable @typescript-eslint/no-var-requires */
+const exported = require('react-hook-form');
+const assert = require('assert');
+const fs = require('fs');
+
+/**
+ * When this fails, fine the update one-liner in ./assert-esm-exports.mjs
+ */
+const expected = JSON.parse(
+  fs.readFileSync(
+    require('path').resolve(__dirname, './all-exports.json'),
+    'utf-8',
+  ),
+);
+
+assert.deepStrictEqual(Object.keys(exported), expected);

--- a/scripts/rollup/assert-esm-exports.mjs
+++ b/scripts/rollup/assert-esm-exports.mjs
@@ -1,0 +1,22 @@
+/**
+ * This file, when executed in the postbuild lifecycle, ensures that
+ * the ESM output is valid ESM according to the package.json spec.
+ *
+ * @see https://nodejs.org/docs/latest/api/packages.html#packages_determining_module_system
+ */
+import * as exported from 'react-hook-form';
+import assert from 'assert';
+import fs from 'fs';
+
+/**
+ * A shell one-liner to update this array when neccessary (run from root of repo):
+ *  node -e "import('react-hook-form').then((mod) => console.log(JSON.stringify(Object.keys(mod), null, 2)))" > scripts/rollup/all-exports.json
+ */
+const expected = JSON.parse(
+  fs.readFileSync(
+    new URL('./all-exports.json', import.meta.url).pathname,
+    'utf-8',
+  ),
+);
+
+assert.deepStrictEqual(Object.keys(exported), expected);

--- a/scripts/rollup/createRollupConfig.js
+++ b/scripts/rollup/createRollupConfig.js
@@ -6,7 +6,10 @@ import typescript from 'rollup-plugin-typescript2';
 
 export function createRollupConfig(options, callback) {
   const name = options.name;
-  const outputName = 'dist/' + [name, options.format, 'js'].join('.');
+  // A file with the extension ".mjs" will always be treated as ESM, even when pkg.type is "commonjs" (the default)
+  // https://nodejs.org/docs/latest/api/packages.html#packages_determining_module_system
+  const extName = options.format === 'esm' ? 'mjs' : 'js';
+  const outputName = 'dist/' + [name, options.format, extName].join('.');
 
   const config = {
     input: options.input,

--- a/src/__tests__/controller.server.test.tsx
+++ b/src/__tests__/controller.server.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { renderToString } from 'react-dom/server';
 
 import { Controller } from '../controller';

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act,
   fireEvent,

--- a/src/__tests__/logic/focusFieldBy.test.ts
+++ b/src/__tests__/logic/focusFieldBy.test.ts
@@ -1,10 +1,6 @@
 import focusFieldBy from '../../logic/focusFieldBy';
 import get from '../../utils/get';
 
-jest.mock('../../utils/isHTMLElement', () => ({
-  default: () => true,
-}));
-
 describe('focusFieldBy', () => {
   it('should focus on the first error it encounter', () => {
     const focus = jest.fn();

--- a/src/__tests__/logic/getFieldValue.test.ts
+++ b/src/__tests__/logic/getFieldValue.test.ts
@@ -2,12 +2,14 @@ import getFieldValue from '../../logic/getFieldValue';
 import { Field } from '../../types';
 
 jest.mock('../../logic/getRadioValue', () => ({
+  __esModule: true,
   default: () => ({
     value: 2,
   }),
 }));
 
 jest.mock('../../logic/getCheckboxValue', () => ({
+  __esModule: true,
   default: () => ({
     value: 'testValue',
   }),

--- a/src/__tests__/type.test.tsx
+++ b/src/__tests__/type.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Controller } from '../controller';
 import {

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act,
   fireEvent,

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useFieldArray/append.test.tsx
+++ b/src/__tests__/useFieldArray/append.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { act, renderHook } from '@testing-library/react-hooks';
 

--- a/src/__tests__/useFieldArray/focus.test.tsx
+++ b/src/__tests__/useFieldArray/focus.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { useFieldArray } from '../../useFieldArray';

--- a/src/__tests__/useFieldArray/insert.test.tsx
+++ b/src/__tests__/useFieldArray/insert.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useFieldArray/move.test.tsx
+++ b/src/__tests__/useFieldArray/move.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useFieldArray/prepend.test.tsx
+++ b/src/__tests__/useFieldArray/prepend.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useFieldArray/replace.test.tsx
+++ b/src/__tests__/useFieldArray/replace.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from '@testing-library/react-hooks';
 

--- a/src/__tests__/useFieldArray/swap.test.tsx
+++ b/src/__tests__/useFieldArray/swap.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useFieldArray/update.test.tsx
+++ b/src/__tests__/useFieldArray/update.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm.server.test.tsx
+++ b/src/__tests__/useForm.server.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { renderToString } from 'react-dom/server';
 
 import { useForm } from '../useForm';

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm/clearErrors.test.tsx
+++ b/src/__tests__/useForm/clearErrors.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm/getValues.test.tsx
+++ b/src/__tests__/useForm/getValues.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 

--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm/resetField.test.tsx
+++ b/src/__tests__/useForm/resetField.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { useForm } from '../../useForm';

--- a/src/__tests__/useForm/resolver.test.tsx
+++ b/src/__tests__/useForm/resolver.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act,
   fireEvent,

--- a/src/__tests__/useForm/setError.test.tsx
+++ b/src/__tests__/useForm/setError.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { act, renderHook } from '@testing-library/react-hooks';
 

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useForm/watch.test.tsx
+++ b/src/__tests__/useForm/watch.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act as actComponent,
   fireEvent,

--- a/src/__tests__/useFormContext.test.tsx
+++ b/src/__tests__/useFormContext.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import { act, renderHook } from '@testing-library/react-hooks';
 

--- a/src/__tests__/useFormState.test.tsx
+++ b/src/__tests__/useFormState.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act,
   act as actComponent,

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   act,
   fireEvent,

--- a/src/__tests__/utils/isMessage.test.ts
+++ b/src/__tests__/utils/isMessage.test.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import isMessage from '../../utils/isMessage';
 

--- a/src/controller.native.test.tsx
+++ b/src/controller.native.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Button, Text, TextInput, View } from 'react-native';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 

--- a/src/logic/mapCurrentIds.ts
+++ b/src/logic/mapCurrentIds.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { FieldValues } from '../types';
 

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { RegisterOptions } from './validator';
 import {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Subject, Subscription } from '../utils/createSubject';
 

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import getEventValue from './logic/getEventValue';
 import isNameInFieldArray from './logic/isNameInFieldArray';

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import focusFieldBy from './logic/focusFieldBy';
 import getFocusFieldName from './logic/getFocusFieldName';

--- a/src/useForm.native.test.tsx
+++ b/src/useForm.native.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Button, Text, TextInput, View } from 'react-native';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { createFormControl } from './logic/createFormControl';
 import getProxyFormState from './logic/getProxyFormState';

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import omit from './utils/omit';
 import { FieldValues, FormProviderProps, UseFormReturn } from './types';

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import getProxyFormState from './logic/getProxyFormState';
 import shouldRenderFormState from './logic/shouldRenderFormState';

--- a/src/useSubscribe.ts
+++ b/src/useSubscribe.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Subject, Subscription } from './utils/createSubject';
 

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import generateWatchOutput from './logic/generateWatchOutput';
 import shouldSubscribeByName from './logic/shouldSubscribeByName';

--- a/src/utils/isMessage.ts
+++ b/src/utils/isMessage.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Message } from '../types';
 import isString from '../utils/isString';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "declaration": true,
     "noEmit": true,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Building off of #7244, hopefully addressing CRA issues (#7251) and https://github.com/react-hook-form/resolvers/issues/301.

I believe the root cause for the CRA issue is that RHF uses the namespace import form (`import * as React from 'react'`) when it should be using a default import (`import React from 'react'`). React itself is not ESM, it's just a default export that Babel et al make-believe is a series of named exports, thus the error message folks are encountering in non-ESM tooling.

I was surprised RHF isn't using `esModuleInterop: true` in its tsconfig, and that has been addressed here. The test mock changes (one unused, one needing `__esModule: true` flags) were triggered by this tsconfig change.

Refs #7095
Refs #7088
Refs https://github.com/react-hook-form/resolvers/issues/271
Refs https://github.com/vercel/next.js/issues/30750