### PR TITLE
fix compact util type

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -484,7 +484,7 @@ export function createFormControl<
     return generateWatchOutput(names, _names, fieldValues, isGlobal);
   };
 
-  const _getFieldArray = (name: InternalFieldName) =>
+  const _getFieldArray = (name: InternalFieldName): any[] =>
     compact(
       get(
         _stateFlags.mount ? _formValues : _defaultValues,

--- a/src/utils/compact.ts
+++ b/src/utils/compact.ts
@@ -1,1 +1,1 @@
-export default (value: any[]) => (value || []).filter(Boolean);
+export default <TValue>(value: TValue[]) => value.filter(Boolean);

--- a/src/utils/get.ts
+++ b/src/utils/get.ts
@@ -3,10 +3,11 @@ import isNullOrUndefined from './isNullOrUndefined';
 import isObject from './isObject';
 import isUndefined from './isUndefined';
 
-export default <T>(obj: T, path: string, defaultValue?: unknown) => {
+export default <T>(obj: T, path: string, defaultValue?: unknown): any => {
   if (isObject(obj) && path) {
     const result = compact(path.split(/[,[\].]+?/)).reduce(
-      (result, key) => (isNullOrUndefined(result) ? result : result[key]),
+      (result, key) =>
+        isNullOrUndefined(result) ? result : result[key as keyof {}],
       obj,
     );
 


### PR DESCRIPTION
Hello,
I fixed type in compact util.

I also changed the logic/createFormControl.ts and utils/get.ts, because the previous type of compact util influenced the returned result (functions return the same as before, I did not interfere with it).

I believe that the function itself should decide when it returns "any". Then the subsequent type change is easier if possible, because we know what causes the return type.