### PR TITLE
Force Git to keep CRLF line endings for API Extractor report

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 api-extractor.json  linguist-language=JSON-with-Comments
+reports/api-extractor.md eol=crlf


### PR DESCRIPTION
API Extractor produces CRLF on all operating systems.
This PR forces Git to keep CRLF line endings.