### PR TITLE
Add user facing path types

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -150,7 +150,8 @@ declare namespace Either {
         TypedFieldPath_2 as TypedFieldPath,
         FieldPath_4 as FieldPath,
         TypedFieldArrayPath_3 as TypedFieldArrayPath,
-        FieldArrayPath_4 as FieldArrayPath
+        FieldArrayPath_4 as FieldArrayPath,
+        FieldPaths
     }
 }
 export { Either }
@@ -242,6 +243,11 @@ type FieldPath_3<TFieldValues extends FieldValues, TPathString extends PathStrin
 
 // @public
 type FieldPath_4<TFieldValues extends FieldValues, TPathString extends PathString> = Branded.FieldPath<TFieldValues> | Lazy.FieldPath<TFieldValues, TPathString>;
+
+// @public
+type FieldPaths<TFieldValues extends FieldValues, TPathStrings extends ReadonlyArray<PathString>> = {
+    [Idx in keyof TPathStrings]: FieldPath_4<TFieldValues, Extract<TPathStrings[Idx], PathString>>;
+};
 
 // @public
 export type FieldPathValue<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = PathValue<TFieldValues, TFieldPath>;

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -503,7 +503,7 @@ type TypedFieldPath<TFieldValues extends FieldValues, TValue, TValueSet = TValue
 // Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type TypedFieldPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = TPathString extends Branded.FieldPath<any> ? TPathString extends Branded.TypedFieldPath<TFieldValues, TValue, TValueSet> ? TPathString : never : AutoCompletePath<TFieldValues, TPathString, AccessPattern<TValue, TValueSet>>;
+type TypedFieldPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = TPathString extends Branded.FieldPath<any> ? never : AutoCompletePath<TFieldValues, TPathString, AccessPattern<TValue, TValueSet>>;
 
 // @public (undocumented)
 export type UnpackNestedValue<T> = T extends NestedValue<infer U> ? U : T extends Date | FileList | File ? T : T extends object ? {

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -186,10 +186,10 @@ export type FieldArrayName = string;
 // @public
 export type FieldArrayPath<TFieldValues extends FieldValues> = ArrayPath<TFieldValues>;
 
-// @public (undocumented)
+// @public
 type FieldArrayPath_2<TFieldValues extends FieldValues> = TypedFieldArrayPath<TFieldValues, FieldValues, never>;
 
-// @public (undocumented)
+// @public
 type FieldArrayPath_3<TFieldValues extends FieldValues, TPathString extends PathString> = TypedFieldArrayPath_2<TFieldValues, TPathString, FieldValues, never>;
 
 // @public
@@ -221,10 +221,10 @@ export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<
 // @public
 export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
 
-// @public (undocumented)
+// @public
 type FieldPath_2<TFieldValues extends FieldValues> = TypedFieldPath<TFieldValues, unknown, never>;
 
-// @public (undocumented)
+// @public
 type FieldPath_3<TFieldValues extends FieldValues, TPathString extends PathString> = TypedFieldPath_2<TFieldValues, TPathString, unknown, never>;
 
 // @public
@@ -488,13 +488,13 @@ export type TriggerConfig = Partial<{
     shouldFocus: boolean;
 }>;
 
-// @public (undocumented)
+// @public
 type TypedFieldArrayPath<TFieldValues extends FieldValues, TArrayValues extends FieldValues, TArrayValuesSet extends FieldValues = TArrayValues> = TypedFieldPath<TFieldValues, ReadonlyArray<TArrayValues> | null | undefined, TArrayValuesSet[]>;
 
-// @public (undocumented)
+// @public
 type TypedFieldArrayPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TArrayValues extends FieldValues, TArrayValuesSet extends FieldValues = TArrayValues> = TypedFieldPath_2<TFieldValues, TPathString, ReadonlyArray<TArrayValues> | null | undefined, TArrayValuesSet[]>;
 
-// @public (undocumented)
+// @public
 type TypedFieldPath<TFieldValues extends FieldValues, TValue, TValueSet = TValue> = string & {
     [FORM_VALUES]: TFieldValues;
     [ACCESS_PATTERN]: AccessPattern<TValue, TValueSet>;
@@ -502,7 +502,7 @@ type TypedFieldPath<TFieldValues extends FieldValues, TValue, TValueSet = TValue
 
 // Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public
 type TypedFieldPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = TPathString extends Branded.FieldPath<any> ? never : AutoCompletePath<TFieldValues, TPathString, AccessPattern<TValue, TValueSet>>;
 
 // @public (undocumented)
@@ -754,7 +754,7 @@ export type WatchObserver<TFieldValues> = (value: UnpackNestedValue<DeepPartial<
 // Warnings were encountered during analysis:
 //
 // src/types/form.ts:193:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
-// src/types/path/branded.ts:14:3 - (ae-forgotten-export) The symbol "AccessPattern" needs to be exported by the entry point index.d.ts
+// src/types/path/branded.ts:27:3 - (ae-forgotten-export) The symbol "AccessPattern" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -503,7 +503,7 @@ type TypedFieldPath<TFieldValues extends FieldValues, TValue, TValueSet = TValue
 // Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-type TypedFieldPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = AutoCompletePath<TFieldValues, TPathString, AccessPattern<TValue, TValueSet>>;
+type TypedFieldPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = TPathString extends Branded.FieldPath<any> ? TPathString extends Branded.TypedFieldPath<TFieldValues, TValue, TValueSet> ? TPathString : never : AutoCompletePath<TFieldValues, TPathString, AccessPattern<TValue, TValueSet>>;
 
 // @public (undocumented)
 export type UnpackNestedValue<T> = T extends NestedValue<infer U> ? U : T extends Date | FileList | File ? T : T extends object ? {

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -31,6 +31,16 @@ export type BatchFieldArrayUpdate = <T extends Function, TFieldValues, TFieldArr
     argB?: unknown;
 }, updatedFieldArrayValues?: Partial<FieldArray<TFieldValues, TFieldArrayName>>[], shouldSetValue?: boolean, shouldSetFields?: boolean, shouldSetError?: boolean) => void;
 
+declare namespace Branded {
+    export {
+        TypedFieldPath,
+        FieldPath_2 as FieldPath,
+        TypedFieldArrayPath,
+        FieldArrayPath_2 as FieldArrayPath
+    }
+}
+export { Branded }
+
 // @public (undocumented)
 export type ChangeHandler = (event: {
     target: any;
@@ -176,6 +186,12 @@ export type FieldArrayName = string;
 // @public
 export type FieldArrayPath<TFieldValues extends FieldValues> = ArrayPath<TFieldValues>;
 
+// @public (undocumented)
+type FieldArrayPath_2<TFieldValues extends FieldValues> = TypedFieldPath<TFieldValues, ReadonlyArray<FieldValues> | null | undefined, never[]>;
+
+// @public (undocumented)
+type FieldArrayPath_3<TFieldValues extends FieldValues, TPathString extends PathString> = TypedFieldArrayPath_2<TFieldValues, TPathString, FieldValues, never>;
+
 // @public
 export type FieldArrayPathValue<TFieldValues extends FieldValues, TFieldArrayPath extends FieldArrayPath<TFieldValues>> = PathValue<TFieldValues, TFieldArrayPath>;
 
@@ -204,6 +220,12 @@ export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<
 
 // @public
 export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
+
+// @public (undocumented)
+type FieldPath_2<TFieldValues extends FieldValues> = TypedFieldPath<TFieldValues, unknown, never>;
+
+// @public (undocumented)
+type FieldPath_3<TFieldValues extends FieldValues, TPathString extends PathString> = TypedFieldPath_2<TFieldValues, TPathString, unknown, never>;
 
 // @public
 export type FieldPathValue<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = PathValue<TFieldValues, TFieldPath>;
@@ -297,20 +319,15 @@ export type KeepStateOptions = Partial<{
     keepSubmitCount: boolean;
 }>;
 
-// Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "AccessPattern" needs to be exported by the entry point index.d.ts
-//
-// @public
-export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<T, TPathString, AccessPattern<ReadonlyArray<FieldValues> | null | undefined, never[]>>;
-
-// @public
-export type LazyFieldArrayPath<TFieldValues extends FieldValues, TPathString extends PathString> = LazyArrayPath<TFieldValues, TPathString>;
-
-// @public
-export type LazyFieldPath<TFieldValues extends FieldValues, TPathString extends PathString> = LazyPath<TFieldValues, TPathString>;
-
-// @public
-export type LazyPath<T, TPathString extends PathString> = AutoCompletePath<T, TPathString>;
+declare namespace Lazy {
+    export {
+        TypedFieldPath_2 as TypedFieldPath,
+        FieldPath_3 as FieldPath,
+        TypedFieldArrayPath_2 as TypedFieldArrayPath,
+        FieldArrayPath_3 as FieldArrayPath
+    }
+}
+export { Lazy }
 
 // @public (undocumented)
 export type LiteralUnion<T extends U, U extends Primitive> = T | (U & {
@@ -470,6 +487,23 @@ export type SubmitHandler<TFieldValues extends FieldValues> = (data: UnpackNeste
 export type TriggerConfig = Partial<{
     shouldFocus: boolean;
 }>;
+
+// @public (undocumented)
+type TypedFieldArrayPath<TFieldValues extends FieldValues, TArrayValues extends FieldValues, TArrayValuesSet extends FieldValues = TArrayValues> = TypedFieldPath<TFieldValues, ReadonlyArray<TArrayValues> | null | undefined, TArrayValuesSet[]>;
+
+// @public (undocumented)
+type TypedFieldArrayPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TArrayValues extends FieldValues, TArrayValuesSet extends FieldValues = TArrayValues> = TypedFieldPath_2<TFieldValues, TPathString, ReadonlyArray<TArrayValues> | null | undefined, TArrayValuesSet[]>;
+
+// @public (undocumented)
+type TypedFieldPath<TFieldValues extends FieldValues, TValue, TValueSet = TValue> = string & {
+    [FORM_VALUES]: TFieldValues;
+    [ACCESS_PATTERN]: AccessPattern<TValue, TValueSet>;
+};
+
+// Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+type TypedFieldPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = AutoCompletePath<TFieldValues, TPathString, AccessPattern<TValue, TValueSet>>;
 
 // @public (undocumented)
 export type UnpackNestedValue<T> = T extends NestedValue<infer U> ? U : T extends Date | FileList | File ? T : T extends object ? {
@@ -720,6 +754,7 @@ export type WatchObserver<TFieldValues> = (value: UnpackNestedValue<DeepPartial<
 // Warnings were encountered during analysis:
 //
 // src/types/form.ts:193:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/path/branded.ts:14:3 - (ae-forgotten-export) The symbol "AccessPattern" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -145,6 +145,16 @@ export type DefaultValues<TFieldValues> = UnpackNestedValue<DeepPartial<TFieldVa
 // @public (undocumented)
 export type DelayCallback = (name: InternalFieldName, error: FieldError) => void;
 
+declare namespace Either {
+    export {
+        TypedFieldPath_2 as TypedFieldPath,
+        FieldPath_4 as FieldPath,
+        TypedFieldArrayPath_3 as TypedFieldArrayPath,
+        FieldArrayPath_4 as FieldArrayPath
+    }
+}
+export { Either }
+
 // @public (undocumented)
 export type EmptyObject = {
     [K in string | number]: never;
@@ -193,6 +203,9 @@ type FieldArrayPath_2<TFieldValues extends FieldValues> = TypedFieldArrayPath<TF
 type FieldArrayPath_3<TFieldValues extends FieldValues, TPathString extends PathString> = TypedFieldArrayPath_2<TFieldValues, TPathString, FieldValues, never>;
 
 // @public
+type FieldArrayPath_4<TFieldValues extends FieldValues, TPathString extends PathString> = Branded.FieldArrayPath<TFieldValues> | Lazy.FieldArrayPath<TFieldValues, TPathString>;
+
+// @public
 export type FieldArrayPathValue<TFieldValues extends FieldValues, TFieldArrayPath extends FieldArrayPath<TFieldValues>> = PathValue<TFieldValues, TFieldArrayPath>;
 
 // @public (undocumented)
@@ -225,7 +238,10 @@ export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
 type FieldPath_2<TFieldValues extends FieldValues> = TypedFieldPath<TFieldValues, unknown, never>;
 
 // @public
-type FieldPath_3<TFieldValues extends FieldValues, TPathString extends PathString> = TypedFieldPath_2<TFieldValues, TPathString, unknown, never>;
+type FieldPath_3<TFieldValues extends FieldValues, TPathString extends PathString> = TypedFieldPath_3<TFieldValues, TPathString, unknown, never>;
+
+// @public
+type FieldPath_4<TFieldValues extends FieldValues, TPathString extends PathString> = Branded.FieldPath<TFieldValues> | Lazy.FieldPath<TFieldValues, TPathString>;
 
 // @public
 export type FieldPathValue<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = PathValue<TFieldValues, TFieldPath>;
@@ -321,7 +337,7 @@ export type KeepStateOptions = Partial<{
 
 declare namespace Lazy {
     export {
-        TypedFieldPath_2 as TypedFieldPath,
+        TypedFieldPath_3 as TypedFieldPath,
         FieldPath_3 as FieldPath,
         TypedFieldArrayPath_2 as TypedFieldArrayPath,
         FieldArrayPath_3 as FieldArrayPath
@@ -492,7 +508,10 @@ export type TriggerConfig = Partial<{
 type TypedFieldArrayPath<TFieldValues extends FieldValues, TArrayValues extends FieldValues, TArrayValuesSet extends FieldValues = TArrayValues> = TypedFieldPath<TFieldValues, ReadonlyArray<TArrayValues> | null | undefined, TArrayValuesSet[]>;
 
 // @public
-type TypedFieldArrayPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TArrayValues extends FieldValues, TArrayValuesSet extends FieldValues = TArrayValues> = TypedFieldPath_2<TFieldValues, TPathString, ReadonlyArray<TArrayValues> | null | undefined, TArrayValuesSet[]>;
+type TypedFieldArrayPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TArrayValues extends FieldValues, TArrayValuesSet extends FieldValues = TArrayValues> = TypedFieldPath_3<TFieldValues, TPathString, ReadonlyArray<TArrayValues> | null | undefined, TArrayValuesSet[]>;
+
+// @public
+type TypedFieldArrayPath_3<TFieldValues extends FieldValues, TPathString extends PathString, TArrayValues extends FieldValues, TArrayValuesSet extends FieldValues = TArrayValues> = Branded.TypedFieldArrayPath<TFieldValues, TArrayValues, TArrayValuesSet> | Lazy.TypedFieldArrayPath<TFieldValues, TPathString, TArrayValues, TArrayValuesSet>;
 
 // @public
 type TypedFieldPath<TFieldValues extends FieldValues, TValue, TValueSet = TValue> = string & {
@@ -500,10 +519,13 @@ type TypedFieldPath<TFieldValues extends FieldValues, TValue, TValueSet = TValue
     [ACCESS_PATTERN]: AccessPattern<TValue, TValueSet>;
 };
 
+// @public
+type TypedFieldPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = Branded.TypedFieldPath<TFieldValues, TValue, TValueSet> | Lazy.TypedFieldPath<TFieldValues, TPathString, TValue, TValueSet>;
+
 // Warning: (ae-forgotten-export) The symbol "AutoCompletePath" needs to be exported by the entry point index.d.ts
 //
 // @public
-type TypedFieldPath_2<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = TPathString extends Branded.FieldPath<any> ? never : AutoCompletePath<TFieldValues, TPathString, AccessPattern<TValue, TValueSet>>;
+type TypedFieldPath_3<TFieldValues extends FieldValues, TPathString extends PathString, TValue, TValueSet = TValue> = TPathString extends Branded.FieldPath<any> ? never : AutoCompletePath<TFieldValues, TPathString, AccessPattern<TValue, TValueSet>>;
 
 // @public (undocumented)
 export type UnpackNestedValue<T> = T extends NestedValue<infer U> ? U : T extends Date | FileList | File ? T : T extends object ? {

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -187,7 +187,7 @@ export type FieldArrayName = string;
 export type FieldArrayPath<TFieldValues extends FieldValues> = ArrayPath<TFieldValues>;
 
 // @public (undocumented)
-type FieldArrayPath_2<TFieldValues extends FieldValues> = TypedFieldPath<TFieldValues, ReadonlyArray<FieldValues> | null | undefined, never[]>;
+type FieldArrayPath_2<TFieldValues extends FieldValues> = TypedFieldArrayPath<TFieldValues, FieldValues, never>;
 
 // @public (undocumented)
 type FieldArrayPath_3<TFieldValues extends FieldValues, TPathString extends PathString> = TypedFieldArrayPath_2<TFieldValues, TPathString, FieldValues, never>;

--- a/src/__tests__/types/path/either.test-d.ts
+++ b/src/__tests__/types/path/either.test-d.ts
@@ -4,6 +4,7 @@ import { Branded, PathString } from '../../../types';
 import {
   FieldArrayPath,
   FieldPath,
+  FieldPaths,
   TypedFieldArrayPath,
   TypedFieldPath,
 } from '../../../types/path/either';
@@ -94,5 +95,25 @@ import { _, InfiniteType } from '../__fixtures__';
 
     const actual = fn('foo.value');
     expectType<'foo.value'>(actual);
+  }
+}
+
+/** {@link FieldPaths} */ {
+  /** it should infer branded types */ {
+    const fn = <P extends ReadonlyArray<PathString>>(
+      path: FieldPaths<InfiniteType<number>, P>,
+    ): P => path as never;
+
+    const actual = fn(_ as [Branded.FieldPath<InfiniteType<number>>]);
+    expectType<[Branded.FieldPath<InfiniteType<number>>]>(actual);
+  }
+
+  /** it should infer string types */ {
+    const fn = <P extends ReadonlyArray<PathString>>(
+      path: FieldPaths<InfiniteType<number>, P>,
+    ): P => path as never;
+
+    const actual = fn(_ as ['foo.value']);
+    expectType<['foo.value']>(actual);
   }
 }

--- a/src/__tests__/types/path/either.test-d.ts
+++ b/src/__tests__/types/path/either.test-d.ts
@@ -1,0 +1,98 @@
+import { expectType } from 'tsd';
+
+import { Branded, PathString } from '../../../types';
+import {
+  FieldArrayPath,
+  FieldPath,
+  TypedFieldArrayPath,
+  TypedFieldPath,
+} from '../../../types/path/either';
+import { _, InfiniteType } from '../__fixtures__';
+
+/** {@link TypedFieldPath} */ {
+  /** it should infer branded types */ {
+    const fn = <P extends PathString>(
+      path: TypedFieldPath<InfiniteType<number>, P, number>,
+    ): P => path as never;
+
+    const actual = fn(
+      _ as Branded.TypedFieldPath<InfiniteType<number>, number>,
+    );
+    expectType<Branded.TypedFieldPath<InfiniteType<number>, number>>(actual);
+  }
+
+  /** it should infer string types */ {
+    const fn = <P extends PathString>(
+      path: TypedFieldPath<InfiniteType<number>, P, number>,
+    ): P => path as never;
+
+    const actual = fn('foo.value');
+    expectType<'foo.value'>(actual);
+  }
+}
+
+/** {@link FieldPath} */ {
+  /** it should infer branded types */ {
+    const fn = <P extends PathString>(
+      path: FieldPath<InfiniteType<number>, P>,
+    ): P => path as never;
+
+    const actual = fn(_ as Branded.FieldPath<InfiniteType<number>>);
+    expectType<Branded.FieldPath<InfiniteType<number>>>(actual);
+  }
+
+  /** it should infer string types */ {
+    const fn = <P extends PathString>(
+      path: FieldPath<InfiniteType<number>, P>,
+    ): P => path as never;
+
+    const actual = fn('foo.value');
+    expectType<'foo.value'>(actual);
+  }
+}
+
+/** {@link TypedFieldArrayPath} */ {
+  /** it should infer branded types */ {
+    type Foo = { foo: string };
+    const fn = <P extends PathString>(
+      path: TypedFieldArrayPath<InfiniteType<Foo[]>, P, Foo>,
+    ): P => path as never;
+
+    const actual = fn(
+      _ as Branded.TypedFieldArrayPath<InfiniteType<Foo[]>, Foo>,
+    );
+    expectType<Branded.TypedFieldArrayPath<InfiniteType<Foo[]>, Foo>>(actual);
+  }
+
+  /** it should infer string types */ {
+    type Foo = { foo: string };
+    const fn = <P extends PathString>(
+      path: TypedFieldArrayPath<InfiniteType<Foo[]>, P, Foo>,
+    ): P => path as never;
+
+    const actual = fn('foo.value');
+    expectType<'foo.value'>(actual);
+  }
+}
+
+/** {@link FieldArrayPath} */ {
+  /** it should infer branded types */ {
+    type Foo = { foo: string };
+    const fn = <P extends PathString>(
+      path: FieldArrayPath<InfiniteType<Foo[]>, P>,
+    ): P => path as never;
+
+    const actual = fn(_ as Branded.FieldArrayPath<InfiniteType<Foo[]>>);
+    expectType<Branded.FieldArrayPath<InfiniteType<Foo[]>>>(actual);
+  }
+
+  /** it should infer string types */ {
+    type Foo = { foo: string };
+    const fn = <P extends PathString>(
+      path: FieldArrayPath<InfiniteType<Foo[]>, P>,
+    ): P => path as never;
+
+    const actual = fn('foo.value');
+    expectType<'foo.value'>(actual);
+  }
+}

--- a/src/__tests__/types/path/internal/autoCompletePath.test-d.ts
+++ b/src/__tests__/types/path/internal/autoCompletePath.test-d.ts
@@ -300,30 +300,31 @@ import { _, InfiniteType, NullableInfiniteType } from '../../__fixtures__';
   /** TS should be able to infer the generic */ {
     const fn = <P extends PathString>(
       path: AutoCompletePath<InfiniteType<string>, P>,
-    ) => path;
+    ): P => path as never;
 
     const actual = fn('foo.bar');
-    expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
+    expectType<'foo.bar'>(actual);
   }
 
   /** TS should be able to infer the generic from an object property */ {
     interface FnProps<P extends PathString> {
       path: AutoCompletePath<InfiniteType<string>, P>;
     }
-    const fn = <P extends PathString>({ path }: FnProps<P>) => path;
+    const fn = <P extends PathString>({ path }: FnProps<P>): P => path as never;
 
     const actual = fn({ path: 'foo.bar' });
-    expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
+    expectType<'foo.bar'>(actual);
   }
 
   /** TS should be able to infer the generic from a nested object property */ {
     interface FnProps<P extends PathString> {
       nested: { path: AutoCompletePath<InfiniteType<string>, P> };
     }
-    const fn = <P extends PathString>({ nested: { path } }: FnProps<P>) => path;
+    const fn = <P extends PathString>({ nested: { path } }: FnProps<P>): P =>
+      path as never;
 
     const actual = fn({ nested: { path: 'foo.bar' } });
-    expectType<'foo' | 'foo.bar' | 'foo.bar.0'>(actual);
+    expectType<'foo.bar'>(actual);
   }
 
   /** it should not suggest keys containing dots */ {

--- a/src/__tests__/types/path/internal/pathGetValue.test-d.ts
+++ b/src/__tests__/types/path/internal/pathGetValue.test-d.ts
@@ -49,14 +49,14 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
     expectType<number | undefined>(actual);
   }
 
-  /** it should add undefined if the key is not valid */ {
+  /** it should add unknown if the key is not valid */ {
     const actual = _ as KeyGetValue<{ foo: string }, 'foobar'>;
-    expectType<undefined>(actual);
+    expectType<unknown>(actual);
   }
 
-  /** it should evaluate to undefined if the key is out of bounds */ {
+  /** it should evaluate to unknown if the key is out of bounds */ {
     const actual = _ as KeyGetValue<[string], '1'>;
-    expectType<undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should work on path unions */ {
@@ -67,9 +67,9 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
     expectType<number | string>(actual);
   }
 
-  /** it should add undefined if one of the keys doesn't exist */ {
+  /** it should evaluate to unknown if one of the keys doesn't exist */ {
     const actual = _ as KeyGetValue<{ foo: number }, 'foo' | 'bar'>;
-    expectType<number | undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should add null if the type may be null */ {
@@ -87,14 +87,14 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
     expectType<string | null | undefined>(actual);
   }
 
-  /** it should evaluate to undefined if the type is not traversable */ {
+  /** it should evaluate to unknown if the type is not traversable */ {
     const actual = _ as KeyGetValue<string, 'foo'>;
-    expectType<undefined>(actual);
+    expectType<unknown>(actual);
   }
 
-  /** it should evaluate to undefined if the key is non-numeric */ {
+  /** it should evaluate to unknown if the key is non-numeric */ {
     const actual = _ as KeyGetValue<string[], 'foo'>;
-    expectType<undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should work on unions of object */ {
@@ -117,14 +117,14 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
     expectType<number | string>(actual);
   }
 
-  /** it should add undefined if the key doesn't exist in one of the types */ {
+  /** it should evaluate to unknown if the key doesn't exist in one of the types */ {
     const actual = _ as KeyGetValue<{ foo: number } | { bar: string }, 'foo'>;
-    expectType<number | undefined>(actual);
+    expectType<unknown>(actual);
   }
 
-  /** it should add undefined if the key is out of bounds in one of the types */ {
+  /** it should evaluate to unknown if the key is out of bounds in one of the types */ {
     const actual = _ as KeyGetValue<[] | [number], '0'>;
-    expectType<number | undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should evaluate to any if the type is any */ {
@@ -183,9 +183,9 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
     expectType<boolean>(actual);
   }
 
-  /** it should evaluate to undefined if the path is not valid */ {
+  /** it should evaluate to unknown if the path is not valid */ {
     const actual = _ as PathGetValue<InfiniteType<string>, ['foobar']>;
-    expectType<undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should be implemented tail recursively */ {
@@ -201,12 +201,12 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
     expectType<number | InfiniteType<number>>(actual);
   }
 
-  /** it should add undefined if one of the paths doesn't exist */ {
+  /** it should evaluate to unknown if one of the paths doesn't exist */ {
     const actual = _ as PathGetValue<
       InfiniteType<number>,
       ['foo', 'value'] | ['foo', 'foobar']
     >;
-    expectType<number | undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should add null if the path contains a nullable */ {
@@ -230,9 +230,9 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
     expectType<string | undefined>(actual);
   }
 
-  /** it should evaluate to undefined if the type is not traversable */ {
+  /** it should evaluate to unknown if the type is not traversable */ {
     const actual = _ as PathGetValue<string, ['foo']>;
-    expectType<undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should work on type unions */ {
@@ -243,12 +243,12 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
     expectType<number | string>(actual);
   }
 
-  /** it should add undefined if the path doesn't exist in one of the types */ {
+  /** it should evaluate to unknown if the path doesn't exist in one of the types */ {
     const actual = _ as PathGetValue<
       InfiniteType<number> | Nested<string>,
       ['foo', 'value']
     >;
-    expectType<number | undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should evaluate to any if the type is any */ {
@@ -263,7 +263,7 @@ import { _, HundredTuple, InfiniteType, Nested } from '../../__fixtures__';
 
   /** it should not evaluate to any if it doesn't encounter any */ {
     const actual = _ as PathGetValue<{ foo: any }, ['bar', 'baz']>;
-    expectType<undefined>(actual);
+    expectType<unknown>(actual);
   }
 
   /** it should not create a union which is too complex to represent */ {

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -1,7 +1,18 @@
 import { expectType } from 'tsd';
 
-import { FieldArrayPath } from '../../../types/path/lazy';
+import { Branded } from '../../../types';
+import { FieldArrayPath, FieldPath } from '../../../types/path/lazy';
 import { _, InfiniteType } from '../__fixtures__';
+
+/** {@link FieldPath} */ {
+  /** it should evaluate to never for branded paths */ {
+    const actual = _ as FieldPath<
+      { foo: string },
+      Branded.FieldPath<{ foo: string }>
+    >;
+    expectType<never>(actual);
+  }
+}
 
 /** {@link FieldArrayPath} */ {
   /** it should not accept primitive arrays */ {

--- a/src/__tests__/types/path/lazy.test-d.ts
+++ b/src/__tests__/types/path/lazy.test-d.ts
@@ -1,21 +1,21 @@
 import { expectType } from 'tsd';
 
-import { LazyArrayPath } from '../../../types';
+import { FieldArrayPath } from '../../../types/path/lazy';
 import { _, InfiniteType } from '../__fixtures__';
 
-/** {@link LazyArrayPath} */ {
+/** {@link FieldArrayPath} */ {
   /** it should not accept primitive arrays */ {
-    const actual = _ as LazyArrayPath<InfiniteType<number[]>, 'foo.value'>;
+    const actual = _ as FieldArrayPath<InfiniteType<number[]>, 'foo.value'>;
     expectType<'foo'>(actual);
   }
 
   /** it should accept non-primitive arrays */ {
-    const actual = _ as LazyArrayPath<{ foo: { bar: object[] } }, 'foo.bar'>;
+    const actual = _ as FieldArrayPath<{ foo: { bar: object[] } }, 'foo.bar'>;
     expectType<'foo' | `foo.bar` | `foo.bar.${number}`>(actual);
   }
 
   /** it should not accept non-primitive readonly arrays */ {
-    const actual = _ as LazyArrayPath<
+    const actual = _ as FieldArrayPath<
       { foo: { bar: readonly object[] } },
       'foo.bar'
     >;
@@ -23,12 +23,12 @@ import { _, InfiniteType } from '../__fixtures__';
   }
 
   /** it should not accept tuples */ {
-    const actual = _ as LazyArrayPath<InfiniteType<number[]>, 'foo.bar'>;
+    const actual = _ as FieldArrayPath<InfiniteType<number[]>, 'foo.bar'>;
     expectType<'foo' | 'foo.bar.0'>(actual);
   }
 
   /** it should accept non-primitive nullable arrays */ {
-    const actual = _ as LazyArrayPath<
+    const actual = _ as FieldArrayPath<
       { foo: { bar: object[] | null | undefined } },
       'foo.bar'
     >;
@@ -36,7 +36,7 @@ import { _, InfiniteType } from '../__fixtures__';
   }
 
   /** it should not accept non-primitive arrays with nullable values */ {
-    const actual = _ as LazyArrayPath<
+    const actual = _ as FieldArrayPath<
       { foo: { bar: Array<object | null | undefined> } },
       'foo.bar'
     >;

--- a/src/__tests__/types/path/value.test-d.ts
+++ b/src/__tests__/types/path/value.test-d.ts
@@ -52,10 +52,18 @@ import { _ } from '../__fixtures__';
 }
 
 /** {@link FieldPathValues} */ {
-  /** it should resolve all paths */ {
+  /** it should resolve string paths */ {
     const actual = _ as FieldPathValues<
       { foo: string; bar: number },
       ['foo', 'bar']
+    >;
+    expectType<[string, number]>(actual);
+  }
+
+  /** it should resolve branded paths */ {
+    const actual = _ as FieldPathValues<
+      {},
+      [Branded.TypedFieldPath<{}, string>, Branded.TypedFieldPath<{}, number>]
     >;
     expectType<[string, number]>(actual);
   }

--- a/src/__tests__/types/path/value.test-d.ts
+++ b/src/__tests__/types/path/value.test-d.ts
@@ -1,0 +1,62 @@
+import { expectType } from 'tsd';
+
+import { Branded } from '../../../types';
+import {
+  FieldPathSetValue,
+  FieldPathValue,
+  FieldPathValues,
+} from '../../../types/path/value';
+import { _ } from '../__fixtures__';
+
+/** {@link FieldPathValue} */ {
+  /** it should get the type of a branded path */ {
+    const actual = _ as FieldPathValue<{}, Branded.TypedFieldPath<{}, number>>;
+    expectType<number>(actual);
+  }
+
+  /** it should evaluate to unknown if the branded path is not applicable */ {
+    const actual = _ as FieldPathValue<
+      { foo: string },
+      Branded.TypedFieldPath<{}, number>
+    >;
+    expectType<unknown>(actual);
+  }
+
+  /** it should get the type of a string path */ {
+    const actual = _ as FieldPathValue<{ foo: number }, 'foo'>;
+    expectType<number>(actual);
+  }
+}
+
+/** {@link FieldPathSetValue} */ {
+  /** it should get the set type of a branded path */ {
+    const actual = _ as FieldPathSetValue<
+      {},
+      Branded.TypedFieldPath<{}, number>
+    >;
+    expectType<number>(actual);
+  }
+
+  /** it should evaluate to never if the branded path is not applicable */ {
+    const actual = _ as FieldPathSetValue<
+      { foo: string },
+      Branded.TypedFieldPath<{}, number>
+    >;
+    expectType<never>(actual);
+  }
+
+  /** it should get the set type of a string path */ {
+    const actual = _ as FieldPathSetValue<{ foo: number }, 'foo'>;
+    expectType<number>(actual);
+  }
+}
+
+/** {@link FieldPathValues} */ {
+  /** it should resolve all paths */ {
+    const actual = _ as FieldPathValues<
+      { foo: string; bar: number },
+      ['foo', 'bar']
+    >;
+    expectType<[string, number]>(actual);
+  }
+}

--- a/src/types/path/branded.ts
+++ b/src/types/path/branded.ts
@@ -30,8 +30,5 @@ export type TypedFieldArrayPath<
   TArrayValuesSet[]
 >;
 
-export type FieldArrayPath<TFieldValues extends FieldValues> = TypedFieldPath<
-  TFieldValues,
-  ReadonlyArray<FieldValues> | null | undefined,
-  never[]
->;
+export type FieldArrayPath<TFieldValues extends FieldValues> =
+  TypedFieldArrayPath<TFieldValues, FieldValues, never>;

--- a/src/types/path/branded.ts
+++ b/src/types/path/branded.ts
@@ -6,32 +6,32 @@ declare const FORM_VALUES: unique symbol;
 declare const ACCESS_PATTERN: unique symbol;
 
 export type TypedFieldPath<
-  TFormValues extends FieldValues,
+  TFieldValues extends FieldValues,
   TValue,
   TValueSet = TValue,
 > = string & {
-  [FORM_VALUES]: TFormValues;
+  [FORM_VALUES]: TFieldValues;
   [ACCESS_PATTERN]: AccessPattern<TValue, TValueSet>;
 };
 
-export type FieldPath<TFormValues extends FieldValues> = TypedFieldPath<
-  TFormValues,
+export type FieldPath<TFieldValues extends FieldValues> = TypedFieldPath<
+  TFieldValues,
   unknown,
   never
 >;
 
 export type TypedFieldArrayPath<
-  TFormValues extends FieldValues,
+  TFieldValues extends FieldValues,
   TArrayValues extends FieldValues,
   TArrayValuesSet extends FieldValues = TArrayValues,
 > = TypedFieldPath<
-  TFormValues,
+  TFieldValues,
   ReadonlyArray<TArrayValues> | null | undefined,
   TArrayValuesSet[]
 >;
 
-export type FieldArrayPath<TFormValues extends FieldValues> = TypedFieldPath<
-  TFormValues,
+export type FieldArrayPath<TFieldValues extends FieldValues> = TypedFieldPath<
+  TFieldValues,
   ReadonlyArray<FieldValues> | null | undefined,
   never[]
 >;

--- a/src/types/path/branded.ts
+++ b/src/types/path/branded.ts
@@ -5,6 +5,19 @@ import { AccessPattern } from './internal/utils';
 declare const FORM_VALUES: unique symbol;
 declare const ACCESS_PATTERN: unique symbol;
 
+/**
+ * Type which describes a path through a form.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TValue - the value which may be read from the path
+ * @typeParam TValueSet - the value which can be written to the path
+ * @example
+ * ```
+ * declare function getNumber<T extends FieldValues>(
+ *   obj: T,
+ *   path: TypedFieldPath<T, number>,
+ * ): number
+ * ```
+ */
 export type TypedFieldPath<
   TFieldValues extends FieldValues,
   TValue,
@@ -14,12 +27,36 @@ export type TypedFieldPath<
   [ACCESS_PATTERN]: AccessPattern<TValue, TValueSet>;
 };
 
+/**
+ * Type which describes a path through a form.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @example
+ * ```
+ * declare function get<T extends FieldValues, P extends FieldPath<T>>(
+ *   obj: T,
+ *   path: P,
+ * ): FieldPathValue<T, P>
+ * ```
+ */
 export type FieldPath<TFieldValues extends FieldValues> = TypedFieldPath<
   TFieldValues,
   unknown,
   never
 >;
 
+/**
+ * Type which describes a path through a form and points to an array.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TArrayValues - the value which may be read from array at the path
+ * @typeParam TArrayValuesSet - the value which can be written to the array at the path
+ * @example
+ * ```
+ * declare function popNumber<T extends FieldValues>(
+ *   obj: T,
+ *   path: TypedFieldArrayPath<T, number>,
+ * ): number
+ * ```
+ */
 export type TypedFieldArrayPath<
   TFieldValues extends FieldValues,
   TArrayValues extends FieldValues,
@@ -30,5 +67,16 @@ export type TypedFieldArrayPath<
   TArrayValuesSet[]
 >;
 
+/**
+ * Type which describes a path through a form and points to an array.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @example
+ * ```
+ * declare function pop<T extends FieldValues, P extends FieldArrayPath<T>>(
+ *   obj: T,
+ *   path: P,
+ * ): FieldPathValue<T, P>[never]
+ * ```
+ */
 export type FieldArrayPath<TFieldValues extends FieldValues> =
   TypedFieldArrayPath<TFieldValues, FieldValues, never>;

--- a/src/types/path/branded.ts
+++ b/src/types/path/branded.ts
@@ -1,0 +1,37 @@
+import { FieldValues } from '../fields';
+
+import { AccessPattern } from './internal/utils';
+
+declare const FORM_VALUES: unique symbol;
+declare const ACCESS_PATTERN: unique symbol;
+
+export type TypedFieldPath<
+  TFormValues extends FieldValues,
+  TValue,
+  TValueSet = TValue,
+> = string & {
+  [FORM_VALUES]: TFormValues;
+  [ACCESS_PATTERN]: AccessPattern<TValue, TValueSet>;
+};
+
+export type FieldPath<TFormValues extends FieldValues> = TypedFieldPath<
+  TFormValues,
+  unknown,
+  never
+>;
+
+export type TypedFieldArrayPath<
+  TFormValues extends FieldValues,
+  TArrayValues extends FieldValues,
+  TArrayValuesSet extends FieldValues = TArrayValues,
+> = TypedFieldPath<
+  TFormValues,
+  ReadonlyArray<TArrayValues> | null | undefined,
+  TArrayValuesSet[]
+>;
+
+export type FieldArrayPath<TFormValues extends FieldValues> = TypedFieldPath<
+  TFormValues,
+  ReadonlyArray<FieldValues> | null | undefined,
+  never[]
+>;

--- a/src/types/path/either.ts
+++ b/src/types/path/either.ts
@@ -1,0 +1,92 @@
+import { FieldValues } from '../fields';
+
+import * as Branded from './branded';
+import * as Lazy from './lazy';
+import { PathString } from './pathString';
+
+/**
+ * Type which offers autocompletion of paths through a form.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @typeParam TValue - the value which may be read from the path
+ * @typeParam TValueSet - the value which can be written to the path
+ * @example
+ * ```
+ * declare function getNumber<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: TypedFieldPath<T, P, number>,
+ * ): number
+ * ```
+ */
+export type TypedFieldPath<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+  TValue,
+  TValueSet = TValue,
+> =
+  | Branded.TypedFieldPath<TFieldValues, TValue, TValueSet>
+  | Lazy.TypedFieldPath<TFieldValues, TPathString, TValue, TValueSet>;
+
+/**
+ * Type which offers autocompletion of paths through a form.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @example
+ * ```
+ * declare function get<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: FieldPath<T, P>,
+ * ): FieldPathValue<T, P>
+ * ```
+ */
+export type FieldPath<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+> = Branded.FieldPath<TFieldValues> | Lazy.FieldPath<TFieldValues, TPathString>;
+
+/**
+ * Type which offers autocompletion of paths through a form which point to an array.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @typeParam TArrayValues - the value which may be read from array at the path
+ * @typeParam TArrayValuesSet - the value which can be written to the array at the path
+ * @example
+ * ```
+ * declare function popNumber<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: TypedFieldArrayPath<T, P, number>,
+ * ): number
+ * ```
+ */
+export type TypedFieldArrayPath<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+  TArrayValues extends FieldValues,
+  TArrayValuesSet extends FieldValues = TArrayValues,
+> =
+  | Branded.TypedFieldArrayPath<TFieldValues, TArrayValues, TArrayValuesSet>
+  | Lazy.TypedFieldArrayPath<
+      TFieldValues,
+      TPathString,
+      TArrayValues,
+      TArrayValuesSet
+    >;
+
+/**
+ * Type which offers autocompletion of paths through a form which point to an array.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @example
+ * ```
+ * declare function pop<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: FieldArrayPath<T, P>,
+ * ): FieldPathValue<T, P>[never]
+ * ```
+ */
+export type FieldArrayPath<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+> =
+  | Branded.FieldArrayPath<TFieldValues>
+  | Lazy.FieldArrayPath<TFieldValues, TPathString>;

--- a/src/types/path/either.ts
+++ b/src/types/path/either.ts
@@ -90,3 +90,25 @@ export type FieldArrayPath<
 > =
   | Branded.FieldArrayPath<TFieldValues>
   | Lazy.FieldArrayPath<TFieldValues, TPathString>;
+
+/**
+ * Type which offers autocompletion for a tuple of paths through a form.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathStrings - the string representations of the paths
+ * @example
+ * ```
+ * declare function get<
+ *   T extends FieldValues,
+ *   P extends ReadonlyArray<PathString>,
+ * >(obj: T, paths: FieldPaths<T, P>): FieldPathValues<T, P>
+ * ```
+ */
+export type FieldPaths<
+  TFieldValues extends FieldValues,
+  TPathStrings extends ReadonlyArray<PathString>,
+> = {
+  [Idx in keyof TPathStrings]: FieldPath<
+    TFieldValues,
+    Extract<TPathStrings[Idx], PathString>
+  >;
+};

--- a/src/types/path/index.ts
+++ b/src/types/path/index.ts
@@ -3,14 +3,11 @@ import { Primitive } from '../utils';
 
 import { TupleKeys } from './internal/keys';
 import { ArrayKey, IsTuple } from './internal/utils';
+import * as Branded from './branded';
+import * as Lazy from './lazy';
 
 /** Re-export public API */
-export {
-  LazyArrayPath,
-  LazyFieldArrayPath,
-  LazyFieldPath,
-  LazyPath,
-} from './lazy';
+export { Branded, Lazy };
 export { PathString } from './pathString';
 
 /**

--- a/src/types/path/index.ts
+++ b/src/types/path/index.ts
@@ -4,10 +4,11 @@ import { Primitive } from '../utils';
 import { TupleKeys } from './internal/keys';
 import { ArrayKey, IsTuple } from './internal/utils';
 import type * as Branded from './branded';
+import type * as Either from './either';
 import type * as Lazy from './lazy';
 
 /** Re-export public API */
-export type { Branded, Lazy };
+export type { Branded, Either, Lazy };
 export type { PathString } from './pathString';
 
 /**

--- a/src/types/path/index.ts
+++ b/src/types/path/index.ts
@@ -3,12 +3,12 @@ import { Primitive } from '../utils';
 
 import { TupleKeys } from './internal/keys';
 import { ArrayKey, IsTuple } from './internal/utils';
-import * as Branded from './branded';
-import * as Lazy from './lazy';
+import type * as Branded from './branded';
+import type * as Lazy from './lazy';
 
 /** Re-export public API */
-export { Branded, Lazy };
-export { PathString } from './pathString';
+export type { Branded, Lazy };
+export type { PathString } from './pathString';
 
 /**
  * Helper type for recursively constructing paths through a type.

--- a/src/types/path/internal/pathGetValue.ts
+++ b/src/types/path/internal/pathGetValue.ts
@@ -18,9 +18,9 @@ import { ArrayKey, AsKey, IsTuple, Key, MapKeys } from './utils';
  */
 type TryGet<T, K> = K extends keyof T
   ? T[K]
-  : T extends null
-  ? null
-  : undefined;
+  : T extends null | undefined
+  ? T
+  : unknown;
 
 /**
  * Type to access an array type by a key.

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -4,70 +4,35 @@ import { AutoCompletePath } from './internal/autoCompletePath';
 import { AccessPattern } from './internal/utils';
 import { PathString } from './pathString';
 
-/**
- * Type which given a type and a {@link PathString} into it returns
- *  - its parent/predecessor {@link PathString}
- *  - the {@link PathString} itself, if it exists within the type
- *  - all its child/successor paths that point to a type which is traversable
- * In case the path does not exist it returns all of the above for the last
- * valid path.
- * @typeParam T           - type which is indexed by the path
- * @typeParam TPathString - the current path into the type as a
- *                          {@link PathString}
- * @example
- * ```
- * LazyPath<{foo: {bar: string}}, 'foo'> = 'foo' | 'foo.bar'
- * LazyPath<{foo: {bar: string}}, 'foo.ba'> = 'foo' | 'foo.bar'
- * LazyPath<{foo: {bar: string}}, 'foo.bar'> = 'foo' | 'foo.bar'
- * LazyPath<{foo: {bar: {baz: string}}}, 'foo.bar'>
- *   = 'foo' | 'foo.bar' | 'foo.bar.baz'
- * ```
- */
-export type LazyPath<T, TPathString extends PathString> = AutoCompletePath<
-  T,
-  TPathString
->;
-
-/**
- * See {@link LazyPath}
- */
-export type LazyFieldPath<
+export type TypedFieldPath<
   TFieldValues extends FieldValues,
   TPathString extends PathString,
-> = LazyPath<TFieldValues, TPathString>;
-
-/**
- * Type which given a type and a {@link PathString} into it returns
- *  - its parent/predecessor {@link PathString}
- *  - the {@link PathString} itself, if it exists within the type,
- *    and the type, that it points to, is an array type
- *  - all its child/successor paths that point to a type which is either
- *    traversable or is an array type.
- * In case the path does not exist it returns all of the above for the last
- * valid path.
- * @typeParam T           - type which is indexed by the path
- * @typeParam TPathString - the current path into the type as a
- *                          {@link PathString}
- * @example
- * @example
- * ```
- * LazyArrayPath<{foo: {bar: string[]}}, 'foo'> = 'foo.bar'
- * LazyArrayPath<{foo: {bar: string[]}}, 'foo.ba'> = 'foo' | 'foo.bar'
- * LazyArrayPath<{foo: {bar: string[]}}, 'foo.bar'> = 'foo' | 'foo.bar'
- * LazyArrayPath<{foo: {bar: {baz: string[]}}}, 'foo.bar'>
- *   = 'foo' | 'foo.bar.baz'
- * ```
- */
-export type LazyArrayPath<T, TPathString extends PathString> = AutoCompletePath<
-  T,
+  TValue,
+  TValueSet = TValue,
+> = AutoCompletePath<
+  TFieldValues,
   TPathString,
-  AccessPattern<ReadonlyArray<FieldValues> | null | undefined, never[]>
+  AccessPattern<TValue, TValueSet>
 >;
 
-/**
- * See {@link LazyArrayPath}
- */
-export type LazyFieldArrayPath<
+export type FieldPath<
   TFieldValues extends FieldValues,
   TPathString extends PathString,
-> = LazyArrayPath<TFieldValues, TPathString>;
+> = TypedFieldPath<TFieldValues, TPathString, unknown, never>;
+
+export type TypedFieldArrayPath<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+  TArrayValues extends FieldValues,
+  TArrayValuesSet extends FieldValues = TArrayValues,
+> = TypedFieldPath<
+  TFieldValues,
+  TPathString,
+  ReadonlyArray<TArrayValues> | null | undefined,
+  TArrayValuesSet[]
+>;
+
+export type FieldArrayPath<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+> = TypedFieldArrayPath<TFieldValues, TPathString, FieldValues, never>;

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -11,9 +11,7 @@ export type TypedFieldPath<
   TValue,
   TValueSet = TValue,
 > = TPathString extends Branded.FieldPath<any>
-  ? TPathString extends Branded.TypedFieldPath<TFieldValues, TValue, TValueSet>
-    ? TPathString
-    : never
+  ? never
   : AutoCompletePath<
       TFieldValues,
       TPathString,

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -2,6 +2,7 @@ import { FieldValues } from '../fields';
 
 import { AutoCompletePath } from './internal/autoCompletePath';
 import { AccessPattern } from './internal/utils';
+import * as Branded from './branded';
 import { PathString } from './pathString';
 
 export type TypedFieldPath<
@@ -9,11 +10,15 @@ export type TypedFieldPath<
   TPathString extends PathString,
   TValue,
   TValueSet = TValue,
-> = AutoCompletePath<
-  TFieldValues,
-  TPathString,
-  AccessPattern<TValue, TValueSet>
->;
+> = TPathString extends Branded.FieldPath<any>
+  ? TPathString extends Branded.TypedFieldPath<TFieldValues, TValue, TValueSet>
+    ? TPathString
+    : never
+  : AutoCompletePath<
+      TFieldValues,
+      TPathString,
+      AccessPattern<TValue, TValueSet>
+    >;
 
 export type FieldPath<
   TFieldValues extends FieldValues,

--- a/src/types/path/lazy.ts
+++ b/src/types/path/lazy.ts
@@ -5,6 +5,20 @@ import { AccessPattern } from './internal/utils';
 import * as Branded from './branded';
 import { PathString } from './pathString';
 
+/**
+ * Type which offers autocompletion of paths through a form.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @typeParam TValue - the value which may be read from the path
+ * @typeParam TValueSet - the value which can be written to the path
+ * @example
+ * ```
+ * declare function getNumber<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: TypedFieldPath<T, P, number>,
+ * ): number
+ * ```
+ */
 export type TypedFieldPath<
   TFieldValues extends FieldValues,
   TPathString extends PathString,
@@ -18,11 +32,37 @@ export type TypedFieldPath<
       AccessPattern<TValue, TValueSet>
     >;
 
+/**
+ * Type which offers autocompletion of paths through a form.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @example
+ * ```
+ * declare function get<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: FieldPath<T, P>,
+ * ): FieldPathValue<T, P>
+ * ```
+ */
 export type FieldPath<
   TFieldValues extends FieldValues,
   TPathString extends PathString,
 > = TypedFieldPath<TFieldValues, TPathString, unknown, never>;
 
+/**
+ * Type which offers autocompletion of paths through a form which point to an array.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @typeParam TArrayValues - the value which may be read from array at the path
+ * @typeParam TArrayValuesSet - the value which can be written to the array at the path
+ * @example
+ * ```
+ * declare function popNumber<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: TypedFieldArrayPath<T, P, number>,
+ * ): number
+ * ```
+ */
 export type TypedFieldArrayPath<
   TFieldValues extends FieldValues,
   TPathString extends PathString,
@@ -35,6 +75,18 @@ export type TypedFieldArrayPath<
   TArrayValuesSet[]
 >;
 
+/**
+ * Type which offers autocompletion of paths through a form which point to an array.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @example
+ * ```
+ * declare function pop<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: FieldArrayPath<T, P>,
+ * ): FieldPathValue<T, P>[never]
+ * ```
+ */
 export type FieldArrayPath<
   TFieldValues extends FieldValues,
   TPathString extends PathString,

--- a/src/types/path/value.ts
+++ b/src/types/path/value.ts
@@ -27,3 +27,13 @@ export type FieldPathSetValue<
     ? Value
     : never
   : PathSetValue<TFieldValues, SplitPathString<TPathString>>;
+
+export type FieldPathValues<
+  TFieldValues extends FieldValues,
+  TPathString extends ReadonlyArray<PathString>,
+> = {
+  [Idx in keyof TPathString]: FieldPathValue<
+    TFieldValues,
+    TPathString[Idx] & PathString
+  >;
+};

--- a/src/types/path/value.ts
+++ b/src/types/path/value.ts
@@ -6,6 +6,18 @@ import { SplitPathString } from './internal/pathTuple';
 import * as Branded from './branded';
 import { PathString } from './pathString';
 
+/**
+ * Type for getting the value of a path.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @example
+ * ```
+ * declare function get<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: Lazy.FieldPath<T, P>,
+ * ): FieldPathValue<T, P>
+ * ```
+ */
 export type FieldPathValue<
   TFieldValues extends FieldValues,
   TPathString extends PathString,
@@ -15,6 +27,19 @@ export type FieldPathValue<
     : unknown
   : PathGetValue<TFieldValues, SplitPathString<TPathString>>;
 
+/**
+ * Type for getting the value which required for setting a path.
+ * @typeParam TFieldValues - the field values for which this path is valid
+ * @typeParam TPathString - the string representation of the path
+ * @example
+ * ```
+ * declare function set<T extends FieldValues, P extends PathString>(
+ *   obj: T,
+ *   path: Lazy.FieldPath<T, P>,
+ *   value: FieldPathSetValue<T, P>
+ * ): void
+ * ```
+ */
 export type FieldPathSetValue<
   TFieldValues extends FieldValues,
   TPathString extends PathString,
@@ -28,12 +53,24 @@ export type FieldPathSetValue<
     : never
   : PathSetValue<TFieldValues, SplitPathString<TPathString>>;
 
+/**
+ * Type for getting the values of a tuple of paths.
+ * @typeParam TFieldValues - the field values for which the paths are valid
+ * @typeParam TPathStrings - the string representations of the paths
+ * @example
+ * ```
+ * declare function get<
+ *   T extends FieldValues,
+ *   P extends ReadonlyArray<Branded.FieldPath<T>>,
+ * >(obj: T, paths: P): FieldPathValues<T, P>
+ * ```
+ */
 export type FieldPathValues<
   TFieldValues extends FieldValues,
-  TPathString extends ReadonlyArray<PathString>,
+  TPathStrings extends ReadonlyArray<PathString>,
 > = {
-  [Idx in keyof TPathString]: FieldPathValue<
+  [Idx in keyof TPathStrings]: FieldPathValue<
     TFieldValues,
-    TPathString[Idx] & PathString
+    TPathStrings[Idx] & PathString
   >;
 };

--- a/src/types/path/value.ts
+++ b/src/types/path/value.ts
@@ -1,0 +1,29 @@
+import { FieldValues } from '../fields';
+
+import { PathGetValue } from './internal/pathGetValue';
+import { PathSetValue } from './internal/pathSetValue';
+import { SplitPathString } from './internal/pathTuple';
+import * as Branded from './branded';
+import { PathString } from './pathString';
+
+export type FieldPathValue<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+> = TPathString extends Branded.FieldPath<any>
+  ? TPathString extends Branded.TypedFieldPath<TFieldValues, infer Value, never>
+    ? Value
+    : never
+  : PathGetValue<TFieldValues, SplitPathString<TPathString>>;
+
+export type FieldPathSetValue<
+  TFieldValues extends FieldValues,
+  TPathString extends PathString,
+> = TPathString extends Branded.FieldPath<any>
+  ? TPathString extends Branded.TypedFieldPath<
+      TFieldValues,
+      unknown,
+      infer Value
+    >
+    ? Value
+    : never
+  : PathSetValue<TFieldValues, SplitPathString<TPathString>>;

--- a/src/types/path/value.ts
+++ b/src/types/path/value.ts
@@ -12,7 +12,7 @@ export type FieldPathValue<
 > = TPathString extends Branded.FieldPath<any>
   ? TPathString extends Branded.TypedFieldPath<TFieldValues, infer Value, never>
     ? Value
-    : never
+    : unknown
   : PathGetValue<TFieldValues, SplitPathString<TPathString>>;
 
 export type FieldPathSetValue<

--- a/src/types/path/value.ts
+++ b/src/types/path/value.ts
@@ -14,7 +14,7 @@ import { PathString } from './pathString';
  * ```
  * declare function get<T extends FieldValues, P extends PathString>(
  *   obj: T,
- *   path: Lazy.FieldPath<T, P>,
+ *   path: Either.FieldPath<T, P>,
  * ): FieldPathValue<T, P>
  * ```
  */
@@ -35,7 +35,7 @@ export type FieldPathValue<
  * ```
  * declare function set<T extends FieldValues, P extends PathString>(
  *   obj: T,
- *   path: Lazy.FieldPath<T, P>,
+ *   path: Either.FieldPath<T, P>,
  *   value: FieldPathSetValue<T, P>
  * ): void
  * ```
@@ -61,8 +61,8 @@ export type FieldPathSetValue<
  * ```
  * declare function get<
  *   T extends FieldValues,
- *   P extends ReadonlyArray<Branded.FieldPath<T>>,
- * >(obj: T, paths: P): FieldPathValues<T, P>
+ *   P extends ReadonlyArray<PathString>,
+ * >(obj: T, paths: Either.FieldPaths<T, P>): FieldPathValues<T, P>
  * ```
  */
 export type FieldPathValues<
@@ -71,6 +71,6 @@ export type FieldPathValues<
 > = {
   [Idx in keyof TPathStrings]: FieldPathValue<
     TFieldValues,
-    TPathStrings[Idx] & PathString
+    Extract<TPathStrings[Idx], PathString>
   >;
 };


### PR DESCRIPTION
- Adds `Branded`, `Lazy`, and `Either` type namespaces.
  - Each contain a `FieldPath`, `TypedFieldPath`, `FieldArrayPath`, and `TypedFieldArrayPath` type
  - `Lazy`: These types only offer autocompletion for paths at function call sites.
  - `Branded`: Branded paths should only be obtainable by proving to the compiler that the paths are valid, i.e. by calling a function which accepts lazy paths and returns branded paths. These types can be used in all contexts (unlike `Lazy`).
  - `Either`: These types accept branded and lazy paths. `Either` can be used wherever `Lazy` can be used and should be preferred over `Lazy`.
- Adds `FieldPathValue`, `FieldPathValues`, and `FieldPathSetValue` types for getting the value type of lazy and branded paths.
- Various smaller fixes and improvements to type tests.

The types from `Branded` and the types `FieldPathValue`, `FieldPathValues`, and `FieldPathSetValue` will become the default export of the `types/path` module once the old types are removed in the next PR.

This is the final PR before the storm (i.e. replacing all the types in the public API).

@bluebill1049 