### PR TITLE
Add AccessPattern type to constrain property accesses by a Get and Set type

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -298,10 +298,10 @@ export type KeepStateOptions = Partial<{
 }>;
 
 // Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "Traversable" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "Constraint" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<T, TPathString, ReadonlyArray<Traversable> | null | undefined>;
+export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<T, TPathString, Constraint<ReadonlyArray<FieldValues> | null | undefined, never[]>>;
 
 // @public
 export type LazyFieldArrayPath<TFieldValues extends FieldValues, TPathString extends PathString> = LazyArrayPath<TFieldValues, TPathString>;

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -298,10 +298,10 @@ export type KeepStateOptions = Partial<{
 }>;
 
 // Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "Constraint" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "AccessPattern" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<T, TPathString, Constraint<ReadonlyArray<FieldValues> | null | undefined, never[]>>;
+export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<T, TPathString, AccessPattern<ReadonlyArray<FieldValues> | null | undefined, never[]>>;
 
 // @public
 export type LazyFieldArrayPath<TFieldValues extends FieldValues, TPathString extends PathString> = LazyArrayPath<TFieldValues, TPathString>;

--- a/src/__tests__/types/path/common.test-d.ts
+++ b/src/__tests__/types/path/common.test-d.ts
@@ -177,22 +177,22 @@ import {
 /** {@link Constraint} */ {
   type Extends<A, B> = A extends B ? true : false;
 
-  /** it should extend if Super is a supertype */ {
-    const actual = _ as Extends<Constraint<1, 1 | 2>, Constraint<1, 1>>;
-    expectType<true>(actual);
-  }
-
-  /** it should extend if Sub is a subtype */ {
+  /** it should extend if it's a subtype */ {
     const actual = _ as Extends<Constraint<1, 1>, Constraint<1 | 2, 1>>;
     expectType<true>(actual);
   }
 
-  /** it shouldn't extend if Sub is a supertype */ {
+  /** it should extend if it's a supertype */ {
+    const actual = _ as Extends<Constraint<1, 1 | 2>, Constraint<1, 1>>;
+    expectType<true>(actual);
+  }
+
+  /** it shouldn't extend if it isn't a subtype */ {
     const actual = _ as Extends<Constraint<1 | 2, 1>, Constraint<1, 1>>;
     expectType<false>(actual);
   }
 
-  /** it shouldn't extend if Super is a subtype */ {
+  /** it shouldn't extend if it isn't a supertype */ {
     const actual = _ as Extends<Constraint<1, 1>, Constraint<1, 1 | 2>>;
     expectType<false>(actual);
   }

--- a/src/__tests__/types/path/common.test-d.ts
+++ b/src/__tests__/types/path/common.test-d.ts
@@ -1,11 +1,11 @@
 import { expectType } from 'tsd';
 
 import {
+  AccessPattern,
   ArrayKey,
   AsKey,
   AsPathTuple,
   CheckKeyConstraint,
-  Constraint,
   ContainsIndexable,
   GetKey,
   GetPath,
@@ -174,26 +174,38 @@ import {
   }
 }
 
-/** {@link Constraint} */ {
+/** {@link AccessPattern} */ {
   type Extends<A, B> = A extends B ? true : false;
 
   /** it should extend if it's a subtype */ {
-    const actual = _ as Extends<Constraint<1, 1>, Constraint<1 | 2, 1>>;
+    const actual = _ as Extends<
+      AccessPattern<'abcd', 'abcd'>,
+      AccessPattern<string, 'abcd'>
+    >;
     expectType<true>(actual);
   }
 
   /** it should extend if it's a supertype */ {
-    const actual = _ as Extends<Constraint<1, 1 | 2>, Constraint<1, 1>>;
+    const actual = _ as Extends<
+      AccessPattern<'abcd', string>,
+      AccessPattern<'abcd', 'abcd'>
+    >;
     expectType<true>(actual);
   }
 
   /** it shouldn't extend if it isn't a subtype */ {
-    const actual = _ as Extends<Constraint<1 | 2, 1>, Constraint<1, 1>>;
+    const actual = _ as Extends<
+      AccessPattern<string, 'abcd'>,
+      AccessPattern<'abcd', 'abcd'>
+    >;
     expectType<false>(actual);
   }
 
   /** it shouldn't extend if it isn't a supertype */ {
-    const actual = _ as Extends<Constraint<1, 1>, Constraint<1, 1 | 2>>;
+    const actual = _ as Extends<
+      AccessPattern<'abcd', 'abcd'>,
+      AccessPattern<'abcd', string>
+    >;
     expectType<false>(actual);
   }
 }
@@ -203,7 +215,7 @@ import {
     const actual = _ as CheckKeyConstraint<
       { foo: string; bar: number },
       'foo' | 'bar',
-      Constraint<string>
+      AccessPattern<string>
     >;
     expectType<'foo'>(actual);
   }
@@ -351,32 +363,38 @@ import {
   }
 
   /** it should only return the keys of string properties */ {
-    const actual = _ as Keys<{ foo: 'foo'; bar: number }, Constraint<string>>;
+    const actual = _ as Keys<
+      { foo: 'foo'; bar: number },
+      AccessPattern<string>
+    >;
     expectType<'foo'>(actual);
   }
 
   /** it should only return the keys of properties which can be set to a string */ {
     const actual = _ as Keys<
       { foo: string; bar: 'bar' },
-      Constraint<string, string>
+      AccessPattern<string, string>
     >;
     expectType<'foo'>(actual);
   }
 
   /** it should only return the keys of string properties */ {
-    const actual = _ as Keys<{ 1: string; 2: number }, Constraint<string>>;
+    const actual = _ as Keys<{ 1: string; 2: number }, AccessPattern<string>>;
     expectType<'1'>(actual);
   }
 
   /** it should return only the required keys when undefined is excluded */ {
-    const actual = _ as Keys<{ foo: string; bar?: string }, Constraint<string>>;
+    const actual = _ as Keys<
+      { foo: string; bar?: string },
+      AccessPattern<string>
+    >;
     expectType<'foo'>(actual);
   }
 
   /** it should return the optional keys when undefined is included */ {
     const actual = _ as Keys<
       { foo: string; bar?: string },
-      Constraint<string | undefined>
+      AccessPattern<string | undefined>
     >;
     expectType<'foo' | 'bar'>(actual);
   }

--- a/src/__tests__/types/path/common.test-d.ts
+++ b/src/__tests__/types/path/common.test-d.ts
@@ -174,6 +174,30 @@ import {
   }
 }
 
+/** {@link Constraint} */ {
+  type Extends<A, B> = A extends B ? true : false;
+
+  /** it should extend if Super is a supertype */ {
+    const actual = _ as Extends<Constraint<1, 1 | 2>, Constraint<1, 1>>;
+    expectType<true>(actual);
+  }
+
+  /** it should extend if Sub is a subtype */ {
+    const actual = _ as Extends<Constraint<1, 1>, Constraint<1 | 2, 1>>;
+    expectType<true>(actual);
+  }
+
+  /** it shouldn't extend if Sub is a supertype */ {
+    const actual = _ as Extends<Constraint<1 | 2, 1>, Constraint<1, 1>>;
+    expectType<false>(actual);
+  }
+
+  /** it shouldn't extend if Super is a subtype */ {
+    const actual = _ as Extends<Constraint<1, 1>, Constraint<1, 1 | 2>>;
+    expectType<false>(actual);
+  }
+}
+
 /** {@link CheckKeyConstraint} */ {
   /** it should remove the keys which don't match the constraint */ {
     const actual = _ as CheckKeyConstraint<

--- a/src/__tests__/types/path/common.test-d.ts
+++ b/src/__tests__/types/path/common.test-d.ts
@@ -5,6 +5,7 @@ import {
   AsKey,
   AsPathTuple,
   CheckKeyConstraint,
+  Constraint,
   ContainsIndexable,
   GetKey,
   GetPath,
@@ -178,7 +179,7 @@ import {
     const actual = _ as CheckKeyConstraint<
       { foo: string; bar: number },
       'foo' | 'bar',
-      string
+      Constraint<string>
     >;
     expectType<'foo'>(actual);
   }
@@ -326,22 +327,33 @@ import {
   }
 
   /** it should only return the keys of string properties */ {
-    const actual = _ as Keys<{ foo: string; bar: number }, string>;
+    const actual = _ as Keys<{ foo: 'foo'; bar: number }, Constraint<string>>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should only return the keys of properties which can be set to a string */ {
+    const actual = _ as Keys<
+      { foo: string; bar: 'bar' },
+      Constraint<string, string>
+    >;
     expectType<'foo'>(actual);
   }
 
   /** it should only return the keys of string properties */ {
-    const actual = _ as Keys<{ 1: string; 2: number }, string>;
+    const actual = _ as Keys<{ 1: string; 2: number }, Constraint<string>>;
     expectType<'1'>(actual);
   }
 
   /** it should return only the required keys when undefined is excluded */ {
-    const actual = _ as Keys<{ foo: string; bar?: string }, string>;
+    const actual = _ as Keys<{ foo: string; bar?: string }, Constraint<string>>;
     expectType<'foo'>(actual);
   }
 
   /** it should return the optional keys when undefined is included */ {
-    const actual = _ as Keys<{ foo: string; bar?: string }, string | undefined>;
+    const actual = _ as Keys<
+      { foo: string; bar?: string },
+      Constraint<string | undefined>
+    >;
     expectType<'foo' | 'bar'>(actual);
   }
 

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -1,7 +1,7 @@
 import { expectType } from 'tsd';
 
 import { LazyArrayPath, PathString } from '../../../types';
-import { Constraint } from '../../../types/path/common';
+import { AccessPattern } from '../../../types/path/common';
 import {
   AutoCompletePath,
   SuggestChildPaths,
@@ -56,7 +56,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as SuggestChildPaths<
       InfiniteType<string>,
       ['foo'],
-      Constraint<number>
+      AccessPattern<number>
     >;
     expectType<'foo.foo' | 'foo.bar' | 'foo.baz'>(actual);
   }
@@ -116,7 +116,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as SuggestPaths<
       InfiniteType<string>,
       ['foo', 'foo'],
-      Constraint<number>
+      AccessPattern<number>
     >;
     expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
   }
@@ -125,7 +125,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as SuggestPaths<
       NullableInfiniteType<string>,
       ['foo', 'foo'],
-      Constraint<string>
+      AccessPattern<string>
     >;
     expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
   }
@@ -175,7 +175,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       'foo.value',
-      Constraint<number>
+      AccessPattern<number>
     >;
     expectType<'foo'>(actual);
   }
@@ -206,7 +206,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       'foo.value',
-      Constraint<string>
+      AccessPattern<string>
     >;
     expectType<'foo' | 'foo.value'>(actual);
   }
@@ -215,13 +215,13 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       { foo: any },
       'foo.bar.baz',
-      Constraint<string>
+      AccessPattern<string>
     >;
     expectType<'foo.bar' | 'foo.bar.baz' | `foo.bar.baz.${string}`>(actual);
   }
 
   /** it should accept string when the type is any */ {
-    const actual = _ as AutoCompletePath<any, string, Constraint<string>>;
+    const actual = _ as AutoCompletePath<any, string, AccessPattern<string>>;
     expectType<string>(actual);
   }
 
@@ -229,7 +229,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       any,
-      Constraint<string>
+      AccessPattern<string>
     >;
     expectType<any>(actual);
   }
@@ -238,7 +238,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       never,
-      Constraint<string>
+      AccessPattern<string>
     >;
     expectType<never>(actual);
   }
@@ -247,7 +247,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       NullableInfiniteType<string>,
       'foo.value',
-      Constraint<string>
+      AccessPattern<string>
     >;
     expectType<'foo'>(actual);
   }
@@ -256,7 +256,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       NullableInfiniteType<string>,
       'foo.value',
-      Constraint<string | null | undefined>
+      AccessPattern<string | null | undefined>
     >;
     expectType<'foo' | 'foo.value'>(actual);
   }
@@ -265,7 +265,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       'foo.foo',
-      Constraint<string>
+      AccessPattern<string>
     >;
     expectType<
       'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz' | 'foo.foo.value'
@@ -276,7 +276,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       'foo.foo',
-      Constraint<number>
+      AccessPattern<number>
     >;
     expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
   }

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -1,6 +1,7 @@
 import { expectType } from 'tsd';
 
 import { LazyArrayPath, PathString } from '../../../types';
+import { Constraint } from '../../../types/path/common';
 import {
   AutoCompletePath,
   SuggestChildPaths,
@@ -55,7 +56,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as SuggestChildPaths<
       InfiniteType<string>,
       ['foo'],
-      number
+      Constraint<number>
     >;
     expectType<'foo.foo' | 'foo.bar' | 'foo.baz'>(actual);
   }
@@ -115,7 +116,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as SuggestPaths<
       InfiniteType<string>,
       ['foo', 'foo'],
-      number
+      Constraint<number>
     >;
     expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
   }
@@ -124,7 +125,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as SuggestPaths<
       NullableInfiniteType<string>,
       ['foo', 'foo'],
-      string
+      Constraint<string>
     >;
     expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
   }
@@ -174,7 +175,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       'foo.value',
-      number
+      Constraint<number>
     >;
     expectType<'foo'>(actual);
   }
@@ -205,28 +206,40 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       'foo.value',
-      string
+      Constraint<string>
     >;
     expectType<'foo' | 'foo.value'>(actual);
   }
 
   /** it should accept string when any is encountered */ {
-    const actual = _ as AutoCompletePath<{ foo: any }, 'foo.bar.baz', string>;
+    const actual = _ as AutoCompletePath<
+      { foo: any },
+      'foo.bar.baz',
+      Constraint<string>
+    >;
     expectType<'foo.bar' | 'foo.bar.baz' | `foo.bar.baz.${string}`>(actual);
   }
 
   /** it should accept string when the type is any */ {
-    const actual = _ as AutoCompletePath<any, string, string>;
+    const actual = _ as AutoCompletePath<any, string, Constraint<string>>;
     expectType<string>(actual);
   }
 
   /** it should evaluate to any when the path is any */ {
-    const actual = _ as AutoCompletePath<InfiniteType<string>, any, string>;
+    const actual = _ as AutoCompletePath<
+      InfiniteType<string>,
+      any,
+      Constraint<string>
+    >;
     expectType<any>(actual);
   }
 
   /** it should evaluate to never when the path is never */ {
-    const actual = _ as AutoCompletePath<InfiniteType<string>, never, string>;
+    const actual = _ as AutoCompletePath<
+      InfiniteType<string>,
+      never,
+      Constraint<string>
+    >;
     expectType<never>(actual);
   }
 
@@ -234,7 +247,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       NullableInfiniteType<string>,
       'foo.value',
-      string
+      Constraint<string>
     >;
     expectType<'foo'>(actual);
   }
@@ -243,7 +256,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       NullableInfiniteType<string>,
       'foo.value',
-      string | null | undefined
+      Constraint<string | null | undefined>
     >;
     expectType<'foo' | 'foo.value'>(actual);
   }
@@ -252,7 +265,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       'foo.foo',
-      string
+      Constraint<string>
     >;
     expectType<
       'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz' | 'foo.foo.value'
@@ -263,7 +276,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
     const actual = _ as AutoCompletePath<
       InfiniteType<string>,
       'foo.foo',
-      number
+      Constraint<number>
     >;
     expectType<'foo' | 'foo.foo.foo' | 'foo.foo.bar' | 'foo.foo.baz'>(actual);
   }
@@ -379,18 +392,21 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
   }
 
   /** it should accept non-primitive arrays */ {
-    const actual = _ as LazyArrayPath<InfiniteType<number[]>, 'foo.baz'>;
-    expectType<'foo' | 'foo.baz' | `foo.baz.${number}`>(actual);
+    const actual = _ as LazyArrayPath<{ foo: { bar: object[] } }, 'foo.bar'>;
+    expectType<'foo' | `foo.bar` | `foo.bar.${number}`>(actual);
   }
 
-  /** it should not accept primitive tuples */ {
-    const actual = _ as LazyArrayPath<InfiniteType<[number]>, 'foo.value'>;
-    expectType<'foo'>(actual);
+  /** it should not accept non-primitive readonly arrays */ {
+    const actual = _ as LazyArrayPath<
+      { foo: { bar: readonly object[] } },
+      'foo.bar'
+    >;
+    expectType<'foo' | `foo.bar.${number}`>(actual);
   }
 
-  /** it should accept non-primitive tuples */ {
+  /** it should not accept tuples */ {
     const actual = _ as LazyArrayPath<InfiniteType<number[]>, 'foo.bar'>;
-    expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
+    expectType<'foo' | 'foo.bar.0'>(actual);
   }
 
   /** it should accept non-primitive nullable arrays */ {

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -401,7 +401,7 @@ import { _, InfiniteType, NullableInfiniteType } from '../__fixtures__';
       { foo: { bar: readonly object[] } },
       'foo.bar'
     >;
-    expectType<'foo' | `foo.bar.${number}`>(actual);
+    expectType<'foo' | `foo.bar` | `foo.bar.${number}`>(actual);
   }
 
   /** it should not accept tuples */ {

--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -412,7 +412,7 @@ export type ObjectKeys<T extends Traversable> = Exclude<
  * @typeParam Get - constrains a type to be a subtype of this type,
  *                  i.e. the type when getting the property
  * @typeParam Set - constrains a type to be a supertype of this type,
- *                  i.e. the type you required for setting the property
+ *                  i.e. the type required for setting the property
  * @example
  * ```
  *  'abcd' is a subtype   of string

--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -408,12 +408,20 @@ export type ObjectKeys<T extends Traversable> = Exclude<
 >;
 
 /**
- * Type which represents a constraint
- * @typeParam Get - covariant constraint, i.e. the type when getting a property
- * @typeParam Set - contravariant constraint, i.e. the type when setting a
- *                  property
+ * Type which represents a constraint:
+ *  - 1 is a subtype of 1 | 2
+ *  - 1 | 2 is a supertype of 1
+ *  - Constraint<1    , 1    >  extends         Constraint<1 | 2, 1    >
+ *  - Constraint<1    , 1 | 2>  extends         Constraint<1    , 1    >
+ *  - Constraint<1 | 2, 1    >  doesn't extend  Constraint<1    , 1    >
+ *  - Constraint<1    , 1    >  doesn't extend  Constraint<1    , 1 | 2>
+ * @typeParam Sub   - constrains a type to be a subtype
+ * @typeParam Super - constrains a type to be a supertype
  */
-export type Constraint<Get = unknown, Set = never> = [Get, (_: Set) => void];
+export type Constraint<Sub = unknown, Super = never> = [
+  Sub,
+  (_: Super) => void,
+];
 
 /**
  * Type to check whether a type's property matches the constraint type

--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -409,21 +409,21 @@ export type ObjectKeys<T extends Traversable> = Exclude<
 
 /**
  * Type which represents a property access.
+ * @typeParam Get - the type when getting the property (covariant)
+ * @typeParam Set - the type required for setting the property (contravariant)
+ * @remarks
  * See {@link https://dmitripavlutin.com/typescript-covariance-contravariance/}
  * for an explanation of covariance and contravariance.
- * @typeParam Get - constrains a type to be a subtype of this type,
- *                  i.e. the type when getting the property
- * @typeParam Set - constrains a type to be a supertype of this type,
- *                  i.e. the type required for setting the property
- * @example
- * ```
- *  'abcd' is a subtype   of string
- *  string is a supertype of 'abcd'
- *  AccessPattern<'abcd', 'abcd'>  extends         AccessPattern<string, 'abcd'>
- *  AccessPattern<'abcd', string>  extends         AccessPattern<'abcd', 'abcd'>
- *  AccessPattern<string, 'abcd'>  doesn't extend  AccessPattern<'abcd', 'abcd'>
- *  AccessPattern<'abcd', 'abcd'>  doesn't extend  AccessPattern<'abcd', string>
- * ```
+ *
+ * Using it as a constraint:
+ *  - `'abcd'` is a subtype   of `string`
+ *  - `string` is a supertype of `'abcd'`
+ *
+ * Therefore,
+ *  - `AccessPattern<'abcd', 'abcd'>` extends        `AccessPattern<string, 'abcd'>`
+ *  - `AccessPattern<'abcd', string>` extends        `AccessPattern<'abcd', 'abcd'>`
+ *  - `AccessPattern<string, 'abcd'>` doesn't extend `AccessPattern<'abcd', 'abcd'>`
+ *  - `AccessPattern<'abcd', 'abcd'>` doesn't extend `AccessPattern<'abcd', string>`
  */
 export type AccessPattern<Get = unknown, Set = never> = (_: Set) => Get;
 

--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -408,7 +408,9 @@ export type ObjectKeys<T extends Traversable> = Exclude<
 >;
 
 /**
- * Type which represents a property access
+ * Type which represents a property access.
+ * See {@link https://dmitripavlutin.com/typescript-covariance-contravariance/}
+ * for an explanation of covariance and contravariance.
  * @typeParam Get - constrains a type to be a subtype of this type,
  *                  i.e. the type when getting the property
  * @typeParam Set - constrains a type to be a supertype of this type,

--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -415,12 +415,12 @@ export type ObjectKeys<T extends Traversable> = Exclude<
  *  - Constraint<1    , 1 | 2>  extends         Constraint<1    , 1    >
  *  - Constraint<1 | 2, 1    >  doesn't extend  Constraint<1    , 1    >
  *  - Constraint<1    , 1    >  doesn't extend  Constraint<1    , 1 | 2>
- * @typeParam Sub   - constrains a type to be a subtype
- * @typeParam Super - constrains a type to be a supertype
+ * @typeParam Super - constrains a type to be a subtype of this type
+ * @typeParam Sub   - constrains a type to be a supertype of this type
  */
-export type Constraint<Sub = unknown, Super = never> = [
-  Sub,
-  (_: Super) => void,
+export type Constraint<Super = unknown, Sub = never> = [
+  Super,
+  (_: Sub) => void,
 ];
 
 /**

--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -408,15 +408,18 @@ export type ObjectKeys<T extends Traversable> = Exclude<
 >;
 
 /**
- * Type which represents a constraint:
- *  - 1 is a subtype of 1 | 2
- *  - 1 | 2 is a supertype of 1
- *  - Constraint<1    , 1    >  extends         Constraint<1 | 2, 1    >
- *  - Constraint<1    , 1 | 2>  extends         Constraint<1    , 1    >
- *  - Constraint<1 | 2, 1    >  doesn't extend  Constraint<1    , 1    >
- *  - Constraint<1    , 1    >  doesn't extend  Constraint<1    , 1 | 2>
+ * Type which represents a constraint
  * @typeParam Super - constrains a type to be a subtype of this type
  * @typeParam Sub   - constrains a type to be a supertype of this type
+ * @example
+ * ```
+ *  1 is a subtype of 1 | 2
+ *  1 | 2 is a supertype of 1
+ *  Constraint<1    , 1    >  extends         Constraint<1 | 2, 1    >
+ *  Constraint<1    , 1 | 2>  extends         Constraint<1    , 1    >
+ *  Constraint<1 | 2, 1    >  doesn't extend  Constraint<1    , 1    >
+ *  Constraint<1    , 1    >  doesn't extend  Constraint<1    , 1 | 2>
+ * ```
  */
 export type Constraint<Super = unknown, Sub = never> = [
   Super,

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -256,7 +256,7 @@ export type LazyFieldPath<
 export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<
   T,
   TPathString,
-  Constraint<FieldValues[] | null | undefined, never[]>
+  Constraint<ReadonlyArray<FieldValues> | null | undefined, never[]>
 >;
 
 /**

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -2,6 +2,7 @@ import { FieldValues } from '../fields';
 import { IsNever } from '../utils';
 
 import {
+  Constraint,
   GetPath,
   HasPath,
   JoinPathTuple,
@@ -36,7 +37,13 @@ export type SuggestParentPath<PT extends PathTuple> = JoinPathTuple<
  * @typeParam U   - constraint type
  */
 type SuggestChildPathsImpl<PT extends PathTuple, TPT, U> = JoinPathTuple<
-  [...PT, Keys<TPT, U> | Keys<TPT, Traversable | undefined | null>]
+  [
+    ...PT,
+    (
+      | Keys<TPT, Constraint<U>>
+      | Keys<TPT, Constraint<Traversable | undefined | null>>
+    ),
+  ]
 >;
 
 /**

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -10,6 +10,7 @@ import {
   Keys,
   PathString,
   PathTuple,
+  SetPath,
   SplitPathString,
   Traversable,
   UnionToIntersection,
@@ -34,16 +35,14 @@ export type SuggestParentPath<PT extends PathTuple> = JoinPathTuple<
  * Type to implement {@link SuggestChildPaths}.
  * @typeParam PT  - the current path as a {@link PathTuple}
  * @typeParam TPT - the type at that path
- * @typeParam U   - constraint type
+ * @typeParam C   - constraint
  */
-type SuggestChildPathsImpl<PT extends PathTuple, TPT, U> = JoinPathTuple<
-  [
-    ...PT,
-    (
-      | Keys<TPT, Constraint<U>>
-      | Keys<TPT, Constraint<Traversable | undefined | null>>
-    ),
-  ]
+type SuggestChildPathsImpl<
+  PT extends PathTuple,
+  TPT,
+  C extends Constraint,
+> = JoinPathTuple<
+  [...PT, Keys<TPT, C> | Keys<TPT, Constraint<Traversable | undefined | null>>]
 >;
 
 /**
@@ -53,31 +52,38 @@ type SuggestChildPathsImpl<PT extends PathTuple, TPT, U> = JoinPathTuple<
  * aren't traversable.
  * @typeParam T  - type which is indexed by the path
  * @typeParam PT - the current path into the type as a {@link PathTuple}
- * @typeParam U  - constraint type
+ * @typeParam C  - constraint
  * @example
  * ```
- * SuggestChildPaths<{foo: string, bar: string}, [], string> = 'foo' | 'bar'
- * SuggestChildPaths<{foo: string, bar: number}, [], string> = 'foo'
- * SuggestChildPaths<{foo: {bar: string}}, ['foo'], string> = 'foo.bar'
- * SuggestChildPaths<{foo: {bar: string[]}}, ['foo'], string> = 'foo.bar'
+ * SuggestChildPaths<{foo: string, bar: string}, [], Constraint<string>>
+ *   = 'foo' | 'bar'
+ * SuggestChildPaths<{foo: string, bar: number}, [], Constraint<string>>
+ *   = 'foo'
+ * SuggestChildPaths<{foo: {bar: string}}, ['foo']> = 'foo.bar'
+ * SuggestChildPaths<{foo: {bar: string[]}}, ['foo']> = 'foo.bar'
  * ```
  */
 export type SuggestChildPaths<
   T,
   PT extends PathTuple,
-  U = unknown,
-> = PT extends any ? SuggestChildPathsImpl<PT, GetPath<T, PT>, U> : never;
+  C extends Constraint = Constraint,
+> = PT extends any ? SuggestChildPathsImpl<PT, GetPath<T, PT>, C> : never;
 
 /**
  * Type to implement {@link SuggestPaths} without having to compute the valid
  * path prefix more than once.
  * @typeParam T   - type which is indexed by the path
  * @typeParam PT  - the current path into the type as a {@link PathTuple}
- * @typeParam U   - constraint type
+ * @typeParam C   - constraint
  * @typeParam VPT - the valid path prefix for the given path
  */
-type SuggestPathsImpl<T, PT extends PathTuple, U, VPT extends PathTuple> =
-  | SuggestChildPaths<T, VPT, U>
+type SuggestPathsImpl<
+  T,
+  PT extends PathTuple,
+  C extends Constraint,
+  VPT extends PathTuple,
+> =
+  | SuggestChildPaths<T, VPT, C>
   | (PT extends VPT ? SuggestParentPath<VPT> : JoinPathTuple<VPT>);
 
 /**
@@ -89,23 +95,23 @@ type SuggestPathsImpl<T, PT extends PathTuple, U, VPT extends PathTuple> =
  * valid path (see {@link ValidPathPrefix}).
  * @typeParam T  - type which is indexed by the path
  * @typeParam PT - the current path into the type as a {@link PathTuple}
- * @typeParam U  - constraint type
+ * @typeParam C  - constraint
  * @example
  * ```
  * SuggestPaths<{foo: {bar: string}}, ['foo'], string> = 'foo.bar'
- * SuggestPaths<{foo: {bar: string}}, ['foo', 'ba'], string>
+ * SuggestPaths<{foo: {bar: string}}, ['foo', 'ba'], Constraint<string>>
  *   = 'foo' | 'foo.bar'
- * SuggestPaths<{foo: {bar: string}}, ['foo', 'bar'], string>
+ * SuggestPaths<{foo: {bar: string}}, ['foo', 'bar'], Constraint<string>>
  *   = 'foo'
- * SuggestPaths<{foo: {bar: {baz: string}}}, ['foo', 'bar'], string>
+ * SuggestPaths<{foo: {bar: {baz: string}}}, ['foo', 'bar'], Constraint<string>>
  *   = 'foo' | 'foo.bar.baz'
  * ```
  */
 export type SuggestPaths<
   T,
   PT extends PathTuple,
-  U = unknown,
-> = SuggestPathsImpl<T, PT, U, ValidPathPrefix<T, PT>>;
+  C extends Constraint = Constraint,
+> = SuggestPathsImpl<T, PT, C, ValidPathPrefix<T, PT>>;
 
 /**
  * Type to test whether the path is a union of paths.
@@ -125,15 +131,15 @@ type IsPathUnion<PS extends PathString> = IsNever<UnionToIntersection<PS>>;
  * @typeParam T  - type which is indexed by the path
  * @typeParam PS - the current path into the type as a {@link PathString}
  * @typeParam PT - the current path into the type as a {@link PathTuple}
- * @typeParam U  - constraint type
+ * @typeParam C  - constraint
  */
 type AutoCompletePathCheckConstraint<
   T,
   PS extends PathString,
   PT extends PathTuple,
-  U,
+  C extends Constraint,
 > = HasPath<T, PT> extends true
-  ? GetPath<T, PT> extends U
+  ? Constraint<GetPath<T, PT>, SetPath<T, PT>> extends C
     ? PS extends JoinPathTuple<PT>
       ? PS
       : JoinPathTuple<PT>
@@ -146,11 +152,14 @@ type AutoCompletePathCheckConstraint<
  * @typeParam T  - type which is indexed by the path
  * @typeParam PS - the current path into the type as a {@link PathString}
  * @typeParam PT - the current path into the type as a {@link PathTuple}
- * @typeParam U  - constraint type
+ * @typeParam C  - constraint
  */
-type AutoCompletePathImpl<T, PS extends PathString, PT extends PathTuple, U> =
-  | SuggestPaths<T, PT, U>
-  | AutoCompletePathCheckConstraint<T, PS, PT, U>;
+type AutoCompletePathImpl<
+  T,
+  PS extends PathString,
+  PT extends PathTuple,
+  C extends Constraint,
+> = SuggestPaths<T, PT, C> | AutoCompletePathCheckConstraint<T, PS, PT, C>;
 
 /**
  * Type which given a type and a {@link PathString} into it returns
@@ -168,26 +177,26 @@ type AutoCompletePathImpl<T, PS extends PathString, PT extends PathTuple, U> =
  *    which don't match the constraint type.
  * @typeParam T  - type which is indexed by the path
  * @typeParam PS - the current path into the type as a {@link PathString}
- * @typeParam U  - constraint type
+ * @typeParam C  - constraint
  * @example
  * ```
- * AutoCompletePath<{foo: {bar: string}}, 'foo', string> = 'foo.bar'
- * AutoCompletePath<{foo: {bar: string}}, 'foo.ba', string>
+ * AutoCompletePath<{foo: {bar: string}}, 'foo', Constraint<string>> = 'foo.bar'
+ * AutoCompletePath<{foo: {bar: string}}, 'foo.ba', Constraint<string>>
  *   = 'foo' | 'foo.bar'
- * AutoCompletePath<{foo: {bar: string}}, 'foo.bar', string>
+ * AutoCompletePath<{foo: {bar: string}}, 'foo.bar', Constraint<string>>
  *   = 'foo' | 'foo.bar'
- * AutoCompletePath<{foo: {bar: {baz: string}}}, 'foo.bar', string>
+ * AutoCompletePath<{foo: {bar: {baz: string}}}, 'foo.bar', Constraint<string>>
  *   = 'foo' | 'foo.bar.baz'
  * ```
  */
 export type AutoCompletePath<
   T,
   PS extends PathString,
-  U = unknown,
+  C extends Constraint = Constraint,
 > = IsPathUnion<PS> extends false
-  ? AutoCompletePathImpl<T, PS, SplitPathString<PS>, U>
+  ? AutoCompletePathImpl<T, PS, SplitPathString<PS>, C>
   : PS extends any
-  ? AutoCompletePathCheckConstraint<T, PS, SplitPathString<PS>, U>
+  ? AutoCompletePathCheckConstraint<T, PS, SplitPathString<PS>, C>
   : never;
 
 /**
@@ -247,7 +256,7 @@ export type LazyFieldPath<
 export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<
   T,
   TPathString,
-  ReadonlyArray<Traversable> | null | undefined
+  Constraint<FieldValues[] | null | undefined, never[]>
 >;
 
 /**

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -2,7 +2,7 @@ import { FieldValues } from '../fields';
 import { IsNever } from '../utils';
 
 import {
-  Constraint,
+  AccessPattern,
   GetPath,
   HasPath,
   JoinPathTuple,
@@ -40,9 +40,12 @@ export type SuggestParentPath<PT extends PathTuple> = JoinPathTuple<
 type SuggestChildPathsImpl<
   PT extends PathTuple,
   TPT,
-  C extends Constraint,
+  C extends AccessPattern,
 > = JoinPathTuple<
-  [...PT, Keys<TPT, C> | Keys<TPT, Constraint<Traversable | undefined | null>>]
+  [
+    ...PT,
+    Keys<TPT, C> | Keys<TPT, AccessPattern<Traversable | undefined | null>>,
+  ]
 >;
 
 /**
@@ -55,9 +58,9 @@ type SuggestChildPathsImpl<
  * @typeParam C  - constraint
  * @example
  * ```
- * SuggestChildPaths<{foo: string, bar: string}, [], Constraint<string>>
+ * SuggestChildPaths<{foo: string, bar: string}, [], AccessPattern<string>>
  *   = 'foo' | 'bar'
- * SuggestChildPaths<{foo: string, bar: number}, [], Constraint<string>>
+ * SuggestChildPaths<{foo: string, bar: number}, [], AccessPattern<string>>
  *   = 'foo'
  * SuggestChildPaths<{foo: {bar: string}}, ['foo']> = 'foo.bar'
  * SuggestChildPaths<{foo: {bar: string[]}}, ['foo']> = 'foo.bar'
@@ -66,7 +69,7 @@ type SuggestChildPathsImpl<
 export type SuggestChildPaths<
   T,
   PT extends PathTuple,
-  C extends Constraint = Constraint,
+  C extends AccessPattern = AccessPattern,
 > = PT extends any ? SuggestChildPathsImpl<PT, GetPath<T, PT>, C> : never;
 
 /**
@@ -80,7 +83,7 @@ export type SuggestChildPaths<
 type SuggestPathsImpl<
   T,
   PT extends PathTuple,
-  C extends Constraint,
+  C extends AccessPattern,
   VPT extends PathTuple,
 > =
   | SuggestChildPaths<T, VPT, C>
@@ -99,18 +102,18 @@ type SuggestPathsImpl<
  * @example
  * ```
  * SuggestPaths<{foo: {bar: string}}, ['foo'], string> = 'foo.bar'
- * SuggestPaths<{foo: {bar: string}}, ['foo', 'ba'], Constraint<string>>
+ * SuggestPaths<{foo: {bar: string}}, ['foo', 'ba'], AccessPattern<string>>
  *   = 'foo' | 'foo.bar'
- * SuggestPaths<{foo: {bar: string}}, ['foo', 'bar'], Constraint<string>>
+ * SuggestPaths<{foo: {bar: string}}, ['foo', 'bar'], AccessPattern<string>>
  *   = 'foo'
- * SuggestPaths<{foo: {bar: {baz: string}}}, ['foo', 'bar'], Constraint<string>>
+ * SuggestPaths<{foo: {bar: {baz: string}}}, ['foo', 'bar'], AccessPattern<string>>
  *   = 'foo' | 'foo.bar.baz'
  * ```
  */
 export type SuggestPaths<
   T,
   PT extends PathTuple,
-  C extends Constraint = Constraint,
+  C extends AccessPattern = AccessPattern,
 > = SuggestPathsImpl<T, PT, C, ValidPathPrefix<T, PT>>;
 
 /**
@@ -137,9 +140,9 @@ type AutoCompletePathCheckConstraint<
   T,
   PS extends PathString,
   PT extends PathTuple,
-  C extends Constraint,
+  C extends AccessPattern,
 > = HasPath<T, PT> extends true
-  ? Constraint<GetPath<T, PT>, SetPath<T, PT>> extends C
+  ? AccessPattern<GetPath<T, PT>, SetPath<T, PT>> extends C
     ? PS extends JoinPathTuple<PT>
       ? PS
       : JoinPathTuple<PT>
@@ -158,7 +161,7 @@ type AutoCompletePathImpl<
   T,
   PS extends PathString,
   PT extends PathTuple,
-  C extends Constraint,
+  C extends AccessPattern,
 > = SuggestPaths<T, PT, C> | AutoCompletePathCheckConstraint<T, PS, PT, C>;
 
 /**
@@ -180,19 +183,19 @@ type AutoCompletePathImpl<
  * @typeParam C  - constraint
  * @example
  * ```
- * AutoCompletePath<{foo: {bar: string}}, 'foo', Constraint<string>> = 'foo.bar'
- * AutoCompletePath<{foo: {bar: string}}, 'foo.ba', Constraint<string>>
+ * AutoCompletePath<{foo: {bar: string}}, 'foo', AccessPattern<string>> = 'foo.bar'
+ * AutoCompletePath<{foo: {bar: string}}, 'foo.ba', AccessPattern<string>>
  *   = 'foo' | 'foo.bar'
- * AutoCompletePath<{foo: {bar: string}}, 'foo.bar', Constraint<string>>
+ * AutoCompletePath<{foo: {bar: string}}, 'foo.bar', AccessPattern<string>>
  *   = 'foo' | 'foo.bar'
- * AutoCompletePath<{foo: {bar: {baz: string}}}, 'foo.bar', Constraint<string>>
+ * AutoCompletePath<{foo: {bar: {baz: string}}}, 'foo.bar', AccessPattern<string>>
  *   = 'foo' | 'foo.bar.baz'
  * ```
  */
 export type AutoCompletePath<
   T,
   PS extends PathString,
-  C extends Constraint = Constraint,
+  C extends AccessPattern = AccessPattern,
 > = IsPathUnion<PS> extends false
   ? AutoCompletePathImpl<T, PS, SplitPathString<PS>, C>
   : PS extends any
@@ -256,7 +259,7 @@ export type LazyFieldPath<
 export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<
   T,
   TPathString,
-  Constraint<ReadonlyArray<FieldValues> | null | undefined, never[]>
+  AccessPattern<ReadonlyArray<FieldValues> | null | undefined, never[]>
 >;
 
 /**


### PR DESCRIPTION
Adds the `AccessPattern` type to constrain a path or key by a `Get` and `Set` type.
The `Get` type is covariant and the `Set` type is contravariant. 
See https://dmitripavlutin.com/typescript-covariance-contravariance/

The idea is that accessing the property `foo` of the type `{ foo?: number } | { foo: number }` yields the type `(number | undefined) | number`, or just `number | undefined`. 
However, when trying to set the value of the `foo` property, the type would have to match both `number | undefined` and `number`, i.e. `(number | undefined) & number` or just `number`. 

`AccessPattern` allows these constraints to be modelled. In this case the access pattern of `foo` would be `AccessPattern<number | undefined, number>`.