### PR TITLE
Implement SetKey and SetPath

### DIFF
--- a/src/__tests__/types/path/common.test-d.ts
+++ b/src/__tests__/types/path/common.test-d.ts
@@ -17,6 +17,7 @@ import {
   NumericKeys,
   ObjectKeys,
   PathString,
+  SetKey,
   SplitPathString,
   ToKey,
   TupleKeys,
@@ -556,6 +557,157 @@ import {
 
   /** it should access methods on tuples */ {
     const actual = _ as GetKey<[number], 'toString'>;
+    expectType<() => string>(actual);
+  }
+}
+
+/** {@link SetKey} */ {
+  /** it should traverse an object */ {
+    const actual = _ as SetKey<{ foo: number; bar: string }, 'foo'>;
+    expectType<number>(actual);
+  }
+
+  /** it should traverse an index signature */ {
+    const actual = _ as SetKey<Record<string, number>, string>;
+    expectType<number>(actual);
+  }
+
+  /** it should traverse a numeric index signature */ {
+    const actual = _ as SetKey<Record<number, string>, `${number}`>;
+    expectType<string>(actual);
+  }
+
+  /** it should traverse an object with numeric keys */ {
+    const actual = _ as SetKey<{ 0: number }, '0'>;
+    expectType<number>(actual);
+  }
+
+  /** it should traverse a tuple */ {
+    const actual = _ as SetKey<[boolean, string], '1'>;
+    expectType<string>(actual);
+  }
+
+  /** it should traverse an array */ {
+    const actual = _ as SetKey<boolean[], '42'>;
+    expectType<boolean>(actual);
+  }
+
+  /** it should handle optional keys */ {
+    const actual = _ as SetKey<{ foo?: number }, 'foo'>;
+    expectType<number | undefined>(actual);
+  }
+
+  /** it should handle optional indexes */ {
+    const actual = _ as SetKey<[foo?: number], '0'>;
+    expectType<number | undefined>(actual);
+  }
+
+  /** it should evaluate to never if the key is not valid */ {
+    const actual = _ as SetKey<{ foo: string }, 'foobar'>;
+    expectType<never>(actual);
+  }
+
+  /** it should evaluate to never if the key is out of bounds */ {
+    const actual = _ as SetKey<[string], '1'>;
+    expectType<never>(actual);
+  }
+
+  /** it should work on path unions */ {
+    const actual = _ as SetKey<
+      { foo: { foo: string }; bar: { bar: string } },
+      'foo' | 'bar'
+    >;
+    expectType<{ foo: string } & { bar: string }>(actual);
+  }
+
+  /** it should evaluate to never if one of the keys doesn't exist */ {
+    const actual = _ as SetKey<{ foo: number }, 'foo' | 'bar'>;
+    expectType<never>(actual);
+  }
+
+  /** it shouldn't add null if the type may be null */ {
+    const actual = _ as SetKey<null | { foo: string }, 'foo'>;
+    expectType<string>(actual);
+  }
+
+  /** it shouldn't add undefined if the type may be undefined */ {
+    const actual = _ as SetKey<undefined | { foo: string }, 'foo'>;
+    expectType<string>(actual);
+  }
+
+  /** it shouldn't add null and undefined if the type may be null or undefined */ {
+    const actual = _ as SetKey<null | undefined | { foo: string }, 'foo'>;
+    expectType<string>(actual);
+  }
+
+  /** it should evaluate to never if the type is not traversable */ {
+    const actual = _ as SetKey<string, 'foo'>;
+    expectType<never>(actual);
+  }
+
+  /** it should evaluate to never if the key is non-numeric */ {
+    const actual = _ as SetKey<string[], 'foo'>;
+    expectType<never>(actual);
+  }
+
+  /** it should work on unions of object */ {
+    const actual = _ as SetKey<
+      { foo: { foo: string } } | { foo: { bar: string } },
+      'foo'
+    >;
+    expectType<{ foo: string } & { bar: string }>(actual);
+  }
+
+  /** it should work on unions of object and tuple */ {
+    const actual = _ as SetKey<{ 0: { foo: string } } | [{ bar: string }], '0'>;
+    expectType<{ foo: string } & { bar: string }>(actual);
+  }
+
+  /** it should work on unions of object and array */ {
+    const actual = _ as SetKey<
+      { 0: { foo: string } } | Array<{ bar: string }>,
+      '0'
+    >;
+    expectType<{ foo: string } & { bar: string }>(actual);
+  }
+
+  /** it should work on unions of tuple and array */ {
+    const actual = _ as SetKey<[{ foo: string }] | Array<{ bar: string }>, '0'>;
+    expectType<{ foo: string } & { bar: string }>(actual);
+  }
+
+  /** it should evaluate to never if the key doesn't exist in one of the types */ {
+    const actual = _ as SetKey<{ foo: number } | { bar: string }, 'foo'>;
+    expectType<never>(actual);
+  }
+
+  /** it should evaluate to never if the key is out of bounds in one of the types */ {
+    const actual = _ as SetKey<[] | [number], '0'>;
+    expectType<never>(actual);
+  }
+
+  /** it should evaluate to never if the type is null or undefined */ {
+    const actual = _ as SetKey<null | undefined, string>;
+    expectType<never>(actual);
+  }
+
+  /** it should evaluate to any if the type is any */ {
+    const actual = _ as SetKey<any, string>;
+    expectType<any>(actual);
+  }
+
+  /** it should access methods on primitives */ {
+    const actual = _ as SetKey<string, 'toString'>;
+    expectType<() => string>(actual);
+  }
+
+  /** it should access methods on arrays */ {
+    const actual = _ as SetKey<number[], 'toString'>;
+    expectType<() => string>(actual);
+  }
+
+  /** it should access methods on tuples */ {
+    const actual = _ as SetKey<[number], 'toString'>;
     expectType<() => string>(actual);
   }
 }

--- a/src/__tests__/types/path/common.test-d.ts
+++ b/src/__tests__/types/path/common.test-d.ts
@@ -6,8 +6,8 @@ import {
   AsPathTuple,
   CheckKeyConstraint,
   ContainsIndexable,
-  EvaluateKey,
-  EvaluatePath,
+  GetKey,
+  GetPath,
   HasKey,
   HasPath,
   IsTuple,
@@ -423,142 +423,139 @@ import {
   }
 }
 
-/** {@link EvaluateKey} */ {
+/** {@link GetKey} */ {
   /** it should traverse an object */ {
-    const actual = _ as EvaluateKey<{ foo: number; bar: string }, 'foo'>;
+    const actual = _ as GetKey<{ foo: number; bar: string }, 'foo'>;
     expectType<number>(actual);
   }
 
   /** it should traverse an index signature */ {
-    const actual = _ as EvaluateKey<Record<string, number>, string>;
+    const actual = _ as GetKey<Record<string, number>, string>;
     expectType<number>(actual);
   }
 
   /** it should traverse a numeric index signature */ {
-    const actual = _ as EvaluateKey<Record<number, string>, `${number}`>;
+    const actual = _ as GetKey<Record<number, string>, `${number}`>;
     expectType<string>(actual);
   }
 
   /** it should traverse an object with numeric keys */ {
-    const actual = _ as EvaluateKey<{ 0: number }, '0'>;
+    const actual = _ as GetKey<{ 0: number }, '0'>;
     expectType<number>(actual);
   }
 
   /** it should traverse a tuple */ {
-    const actual = _ as EvaluateKey<[boolean, string], '1'>;
+    const actual = _ as GetKey<[boolean, string], '1'>;
     expectType<string>(actual);
   }
 
   /** it should traverse an array */ {
-    const actual = _ as EvaluateKey<boolean[], '42'>;
+    const actual = _ as GetKey<boolean[], '42'>;
     expectType<boolean>(actual);
   }
 
   /** it should handle optional keys */ {
-    const actual = _ as EvaluateKey<{ foo?: number }, 'foo'>;
+    const actual = _ as GetKey<{ foo?: number }, 'foo'>;
     expectType<number | undefined>(actual);
   }
 
   /** it should handle optional indexes */ {
-    const actual = _ as EvaluateKey<[foo?: number], '0'>;
+    const actual = _ as GetKey<[foo?: number], '0'>;
     expectType<number | undefined>(actual);
   }
 
   /** it should add undefined if the key is not valid */ {
-    const actual = _ as EvaluateKey<{ foo: string }, 'foobar'>;
+    const actual = _ as GetKey<{ foo: string }, 'foobar'>;
     expectType<undefined>(actual);
   }
 
   /** it should evaluate to undefined if the key is out of bounds */ {
-    const actual = _ as EvaluateKey<[string], '1'>;
+    const actual = _ as GetKey<[string], '1'>;
     expectType<undefined>(actual);
   }
 
   /** it should work on path unions */ {
-    const actual = _ as EvaluateKey<
-      { foo: number; bar: string },
-      'foo' | 'bar'
-    >;
+    const actual = _ as GetKey<{ foo: number; bar: string }, 'foo' | 'bar'>;
     expectType<number | string>(actual);
   }
 
   /** it should add undefined if one of the keys doesn't exist */ {
-    const actual = _ as EvaluateKey<{ foo: number }, 'foo' | 'bar'>;
+    const actual = _ as GetKey<{ foo: number }, 'foo' | 'bar'>;
     expectType<number | undefined>(actual);
   }
 
   /** it should add null if the type may be null */ {
-    const actual = _ as EvaluateKey<null | { foo: string }, 'foo'>;
+    const actual = _ as GetKey<null | { foo: string }, 'foo'>;
     expectType<string | null>(actual);
   }
 
   /** it should add undefined if the type may be undefined */ {
-    const actual = _ as EvaluateKey<undefined | { foo: string }, 'foo'>;
+    const actual = _ as GetKey<undefined | { foo: string }, 'foo'>;
     expectType<string | undefined>(actual);
   }
 
   /** it should add null and undefined if the type may be null or undefined */ {
-    const actual = _ as EvaluateKey<null | undefined | { foo: string }, 'foo'>;
+    const actual = _ as GetKey<null | undefined | { foo: string }, 'foo'>;
     expectType<string | null | undefined>(actual);
   }
 
   /** it should evaluate to undefined if the type is not traversable */ {
-    const actual = _ as EvaluateKey<string, 'foo'>;
+    const actual = _ as GetKey<string, 'foo'>;
     expectType<undefined>(actual);
   }
 
   /** it should evaluate to undefined if the key is non-numeric */ {
-    const actual = _ as EvaluateKey<string[], 'foo'>;
+    const actual = _ as GetKey<string[], 'foo'>;
     expectType<undefined>(actual);
   }
 
   /** it should work on unions of object */ {
-    const actual = _ as EvaluateKey<{ foo: number } | { foo: string }, 'foo'>;
+    const actual = _ as GetKey<{ foo: number } | { foo: string }, 'foo'>;
     expectType<number | string>(actual);
   }
 
   /** it should work on unions of object and tuple */ {
-    const actual = _ as EvaluateKey<{ 0: number } | [string], '0'>;
+    const actual = _ as GetKey<{ 0: number } | [string], '0'>;
     expectType<number | string>(actual);
   }
 
   /** it should work on unions of object and array */ {
-    const actual = _ as EvaluateKey<{ 0: number } | string[], '0'>;
+    const actual = _ as GetKey<{ 0: number } | string[], '0'>;
     expectType<number | string>(actual);
   }
 
   /** it should work on unions of tuple and array */ {
-    const actual = _ as EvaluateKey<[number] | string[], '0'>;
+    const actual = _ as GetKey<[number] | string[], '0'>;
     expectType<number | string>(actual);
   }
 
   /** it should add undefined if the key doesn't exist in one of the types */ {
-    const actual = _ as EvaluateKey<{ foo: number } | { bar: string }, 'foo'>;
+    const actual = _ as GetKey<{ foo: number } | { bar: string }, 'foo'>;
     expectType<number | undefined>(actual);
   }
 
   /** it should add undefined if the key is out of bounds in one of the types */ {
-    const actual = _ as EvaluateKey<[] | [number], '0'>;
+    const actual = _ as GetKey<[] | [number], '0'>;
     expectType<number | undefined>(actual);
   }
 
   /** it should evaluate to any if the type is any */ {
-    const actual = _ as EvaluateKey<any, string>;
+    const actual = _ as GetKey<any, string>;
     expectType<any>(actual);
   }
 
   /** it should access methods on primitives */ {
-    const actual = _ as EvaluateKey<string, 'toString'>;
+    const actual = _ as GetKey<string, 'toString'>;
     expectType<() => string>(actual);
   }
 
   /** it should access methods on arrays */ {
-    const actual = _ as EvaluateKey<number[], 'toString'>;
+    const actual = _ as GetKey<number[], 'toString'>;
     expectType<() => string>(actual);
   }
 
   /** it should access methods on tuples */ {
-    const actual = _ as EvaluateKey<[number], 'toString'>;
+    const actual = _ as GetKey<[number], 'toString'>;
     expectType<() => string>(actual);
   }
 }
@@ -678,53 +675,44 @@ import {
   }
 }
 
-/** {@link EvaluatePath} */ {
+/** {@link GetPath} */ {
   /** it should traverse an object */ {
-    const actual = _ as EvaluatePath<
-      InfiniteType<number>,
-      ['foo', 'foo', 'value']
-    >;
+    const actual = _ as GetPath<InfiniteType<number>, ['foo', 'foo', 'value']>;
     expectType<number>(actual);
   }
 
   /** it should traverse an index signature */ {
-    const actual = _ as EvaluatePath<Record<string, number>, [string]>;
+    const actual = _ as GetPath<Record<string, number>, [string]>;
     expectType<number>(actual);
   }
 
   /** it should traverse a numeric index signature */ {
-    const actual = _ as EvaluatePath<Record<number, string>, [`${number}`]>;
+    const actual = _ as GetPath<Record<number, string>, [`${number}`]>;
     expectType<string>(actual);
   }
 
   /** it should traverse a tuple */ {
-    const actual = _ as EvaluatePath<
-      InfiniteType<boolean>,
-      ['bar', '0', 'value']
-    >;
+    const actual = _ as GetPath<InfiniteType<boolean>, ['bar', '0', 'value']>;
     expectType<boolean>(actual);
   }
 
   /** it should traverse an array */ {
-    const actual = _ as EvaluatePath<
-      InfiniteType<boolean>,
-      ['baz', '42', 'value']
-    >;
+    const actual = _ as GetPath<InfiniteType<boolean>, ['baz', '42', 'value']>;
     expectType<boolean>(actual);
   }
 
   /** it should evaluate to never if the path is not valid */ {
-    const actual = _ as EvaluatePath<InfiniteType<string>, ['foobar']>;
+    const actual = _ as GetPath<InfiniteType<string>, ['foobar']>;
     expectType<undefined>(actual);
   }
 
   /** it should be implemented tail recursively */ {
-    const actual = _ as EvaluatePath<InfiniteType<string>, HundredTuple<'foo'>>;
+    const actual = _ as GetPath<InfiniteType<string>, HundredTuple<'foo'>>;
     expectType<InfiniteType<string>>(actual);
   }
 
   /** it should work on path unions */ {
-    const actual = _ as EvaluatePath<
+    const actual = _ as GetPath<
       InfiniteType<number>,
       ['foo', 'foo'] | ['foo', 'value']
     >;
@@ -732,7 +720,7 @@ import {
   }
 
   /** it should add undefined if one of the paths doesn't exist */ {
-    const actual = _ as EvaluatePath<
+    const actual = _ as GetPath<
       InfiniteType<number>,
       ['foo', 'value'] | ['foo', 'foobar']
     >;
@@ -740,7 +728,7 @@ import {
   }
 
   /** it should add null if the path contains a nullable */ {
-    const actual = _ as EvaluatePath<
+    const actual = _ as GetPath<
       { foo: null | { bar: string } },
       ['foo', 'bar']
     >;
@@ -748,12 +736,12 @@ import {
   }
 
   /** it should add undefined if the path contains an optional */ {
-    const actual = _ as EvaluatePath<{ foo?: { bar: string } }, ['foo', 'bar']>;
+    const actual = _ as GetPath<{ foo?: { bar: string } }, ['foo', 'bar']>;
     expectType<string | undefined>(actual);
   }
 
   /** it should add undefined if the path contains an undefineable */ {
-    const actual = _ as EvaluatePath<
+    const actual = _ as GetPath<
       { foo: undefined | { bar: string } },
       ['foo', 'bar']
     >;
@@ -761,12 +749,12 @@ import {
   }
 
   /** it should evaluate to undefined if the type is not traversable */ {
-    const actual = _ as EvaluatePath<string, ['foo']>;
+    const actual = _ as GetPath<string, ['foo']>;
     expectType<undefined>(actual);
   }
 
   /** it should work on type unions */ {
-    const actual = _ as EvaluatePath<
+    const actual = _ as GetPath<
       InfiniteType<number> | InfiniteType<string>,
       ['foo', 'value']
     >;
@@ -774,7 +762,7 @@ import {
   }
 
   /** it should add undefined if the path doesn't exist in one of the types */ {
-    const actual = _ as EvaluatePath<
+    const actual = _ as GetPath<
       InfiniteType<number> | Nested<string>,
       ['foo', 'value']
     >;
@@ -782,27 +770,24 @@ import {
   }
 
   /** it should evaluate to any if the type is any */ {
-    const actual = _ as EvaluatePath<any, ['foo']>;
+    const actual = _ as GetPath<any, ['foo']>;
     expectType<any>(actual);
   }
 
   /** it should evaluate to any if it encounters any */ {
-    const actual = _ as EvaluatePath<{ foo: any }, ['foo', 'bar', 'baz']>;
+    const actual = _ as GetPath<{ foo: any }, ['foo', 'bar', 'baz']>;
     expectType<any>(actual);
   }
 
   /** it should not evaluate to any if it doesn't encounter any */ {
-    const actual = _ as EvaluatePath<{ foo: any }, ['bar', 'baz']>;
+    const actual = _ as GetPath<{ foo: any }, ['bar', 'baz']>;
     expectType<undefined>(actual);
   }
 
   /** it should not create a union which is too complex to represent */ {
     const makeSetter =
       <T>() =>
-      <PS extends PathString>(
-        _: PS,
-        value: EvaluatePath<T, SplitPathString<PS>>,
-      ) =>
+      <PS extends PathString>(_: PS, value: GetPath<T, SplitPathString<PS>>) =>
         value;
 
     const setter = makeSetter<{ foo: string }>();

--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -182,7 +182,6 @@ type TryGet<T, K> = K extends keyof T
 
 /**
  * Type to access an array type by a key.
- * Returns undefined if the key is non-numeric.
  * @typeParam T - type which is indexed by the key
  * @typeParam K - key into the type
  * ```
@@ -196,14 +195,24 @@ type TryGetArray<
 > = K extends `${ArrayKey}` ? T[number] : TryGet<T, K>;
 
 /**
- * Type to evaluate the type which the given key points to.
+ * Type to evaluate the type which the given key points to. This type is the
+ * covariant equivalent of {@link SetKey}.
+ *  - If either T or K is union, it will evaluate to the union of the types at
+ *    the given key(s).
+ *  - If T can be null or undefined, the resulting type will also include null
+ *    or undefined.
+ *  - If a key doesn't exist, or may be optional, the resulting type will
+ *    include undefined.
  * @typeParam T - type which is indexed by the key
  * @typeParam K - key into the type
  * @example
  * ```
  * GetKey<{foo: string}, 'foo'> = string
- * GetKey<[number, string], '1'> = string
- * GetKey<string[], '1'> = string
+ * GetKey<{foo: string, bar: number}, 'foo' | 'bar'> = string | number
+ * GetKey<{foo: string} | {foo: number}, 'foo'> = string | number
+ * GetKey<null | {foo: string}, 'foo'> = null | string
+ * GetKey<{bar: string}, 'foo'> = undefined
+ * GetKey<{foo?: string}, 'foo'> = undefined | string
  * ```
  */
 export type GetKey<T, K extends Key> = T extends ReadonlyArray<any>
@@ -227,6 +236,71 @@ export type GetKey<T, K extends Key> = T extends ReadonlyArray<any>
 export type GetPath<T, PT extends PathTuple> = PT extends [infer K, ...infer R]
   ? GetPath<GetKey<T, AsKey<K>>, AsPathTuple<R>>
   : T;
+
+/**
+ * Type to access a type by a key. Returns never
+ *  - if it can't be indexed by that key.
+ *  - if the type is not traversable.
+ * @typeParam T - type which is indexed by the key
+ * @typeParam K - key into the type
+ * ```
+ * TrySet<{foo: string}, 'foo'> = string
+ * TrySet<{foo: string}, 'bar'> = never
+ * TrySet<null, 'foo'> = never
+ * TrySet<string, 'foo'> = never
+ * ```
+ */
+type TrySet<T, K> = K extends keyof T ? T[K] : never;
+
+/**
+ * Type to access an array type by a key.
+ * @typeParam T - type which is indexed by the key
+ * @typeParam K - key into the type
+ * ```
+ * TrySetArray<string[], '0'> = string
+ * TrySetArray<string[], 'foo'> = never
+ * ```
+ */
+type TrySetArray<
+  T extends ReadonlyArray<any>,
+  K extends Key,
+> = K extends `${ArrayKey}` ? T[number] : TrySet<T, K>;
+
+/**
+ * Type to implement {@link SetKey}. Wraps everything into a tuple.
+ * @typeParam T - non-nullable type which is indexed by the key
+ * @typeParam K - key into the type, mustn't be a union of keys
+ */
+type SetKeyImpl<T, K extends Key> = T extends ReadonlyArray<any>
+  ? IsTuple<T> extends true
+    ? [TrySet<T, K>]
+    : [TrySetArray<T, K>]
+  : [TrySet<MapKeys<T>, K>];
+
+/**
+ * Type to evaluate the type which the given key points to. This type is the
+ * contravariant equivalent of {@link GetKey}.
+ *  - If either T or K is union, it will evaluate to the intersection of the
+ *    types at the given key(s).
+ *  - If T can be null or undefined, the resulting type won't include null or
+ *    undefined.
+ *  - If a key doesn't exist,the resulting type will be never.
+ *  - If a key may be optional, the resulting type will include undefined.
+ * @typeParam T - type which is indexed by the key
+ * @typeParam K - key into the type
+ * @example
+ * ```
+ * SetKey<{foo: string}, 'foo'> = string
+ * SetKey<{foo: string, bar: number}, 'foo' | 'bar'> = string & number
+ * SetKey<{foo: string} | {foo: number}, 'foo'> = string & number
+ * SetKey<null | {foo: string}, 'foo'> = string
+ * SetKey<{bar: string}, 'foo'> = never
+ * SetKey<{foo?: string}, 'foo'> = undefined | string
+ * ```
+ */
+export type SetKey<T, K extends Key> = UnionToIntersection<
+  K extends any ? SetKeyImpl<NonNullable<T>, K> : never
+>[never];
 
 /**
  * Type which given a tuple type returns its own keys, i.e. only its indices.

--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -168,13 +168,13 @@ type MapKeys<T> = { [K in keyof T as ToKey<K>]: T[K] };
  * @typeParam T - type which is indexed by the key
  * @typeParam K - key into the type
  * ```
- * TryAccess<{foo: string}, 'foo'> = string
- * TryAccess<{foo: string}, 'bar'> = undefined
- * TryAccess<null, 'foo'> = null
- * TryAccess<string, 'foo'> = undefined
+ * TryGet<{foo: string}, 'foo'> = string
+ * TryGet<{foo: string}, 'bar'> = undefined
+ * TryGet<null, 'foo'> = null
+ * TryGet<string, 'foo'> = undefined
  * ```
  */
-type TryAccess<T, K> = K extends keyof T
+type TryGet<T, K> = K extends keyof T
   ? T[K]
   : T extends null
   ? null
@@ -186,14 +186,14 @@ type TryAccess<T, K> = K extends keyof T
  * @typeParam T - type which is indexed by the key
  * @typeParam K - key into the type
  * ```
- * TryAccessArray<string[], '0'> = string
- * TryAccessArray<string[], 'foo'> = undefined
+ * TryGetArray<string[], '0'> = string
+ * TryGetArray<string[], 'foo'> = undefined
  * ```
  */
-type TryAccessArray<
+type TryGetArray<
   T extends ReadonlyArray<any>,
   K extends Key,
-> = K extends `${ArrayKey}` ? T[number] : TryAccess<T, K>;
+> = K extends `${ArrayKey}` ? T[number] : TryGet<T, K>;
 
 /**
  * Type to evaluate the type which the given key points to.
@@ -201,16 +201,16 @@ type TryAccessArray<
  * @typeParam K - key into the type
  * @example
  * ```
- * EvaluateKey<{foo: string}, 'foo'> = string
- * EvaluateKey<[number, string], '1'> = string
- * EvaluateKey<string[], '1'> = string
+ * GetKey<{foo: string}, 'foo'> = string
+ * GetKey<[number, string], '1'> = string
+ * GetKey<string[], '1'> = string
  * ```
  */
-export type EvaluateKey<T, K extends Key> = T extends ReadonlyArray<any>
+export type GetKey<T, K extends Key> = T extends ReadonlyArray<any>
   ? IsTuple<T> extends true
-    ? TryAccess<T, K>
-    : TryAccessArray<T, K>
-  : TryAccess<MapKeys<T>, K>;
+    ? TryGet<T, K>
+    : TryGetArray<T, K>
+  : TryGet<MapKeys<T>, K>;
 
 /**
  * Type to evaluate the type which the given path points to.
@@ -218,17 +218,14 @@ export type EvaluateKey<T, K extends Key> = T extends ReadonlyArray<any>
  * @typeParam PT - path into the deeply nested type
  * @example
  * ```
- * EvaluatePath<{foo: {bar: string}}, ['foo', 'bar']> = string
- * EvaluatePath<[number, string], ['1']> = string
- * EvaluatePath<number, []> = number
- * EvaluatePath<number, ['foo']> = undefined
+ * GetPath<{foo: {bar: string}}, ['foo', 'bar']> = string
+ * GetPath<[number, string], ['1']> = string
+ * GetPath<number, []> = number
+ * GetPath<number, ['foo']> = undefined
  * ```
  */
-export type EvaluatePath<T, PT extends PathTuple> = PT extends [
-  infer K,
-  ...infer R
-]
-  ? EvaluatePath<EvaluateKey<T, AsKey<K>>, AsPathTuple<R>>
+export type GetPath<T, PT extends PathTuple> = PT extends [infer K, ...infer R]
+  ? GetPath<GetKey<T, AsKey<K>>, AsPathTuple<R>>
   : T;
 
 /**
@@ -305,7 +302,7 @@ export type ObjectKeys<T extends Traversable> = Exclude<
  * ```
  */
 export type CheckKeyConstraint<T, K extends Key, U> = K extends any
-  ? EvaluateKey<T, K> extends U
+  ? GetKey<T, K> extends U
     ? K
     : never
   : never;
@@ -389,7 +386,7 @@ type ValidPathPrefixImpl<
 > = PT extends [infer K, ...infer R]
   ? HasKey<T, AsKey<K>> extends true
     ? ValidPathPrefixImpl<
-        EvaluateKey<T, AsKey<K>>,
+        GetKey<T, AsKey<K>>,
         AsPathTuple<R>,
         AsPathTuple<[...VPT, K]>
       >

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -2,7 +2,7 @@ import { FieldValues } from '../fields';
 import { IsNever } from '../utils';
 
 import {
-  EvaluatePath,
+  GetPath,
   HasPath,
   JoinPathTuple,
   Key,
@@ -59,7 +59,7 @@ export type SuggestChildPaths<
   T,
   PT extends PathTuple,
   U = unknown,
-> = PT extends any ? SuggestChildPathsImpl<PT, EvaluatePath<T, PT>, U> : never;
+> = PT extends any ? SuggestChildPathsImpl<PT, GetPath<T, PT>, U> : never;
 
 /**
  * Type to implement {@link SuggestPaths} without having to compute the valid
@@ -126,7 +126,7 @@ type AutoCompletePathCheckConstraint<
   PT extends PathTuple,
   U,
 > = HasPath<T, PT> extends true
-  ? EvaluatePath<T, PT> extends U
+  ? GetPath<T, PT> extends U
     ? PS extends JoinPathTuple<PT>
       ? PS
       : JoinPathTuple<PT>


### PR DESCRIPTION
# Changes
- Rename `EvaluateKey` to `GetKey`
- Rename `EvaluatePath` to `GetPath`
- Add `SetKey` as contravariant equivalent of `GetKey`
- Add `SetPath` as contravariant equivalent of `GetPath`

# Examples

```ts
// ✔ correct
function get<T, P extends PathTuple>(obj: T, path: P): GetPath<T, P>

// ❌ wrong
function get<T, P extends PathTuple>(obj: T, path: P): SetPath<T, P>
                                                       ^^^^^^^^^^^^^
```

```ts
// ✔ correct
function set<T, P extends PathTuple>(obj: T, path: P, value: SetPath<T, P>): void

// ❌ wrong
function set<T, P extends PathTuple>(obj: T, path: P, value: GetPath<T, P>): void
                                                             ^^^^^^^^^^^^^
```