### PR TITLE
avoid `errors` state update with `replace` and `update` API

### DIFF
--- a/src/__tests__/useFieldArray/update.test.tsx
+++ b/src/__tests__/useFieldArray/update.test.tsx
@@ -462,4 +462,67 @@ describe('update', () => {
       expect(resolver).toBeCalled();
     });
   });
+
+  it('should not update errors state', async () => {
+    const App = () => {
+      const {
+        control,
+        register,
+        trigger,
+        formState: { errors },
+      } = useForm({
+        defaultValues: {
+          test: [
+            {
+              firstName: '',
+            },
+          ],
+        },
+      });
+      const { fields, update } = useFieldArray({
+        name: 'test',
+        control,
+      });
+
+      React.useEffect(() => {
+        trigger();
+      }, [trigger]);
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <input
+              key={field.id}
+              {...register(`test.${i}.firstName` as const, {
+                required: 'This is required',
+              })}
+            />
+          ))}
+          <p>{errors.test?.[0].firstName?.message}</p>
+          <button
+            type={'button'}
+            onClick={() =>
+              update(0, {
+                firstName: 'firstName',
+              })
+            }
+          >
+            update
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    await waitFor(async () => {
+      screen.getByText('This is required');
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(async () => {
+      screen.getByText('This is required');
+    });
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -181,6 +181,7 @@ export function createFormControl<
     values = [],
     shouldSetValues = true,
     shouldSetFields = true,
+    shouldSetError = true,
   ) => {
     _stateFlags.action = true;
 
@@ -189,7 +190,7 @@ export function createFormControl<
       shouldSetValues && set(_fields, name, fieldValues);
     }
 
-    if (Array.isArray(get(_formState.errors, name))) {
+    if (shouldSetError && Array.isArray(get(_formState.errors, name))) {
       const errors = method(get(_formState.errors, name), args.argA, args.argB);
       shouldSetValues && set(_formState.errors, name, errors);
       unsetEmptyArray(_formState.errors, name);

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -325,6 +325,7 @@ export type BatchFieldArrayUpdate = <
   >[],
   shouldSetValue?: boolean,
   shouldSetFields?: boolean,
+  shouldSetError?: boolean,
 ) => void;
 
 export type Control<

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -260,6 +260,7 @@ export const useFieldArray = <
       fieldArrayValues,
       true,
       false,
+      false,
     );
   };
 
@@ -282,6 +283,7 @@ export const useFieldArray = <
       {},
       fieldArrayValues,
       true,
+      false,
       false,
     );
   };


### PR DESCRIPTION
ref: https://codesandbox.io/s/react-hook-form-usefieldarray-forked-zovjl?file=/src/index.js

- [x] unit tests