### PR TITLE
Re-add LazyPath

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -297,6 +297,21 @@ export type KeepStateOptions = Partial<{
     keepSubmitCount: boolean;
 }>;
 
+// Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "Traversable" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<T, TPathString, ReadonlyArray<Traversable> | null | undefined>;
+
+// @public
+export type LazyFieldArrayPath<TFieldValues extends FieldValues, TPathString extends PathString> = LazyArrayPath<TFieldValues, TPathString>;
+
+// @public
+export type LazyFieldPath<TFieldValues extends FieldValues, TPathString extends PathString> = LazyPath<TFieldValues, TPathString>;
+
+// @public
+export type LazyPath<T, TPathString extends PathString> = AutoCompletePath<T, TPathString>;
+
 // @public (undocumented)
 export type LiteralUnion<T extends U, U extends Primitive> = T | (U & {
     _?: never;

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -1,0 +1,411 @@
+import { expectType } from 'tsd';
+
+import { LazyArrayPath, PathString } from '../../../types';
+import {
+  AutoCompletePath,
+  SuggestChildPaths,
+  SuggestParentPath,
+  SuggestPaths,
+} from '../../../types/path/lazy';
+import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
+
+/** {@link SuggestParentPath} */ {
+  /** it should evaluate to the parent path */ {
+    const actual = _ as SuggestParentPath<['foo', 'bar', 'baz']>;
+    expectType<'foo.bar'>(actual);
+  }
+
+  /** it should evaluate to never if there is no parent path */ {
+    const actual = _ as SuggestParentPath<['foo']>;
+    expectType<never>(actual);
+  }
+
+  /** it should be distributive on path unions */ {
+    const actual = _ as SuggestParentPath<
+      ['foo', 'bar', 'baz'] | ['foo', 'baz', 'bar', '42']
+    >;
+    expectType<'foo.bar' | 'foo.baz.bar'>(actual);
+  }
+}
+
+/** {@link SuggestChildPaths} */ {
+  /** it should suggest paths when the current path is empty */ {
+    const actual = _ as SuggestChildPaths<InfiniteType<string>, []>;
+    expectType<'foo' | 'bar' | 'baz' | 'value'>(actual);
+  }
+
+  /** it should suggest paths when the current path is not empty */ {
+    const actual = _ as SuggestChildPaths<InfiniteType<string>, ['foo', 'foo']>;
+    expectType<'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz' | 'foo.foo.value'>(
+      actual,
+    );
+  }
+
+  /** it should suggest paths when the path is optional */ {
+    const actual = _ as SuggestChildPaths<
+      NullableInfiniteType<string>,
+      ['foo', 'foo']
+    >;
+    expectType<'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz' | 'foo.foo.value'>(
+      actual,
+    );
+  }
+
+  /** it should suggest only matching or traversable paths */ {
+    const actual = _ as SuggestChildPaths<
+      InfiniteType<string>,
+      ['foo'],
+      number
+    >;
+    expectType<'foo.foo' | 'foo.bar' | 'foo.baz'>(actual);
+  }
+
+  /** it should suggest paths into a tuple */ {
+    const actual = _ as SuggestChildPaths<InfiniteType<string>, ['bar']>;
+    expectType<`bar.0`>(actual);
+  }
+
+  /** it should suggest paths into an array */ {
+    const actual = _ as SuggestChildPaths<InfiniteType<string>, ['baz']>;
+    expectType<`baz.${number}`>(actual);
+  }
+
+  /** it should evaluate to never if the path does not exist */ {
+    const actual = _ as SuggestChildPaths<InfiniteType<string>, ['foobar']>;
+    expectType<never>(actual);
+  }
+
+  /** it should be distributive on path unions */ {
+    const actual = _ as SuggestChildPaths<
+      InfiniteType<string>,
+      ['foo', 'foo'] | ['foo', 'bar']
+    >;
+    expectType<
+      | 'foo.foo.foo'
+      | 'foo.foo.bar'
+      | 'foo.foo.baz'
+      | 'foo.foo.value'
+      | 'foo.bar.0'
+    >(actual);
+  }
+}
+
+/** {@link SuggestPaths} */ {
+  /** it should suggest all top level paths when the path is empty */ {
+    const actual = _ as SuggestPaths<InfiniteType<string>, []>;
+    expectType<'foo' | 'bar' | 'baz' | 'value'>(actual);
+  }
+
+  /** it should suggest the sibling paths if the path is valid */ {
+    const actual = _ as SuggestPaths<InfiniteType<string>, ['fo']>;
+    expectType<'foo' | 'bar' | 'baz' | 'value'>(actual);
+  }
+
+  /** it should suggest the child paths if the path is valid */ {
+    const actual = _ as SuggestPaths<InfiniteType<string>, ['foo']>;
+    expectType<'foo.foo' | 'foo.bar' | 'foo.baz' | 'foo.value'>(actual);
+  }
+
+  /** it should suggest the parent path */ {
+    const actual = _ as SuggestPaths<InfiniteType<string>, ['foo', 'value']>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not suggest paths which point to the wrong type */ {
+    const actual = _ as SuggestPaths<
+      InfiniteType<string>,
+      ['foo', 'foo'],
+      number
+    >;
+    expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
+  }
+
+  /** it should not suggest paths which point don't include null or undefined */ {
+    const actual = _ as SuggestPaths<
+      NullableInfiniteType<string>,
+      ['foo', 'foo'],
+      string
+    >;
+    expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
+  }
+
+  /** it should be distributive on path unions */ {
+    const actual = _ as SuggestPaths<
+      InfiniteType<string>,
+      ['bar', '0'] | ['foo', 'foo']
+    >;
+    expectType<
+      | 'bar'
+      | 'foo'
+      | 'bar.0.foo'
+      | 'bar.0.bar'
+      | 'bar.0.baz'
+      | 'bar.0.value'
+      | 'foo.foo.foo'
+      | 'foo.foo.bar'
+      | 'foo.foo.baz'
+      | 'foo.foo.value'
+    >(actual);
+  }
+}
+
+/** {@link AutoCompletePath} */ {
+  /** it should suggest all top level paths when the path is empty */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, ''>;
+    expectType<'foo' | 'bar' | 'baz' | 'value'>(actual);
+  }
+
+  /** it should not suggest the current path if it is invalid */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, 'foo.foobar'>;
+    expectType<'foo' | 'foo.foo' | 'foo.bar' | 'foo.baz' | 'foo.value'>(actual);
+  }
+
+  /** it should suggest the current path if it is valid */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, 'foo'>;
+    expectType<'foo' | 'foo.foo' | 'foo.bar' | 'foo.baz' | 'foo.value'>(actual);
+  }
+
+  /** it should suggest the current path and the parent path */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, 'foo.value'>;
+    expectType<'foo' | 'foo.value'>(actual);
+  }
+
+  /** it should not suggest the current path if it has the wrong value */ {
+    const actual = _ as AutoCompletePath<
+      InfiniteType<string>,
+      'foo.value',
+      number
+    >;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not accept trailing dots */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, 'foo.'>;
+    expectType<'foo' | 'foo.foo' | 'foo.bar' | 'foo.baz' | 'foo.value'>(actual);
+  }
+
+  /** it should not accept leading dots */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, '.foo'>;
+    expectType<'foo' | 'foo.foo' | 'foo.bar' | 'foo.baz' | 'foo.value'>(actual);
+  }
+
+  /** it should not accept repeated dots */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, 'foo..foo'>;
+    expectType<
+      | 'foo'
+      | 'foo.foo'
+      | 'foo.foo.foo'
+      | 'foo.foo.bar'
+      | 'foo.foo.baz'
+      | 'foo.foo.value'
+    >(actual);
+  }
+
+  /** it should suggest the current path if it has the correct value */ {
+    const actual = _ as AutoCompletePath<
+      InfiniteType<string>,
+      'foo.value',
+      string
+    >;
+    expectType<'foo' | 'foo.value'>(actual);
+  }
+
+  /** it should accept string when any is encountered */ {
+    const actual = _ as AutoCompletePath<{ foo: any }, 'foo.bar.baz', string>;
+    expectType<'foo.bar' | 'foo.bar.baz' | `foo.bar.baz.${string}`>(actual);
+  }
+
+  /** it should accept string when the type is any */ {
+    const actual = _ as AutoCompletePath<any, string, string>;
+    expectType<string>(actual);
+  }
+
+  /** it should evaluate to any when the path is any */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, any, string>;
+    expectType<any>(actual);
+  }
+
+  /** it should evaluate to never when the path is never */ {
+    const actual = _ as AutoCompletePath<InfiniteType<string>, never, string>;
+    expectType<never>(actual);
+  }
+
+  /** it should not suggest the current path if null and undefined are excluded */ {
+    const actual = _ as AutoCompletePath<
+      NullableInfiniteType<string>,
+      'foo.value',
+      string
+    >;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not suggest the current path if null and undefined are included */ {
+    const actual = _ as AutoCompletePath<
+      NullableInfiniteType<string>,
+      'foo.value',
+      string | null | undefined
+    >;
+    expectType<'foo' | 'foo.value'>(actual);
+  }
+
+  /** it should suggest paths which point to the correct type */ {
+    const actual = _ as AutoCompletePath<
+      InfiniteType<string>,
+      'foo.foo',
+      string
+    >;
+    expectType<
+      'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz' | 'foo.foo.value'
+    >(actual);
+  }
+
+  /** it should not suggest paths which point to the wrong type */ {
+    const actual = _ as AutoCompletePath<
+      InfiniteType<string>,
+      'foo.foo',
+      number
+    >;
+    expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
+  }
+
+  /** it should not suggest any child or parent paths for path unions */ {
+    const actual = _ as AutoCompletePath<
+      InfiniteType<string>,
+      'bar.0' | 'foo.foo'
+    >;
+    expectType<'bar.0' | 'foo.foo'>(actual);
+  }
+
+  /** it should not suggest invalid paths for path unions */ {
+    const actual = _ as AutoCompletePath<
+      InfiniteType<string>,
+      'bar.0' | 'foo.foobar'
+    >;
+    expectType<'bar.0'>(actual);
+  }
+
+  /** TS should be able to infer the generic */ {
+    const fn = <P extends PathString>(
+      path: AutoCompletePath<InfiniteType<string>, P>,
+    ) => path;
+
+    const actual = fn('foo.bar');
+    expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
+  }
+
+  /** TS should be able to infer the generic from an object property */ {
+    interface FnProps<P extends PathString> {
+      path: AutoCompletePath<InfiniteType<string>, P>;
+    }
+    const fn = <P extends PathString>({ path }: FnProps<P>) => path;
+
+    const actual = fn({ path: 'foo.bar' });
+    expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
+  }
+
+  /** TS should be able to infer the generic from a nested object property */ {
+    interface FnProps<P extends PathString> {
+      nested: { path: AutoCompletePath<InfiniteType<string>, P> };
+    }
+    const fn = <P extends PathString>({ nested: { path } }: FnProps<P>) => path;
+
+    const actual = fn({ nested: { path: 'foo.bar' } });
+    expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
+  }
+
+  /** it should not suggest keys containing dots */ {
+    const actual = _ as AutoCompletePath<{ foo: { 'foo.bar': string } }, 'foo'>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not suggest blank keys */ {
+    const actual = _ as AutoCompletePath<{ foo: { '': string } }, 'foo'>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should suggest index signatures */ {
+    const actual = _ as AutoCompletePath<
+      { foo: Record<string, { bar: string }> },
+      `foo.${string}`
+    >;
+    expectType<'foo' | `foo.${string}` | `foo.${string}.bar`>(actual);
+  }
+
+  /** it should suggest the exact path through the index signature */ {
+    const actual = _ as AutoCompletePath<
+      { foo: Record<string, { bar: string }> },
+      'foo.42'
+    >;
+    expectType<'foo' | `foo.42` | `foo.42.bar`>(actual);
+  }
+
+  /** it should suggest numeric index signatures */ {
+    const actual = _ as AutoCompletePath<
+      { foo: Record<number, { bar: string }> },
+      `foo.${number}`
+    >;
+    expectType<'foo' | `foo.${number}` | `foo.${number}.bar`>(actual);
+  }
+
+  /** it should suggest the exact path through the numeric index signature */ {
+    const actual = _ as AutoCompletePath<
+      { foo: Record<number, { bar: string }> },
+      'foo.42'
+    >;
+    expectType<'foo' | `foo.42` | `foo.42.bar`>(actual);
+  }
+
+  /** it should not accept non-overlapping paths */ {
+    const actual = _ as AutoCompletePath<
+      { foo: { baz: string } } | { bar: { baz: string } },
+      'foo.baz'
+    >;
+    expectType<never>(actual);
+  }
+
+  /** it should suggest/accept only overlapping paths */ {
+    const actual = _ as AutoCompletePath<
+      { foo: { bar: string } } | { foo: { baz: string } },
+      'foo'
+    >;
+    expectType<'foo'>(actual);
+  }
+}
+
+/** {@link LazyArrayPath} */ {
+  /** it should not accept primitive arrays */ {
+    const actual = _ as LazyArrayPath<InfiniteType<number[]>, 'foo.value'>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should accept non-primitive arrays */ {
+    const actual = _ as LazyArrayPath<InfiniteType<number[]>, 'foo.baz'>;
+    expectType<'foo' | 'foo.baz' | `foo.baz.${number}`>(actual);
+  }
+
+  /** it should not accept primitive tuples */ {
+    const actual = _ as LazyArrayPath<InfiniteType<[number]>, 'foo.value'>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should accept non-primitive tuples */ {
+    const actual = _ as LazyArrayPath<InfiniteType<number[]>, 'foo.bar'>;
+    expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
+  }
+
+  /** it should accept non-primitive nullable arrays */ {
+    const actual = _ as LazyArrayPath<
+      { foo: { bar: object[] | null | undefined } },
+      'foo.bar'
+    >;
+    expectType<'foo' | `foo.bar` | `foo.bar.${number}`>(actual);
+  }
+
+  /** it should not accept non-primitive arrays with nullable values */ {
+    const actual = _ as LazyArrayPath<
+      { foo: { bar: Array<object | null | undefined> } },
+      'foo.bar'
+    >;
+    expectType<'foo' | `foo.bar.${number}`>(actual);
+  }
+}

--- a/src/types/path/index.ts
+++ b/src/types/path/index.ts
@@ -11,3 +11,9 @@ export {
   Path,
   PathValue,
 } from './eager';
+export {
+  LazyArrayPath,
+  LazyFieldArrayPath,
+  LazyFieldPath,
+  LazyPath,
+} from './lazy';

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -1,0 +1,252 @@
+import { FieldValues } from '../fields';
+import { IsNever } from '../utils';
+
+import {
+  EvaluatePath,
+  HasPath,
+  JoinPathTuple,
+  Key,
+  Keys,
+  PathString,
+  PathTuple,
+  SplitPathString,
+  Traversable,
+  UnionToIntersection,
+  ValidPathPrefix,
+} from './common';
+
+/**
+ * Type, which given a path, returns the parent path as a {@link PathString}
+ * @typeParam PT - path represented as a {@link PathTuple}
+ * @example
+ * ```
+ * SuggestParentPath<['foo', 'bar', 'baz']> = 'foo.bar'
+ * SuggestParentPath<['foo', 'bar']> = 'foo'
+ * SuggestParentPath<['foo']> = never
+ * ```
+ */
+export type SuggestParentPath<PT extends PathTuple> = JoinPathTuple<
+  PT extends [...infer R, Key] ? R : []
+>;
+
+/**
+ * Type to implement {@link SuggestChildPaths}.
+ * @typeParam PT  - the current path as a {@link PathTuple}
+ * @typeParam TPT - the type at that path
+ * @typeParam U   - constraint type
+ */
+type SuggestChildPathsImpl<PT extends PathTuple, TPT, U> = JoinPathTuple<
+  [...PT, Keys<TPT, U> | Keys<TPT, Traversable | undefined | null>]
+>;
+
+/**
+ * Type, which given a type and a path into the type, returns all paths as
+ * {@link PathString}s which can be used to index the type at that path.
+ * Filters out paths whose value doesn't match the constraint type or
+ * aren't traversable.
+ * @typeParam T  - type which is indexed by the path
+ * @typeParam PT - the current path into the type as a {@link PathTuple}
+ * @typeParam U  - constraint type
+ * @example
+ * ```
+ * SuggestChildPaths<{foo: string, bar: string}, [], string> = 'foo' | 'bar'
+ * SuggestChildPaths<{foo: string, bar: number}, [], string> = 'foo'
+ * SuggestChildPaths<{foo: {bar: string}}, ['foo'], string> = 'foo.bar'
+ * SuggestChildPaths<{foo: {bar: string[]}}, ['foo'], string> = 'foo.bar'
+ * ```
+ */
+export type SuggestChildPaths<
+  T,
+  PT extends PathTuple,
+  U = unknown,
+> = PT extends any ? SuggestChildPathsImpl<PT, EvaluatePath<T, PT>, U> : never;
+
+/**
+ * Type to implement {@link SuggestPaths} without having to compute the valid
+ * path prefix more than once.
+ * @typeParam T   - type which is indexed by the path
+ * @typeParam PT  - the current path into the type as a {@link PathTuple}
+ * @typeParam U   - constraint type
+ * @typeParam VPT - the valid path prefix for the given path
+ */
+type SuggestPathsImpl<T, PT extends PathTuple, U, VPT extends PathTuple> =
+  | SuggestChildPaths<T, VPT, U>
+  | (PT extends VPT ? SuggestParentPath<VPT> : JoinPathTuple<VPT>);
+
+/**
+ * Type which given a type and a {@link PathTuple} into it returns
+ *  - its parent/predecessor {@link PathString}.
+ *  - all its child/successor paths that point to a type which is either
+ *    traversable or matches the constraint type.
+ * In case the path does not exist it returns all of the above for the last
+ * valid path (see {@link ValidPathPrefix}).
+ * @typeParam T  - type which is indexed by the path
+ * @typeParam PT - the current path into the type as a {@link PathTuple}
+ * @typeParam U  - constraint type
+ * @example
+ * ```
+ * SuggestPaths<{foo: {bar: string}}, ['foo'], string> = 'foo.bar'
+ * SuggestPaths<{foo: {bar: string}}, ['foo', 'ba'], string>
+ *   = 'foo' | 'foo.bar'
+ * SuggestPaths<{foo: {bar: string}}, ['foo', 'bar'], string>
+ *   = 'foo'
+ * SuggestPaths<{foo: {bar: {baz: string}}}, ['foo', 'bar'], string>
+ *   = 'foo' | 'foo.bar.baz'
+ * ```
+ */
+export type SuggestPaths<
+  T,
+  PT extends PathTuple,
+  U = unknown,
+> = SuggestPathsImpl<T, PT, U, ValidPathPrefix<T, PT>>;
+
+/**
+ * Type to test whether the path is a union of paths.
+ * @typeParam PS - path
+ * @example
+ * ```
+ * IsPathUnion<'foo'> = false
+ * IsPathUnion<'foo' | 'foo'> = false
+ * IsPathUnion<'foo' | 'foo.bar'> = true
+ * ```
+ */
+type IsPathUnion<PS extends PathString> = IsNever<UnionToIntersection<PS>>;
+
+/**
+ * Type to check the current path against the constraint type.
+ * Returns the path if it is valid and matches the constraint type.
+ * @typeParam T  - type which is indexed by the path
+ * @typeParam PS - the current path into the type as a {@link PathString}
+ * @typeParam PT - the current path into the type as a {@link PathTuple}
+ * @typeParam U  - constraint type
+ */
+type AutoCompletePathCheckConstraint<
+  T,
+  PS extends PathString,
+  PT extends PathTuple,
+  U,
+> = HasPath<T, PT> extends true
+  ? EvaluatePath<T, PT> extends U
+    ? PS extends JoinPathTuple<PT>
+      ? PS
+      : JoinPathTuple<PT>
+    : never
+  : never;
+
+/**
+ * Type to implement {@link AutoCompletePath} without having to compute the
+ * key list more than once.
+ * @typeParam T  - type which is indexed by the path
+ * @typeParam PS - the current path into the type as a {@link PathString}
+ * @typeParam PT - the current path into the type as a {@link PathTuple}
+ * @typeParam U  - constraint type
+ */
+type AutoCompletePathImpl<T, PS extends PathString, PT extends PathTuple, U> =
+  | SuggestPaths<T, PT, U>
+  | AutoCompletePathCheckConstraint<T, PS, PT, U>;
+
+/**
+ * Type which given a type and a {@link PathString} into it returns
+ *  - its parent/predecessor {@link PathString}.
+ *  - the {@link PathString} itself, if it exists within the type and matches
+ *    the constraint type.
+ *  - all its child/successor paths that point to a type which is either
+ *    traversable or matches the constraint type.
+ * Also,
+ *  - in case the path does not exist it returns all of the above for the last
+ *    valid path.
+ *  - in case the path is a union of paths it doesn't suggest any
+ *    parent/predecessor and child/successor paths.
+ *    Otherwise, the returned type may become to large, or it may accept paths
+ *    which don't match the constraint type.
+ * @typeParam T  - type which is indexed by the path
+ * @typeParam PS - the current path into the type as a {@link PathString}
+ * @typeParam U  - constraint type
+ * @example
+ * ```
+ * AutoCompletePath<{foo: {bar: string}}, 'foo', string> = 'foo.bar'
+ * AutoCompletePath<{foo: {bar: string}}, 'foo.ba', string>
+ *   = 'foo' | 'foo.bar'
+ * AutoCompletePath<{foo: {bar: string}}, 'foo.bar', string>
+ *   = 'foo' | 'foo.bar'
+ * AutoCompletePath<{foo: {bar: {baz: string}}}, 'foo.bar', string>
+ *   = 'foo' | 'foo.bar.baz'
+ * ```
+ */
+export type AutoCompletePath<
+  T,
+  PS extends PathString,
+  U = unknown,
+> = IsPathUnion<PS> extends false
+  ? AutoCompletePathImpl<T, PS, SplitPathString<PS>, U>
+  : PS extends any
+  ? AutoCompletePathCheckConstraint<T, PS, SplitPathString<PS>, U>
+  : never;
+
+/**
+ * Type which given a type and a {@link PathString} into it returns
+ *  - its parent/predecessor {@link PathString}
+ *  - the {@link PathString} itself, if it exists within the type
+ *  - all its child/successor paths that point to a type which is traversable
+ * In case the path does not exist it returns all of the above for the last
+ * valid path.
+ * @typeParam T           - type which is indexed by the path
+ * @typeParam TPathString - the current path into the type as a
+ *                          {@link PathString}
+ * @example
+ * ```
+ * LazyPath<{foo: {bar: string}}, 'foo'> = 'foo' | 'foo.bar'
+ * LazyPath<{foo: {bar: string}}, 'foo.ba'> = 'foo' | 'foo.bar'
+ * LazyPath<{foo: {bar: string}}, 'foo.bar'> = 'foo' | 'foo.bar'
+ * LazyPath<{foo: {bar: {baz: string}}}, 'foo.bar'>
+ *   = 'foo' | 'foo.bar' | 'foo.bar.baz'
+ * ```
+ */
+export type LazyPath<T, TPathString extends PathString> = AutoCompletePath<
+  T,
+  TPathString
+>;
+
+/**
+ * See {@link LazyPath}
+ */
+export type LazyFieldPath<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+> = LazyPath<TFieldValues, TPathString>;
+
+/**
+ * Type which given a type and a {@link PathString} into it returns
+ *  - its parent/predecessor {@link PathString}
+ *  - the {@link PathString} itself, if it exists within the type,
+ *    and the type, that it points to, is an array type
+ *  - all its child/successor paths that point to a type which is either
+ *    traversable or is an array type.
+ * In case the path does not exist it returns all of the above for the last
+ * valid path.
+ * @typeParam T           - type which is indexed by the path
+ * @typeParam TPathString - the current path into the type as a
+ *                          {@link PathString}
+ * @example
+ * @example
+ * ```
+ * LazyArrayPath<{foo: {bar: string[]}}, 'foo'> = 'foo.bar'
+ * LazyArrayPath<{foo: {bar: string[]}}, 'foo.ba'> = 'foo' | 'foo.bar'
+ * LazyArrayPath<{foo: {bar: string[]}}, 'foo.bar'> = 'foo' | 'foo.bar'
+ * LazyArrayPath<{foo: {bar: {baz: string[]}}}, 'foo.bar'>
+ *   = 'foo' | 'foo.bar.baz'
+ * ```
+ */
+export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<
+  T,
+  TPathString,
+  ReadonlyArray<Traversable> | null | undefined
+>;
+
+/**
+ * See {@link LazyArrayPath}
+ */
+export type LazyFieldArrayPath<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+> = LazyArrayPath<TFieldValues, TPathString>;


### PR DESCRIPTION
Re-adds LazyPath. LazyPath was removed here https://github.com/react-hook-form/react-hook-form/pull/7366#issuecomment-1001788747 to be re-added in version 8.