### PR TITLE
Refactor Path, ArrayPath, and PathValue

### DIFF
--- a/src/__tests__/types/__fixtures__/traversable.ts
+++ b/src/__tests__/types/__fixtures__/traversable.ts
@@ -13,7 +13,4 @@ export type NullableInfiniteType<T> = NullableBase<InfiniteType<T>, T>;
 
 export type Depth3Type<T> = Base<Base<Base<never, T>, T>, T>;
 
-export type NullableDepth3Type<T> = NullableBase<
-  NullableBase<NullableBase<never, T>, T>,
-  T
->;
+export type NullableDepth2Type<T> = NullableBase<NullableBase<never, T>, T>;

--- a/src/__tests__/types/__fixtures__/traversable.ts
+++ b/src/__tests__/types/__fixtures__/traversable.ts
@@ -5,15 +5,15 @@ interface Base<T, V> {
   value: V;
 }
 
+type NullableBase<T, V> = null | undefined | Partial<Base<T, V>>;
+
 export type InfiniteType<T> = Base<InfiniteType<T>, T>;
 
-export type NullableInfiniteType<T> =
-  | null
-  | undefined
-  | Partial<Base<NullableInfiniteType<T>, T>>;
+export type NullableInfiniteType<T> = NullableBase<InfiniteType<T>, T>;
 
 export type Depth3Type<T> = Base<Base<Base<never, T>, T>, T>;
 
-export interface Nested<T> {
-  nested: T;
-}
+export type NullableDepth3Type<T> = NullableBase<
+  NullableBase<NullableBase<never, T>, T>,
+  T
+>;

--- a/src/__tests__/types/__fixtures__/traversable.ts
+++ b/src/__tests__/types/__fixtures__/traversable.ts
@@ -13,4 +13,4 @@ export type NullableInfiniteType<T> = NullableBase<InfiniteType<T>, T>;
 
 export type Depth3Type<T> = Base<Base<Base<never, T>, T>, T>;
 
-export type NullableDepth2Type<T> = NullableBase<NullableBase<never, T>, T>;
+export type NullableDepth1Type<T> = NullableBase<never, T>;

--- a/src/__tests__/types/path/common.test-d.ts
+++ b/src/__tests__/types/path/common.test-d.ts
@@ -28,7 +28,6 @@ import {
   HundredPathString,
   HundredTuple,
   InfiniteType,
-  Nested,
   NullableInfiniteType,
 } from '../__fixtures__';
 
@@ -775,7 +774,7 @@ import {
 
   /** it should add undefined if the path doesn't exist in one of the types */ {
     const actual = _ as EvaluatePath<
-      InfiniteType<number> | Nested<string>,
+      InfiniteType<number> | { other: string },
       ['foo', 'value']
     >;
     expectType<number | undefined>(actual);

--- a/src/__tests__/types/path/common.test-d.ts
+++ b/src/__tests__/types/path/common.test-d.ts
@@ -546,6 +546,11 @@ import {
     expectType<any>(actual);
   }
 
+  /** it should evaluate to never if the type is never */ {
+    const actual = _ as EvaluateKey<never, string>;
+    expectType<never>(actual);
+  }
+
   /** it should access methods on primitives */ {
     const actual = _ as EvaluateKey<string, 'toString'>;
     expectType<() => string>(actual);

--- a/src/__tests__/types/path/eager.test-d.ts
+++ b/src/__tests__/types/path/eager.test-d.ts
@@ -1,6 +1,7 @@
 import { expectType } from 'tsd';
 
 import { ArrayPath, FieldPathValues, Path, PathValue } from '../../../types';
+import { Key } from '../../../types/path/common';
 import { _, Depth3Type } from '../__fixtures__';
 
 /** {@link Path} */ {
@@ -22,6 +23,175 @@ import { _, Depth3Type } from '../__fixtures__';
   /** it should include paths through arrays */ {
     const actual = _ as Path<{ foo: string[] }>;
     expectType<'foo' | `foo.${number}`>(actual);
+  }
+
+  /** it should return the numeric keys of an object */ {
+    const actual = _ as Path<{ 0: string; '1': string; foo: string }>;
+    expectType<'0' | '1'>(actual);
+  }
+
+  /** it should return the numeric keys of an array */ {
+    const actual = _ as Path<number[]>;
+    expectType<`${number}`>(actual);
+  }
+
+  /** it should return the numeric keys of a tuple */ {
+    const actual = _ as Path<[string, number]>;
+    expectType<'0' | '1'>(actual);
+  }
+
+  /** it should return the overlapping numeric keys of a tuple and array */ {
+    const actual = _ as Path<[number, string] | number[]>;
+    expectType<'0' | '1'>(actual);
+  }
+
+  /** it should return the overlapping numeric keys of an object and array */ {
+    const actual = _ as Path<{ 0: string; '1': string } | number[]>;
+    expectType<'0' | '1'>(actual);
+  }
+
+  /** it should return the overlapping numeric keys of an object and tuple */ {
+    const actual = _ as Path<{ 1: string } | [number, string]>;
+    expectType<'1'>(actual);
+  }
+
+  /** it should return the keys of an object */ {
+    const actual = _ as Path<{ foo: string; bar: number }>;
+    expectType<'foo' | 'bar'>(actual);
+  }
+
+  /** it should return the overlapping keys of a union of objects */ {
+    const actual = _ as Path<
+      { foo: string; bar: number } | { bar: number; baz: string }
+    >;
+    expectType<'bar'>(actual);
+  }
+
+  /** it should not return keys which contain dots */ {
+    const actual = _ as Path<{ foo: string; 'foo.bar': number }>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not return blank keys */ {
+    const actual = _ as Path<{ foo: string; '': number }>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should return the keys of an object */ {
+    const actual = _ as Path<{ foo: string; bar: number }>;
+    expectType<'foo' | 'bar'>(actual);
+  }
+
+  /** it should return the keys of a tuple */ {
+    const actual = _ as Path<[number, string]>;
+    expectType<'0' | '1'>(actual);
+  }
+
+  /** it should return the keys of an array */ {
+    const actual = _ as Path<string[]>;
+    expectType<`${number}`>(actual);
+  }
+
+  /** it should return the optional keys of an object */ {
+    const actual = _ as Path<{ foo?: string; bar?: number }>;
+    expectType<'foo' | 'bar'>(actual);
+  }
+
+  /** it should return the keys of a nullable type */ {
+    const actual = _ as Path<{ foo: string; bar: number } | null>;
+    expectType<'foo' | 'bar'>(actual);
+  }
+
+  /** it should return the keys of an undefinable type */ {
+    const actual = _ as Path<{ foo: string; bar: number } | undefined>;
+    expectType<'foo' | 'bar'>(actual);
+  }
+
+  /** it should return the optional keys of a tuple */ {
+    const actual = _ as Path<[foo?: string, bar?: number]>;
+    expectType<'0' | '1'>(actual);
+  }
+
+  /** it should return the optional keys of a union of tuple and object */ {
+    const actual = _ as Path<[foo?: string] | { 0?: string; 1?: string }>;
+    expectType<'0'>(actual);
+  }
+
+  /** it should only return the keys of string properties */ {
+    const actual = _ as Path<{ foo: string; bar: number }, string>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should only return the keys of string properties */ {
+    const actual = _ as Path<{ 1: string; 2: number }, string>;
+    expectType<'1'>(actual);
+  }
+
+  /** it should return only the required keys when undefined is excluded */ {
+    const actual = _ as Path<{ foo: string; bar?: string }, string>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should return the optional keys when undefined is included */ {
+    const actual = _ as Path<{ foo: string; bar?: string }, string | undefined>;
+    expectType<'foo' | 'bar'>(actual);
+  }
+
+  /** it should return the overlapping keys of a union of objects */ {
+    const actual = _ as Path<
+      { foo: string; bar: number } | { bar: number; baz: string }
+    >;
+    expectType<'bar'>(actual);
+  }
+
+  /** it should return the keys of the tuple when given a tuple and an array */ {
+    const actual = _ as Path<number[] | [number]>;
+    expectType<'0'>(actual);
+  }
+
+  /** it should return the overlapping keys when given a tuple and an object */ {
+    const actual = _ as Path<{ 0: string; 1: number } | [number]>;
+    expectType<'0'>(actual);
+  }
+
+  /** it should return the overlapping keys when given a tuple and an object */ {
+    const actual = _ as Path<{ foo: string } | [number]>;
+    expectType<never>(actual);
+  }
+
+  /** it should return the numeric keys when given an array and an object */ {
+    const actual = _ as Path<{ 0: string; foo: number } | number[]>;
+    expectType<'0'>(actual);
+  }
+
+  /** it should return {@link Key} when given any */ {
+    const actual = _ as Path<any>;
+    expectType<Key>(actual);
+  }
+
+  /** it should return {@link Key} when given never */ {
+    const actual = _ as Path<never>;
+    expectType<Key>(actual);
+  }
+
+  /** it should return never when given unknown */ {
+    const actual = _ as Path<unknown>;
+    expectType<never>(actual);
+  }
+
+  /** it should return never when given a string */ {
+    const actual = _ as Path<string>;
+    expectType<never>(actual);
+  }
+
+  /** it should return never when given undefined */ {
+    const actual = _ as Path<undefined>;
+    expectType<never>(actual);
+  }
+
+  /** it should return never when given null */ {
+    const actual = _ as Path<null>;
+    expectType<never>(actual);
   }
 }
 

--- a/src/__tests__/types/path/eager.test-d.ts
+++ b/src/__tests__/types/path/eager.test-d.ts
@@ -35,6 +35,20 @@ import { _, Depth3Type } from '../__fixtures__';
     expectType<'foo' | `foo.${number}` | `foo.${number}.bar`>(actual);
   }
 
+  /** it should not include non-overlapping paths */ {
+    const actual = _ as Path<
+      { foo: { baz: string } } | { bar: { baz: string } }
+    >;
+    expectType<never>(actual);
+  }
+
+  /** it should include overlapping paths */ {
+    const actual = _ as Path<
+      { foo: { bar: string } } | { foo: { baz: string } }
+    >;
+    expectType<'foo'>(actual);
+  }
+
   /** it should not include keys containing dots */ {
     const actual = _ as Path<{ foo: { 'foo.bar': string } }>;
     expectType<'foo'>(actual);

--- a/src/__tests__/types/path/eager.test-d.ts
+++ b/src/__tests__/types/path/eager.test-d.ts
@@ -25,11 +25,6 @@ import { _, Depth3Type } from '../__fixtures__';
     expectType<'foo' | `foo.${number}`>(actual);
   }
 
-  /** it should return the numeric keys of an object */ {
-    const actual = _ as Path<{ 0: string; '1': string; foo: string }>;
-    expectType<'0' | '1'>(actual);
-  }
-
   /** it should return the numeric keys of an array */ {
     const actual = _ as Path<number[]>;
     expectType<`${number}`>(actual);
@@ -58,13 +53,6 @@ import { _, Depth3Type } from '../__fixtures__';
   /** it should return the keys of an object */ {
     const actual = _ as Path<{ foo: string; bar: number }>;
     expectType<'foo' | 'bar'>(actual);
-  }
-
-  /** it should return the overlapping keys of a union of objects */ {
-    const actual = _ as Path<
-      { foo: string; bar: number } | { bar: number; baz: string }
-    >;
-    expectType<'bar'>(actual);
   }
 
   /** it should not return keys which contain dots */ {
@@ -117,41 +105,11 @@ import { _, Depth3Type } from '../__fixtures__';
     expectType<'0'>(actual);
   }
 
-  /** it should only return the keys of string properties */ {
-    const actual = _ as Path<{ foo: string; bar: number }, string>;
-    expectType<'foo'>(actual);
-  }
-
-  /** it should only return the keys of string properties */ {
-    const actual = _ as Path<{ 1: string; 2: number }, string>;
-    expectType<'1'>(actual);
-  }
-
-  /** it should return only the required keys when undefined is excluded */ {
-    const actual = _ as Path<{ foo: string; bar?: string }, string>;
-    expectType<'foo'>(actual);
-  }
-
-  /** it should return the optional keys when undefined is included */ {
-    const actual = _ as Path<{ foo: string; bar?: string }, string | undefined>;
-    expectType<'foo' | 'bar'>(actual);
-  }
-
   /** it should return the overlapping keys of a union of objects */ {
     const actual = _ as Path<
       { foo: string; bar: number } | { bar: number; baz: string }
     >;
     expectType<'bar'>(actual);
-  }
-
-  /** it should return the keys of the tuple when given a tuple and an array */ {
-    const actual = _ as Path<number[] | [number]>;
-    expectType<'0'>(actual);
-  }
-
-  /** it should return the overlapping keys when given a tuple and an object */ {
-    const actual = _ as Path<{ 0: string; 1: number } | [number]>;
-    expectType<'0'>(actual);
   }
 
   /** it should return the overlapping keys when given a tuple and an object */ {

--- a/src/__tests__/types/path/eager.test-d.ts
+++ b/src/__tests__/types/path/eager.test-d.ts
@@ -16,13 +16,43 @@ import { _, Depth3Type } from '../__fixtures__';
   }
 
   /** it should include paths through tuples */ {
-    const actual = _ as Path<{ foo: [string, number] }>;
-    expectType<'foo' | 'foo.0' | 'foo.1'>(actual);
+    const actual = _ as Path<{ foo: [string, { bar: string }] }>;
+    expectType<'foo' | 'foo.0' | 'foo.1' | 'foo.1.bar'>(actual);
   }
 
   /** it should include paths through arrays */ {
-    const actual = _ as Path<{ foo: string[] }>;
-    expectType<'foo' | `foo.${number}`>(actual);
+    const actual = _ as Path<{ foo: Array<{ bar: string }> }>;
+    expectType<'foo' | `foo.${number}` | `foo.${number}.bar`>(actual);
+  }
+
+  /** it should include index signatures */ {
+    const actual = _ as Path<{ foo: Record<string, { bar: string }> }>;
+    expectType<'foo' | `foo.${string}` | `foo.${string}.bar`>(actual);
+  }
+
+  /** it should include numeric index signatures */ {
+    const actual = _ as Path<{ foo: Record<number, { bar: string }> }>;
+    expectType<'foo' | `foo.${number}` | `foo.${number}.bar`>(actual);
+  }
+
+  /** it should not include keys containing dots */ {
+    const actual = _ as Path<{ foo: { 'foo.bar': string } }>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not include blank keys */ {
+    const actual = _ as Path<{ foo: { '': string } }>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should accept string when any is encountered */ {
+    const actual = _ as Path<{ foo: any }>;
+    expectType<'foo' | `foo.${string}`>(actual);
+  }
+
+  /** it should accept string when the type is any */ {
+    const actual = _ as Path<any>;
+    expectType<string>(actual);
   }
 
   /** it should return the numeric keys of an array */ {

--- a/src/__tests__/types/path/eager.test-d.ts
+++ b/src/__tests__/types/path/eager.test-d.ts
@@ -2,7 +2,7 @@ import { expectType } from 'tsd';
 
 import { ArrayPath, FieldPathValues, Path, PathValue } from '../../../types';
 import { Key } from '../../../types/path/common';
-import { _, Depth3Type } from '../__fixtures__';
+import { _, Depth3Type, NullableDepth2Type } from '../__fixtures__';
 
 /** {@link Path} */ {
   /** it should evaluate to never for an empty object */ {
@@ -47,6 +47,30 @@ import { _, Depth3Type } from '../__fixtures__';
       { foo: { bar: string } } | { foo: { baz: string } }
     >;
     expectType<'foo'>(actual);
+  }
+
+  /** it should work on nullable/optional types */ {
+    const actual = _ as Path<NullableDepth2Type<string>>;
+    expectType<
+      | 'foo'
+      | 'bar'
+      | 'baz'
+      | 'foo.bar'
+      | 'foo.baz'
+      | 'value'
+      | 'foo.foo'
+      | 'foo.value'
+      | 'bar.0'
+      | 'bar.0.foo'
+      | 'bar.0.bar'
+      | 'bar.0.baz'
+      | 'bar.0.value'
+      | `baz.${number}`
+      | `baz.${number}.bar`
+      | `baz.${number}.foo`
+      | `baz.${number}.baz`
+      | `baz.${number}.value`
+    >(actual);
   }
 
   /** it should not include keys containing dots */ {

--- a/src/__tests__/types/path/eager.test-d.ts
+++ b/src/__tests__/types/path/eager.test-d.ts
@@ -2,7 +2,7 @@ import { expectType } from 'tsd';
 
 import { ArrayPath, FieldPathValues, Path, PathValue } from '../../../types';
 import { Key } from '../../../types/path/common';
-import { _, Depth3Type, NullableDepth2Type } from '../__fixtures__';
+import { _, Depth3Type, NullableDepth1Type } from '../__fixtures__';
 
 /** {@link Path} */ {
   /** it should evaluate to never for an empty object */ {
@@ -50,27 +50,10 @@ import { _, Depth3Type, NullableDepth2Type } from '../__fixtures__';
   }
 
   /** it should work on nullable/optional types */ {
-    const actual = _ as Path<NullableDepth2Type<string>>;
-    expectType<
-      | 'foo'
-      | 'bar'
-      | 'baz'
-      | 'foo.bar'
-      | 'foo.baz'
-      | 'value'
-      | 'foo.foo'
-      | 'foo.value'
-      | 'bar.0'
-      | 'bar.0.foo'
-      | 'bar.0.bar'
-      | 'bar.0.baz'
-      | 'bar.0.value'
-      | `baz.${number}`
-      | `baz.${number}.bar`
-      | `baz.${number}.foo`
-      | `baz.${number}.baz`
-      | `baz.${number}.value`
-    >(actual);
+    const actual = _ as Path<NullableDepth1Type<string>>;
+    expectType<'foo' | 'bar' | 'baz' | 'value' | 'bar.0' | `baz.${number}`>(
+      actual,
+    );
   }
 
   /** it should not include keys containing dots */ {

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -356,6 +356,22 @@ import { _, InfiniteType, Nested, NullableInfiniteType } from '../__fixtures__';
     >;
     expectType<'foo' | `foo.42` | `foo.42.bar`>(actual);
   }
+
+  /** it should not accept non-overlapping paths */ {
+    const actual = _ as AutoCompletePath<
+      { foo: { baz: string } } | { bar: { baz: string } },
+      'foo.baz'
+    >;
+    expectType<never>(actual);
+  }
+
+  /** it should suggest/accept only overlapping paths */ {
+    const actual = _ as AutoCompletePath<
+      { foo: { bar: string } } | { foo: { baz: string } },
+      'foo'
+    >;
+    expectType<'foo'>(actual);
+  }
 }
 
 /** {@link LazyArrayPath} */ {

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -314,6 +314,48 @@ import { _, InfiniteType, Nested, NullableInfiniteType } from '../__fixtures__';
     const actual = fn({ nested: { path: 'foo.bar' } });
     expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
   }
+
+  /** it should not suggest keys containing dots */ {
+    const actual = _ as AutoCompletePath<{ foo: { 'foo.bar': string } }, 'foo'>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not suggest blank keys */ {
+    const actual = _ as AutoCompletePath<{ foo: { '': string } }, 'foo'>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should suggest index signatures */ {
+    const actual = _ as AutoCompletePath<
+      { foo: Record<string, { bar: string }> },
+      `foo.${string}`
+    >;
+    expectType<'foo' | `foo.${string}` | `foo.${string}.bar`>(actual);
+  }
+
+  /** it should suggest the exact path through the index signature */ {
+    const actual = _ as AutoCompletePath<
+      { foo: Record<string, { bar: string }> },
+      'foo.42'
+    >;
+    expectType<'foo' | `foo.42` | `foo.42.bar`>(actual);
+  }
+
+  /** it should suggest numeric index signatures */ {
+    const actual = _ as AutoCompletePath<
+      { foo: Record<number, { bar: string }> },
+      `foo.${number}`
+    >;
+    expectType<'foo' | `foo.${number}` | `foo.${number}.bar`>(actual);
+  }
+
+  /** it should suggest the exact path through the numeric index signature */ {
+    const actual = _ as AutoCompletePath<
+      { foo: Record<number, { bar: string }> },
+      'foo.42'
+    >;
+    expectType<'foo' | `foo.42` | `foo.42.bar`>(actual);
+  }
 }
 
 /** {@link LazyArrayPath} */ {

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -7,7 +7,7 @@ import {
   SuggestParentPath,
   SuggestPaths,
 } from '../../../types/path/lazy';
-import { _, InfiniteType, Nested, NullableInfiniteType } from '../__fixtures__';
+import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
 
 /** {@link SuggestParentPath} */ {
   /** it should evaluate to the parent path */ {
@@ -305,11 +305,9 @@ import { _, InfiniteType, Nested, NullableInfiniteType } from '../__fixtures__';
 
   /** TS should be able to infer the generic from a nested object property */ {
     interface FnProps<P extends PathString> {
-      path: AutoCompletePath<InfiniteType<string>, P>;
+      nested: { path: AutoCompletePath<InfiniteType<string>, P> };
     }
-    const fn = <P extends PathString>({
-      nested: { path },
-    }: Nested<FnProps<P>>) => path;
+    const fn = <P extends PathString>({ nested: { path } }: FnProps<P>) => path;
 
     const actual = fn({ nested: { path: 'foo.bar' } });
     expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -1,5 +1,5 @@
 import { FieldValues } from '../fields';
-import { IsNever, Primitive } from '../utils';
+import { IsAny, IsNever, Primitive } from '../utils';
 
 import {
   ArrayKey,
@@ -25,16 +25,13 @@ interface PathState {
 }
 
 /** WIP */
-type Last<T extends ReadonlyArray<any>> = T extends [...unknown[], infer L]
-  ? L
-  : never;
-
-/** WIP */
 type CreatePathMeta<
   PT extends PathTuple,
   T,
   K extends Key,
-> = Key extends Last<PT>
+> = IsAny<T> extends true
+  ? never
+  : IsNever<T> extends true
   ? never
   : IsNever<K> extends true
   ? never
@@ -51,11 +48,20 @@ type GetNext<PM extends PathMeta> = PM extends any
   : never;
 
 /** WIP */
+type GetResult<PM extends PathMeta> = PM extends any
+  ? IsAny<PM['Type']> extends true
+    ? JoinPathTuple<PM['Path']> | JoinPathTuple<[...PM['Path'], Key]>
+    : IsNever<PM['Type']> extends true
+    ? JoinPathTuple<PM['Path']> | JoinPathTuple<[...PM['Path'], Key]>
+    : JoinPathTuple<PM['Path']>
+  : never;
+
+/** WIP */
 type PathImpl<S extends PathState> = IsNever<S['Next']> extends true
   ? S['Result']
   : PathImpl<{
       Next: GetNext<S['Next']>;
-      Result: S['Result'] | JoinPathTuple<S['Next']['Path']>;
+      Result: S['Result'] | GetResult<S['Next']>;
     }>;
 
 /** WIP */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "src/*.test.tsx",
     "src/*.test-d.ts",
     "src/*.test-d.tsx",
+    "src/__tests__",
     "src/__mocks__"
   ]
 }


### PR DESCRIPTION
- [ ] Determine differences between eager and lazy path types.
  - [x] `Path`
    - [x] Run tests for `Keys` against `Path`
    - [x] Write additional tests
  - [ ] `ArrayPath`
    - [ ] Run tests for `Keys` against `ArrayPath`
    - [ ] Write additional tests
  - [ ] `PathValue`
    - [ ] Run tests for `EvaluatePath` and `EvaluateKey` against `PathValue`
- [ ] Refactor types
  - [ ] Refactor `Path`
    - [ ] Use `Keys` to ensure consistency with lazy types
    - [ ] Refactor type to be tail-recursive, i.e. breadth-first traversal
  - [ ] Refactor `ArrayPath`
    - [ ] Use `Keys` to ensure consistency with lazy types
    - [ ] Refactor type to be tail-recursive, i.e. breadth-first traversal
  - [ ] Refactor `PathValue` to use `EvaluatePath`
- [ ] Test compatability
  - [ ] Write tests to ensure that `Path` is assignable to `LazyPath`
  - [ ] Write tests to ensure that `ArrayPath` is assignable to `LazyArrayPath`

## Current `Path` type inconsistencies
- Paths following a string index signature, aren't expanded anymore.
  **This is technically not an error and doesn't improve the IntelliSense.**
  ```
  Input:    Record<string, { bar: string }>
  Expected: string | `${string}.bar`
  Output:   string
  ```
- Paths containing a number index signature are omitted.
  ```
  Input:    Record<number, { bar: string }>
  Expected: `${number}` | `${number}.bar`
  Output:   never
  ```
- Non-overlapping paths are included. Also applies to tuples, arrays, and objects with numeric keys.
  ```
  Input:    { foo: string } | { bar: string }
  Expected: never
  Output:   'foo' | 'bar'
  ```
- Paths which are not supported by `get` are included. (1)
  ```
  Input:    { 'foo.bar': string }
  Expected: never
  Output:   'foo.bar'
  ```
- Paths which are not supported by `get` are included. (2)
  ```
  Input:    { '': string }
  Expected: never
  Output:   ''
  ```
- Primitive types are expanded at the top level.
  ```
  Input:    string 
  Expected: never
  Output:   keyof string
  ```