### PR TITLE
scrollIntoView before focus

### DIFF
--- a/src/logic/focusFieldBy.ts
+++ b/src/logic/focusFieldBy.ts
@@ -1,5 +1,6 @@
 import { FieldRefs, InternalFieldName } from '../types';
 import { get } from '../utils';
+import isFunction from '../utils/isFunction';
 import isObject from '../utils/isObject';
 import isUndefined from '../utils/isUndefined';
 import omit from '../utils/omit';
@@ -20,6 +21,7 @@ const focusFieldBy = (
         if (_f.ref.focus && isUndefined(_f.ref.focus())) {
           break;
         } else if (_f.refs) {
+          isFunction(_f.refs[0]?.scrollIntoView) && _f.refs[0].scrollIntoView();
           _f.refs[0].focus();
           break;
         }


### PR DESCRIPTION
# Overview
focus with scrollIntoView

# Why
When call focus() on  Safari on iOS  and radio/checkbox element, no scroll
When the form is too long to fit in one screen, it's not user friendly (ex: risk miss validation message)

example site https://react-hook-form-sample.vercel.app/sample/iphone-validation-focus/ng

# Concern
It's Problem for Only Safari on iOS.
Perhaps we should call scrollIntoView limited only Safari On iOS.
But, detect is little difficult

# Ref
https://zenn.dev/daisuke7924/articles/5839e0094c5fdf
https://stackoverflow.com/questions/56137175/ios-safari-chrome-wont-scroll-up-to-show-validation-error-message-on-radio-inpu