### PR TITLE
rewerite object get utility

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -262,7 +262,7 @@ export type FormStateSubjectRef<TFieldValues> = Subject<Partial<FormState<TField
 }>;
 
 // @public (undocumented)
-export const get: <T extends Record<string | number | symbol, any> | undefined, U = undefined>(obj: T, path: string, defaultValue?: U | undefined) => any;
+export const get: <T extends Record<string, any>, U = undefined>(obj: T | undefined, path: string, defaultValue?: U | undefined) => any;
 
 // @public (undocumented)
 export type GetIsDirty = <TName extends InternalFieldName, TData>(name?: TName, data?: TData) => boolean;

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -262,7 +262,7 @@ export type FormStateSubjectRef<TFieldValues> = Subject<Partial<FormState<TField
 }>;
 
 // @public (undocumented)
-export const get: <T>(obj: T, path: string, defaultValue?: unknown) => any;
+export const get: <T extends Record<string | number | symbol, any> | undefined, U = undefined>(obj: T, path: string, defaultValue?: U | undefined) => any;
 
 // @public (undocumented)
 export type GetIsDirty = <TName extends InternalFieldName, TData>(name?: TName, data?: TData) => boolean;

--- a/src/utils/get.ts
+++ b/src/utils/get.ts
@@ -1,5 +1,5 @@
 import compact from './compact';
-import isObject from './isObject';
+import isPrimitive from './isPrimitive';
 
 export default <T extends Record<string, any>, U = undefined>(
   obj: T | undefined,
@@ -11,37 +11,28 @@ export default <T extends Record<string, any>, U = undefined>(
   }
 
   const pathKeys = compact(path.split(/[,[\].]+?/));
-  const pathKeysLastIndex = pathKeys.length - 1;
 
   let result: any = obj;
 
-  for (const [index, key] of pathKeys.entries()) {
-    const currentValue = result[key];
+  for (const key of pathKeys) {
+    result = result[key];
 
-    if (currentValue === null) {
-      return null;
+    if (isPrimitive(result)) {
+      if (result === null) {
+        return null;
+      }
+
+      if (result === undefined) {
+        /**
+         * By checking for obj[path] we can handle case like
+         * { 'betty.test.test1[0].test1': 'test' }
+         * TODO: probably this should be removed and just return the defaultValue
+         */
+        return obj[path] !== undefined ? obj[path] : defaultValue;
+      }
+
+      return result;
     }
-
-    if (currentValue === undefined) {
-      result = defaultValue;
-      break;
-    }
-
-    if (
-      index < pathKeysLastIndex &&
-      !isObject(currentValue) &&
-      !Array.isArray(currentValue)
-    ) {
-      result = defaultValue;
-      break;
-    }
-
-    result = currentValue;
-  }
-
-  // handle case like 'betty.test.test1[0].test1': 'test'
-  if (result === undefined && obj[path] !== undefined) {
-    return obj[path];
   }
 
   return result;

--- a/src/utils/get.ts
+++ b/src/utils/get.ts
@@ -1,51 +1,48 @@
 import compact from './compact';
-import isNullOrUndefined from './isNullOrUndefined';
 import isObject from './isObject';
-import isUndefined from './isUndefined';
 
-export default <
-  T extends Record<string | number | symbol, any> | undefined,
-  U = undefined,
->(
-  obj: T,
+export default <T extends Record<string, any>, U = undefined>(
+  obj: T | undefined,
   path: string,
   defaultValue?: U,
 ) => {
-  if (obj && path) {
-    // handle case like 'betty.test.test1[0].test1': 'test'
-    if (!isUndefined(obj[path])) {
-      return obj[path];
-    }
-
-    const pathKeys = compact(path.split(/[,[\].]+?/));
-    const pathKeysLastIndex = pathKeys.length - 1;
-
-    let result: any = obj;
-
-    for (const [index, key] of pathKeys.entries()) {
-      const currentValue = result[key];
-
-      if (isNullOrUndefined(currentValue)) {
-        result = isUndefined(currentValue)
-          ? defaultValue ?? currentValue
-          : currentValue;
-        break;
-      }
-
-      if (
-        index < pathKeysLastIndex &&
-        !isObject(currentValue) &&
-        !Array.isArray(currentValue)
-      ) {
-        result = defaultValue ?? undefined;
-        break;
-      }
-
-      result = currentValue;
-    }
-
-    return result;
+  if (!obj || !path) {
+    return defaultValue;
   }
 
-  return defaultValue ?? undefined;
+  const pathKeys = compact(path.split(/[,[\].]+?/));
+  const pathKeysLastIndex = pathKeys.length - 1;
+
+  let result: any = obj;
+
+  for (const [index, key] of pathKeys.entries()) {
+    const currentValue = result[key];
+
+    if (currentValue === null) {
+      return null;
+    }
+
+    if (currentValue === undefined) {
+      result = defaultValue;
+      break;
+    }
+
+    if (
+      index < pathKeysLastIndex &&
+      !isObject(currentValue) &&
+      !Array.isArray(currentValue)
+    ) {
+      result = defaultValue;
+      break;
+    }
+
+    result = currentValue;
+  }
+
+  // handle case like 'betty.test.test1[0].test1': 'test'
+  if (result === undefined && obj[path] !== undefined) {
+    return obj[path];
+  }
+
+  return result;
 };


### PR DESCRIPTION
Hi, I changed the implementation of the objet get utility.
Firstly we can define `T extends Record<string | number | symbol, any> | undefined` which checks the typing of obj param on the TS level without the need to call the `isObject` utility. Secondly I noticed that when using the reduce implementation we cannot break out of the loop when some property in the nested path like `a,b,c,d,e,f` is undefined or null. There is no sense to loop through the other properties when for example `b` is undefined. When using the for...of loop we can exit early. Generally I think this is now more straightforward to read :)