### PR TITLE
add getMountedFieldPaths

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -582,6 +582,7 @@ export type UseFormReturn<TFieldValues extends FieldValues = FieldValues, TConte
     control: Control<TFieldValues, TContext>;
     register: UseFormRegister<TFieldValues>;
     setFocus: UseFormSetFocus<TFieldValues>;
+    getMountedFieldPaths: () => FieldPath<TFieldValues>[];
 };
 
 // @public (undocumented)

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1501,4 +1501,29 @@ describe('useForm', () => {
 
     expect(tempControl._subjects.state.observers.length).toBeFalsy();
   });
+
+  it('should add mounted components to getMountedFieldPaths', () => {
+    let getMountedFieldPaths: any;
+    const Component = () => {
+      const { register, getMountedFieldPaths: tempGetMountedFieldPaths } =
+        useForm<{
+          test: string;
+        }>();
+
+      getMountedFieldPaths = tempGetMountedFieldPaths;
+
+      return (
+        <div>
+          <input {...register('test', { required: true })} />
+        </div>
+      );
+    };
+    const { unmount } = render(<Component />);
+
+    expect(getMountedFieldPaths()).toEqual(['test']);
+
+    unmount();
+
+    expect(getMountedFieldPaths()).toEqual([]);
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1170,6 +1170,24 @@ export function createFormControl<
     (field.ref.focus ? field.ref : field.refs[0]).focus();
   };
 
+  const getMountedFieldPaths = (): FieldPath<TFieldValues>[] => {
+    const mountedFields: FieldPath<TFieldValues>[] = [];
+    const fieldsThatWereEverMounted = _names.mount as unknown as Set<
+      FieldPath<TFieldValues>
+    >;
+
+    fieldsThatWereEverMounted.forEach((fieldName) => {
+      const field = get(_fields, fieldName);
+      const fieldInfo = field._f;
+
+      if (fieldInfo.mount) {
+        mountedFields.push(fieldName);
+      }
+    });
+
+    return mountedFields;
+  };
+
   return {
     control: {
       register,
@@ -1241,5 +1259,6 @@ export function createFormControl<
     unregister,
     setError,
     setFocus,
+    getMountedFieldPaths,
   };
 }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -382,6 +382,7 @@ export type UseFormReturn<
   control: Control<TFieldValues, TContext>;
   register: UseFormRegister<TFieldValues>;
   setFocus: UseFormSetFocus<TFieldValues>;
+  getMountedFieldPaths: () => FieldPath<TFieldValues>[];
 };
 
 export type UseFormStateProps<TFieldValues> = Partial<{


### PR DESCRIPTION
This adds an API to get the field paths that are currently in the DOM.

## Simple Example

```js
const { register, getMountedFieldPaths } = useForm();

useLayoutEffect(() => 
    const paths = getMountedFieldPaths();
    console.log(paths)
    // ['test', 'long.path.to.field' ]
}, [])

return <div>
    <input {...register('test')} />
    <input {...register('long.path.to.field')} />
</div>
```

## Use Case

I'm making a number of multi-page forms, and I need to ensure that the user has filled out each page before moving on to the next. Using `trigger` without any arguments will check fields that haven't been shown to the user, and always return false. This method allows us to trigger validation only on fields that the user can currently act upon.