### PR TITLE
unstable `getFieldState` API for retrieve field level state

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,9 +1,6 @@
 name: Bug Report
 description: File a bug report
 title: 'issue: '
-labels: ['Status: under investigation']
-assignees:
-  - bluebill1049
 body:
   - type: markdown
     attributes:

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -514,6 +514,14 @@ export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: Field
 export const useFormContext: <TFieldValues extends FieldValues>() => UseFormReturn<TFieldValues, object>;
 
 // @public (undocumented)
+export type _UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName) => {
+    invalid: boolean;
+    isDirty: boolean;
+    isTouched: boolean;
+    error: FieldError;
+};
+
+// @public (undocumented)
 export type UseFormGetValues<TFieldValues extends FieldValues> = {
     (): UnpackNestedValue<TFieldValues>;
     <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName): FieldPathValue<TFieldValues, TFieldName>;
@@ -570,6 +578,7 @@ export type UseFormResetField<TFieldValues extends FieldValues> = <TFieldName ex
 export type UseFormReturn<TFieldValues extends FieldValues = FieldValues, TContext extends object = object> = {
     watch: UseFormWatch<TFieldValues>;
     getValues: UseFormGetValues<TFieldValues>;
+    _getFieldState: _UseFormGetFieldState<TFieldValues>;
     setError: UseFormSetError<TFieldValues>;
     clearErrors: UseFormClearErrors<TFieldValues>;
     setValue: UseFormSetValue<TFieldValues>;
@@ -704,7 +713,7 @@ export type WatchObserver<TFieldValues> = (value: UnpackNestedValue<DeepPartial<
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:193:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:204:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -514,19 +514,11 @@ export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: Field
 export const useFormContext: <TFieldValues extends FieldValues>() => UseFormReturn<TFieldValues, object>;
 
 // @public (undocumented)
-export type _UseFormGetFieldState<TFieldValues extends FieldValues> = {
-    <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName): {
-        invalid: boolean;
-        isDirty: boolean;
-        isTouched: boolean;
-        error: FieldError;
-    };
-    <TFieldName extends FieldPath<TFieldValues>>(formState: FormState<TFieldValues>, name: TFieldName): {
-        invalid: boolean;
-        isDirty: boolean;
-        isTouched: boolean;
-        error: FieldError;
-    };
+export type _UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName, formState?: FormState<TFieldValues>) => {
+    invalid: boolean;
+    isDirty: boolean;
+    isTouched: boolean;
+    error: FieldError;
 };
 
 // @public (undocumented)
@@ -721,7 +713,7 @@ export type WatchObserver<TFieldValues> = (value: UnpackNestedValue<DeepPartial<
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:211:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:205:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -514,11 +514,19 @@ export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: Field
 export const useFormContext: <TFieldValues extends FieldValues>() => UseFormReturn<TFieldValues, object>;
 
 // @public (undocumented)
-export type _UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName) => {
-    invalid: boolean;
-    isDirty: boolean;
-    isTouched: boolean;
-    error: FieldError;
+export type _UseFormGetFieldState<TFieldValues extends FieldValues> = {
+    <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName): {
+        invalid: boolean;
+        isDirty: boolean;
+        isTouched: boolean;
+        error: FieldError;
+    };
+    <TFieldName extends FieldPath<TFieldValues>>(formState: FormState<TFieldValues>, name: TFieldName): {
+        invalid: boolean;
+        isDirty: boolean;
+        isTouched: boolean;
+        error: FieldError;
+    };
 };
 
 // @public (undocumented)
@@ -713,7 +721,7 @@ export type WatchObserver<TFieldValues> = (value: UnpackNestedValue<DeepPartial<
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:204:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:211:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/types/form.test-d.ts
+++ b/src/__tests__/types/form.test-d.ts
@@ -1,5 +1,6 @@
 import { expectType } from 'tsd';
 
+import { FieldError } from '../../types';
 import { useForm } from '../../useForm';
 
 /** {@link UseFormHandleSubmit} */ {
@@ -23,5 +24,23 @@ import { useForm } from '../../useForm';
     }>();
 
     handleSubmit((data) => expectType<{ test: string; test1: number }>(data));
+  }
+}
+
+/** {@link _UseFormGetFieldState} */ {
+  /** it should return associated field state */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const { _getFieldState } = useForm({
+      defaultValues: {
+        test: '',
+      },
+    });
+
+    expectType<{
+      invalid: boolean;
+      isDirty: boolean;
+      isTouched: boolean;
+      error: FieldError;
+    }>(_getFieldState('test'));
   }
 }

--- a/src/__tests__/types/form.test-d.ts
+++ b/src/__tests__/types/form.test-d.ts
@@ -43,4 +43,20 @@ import { useForm } from '../../useForm';
       error: FieldError;
     }>(_getFieldState('test'));
   }
+
+  /** it should return associated field state when formState is supplied */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const { _getFieldState, formState } = useForm({
+      defaultValues: {
+        test: '',
+      },
+    });
+
+    expectType<{
+      invalid: boolean;
+      isDirty: boolean;
+      isTouched: boolean;
+      error: FieldError;
+    }>(_getFieldState('test', formState));
+  }
 }

--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -591,4 +591,44 @@ describe('getFieldState', () => {
       });
     });
   });
+
+  describe('when field is not found', () => {
+    it('should return field state', async () => {
+      const App = () => {
+        const { control, _getFieldState, formState } = useForm<FormValues>({
+          defaultValues: {
+            nested: {
+              first: '',
+              last: '',
+            },
+          },
+        });
+
+        // @ts-expect-error expected to show type error for field name
+        const { isDirty } = _getFieldState(formState, 'nestedMissing');
+
+        // @ts-expect-error expected to show type error for field name
+        const { isTouched } = _getFieldState('nestedMissing');
+
+        return (
+          <form>
+            <NestedInput control={control} />
+            <p>{isDirty ? 'dirty' : 'notDirty'}</p>
+            <p>{isTouched ? 'touched' : 'notTouched'}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.change(screen.getAllByRole('textbox')[0], {
+          target: { value: ' test' },
+        });
+      });
+
+      screen.getByText('notDirty');
+      screen.getByText('notTouched');
+    });
+  });
 });

--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -74,5 +74,70 @@ describe('getFieldState', () => {
 
       screen.getByText('error');
     });
+
+    it('should display isTouched state', async () => {
+      const App = () => {
+        const {
+          register,
+          _getFieldState,
+          formState: { touchedFields },
+        } = useForm({
+          defaultValues: {
+            test: '',
+          },
+        });
+
+        touchedFields;
+
+        return (
+          <form>
+            <input {...register('test')} />
+            <p>{_getFieldState('test')?.isTouched ? 'touched' : ''}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.focus(screen.getByRole('textbox'));
+        fireEvent.blur(screen.getByRole('textbox'));
+      });
+
+      screen.getByText('touched');
+    });
+
+    it('should display isDirty state', async () => {
+      const App = () => {
+        const {
+          register,
+          _getFieldState,
+          formState: { dirtyFields },
+        } = useForm({
+          defaultValues: {
+            test: '',
+          },
+        });
+
+        dirtyFields;
+
+        return (
+          <form>
+            <input {...register('test')} />
+            <p>{_getFieldState('test')?.isDirty ? 'dirty' : ''}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.change(screen.getByRole('textbox'), {
+          target: { value: ' test' },
+        });
+      });
+
+      screen.getByText('dirty');
+    });
   });
 });

--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { useForm } from '../../useForm';
+
+describe('getFieldState', () => {
+  describe('when input is primitive data type', () => {
+    it('should display error state', async () => {
+      const App = () => {
+        const {
+          trigger,
+          register,
+          _getFieldState,
+          formState: { errors },
+        } = useForm({
+          defaultValues: {
+            test: '',
+          },
+        });
+
+        errors;
+
+        return (
+          <form>
+            <input {...register('test', { required: 'This is required' })} />
+            <button type={'button'} onClick={() => trigger()}>
+              trigger
+            </button>
+            <p>{_getFieldState('test')?.error?.message}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+
+      screen.getByText('This is required');
+    });
+
+    it('should display isValid state', async () => {
+      const App = () => {
+        const {
+          trigger,
+          register,
+          _getFieldState,
+          formState: { errors },
+        } = useForm({
+          defaultValues: {
+            test: '',
+          },
+        });
+
+        errors;
+
+        return (
+          <form>
+            <input {...register('test', { required: 'This is required' })} />
+            <button type={'button'} onClick={() => trigger()}>
+              trigger
+            </button>
+            <p>{_getFieldState('test')?.invalid ? 'error' : 'valid'}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+
+      screen.getByText('error');
+    });
+  });
+});

--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -348,7 +348,7 @@ describe('getFieldState', () => {
             },
           });
 
-          const { error } = _getFieldState(formState, 'test');
+          const { error } = _getFieldState('test', formState);
 
           return (
             <form>
@@ -378,7 +378,7 @@ describe('getFieldState', () => {
             },
           });
 
-          const { invalid } = _getFieldState(formState, 'test');
+          const { invalid } = _getFieldState('test', formState);
 
           return (
             <form>
@@ -408,7 +408,7 @@ describe('getFieldState', () => {
             },
           });
 
-          const { isTouched } = _getFieldState(formState, 'test');
+          const { isTouched } = _getFieldState('test', formState);
 
           return (
             <form>
@@ -436,7 +436,7 @@ describe('getFieldState', () => {
             },
           });
 
-          const { isDirty } = _getFieldState(formState, 'test');
+          const { isDirty } = _getFieldState('test', formState);
 
           return (
             <form>
@@ -471,7 +471,7 @@ describe('getFieldState', () => {
               },
             });
 
-          const { error } = _getFieldState(formState, 'nested');
+          const { error } = _getFieldState('nested', formState);
 
           return (
             <form>
@@ -505,7 +505,7 @@ describe('getFieldState', () => {
               },
             });
 
-          const { invalid } = _getFieldState(formState, 'nested');
+          const { invalid } = _getFieldState('nested', formState);
 
           return (
             <form>
@@ -538,7 +538,7 @@ describe('getFieldState', () => {
             },
           });
 
-          const { isTouched } = _getFieldState(formState, 'nested');
+          const { isTouched } = _getFieldState('nested', formState);
 
           return (
             <form>
@@ -569,7 +569,7 @@ describe('getFieldState', () => {
             },
           });
 
-          const { isDirty } = _getFieldState(formState, 'nested');
+          const { isDirty } = _getFieldState('nested', formState);
 
           return (
             <form>

--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
+import { Control } from '../../types';
+import { useController } from '../../useController';
 import { useForm } from '../../useForm';
 
 describe('getFieldState', () => {
@@ -133,6 +135,199 @@ describe('getFieldState', () => {
 
       await act(async () => {
         fireEvent.change(screen.getByRole('textbox'), {
+          target: { value: ' test' },
+        });
+      });
+
+      screen.getByText('dirty');
+    });
+  });
+
+  describe('when input is nested data type', () => {
+    type FormValues = {
+      nested: {
+        first: string;
+        last: string;
+      };
+    };
+
+    const NestedInput = ({ control }: { control: Control<FormValues> }) => {
+      const { field } = useController({
+        control,
+        name: 'nested',
+        rules: {
+          validate: (data) => {
+            return data.first && data.last ? true : 'This is required';
+          },
+        },
+      });
+
+      return (
+        <fieldset>
+          <input
+            value={field.value.first}
+            onChange={(e) => {
+              field.onChange({
+                ...field.value,
+                first: e.target.value,
+              });
+            }}
+            onBlur={field.onBlur}
+          />
+          <input
+            value={field.value.last}
+            onChange={(e) => {
+              field.onChange({
+                ...field.value,
+                last: e.target.value,
+              });
+            }}
+            onBlur={field.onBlur}
+          />
+        </fieldset>
+      );
+    };
+
+    it('should display error state', async () => {
+      const App = () => {
+        const {
+          trigger,
+          _getFieldState,
+          control,
+          formState: { errors },
+        } = useForm<FormValues>({
+          defaultValues: {
+            nested: {
+              first: '',
+              last: '',
+            },
+          },
+        });
+
+        errors;
+
+        return (
+          <form>
+            <NestedInput control={control} />
+            <button type={'button'} onClick={() => trigger()}>
+              trigger
+            </button>
+            <p>{_getFieldState('nested')?.error?.message}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+
+      screen.getByText('This is required');
+    });
+
+    it('should display isValid state', async () => {
+      const App = () => {
+        const {
+          trigger,
+          control,
+          _getFieldState,
+          formState: { errors },
+        } = useForm<FormValues>({
+          defaultValues: {
+            nested: {
+              first: '',
+              last: '',
+            },
+          },
+        });
+
+        errors;
+
+        return (
+          <form>
+            <NestedInput control={control} />
+            <button type={'button'} onClick={() => trigger()}>
+              trigger
+            </button>
+            <p>{_getFieldState('nested')?.invalid ? 'error' : 'valid'}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button'));
+      });
+
+      screen.getByText('error');
+    });
+
+    it('should display isTouched state', async () => {
+      const App = () => {
+        const {
+          control,
+          _getFieldState,
+          formState: { touchedFields },
+        } = useForm<FormValues>({
+          defaultValues: {
+            nested: {
+              first: '',
+              last: '',
+            },
+          },
+        });
+
+        touchedFields;
+
+        return (
+          <form>
+            <NestedInput control={control} />
+            <p>{_getFieldState('nested')?.isTouched ? 'touched' : ''}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.focus(screen.getAllByRole('textbox')[0]);
+        fireEvent.blur(screen.getAllByRole('textbox')[0]);
+      });
+
+      screen.getByText('touched');
+    });
+
+    it('should display isDirty state', async () => {
+      const App = () => {
+        const {
+          control,
+          _getFieldState,
+          formState: { dirtyFields },
+        } = useForm<FormValues>({
+          defaultValues: {
+            nested: {
+              first: '',
+              last: '',
+            },
+          },
+        });
+
+        dirtyFields;
+
+        return (
+          <form>
+            <NestedInput control={control} />
+            <p>{_getFieldState('nested')?.isDirty ? 'dirty' : ''}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await act(async () => {
+        fireEvent.change(screen.getAllByRole('textbox')[0], {
           target: { value: ' test' },
         });
       });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -800,17 +800,12 @@ export function createFormControl<
   ) => {
     const isFieldName = isString(formState);
     const fieldName = isFieldName ? formState : (name as string);
+    const stage = isFieldName ? _formState : formState;
     return {
-      invalid: !!get((isFieldName ? _formState : formState).errors, fieldName),
-      isDirty: !!get(
-        (isFieldName ? _formState : formState).dirtyFields,
-        fieldName,
-      ),
-      isTouched: !!get(
-        (isFieldName ? _formState : formState).touchedFields,
-        fieldName,
-      ),
-      error: get((isFieldName ? _formState : formState).errors, fieldName),
+      invalid: !!get(stage.errors, fieldName),
+      isDirty: get(stage.dirtyFields, fieldName),
+      isTouched: get(stage.touchedFields, fieldName),
+      error: get(stage.errors, fieldName),
     };
   };
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1178,7 +1178,6 @@ export function createFormControl<
       _removeUnmounted,
       _updateFieldArray,
       _getFieldArray,
-      _getFieldState,
       _subjects,
       _proxyFormState,
       get _fields() {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1,5 +1,6 @@
 import { EVENTS, VALIDATION_MODE } from '../constants';
 import {
+  _UseFormGetFieldState,
   BatchFieldArrayUpdate,
   ChangeHandler,
   DeepPartial,
@@ -793,6 +794,15 @@ export function createFormControl<
       : fieldNames.map((name) => get(values, name as InternalFieldName));
   };
 
+  const _getFieldState: _UseFormGetFieldState<TFieldValues> = (
+    name: FieldPath<TFieldValues>,
+  ) => ({
+    invalid: !!get(_formState.errors, name),
+    isDirty: !!get(_formState.dirtyFields, name),
+    isTouched: !!get(_formState.touchedFields, name),
+    error: get(_formState.errors, name),
+  });
+
   const clearErrors: UseFormClearErrors<TFieldValues> = (name) => {
     name
       ? convertToArrayPayload(name).forEach((inputName) =>
@@ -1168,6 +1178,7 @@ export function createFormControl<
       _removeUnmounted,
       _updateFieldArray,
       _getFieldArray,
+      _getFieldState,
       _subjects,
       _proxyFormState,
       get _fields() {
@@ -1228,5 +1239,6 @@ export function createFormControl<
     unregister,
     setError,
     setFocus,
+    _getFieldState,
   };
 }

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -795,17 +795,15 @@ export function createFormControl<
   };
 
   const _getFieldState: _UseFormGetFieldState<TFieldValues> = (
+    name,
     formState,
-    name?,
   ) => {
-    const isFieldName = isString(formState);
-    const fieldName = isFieldName ? formState : (name as string);
-    const stage = isFieldName ? _formState : formState;
+    const stage = formState || _formState;
     return {
-      invalid: !!get(stage.errors, fieldName),
-      isDirty: get(stage.dirtyFields, fieldName),
-      isTouched: get(stage.touchedFields, fieldName),
-      error: get(stage.errors, fieldName),
+      invalid: !!get(stage.errors, name),
+      isDirty: get(stage.dirtyFields, name),
+      isTouched: get(stage.touchedFields, name),
+      error: get(stage.errors, name),
     };
   };
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -797,15 +797,12 @@ export function createFormControl<
   const _getFieldState: _UseFormGetFieldState<TFieldValues> = (
     name,
     formState,
-  ) => {
-    const stage = formState || _formState;
-    return {
-      invalid: !!get(stage.errors, name),
-      isDirty: get(stage.dirtyFields, name),
-      isTouched: get(stage.touchedFields, name),
-      error: get(stage.errors, name),
-    };
-  };
+  ) => ({
+    invalid: !!get((formState || _formState).errors, name),
+    isDirty: get((formState || _formState).dirtyFields, name),
+    isTouched: get((formState || _formState).touchedFields, name),
+    error: get((formState || _formState).errors, name),
+  });
 
   const clearErrors: UseFormClearErrors<TFieldValues> = (name) => {
     name

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -795,13 +795,19 @@ export function createFormControl<
   };
 
   const _getFieldState: _UseFormGetFieldState<TFieldValues> = (
-    name: FieldPath<TFieldValues>,
-  ) => ({
-    invalid: !!get(_formState.errors, name),
-    isDirty: !!get(_formState.dirtyFields, name),
-    isTouched: !!get(_formState.touchedFields, name),
-    error: get(_formState.errors, name),
-  });
+    formState,
+    name?,
+  ) => {
+    const fieldName: string = isString(formState)
+      ? formState
+      : (name as string);
+    return {
+      invalid: !!get((_formState || formState).errors, fieldName),
+      isDirty: !!get((_formState || formState).dirtyFields, fieldName),
+      isTouched: !!get((_formState || formState).touchedFields, fieldName),
+      error: get((_formState || formState).errors, fieldName),
+    };
+  };
 
   const clearErrors: UseFormClearErrors<TFieldValues> = (name) => {
     name

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -798,14 +798,19 @@ export function createFormControl<
     formState,
     name?,
   ) => {
-    const fieldName: string = isString(formState)
-      ? formState
-      : (name as string);
+    const isFieldName = isString(formState);
+    const fieldName = isFieldName ? formState : (name as string);
     return {
-      invalid: !!get((_formState || formState).errors, fieldName),
-      isDirty: !!get((_formState || formState).dirtyFields, fieldName),
-      isTouched: !!get((_formState || formState).touchedFields, fieldName),
-      error: get((_formState || formState).errors, fieldName),
+      invalid: !!get((isFieldName ? _formState : formState).errors, fieldName),
+      isDirty: !!get(
+        (isFieldName ? _formState : formState).dirtyFields,
+        fieldName,
+      ),
+      isTouched: !!get(
+        (isFieldName ? _formState : formState).touchedFields,
+        fieldName,
+      ),
+      error: get((isFieldName ? _formState : formState).errors, fieldName),
     };
   };
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -359,7 +359,6 @@ export type Control<
   _getFieldArray: <TFieldArrayValues>(
     name: InternalFieldName,
   ) => Partial<TFieldArrayValues>[];
-  _getFieldState: _UseFormGetFieldState<TFieldValues>;
   _executeSchema: (
     names: InternalFieldName[],
   ) => Promise<{ errors: FieldErrors }>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -180,22 +180,16 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
   ): [...FieldPathValues<TFieldValues, TFieldNames>];
 };
 
-export type _UseFormGetFieldState<TFieldValues extends FieldValues> = {
-  <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName): {
-    invalid: boolean;
-    isDirty: boolean;
-    isTouched: boolean;
-    error: FieldError;
-  };
-  <TFieldName extends FieldPath<TFieldValues>>(
-    formState: FormState<TFieldValues>,
-    name: TFieldName,
-  ): {
-    invalid: boolean;
-    isDirty: boolean;
-    isTouched: boolean;
-    error: FieldError;
-  };
+export type _UseFormGetFieldState<TFieldValues extends FieldValues> = <
+  TFieldName extends FieldPath<TFieldValues>,
+>(
+  name: TFieldName,
+  formState?: FormState<TFieldValues>,
+) => {
+  invalid: boolean;
+  isDirty: boolean;
+  isTouched: boolean;
+  error: FieldError;
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -180,6 +180,17 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
   ): [...FieldPathValues<TFieldValues, TFieldNames>];
 };
 
+export type _UseFormGetFieldState<TFieldValues extends FieldValues> = <
+  TFieldName extends FieldPath<TFieldValues>,
+>(
+  name: TFieldName,
+) => {
+  invalid: boolean;
+  isDirty: boolean;
+  isTouched: boolean;
+  error: FieldError;
+};
+
 export type UseFormWatch<TFieldValues extends FieldValues> = {
   (): UnpackNestedValue<TFieldValues>;
   <TFieldNames extends readonly FieldPath<TFieldValues>[]>(
@@ -348,6 +359,7 @@ export type Control<
   _getFieldArray: <TFieldArrayValues>(
     name: InternalFieldName,
   ) => Partial<TFieldArrayValues>[];
+  _getFieldState: _UseFormGetFieldState<TFieldValues>;
   _executeSchema: (
     names: InternalFieldName[],
   ) => Promise<{ errors: FieldErrors }>;
@@ -370,6 +382,7 @@ export type UseFormReturn<
 > = {
   watch: UseFormWatch<TFieldValues>;
   getValues: UseFormGetValues<TFieldValues>;
+  _getFieldState: _UseFormGetFieldState<TFieldValues>;
   setError: UseFormSetError<TFieldValues>;
   clearErrors: UseFormClearErrors<TFieldValues>;
   setValue: UseFormSetValue<TFieldValues>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -180,15 +180,22 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
   ): [...FieldPathValues<TFieldValues, TFieldNames>];
 };
 
-export type _UseFormGetFieldState<TFieldValues extends FieldValues> = <
-  TFieldName extends FieldPath<TFieldValues>,
->(
-  name: TFieldName,
-) => {
-  invalid: boolean;
-  isDirty: boolean;
-  isTouched: boolean;
-  error: FieldError;
+export type _UseFormGetFieldState<TFieldValues extends FieldValues> = {
+  <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName): {
+    invalid: boolean;
+    isDirty: boolean;
+    isTouched: boolean;
+    error: FieldError;
+  };
+  <TFieldName extends FieldPath<TFieldValues>>(
+    formState: FormState<TFieldValues>,
+    name: TFieldName,
+  ): {
+    invalid: boolean;
+    isDirty: boolean;
+    isTouched: boolean;
+    error: FieldError;
+  };
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -111,8 +111,8 @@ export function useController<
     formState,
     fieldState: {
       invalid: !!get(formState.errors, name),
-      isDirty: !!get(formState.dirtyFields, name),
-      isTouched: !!get(formState.touchedFields, name),
+      isDirty: get(formState.dirtyFields, name),
+      isTouched: get(formState.touchedFields, name),
       error: get(formState.errors, name),
     },
   };

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -109,11 +109,6 @@ export function useController<
       },
     },
     formState,
-    fieldState: {
-      invalid: !!get(formState.errors, name),
-      isDirty: !!get(formState.dirtyFields, name),
-      isTouched: !!get(formState.touchedFields, name),
-      error: get(formState.errors, name),
-    },
+    fieldState: control._getFieldState(name),
   };
 }

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -109,6 +109,11 @@ export function useController<
       },
     },
     formState,
-    fieldState: control._getFieldState(name),
+    fieldState: {
+      invalid: !!get(formState.errors, name),
+      isDirty: !!get(formState.dirtyFields, name),
+      isTouched: !!get(formState.touchedFields, name),
+      error: get(formState.errors, name),
+    },
   };
 }


### PR DESCRIPTION
New API: `getFieldState`

## Context

Today we have this annoying issue with primitive input (single value) vs nested value input (object/array), it's impossible to determine the type at the build time and hence we introduced `NestedValue`, however, it isn't perfect and does cause other issues.

## Proposal

This API will be the solution for nested/primitive field state issues with TS, get it ready for v8's TS improvement. The end goal is deprecated [`NestedValue`](https://react-hook-form.com/ts/#NestedValue) type and in the flavor of using this method for the nested field. We are planning to introduce to v7 and reduce the migration headache when eventually move into v8. 

## Example

You can retrieve the relevant single field state.

```tsx
const { _getFieldState, formState } = useForm(); // the _ will be removed eventually when it rolls out

// formState subscription is not notified
const { isDirty, isTouched, invalid, error } = _getFieldState('nestedValueField', formState);

// when formState subscription is notified
const { isDirty, isTouched, invalid, error } = _getFieldState('nestedValueField');
```

## Todos

- [x] unit tests
- [ ] release next version (beta)
- [ ] documentation update
- [x] API poll: https://twitter.com/HookForm/status/1482928929061347329