### PR TITLE
add CustomEvent check on getEventValue function

### DIFF
--- a/src/__tests__/logic/getEventValue.test.ts
+++ b/src/__tests__/logic/getEventValue.test.ts
@@ -11,11 +11,14 @@ test('getEventValue should return correct value', () => {
       target: { checked: true, type: 'checkbox', value: 'test' },
     }),
   ).toEqual(true);
-  expect(getEventValue({ target: { value: 'test' }, type: 'test' })).toEqual(
-    'test',
-  );
   expect(getEventValue({ data: 'test' })).toEqual({ data: 'test' });
   expect(getEventValue('test')).toEqual('test');
   expect(getEventValue(undefined)).toEqual(undefined);
   expect(getEventValue(null)).toEqual(null);
+});
+
+test('getEventValue should return correct value if CustomEvent is received', () => {
+  const customEvent = new CustomEvent('event', { detail: { value: 'test' } });
+
+  expect(getEventValue(customEvent)).toEqual('test');
 });

--- a/src/__tests__/utils/isCustomEvent.test.ts
+++ b/src/__tests__/utils/isCustomEvent.test.ts
@@ -1,0 +1,19 @@
+import isCustomEvent from '../../utils/isCustomEvent';
+
+describe('isCustomEvent', () => {
+  it('should return true when object instance is CustomEvent', () => {
+    const mockCustomEvent = new CustomEvent('event');
+
+    expect(isCustomEvent(mockCustomEvent)).toBe(true);
+  });
+
+  it('should return false when object instance is not CustomEvent', () => {
+    const mockEvent = new Event('event');
+
+    expect(isCustomEvent(mockEvent)).toBe(false);
+  });
+
+  it('should return false when parameter received is not CustomEvent', () => {
+    expect(isCustomEvent('something else')).toBe(false);
+  });
+});

--- a/src/logic/getEventValue.ts
+++ b/src/logic/getEventValue.ts
@@ -1,11 +1,21 @@
 import isCheckBoxInput from '../utils/isCheckBoxInput';
+import isCustomEvent from '../utils/isCustomEvent';
 import isObject from '../utils/isObject';
 
 type Event = { target: any };
 
-export default (event: unknown) =>
-  isObject(event) && (event as Event).target
-    ? isCheckBoxInput((event as Event).target)
-      ? (event as Event).target.checked
-      : (event as Event).target.value
-    : event;
+export default (event: unknown) => {
+  if (isObject(event)) {
+    if ((event as Event).target) {
+      return isCheckBoxInput((event as Event).target)
+        ? (event as Event).target.checked
+        : (event as Event).target.value;
+    }
+
+    if ((event as CustomEvent).detail && isCustomEvent(event)) {
+      return (event as CustomEvent).detail.value;
+    }
+  }
+
+  return event;
+};

--- a/src/utils/isCustomEvent.ts
+++ b/src/utils/isCustomEvent.ts
@@ -1,0 +1,1 @@
+export default (event: unknown) => event instanceof CustomEvent;


### PR DESCRIPTION
## Description
We use some inputs built with Web Component and they are all in Shadow DOM.
These inputs use some CustomEvents to propagate the input events outside the Shadow DOM, it's exactly the same way as Ionic Framework does.

When using these kind of input is necessary to wrap it with the Controller component, otherwise it won't be possible to catch the Custom Events, so we did this way: 

```
      <Controller
        control={control}
        name="password"
        render={({ field: { onChange, onBlur, value } }) => (
          <Input
            id="password"
            data-testid="password"
            onBdsChange={onChange}
            onBdsOnBlur={onBlur}
            value={value}
            required
          ></Input>
        )}
      />
```
When testing it won't work. To simulate the typing on a shadow dom input, we need to emit the custom event related to the typing, in my case, the event is the onBdsChange, e.g: 

``` 
export const bdsChangeEvent = (value: string) => {
  return new CustomEvent('bdsChange', { detail: { value } });
};
```
usage with react-testing-library:
```
    const input = (await screen.findByTestId('counter-input')) as HTMLBdsInputElement;
    fireEvent(input, bdsChangeEvent('1500'));
```
It works only when the input isn't wrapped on the Controller component.
This solution is also used by Ionic to test their inputs, as we can see on [this repository](https://github.com/ionic-team/ionic-react-test-utils)

The problem is: in CustomEvents we tend to use the [detail property](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) to pass custom properties and the value from the input itself. This way, react hook form wasn't recognizing the event.detail.value property and wasn't possible to test the inputs and the form.

A quick fix to this would be on every input add this: 
```
      <Controller
        control={control}
        name="password"
        render={({ field: { onChange, onBlur, value } }) => (
          <Input
            id="password"
            data-testid="password"
            **onBdsChange={(ev) => { onChange(ev.detail.value) }}**
            onBdsOnBlur={onBlur}
            value={value}
            required
          ></Input>
        )}
      />
```
But it would be very verbose and this situation can be fixed with a few lines on the library. That's what I did.

I've added a check on the getEventValue file, that verifies if the event received is CustomEvent, and if it is, it will return the event.detail.value property, which in most of cases will be the value of custom inputs.
