### PR TITLE
fix cloneObject utility

### DIFF
--- a/src/__tests__/utils/cloneObject.test.ts
+++ b/src/__tests__/utils/cloneObject.test.ts
@@ -92,11 +92,6 @@ describe('clone', () => {
       other: 'string',
     };
 
-    expect(cloneObject(test)).toEqual({
-      data: {
-        testFunction,
-      },
-      other: 'string',
-    });
+    expect(cloneObject(test).data).toBe(test.data);
   });
 });

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -1,26 +1,36 @@
 import isFunction from './isFunction';
-import isObject from './isObject';
+import isPrimitive from './isPrimitive';
 
-export default function cloneObject<T>(data: T): T {
-  let copy: any;
-  const isArray = Array.isArray(data);
+export default function cloneObject<T>(obj: T): T {
+  let clone: any;
 
-  if (data instanceof Date) {
-    copy = new Date(data);
-  } else if (data instanceof Set) {
-    copy = new Set(data);
-  } else if (isArray || isObject(data)) {
-    copy = isArray ? [] : {};
-    for (const key in data) {
-      if (isFunction(data[key])) {
-        copy = data;
-        break;
-      }
-      copy[key] = cloneObject(data[key]);
-    }
-  } else {
-    return data;
+  if (isPrimitive(obj)) {
+    return obj;
+  } else if (obj instanceof Date) {
+    clone = new Date(obj);
+    return clone;
+  } else if (obj instanceof Set) {
+    clone = new Set([...obj].map(cloneObject));
+    return clone;
   }
 
-  return copy;
+  clone = Object.assign({}, obj);
+
+  for (const key in clone) {
+    if (isFunction(clone[key])) {
+      clone = obj;
+      break;
+    }
+
+    clone[key] =
+      typeof clone[key] === 'object' ? cloneObject(clone[key]) : clone[key];
+  }
+
+  if (Array.isArray(obj)) {
+    clone.length = obj.length;
+    clone = Array.from(clone);
+    return clone;
+  }
+
+  return clone;
 }


### PR DESCRIPTION
Hello,
I rewrote cloneObject utility. 
In this pull request, the file responsible for testing the object tool has also been changed. I changed the assertions from toEqual or toBe.

My justification:
 - toEqual answers the question if you have the same
 - toBe answers the question of whether you are the same (In JavaScript, objects are a reference type.)