### PR TITLE
V8: Remove is prefix

### DIFF
--- a/app/src/conditionalField.tsx
+++ b/app/src/conditionalField.tsx
@@ -10,13 +10,13 @@ const ConditionalField: React.FC = () => {
     watch,
     formState: {
       dirtyFields,
-      isSubmitted,
+      submitted,
       submitCount,
       touchedFields,
-      isDirty,
-      isSubmitting,
-      isSubmitSuccessful,
-      isValid,
+      dirty,
+      submitting,
+      submitSuccessful,
+      valid,
       errors,
     },
   } = useForm<{
@@ -85,12 +85,12 @@ const ConditionalField: React.FC = () => {
       <button id="submit">Submit</button>
       <div id="state">
         {JSON.stringify({
-          isSubmitted,
+          submitted,
           submitCount,
-          isDirty,
-          isSubmitting,
-          isSubmitSuccessful,
-          isValid,
+          dirty,
+          submitting,
+          submitSuccessful,
+          valid,
           touched: Object.keys(touchedFields),
           dirty: Object.keys(dirtyFields),
         })}

--- a/app/src/conditionalField.tsx
+++ b/app/src/conditionalField.tsx
@@ -92,7 +92,7 @@ const ConditionalField: React.FC = () => {
           submitSuccessful,
           valid,
           touched: Object.keys(touchedFields),
-          dirty: Object.keys(dirtyFields),
+          dirtyFields: Object.keys(dirtyFields),
         })}
       </div>
       <div id="result">{JSON.stringify(result)}</div>

--- a/app/src/formState.tsx
+++ b/app/src/formState.tsx
@@ -64,7 +64,7 @@ const FormState = () => {
           submitSuccessful,
           valid,
           touched: Object.keys(touchedFields),
-          dirty: Object.keys(dirtyFields),
+          dirtyFields: Object.keys(dirtyFields),
         })}
       </div>
       <select {...register('select')} defaultValue="test">

--- a/app/src/formState.tsx
+++ b/app/src/formState.tsx
@@ -11,13 +11,13 @@ const FormState = () => {
     handleSubmit,
     formState: {
       dirtyFields,
-      isSubmitted,
+      submitted,
       submitCount,
       touchedFields,
-      isDirty,
-      isSubmitting,
-      isSubmitSuccessful,
-      isValid,
+      dirty,
+      submitting,
+      submitSuccessful,
+      valid,
     },
     reset,
   } = useForm<{
@@ -57,12 +57,12 @@ const FormState = () => {
       />
       <div id="state">
         {JSON.stringify({
-          isSubmitted,
+          submitted,
           submitCount,
-          isDirty,
-          isSubmitting,
-          isSubmitSuccessful,
-          isValid,
+          dirty,
+          submitting,
+          submitSuccessful,
+          valid,
           touched: Object.keys(touchedFields),
           dirty: Object.keys(dirtyFields),
         })}

--- a/app/src/formStateWithNestedFields.tsx
+++ b/app/src/formStateWithNestedFields.tsx
@@ -11,13 +11,13 @@ const FormStateWithNestedFields = () => {
     handleSubmit,
     formState: {
       dirtyFields,
-      isSubmitted,
+      submitted,
       submitCount,
       touchedFields,
-      isDirty,
-      isSubmitting,
-      isSubmitSuccessful,
-      isValid,
+      dirty,
+      submitting,
+      submitSuccessful,
+      valid,
     },
     reset,
   } = useForm<{
@@ -73,12 +73,12 @@ const FormStateWithNestedFields = () => {
       </div>
       <div id="state">
         {JSON.stringify({
-          isDirty,
-          isSubmitted,
+          dirty,
+          submitted,
           submitCount,
-          isSubmitting,
-          isSubmitSuccessful,
-          isValid,
+          submitting,
+          submitSuccessful,
+          valid,
           touched: (
             Object.keys(touchedFields) as Array<keyof typeof touchedFields>
           ).flatMap((topLevelKey) =>

--- a/app/src/formStateWithNestedFields.tsx
+++ b/app/src/formStateWithNestedFields.tsx
@@ -86,7 +86,7 @@ const FormStateWithNestedFields = () => {
               (nestedKey) => `${topLevelKey}.${nestedKey}`,
             ),
           ),
-          dirty: (
+          dirtyFields: (
             Object.keys(dirtyFields) as Array<keyof typeof touchedFields>
           ).flatMap((topLevelKey) =>
             Object.keys(dirtyFields[topLevelKey] || {}).map(

--- a/app/src/formStateWithSchema.tsx
+++ b/app/src/formStateWithSchema.tsx
@@ -24,13 +24,13 @@ const FormStateWithSchema: React.FC = () => {
     handleSubmit,
     formState: {
       dirtyFields,
-      isSubmitted,
+      submitted,
       submitCount,
       touchedFields,
-      isDirty,
-      isSubmitting,
-      isSubmitSuccessful,
-      isValid,
+      dirty,
+      submitting,
+      submitSuccessful,
+      valid,
     },
     reset,
   } = useForm<{
@@ -76,12 +76,12 @@ const FormStateWithSchema: React.FC = () => {
       </button>
       <div id="state">
         {JSON.stringify({
-          isSubmitted,
+          submitted,
           submitCount,
-          isDirty,
-          isSubmitting,
-          isSubmitSuccessful,
-          isValid,
+          dirty,
+          submitting,
+          submitSuccessful,
+          valid,
           touched: Object.keys(touchedFields),
           dirty: Object.keys(dirtyFields),
         })}

--- a/app/src/formStateWithSchema.tsx
+++ b/app/src/formStateWithSchema.tsx
@@ -83,7 +83,7 @@ const FormStateWithSchema: React.FC = () => {
           submitSuccessful,
           valid,
           touched: Object.keys(touchedFields),
-          dirty: Object.keys(dirtyFields),
+          dirtyFields: Object.keys(dirtyFields),
         })}
       </div>
       <div id="renderCount">{renderCounter}</div>

--- a/app/src/isValid.tsx
+++ b/app/src/isValid.tsx
@@ -88,7 +88,7 @@ const valid: React.FC = () => {
           <input {...register('age')} placeholder="age" />
         </>
       )}
-      <div id="valid">{JSON.stringify(valid)}</div>
+      <div id="isValid">{JSON.stringify(valid)}</div>
       <div id="renderCount">{renderCounter}</div>
 
       <button

--- a/app/src/isValid.tsx
+++ b/app/src/isValid.tsx
@@ -14,7 +14,7 @@ const validationSchema = yup
   })
   .required();
 
-const IsValid: React.FC = () => {
+const valid: React.FC = () => {
   const { mode, defaultValues } = useParams();
   const isBuildInValidation = mode === 'build-in';
   const [show, setShow] = React.useState(true);
@@ -22,7 +22,7 @@ const IsValid: React.FC = () => {
     register,
     handleSubmit,
     unregister,
-    formState: { isValid },
+    formState: { valid },
   } = useForm<{
     firstName: string;
     lastName: string;
@@ -88,7 +88,7 @@ const IsValid: React.FC = () => {
           <input {...register('age')} placeholder="age" />
         </>
       )}
-      <div id="isValid">{JSON.stringify(isValid)}</div>
+      <div id="valid">{JSON.stringify(valid)}</div>
       <div id="renderCount">{renderCounter}</div>
 
       <button
@@ -104,4 +104,4 @@ const IsValid: React.FC = () => {
   );
 };
 
-export default IsValid;
+export default valid;

--- a/app/src/setValueCustomRegister.tsx
+++ b/app/src/setValueCustomRegister.tsx
@@ -8,7 +8,7 @@ const SetValueCustomRegister: React.FC = () => {
     register,
     setValue,
     handleSubmit,
-    formState: { touchedFields, isDirty, errors },
+    formState: { touchedFields, dirty, errors },
   } = useForm<{
     firstName: string;
     lastName: string;
@@ -61,7 +61,7 @@ const SetValueCustomRegister: React.FC = () => {
         WithOutError
       </button>
 
-      <div id="dirty">{isDirty.toString()}</div>
+      <div id="dirty">{dirty.toString()}</div>
       <div id="touched">{Object.keys(touchedFields).map((touch) => touch)}</div>
       <div id="renderCount">{renderCounter}</div>
     </form>

--- a/app/src/useFieldArray.tsx
+++ b/app/src/useFieldArray.tsx
@@ -325,7 +325,7 @@ const UseFieldArray: React.FC = () => {
       <div id="renderCount">{renderCount}</div>
       <div id="result">{JSON.stringify(data)}</div>
       <div id="dirty">{dirty ? 'yes' : 'no'}</div>
-      <div id="valid">{valid ? 'yes' : 'no'}</div>
+      <div id="isValid">{valid ? 'yes' : 'no'}</div>
       <div id="dirtyFields">{JSON.stringify(dirtyFields)}</div>
       <div id="touched">{JSON.stringify(touchedFields.data)}</div>
     </form>

--- a/app/src/useFieldArray.tsx
+++ b/app/src/useFieldArray.tsx
@@ -13,7 +13,7 @@ const UseFieldArray: React.FC = () => {
     control,
     handleSubmit,
     register,
-    formState: { isDirty, touchedFields, isValid, dirtyFields, errors },
+    formState: { dirty, touchedFields, valid, dirtyFields, errors },
     reset,
   } = useForm<FormValues>({
     ...(mode === 'default' || withoutFocus
@@ -324,8 +324,8 @@ const UseFieldArray: React.FC = () => {
 
       <div id="renderCount">{renderCount}</div>
       <div id="result">{JSON.stringify(data)}</div>
-      <div id="dirty">{isDirty ? 'yes' : 'no'}</div>
-      <div id="isValid">{isValid ? 'yes' : 'no'}</div>
+      <div id="dirty">{dirty ? 'yes' : 'no'}</div>
+      <div id="valid">{valid ? 'yes' : 'no'}</div>
       <div id="dirtyFields">{JSON.stringify(dirtyFields)}</div>
       <div id="touched">{JSON.stringify(touchedFields.data)}</div>
     </form>

--- a/app/src/useFieldArrayUnregister.tsx
+++ b/app/src/useFieldArrayUnregister.tsx
@@ -51,7 +51,7 @@ const UseFieldArrayUnregister: React.FC = () => {
     unregister,
     setValue,
     getValues,
-    formState: { isDirty, touchedFields, dirtyFields, errors },
+    formState: { dirty, touchedFields, dirtyFields, errors },
   } = useForm<FormInputs>({
     defaultValues: {
       data: [{ name: 'test' }, { name: 'test1' }, { name: 'test2' }],
@@ -165,7 +165,7 @@ const UseFieldArrayUnregister: React.FC = () => {
 
       <div id="renderCount">{renderCount}</div>
       <div id="result">{JSON.stringify(data)}</div>
-      <div id="dirty">{isDirty ? 'yes' : 'no'}</div>
+      <div id="dirty">{dirty ? 'yes' : 'no'}</div>
       <div id="dirtyFields">{JSON.stringify(dirtyFields)}</div>
       <div id="touched">{JSON.stringify(touchedFields.data)}</div>
     </form>

--- a/app/src/useFormState.tsx
+++ b/app/src/useFormState.tsx
@@ -40,7 +40,7 @@ const SubForm = ({ control }: { control: Control<FormInputs> }) => {
       {JSON.stringify({
         dirty,
         touched: Object.keys(touchedFields),
-        dirty: Object.keys(dirtyFields),
+        dirtyFields: Object.keys(dirtyFields),
         submitted,
         submitSuccessful,
         submitCount,

--- a/app/src/useFormState.tsx
+++ b/app/src/useFormState.tsx
@@ -24,13 +24,13 @@ type FormInputs = {
 
 const SubForm = ({ control }: { control: Control<FormInputs> }) => {
   const {
-    isDirty,
+    dirty,
     dirtyFields,
     touchedFields,
-    isSubmitted,
-    isSubmitSuccessful,
+    submitted,
+    submitSuccessful,
     submitCount,
-    isValid,
+    valid,
   } = useFormState({
     control,
   });
@@ -38,13 +38,13 @@ const SubForm = ({ control }: { control: Control<FormInputs> }) => {
   return (
     <p id="state">
       {JSON.stringify({
-        isDirty,
+        dirty,
         touched: Object.keys(touchedFields),
         dirty: Object.keys(dirtyFields),
-        isSubmitted,
-        isSubmitSuccessful,
+        submitted,
+        submitSuccessful,
         submitCount,
-        isValid,
+        valid,
       })}
     </p>
   );

--- a/cypress/integration/conditionalField.ts
+++ b/cypress/integration/conditionalField.ts
@@ -3,14 +3,14 @@ describe('ConditionalField', () => {
     cy.visit('http://localhost:3000/conditionalField');
     cy.get('#state').should(($state) => {
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       });
     });
 
@@ -20,14 +20,14 @@ describe('ConditionalField', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['selectNumber', 'firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['selectNumber', 'firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['selectNumber', 'firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
     cy.get('button#submit').click();
@@ -36,14 +36,14 @@ describe('ConditionalField', () => {
     );
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['selectNumber', 'firstName', 'lastName'],
-        isSubmitted: true,
+        dirtyFields: ['selectNumber', 'firstName', 'lastName'],
+        submitted: true,
         submitCount: 1,
         touched: ['selectNumber', 'firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#result').should(($state) =>
@@ -57,14 +57,14 @@ describe('ConditionalField', () => {
     cy.get('select[name="selectNumber"]').select('2');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['selectNumber', 'firstName', 'lastName'],
-        isSubmitted: true,
+        dirtyFields: ['selectNumber', 'firstName', 'lastName'],
+        submitted: true,
         submitCount: 1,
         touched: ['selectNumber', 'firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: false,
       }),
     );
     cy.get('input[name="min"]').type('10');
@@ -72,27 +72,27 @@ describe('ConditionalField', () => {
     cy.get('input[name="max"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
-        isSubmitted: true,
+        dirtyFields: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
+        submitted: true,
         submitCount: 1,
         touched: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('button#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
-        isSubmitted: true,
+        dirtyFields: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
+        submitted: true,
         submitCount: 2,
         touched: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#result').should(($state) =>
@@ -108,14 +108,14 @@ describe('ConditionalField', () => {
     cy.get('select[name="selectNumber"]').select('3');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
-        isSubmitted: true,
+        dirtyFields: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
+        submitted: true,
         submitCount: 2,
         touched: ['selectNumber', 'firstName', 'lastName', 'min', 'max'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
 
@@ -123,7 +123,7 @@ describe('ConditionalField', () => {
     cy.get('input[name="notRequired"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [
+        dirtyFields: [
           'selectNumber',
           'firstName',
           'lastName',
@@ -131,7 +131,7 @@ describe('ConditionalField', () => {
           'max',
           'notRequired',
         ],
-        isSubmitted: true,
+        submitted: true,
         submitCount: 2,
         touched: [
           'selectNumber',
@@ -141,10 +141,10 @@ describe('ConditionalField', () => {
           'max',
           'notRequired',
         ],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
 

--- a/cypress/integration/formState.ts
+++ b/cypress/integration/formState.ts
@@ -4,14 +4,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -19,28 +19,28 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -49,14 +49,14 @@ describe('form state', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -65,14 +65,14 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName'],
+        submitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -80,14 +80,14 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#renderCount').contains('13');
@@ -98,14 +98,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -113,28 +113,28 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -143,14 +143,14 @@ describe('form state', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -159,14 +159,14 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName'],
+        submitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -174,14 +174,14 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#renderCount').contains('13');
@@ -192,14 +192,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -207,28 +207,28 @@ describe('form state', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -237,14 +237,14 @@ describe('form state', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -253,14 +253,14 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName'],
+        submitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -268,14 +268,14 @@ describe('form state', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#renderCount').contains('13');
@@ -290,14 +290,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -306,14 +306,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -321,28 +321,28 @@ describe('form state', () => {
     cy.get('select[name="select"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['select'],
-        isSubmitted: false,
+        dirtyFields: ['select'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('select[name="select"]').select('');
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -350,28 +350,28 @@ describe('form state', () => {
     cy.get('input[name="checkbox"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['checkbox'],
-        isSubmitted: false,
+        dirtyFields: ['checkbox'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select', 'checkbox'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="checkbox"]').uncheck();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select', 'checkbox'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -379,8 +379,8 @@ describe('form state', () => {
     cy.get('input[name="checkbox-checked"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['checkbox-checked'],
-        isSubmitted: false,
+        dirtyFields: ['checkbox-checked'],
+        submitted: false,
         submitCount: 0,
         touched: [
           'firstName',
@@ -389,17 +389,17 @@ describe('form state', () => {
           'checkbox',
           'checkbox-checked',
         ],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('input[name="checkbox-checked"]').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [
           'firstName',
@@ -408,10 +408,10 @@ describe('form state', () => {
           'checkbox',
           'checkbox-checked',
         ],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -419,8 +419,8 @@ describe('form state', () => {
     cy.get('input[name="radio"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['radio'],
-        isSubmitted: false,
+        dirtyFields: ['radio'],
+        submitted: false,
         submitCount: 0,
         touched: [
           'firstName',
@@ -430,18 +430,18 @@ describe('form state', () => {
           'checkbox-checked',
           'radio',
         ],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('select[name="select"]').select('');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['radio'],
-        isSubmitted: false,
+        dirtyFields: ['radio'],
+        submitted: false,
         submitCount: 0,
         touched: [
           'firstName',
@@ -451,10 +451,10 @@ describe('form state', () => {
           'checkbox-checked',
           'radio',
         ],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('#renderCount').contains('18');
@@ -469,14 +469,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -486,14 +486,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('#renderCount').contains('8');
@@ -508,14 +508,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -523,14 +523,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -544,14 +544,14 @@ describe('form state', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 

--- a/cypress/integration/formStateWithNestedFields.ts
+++ b/cypress/integration/formStateWithNestedFields.ts
@@ -4,14 +4,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -20,14 +20,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -35,14 +35,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -51,14 +51,14 @@ describe('form state with nested fields', () => {
     cy.get('input[name="left.test2"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -67,14 +67,14 @@ describe('form state with nested fields', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1'],
-        isSubmitted: true,
+        dirty: true,
+        dirtyFields: ['left.test1'],
+        submitted: true,
         submitCount: 1,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -82,14 +82,14 @@ describe('form state with nested fields', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: true,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: true,
         submitCount: 2,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#renderCount').contains('13');
@@ -100,14 +100,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -115,28 +115,28 @@ describe('form state with nested fields', () => {
     cy.get('input[name="left.test1"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="left.test1"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -145,14 +145,14 @@ describe('form state with nested fields', () => {
     cy.get('input[name="left.test2"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -161,14 +161,14 @@ describe('form state with nested fields', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1'],
-        isSubmitted: true,
+        dirty: true,
+        dirtyFields: ['left.test1'],
+        submitted: true,
         submitCount: 1,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -176,14 +176,14 @@ describe('form state with nested fields', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: true,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: true,
         submitCount: 2,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#renderCount').contains('13');
@@ -194,14 +194,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -209,28 +209,28 @@ describe('form state with nested fields', () => {
     cy.get('input[name="left.test1"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="left.test1"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -239,14 +239,14 @@ describe('form state with nested fields', () => {
     cy.get('input[name="left.test2"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -255,14 +255,14 @@ describe('form state with nested fields', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1'],
-        isSubmitted: true,
+        dirty: true,
+        dirtyFields: ['left.test1'],
+        submitted: true,
         submitCount: 1,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -270,14 +270,14 @@ describe('form state with nested fields', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: true,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: true,
         submitCount: 2,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#renderCount').contains('13');
@@ -292,14 +292,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -308,14 +308,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -331,14 +331,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -348,14 +348,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('#renderCount').contains('8');
@@ -370,14 +370,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
-        dirty: ['left.test1', 'left.test2'],
-        isSubmitted: false,
+        dirty: true,
+        dirtyFields: ['left.test1', 'left.test2'],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -385,14 +385,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -406,14 +406,14 @@ describe('form state with nested fields', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
-        dirty: [],
-        isSubmitted: false,
+        dirty: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['left.test1', 'left.test2'],
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 

--- a/cypress/integration/formStateWithSchema.ts
+++ b/cypress/integration/formStateWithSchema.ts
@@ -4,14 +4,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -19,28 +19,28 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -49,14 +49,14 @@ describe('form state with schema validation', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -65,14 +65,14 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName'],
+        submitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -80,14 +80,14 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('select[name="select"]').select('1');
@@ -99,14 +99,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -114,28 +114,28 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -144,14 +144,14 @@ describe('form state with schema validation', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -160,14 +160,14 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName'],
+        submitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -175,14 +175,14 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#renderCount').contains('13');
@@ -193,14 +193,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -208,28 +208,28 @@ describe('form state with schema validation', () => {
     cy.get('input[name="firstName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('input[name="firstName"]').clear();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -238,14 +238,14 @@ describe('form state with schema validation', () => {
     cy.get('input[name="lastName"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -254,14 +254,14 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName'],
+        submitted: true,
         submitCount: 1,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -269,14 +269,14 @@ describe('form state with schema validation', () => {
     cy.get('#submit').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: true,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: true,
         submitCount: 2,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: true,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: true,
+        valid: true,
       }),
     );
     cy.get('#renderCount').contains('13');
@@ -291,14 +291,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -307,14 +307,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -322,27 +322,27 @@ describe('form state with schema validation', () => {
     cy.get('select[name="select"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['select'],
-        isSubmitted: false,
+        dirtyFields: ['select'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('select[name="select"]').select('');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -350,27 +350,27 @@ describe('form state with schema validation', () => {
     cy.get('input[name="checkbox"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['checkbox'],
-        isSubmitted: false,
+        dirtyFields: ['checkbox'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select', 'checkbox'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('input[name="checkbox"]').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName', 'select', 'checkbox'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -378,8 +378,8 @@ describe('form state with schema validation', () => {
     cy.get('input[name="checkbox-checked"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['checkbox-checked'],
-        isSubmitted: false,
+        dirtyFields: ['checkbox-checked'],
+        submitted: false,
         submitCount: 0,
         touched: [
           'firstName',
@@ -388,17 +388,17 @@ describe('form state with schema validation', () => {
           'checkbox',
           'checkbox-checked',
         ],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('input[name="checkbox-checked"]').click();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [
           'firstName',
@@ -407,10 +407,10 @@ describe('form state with schema validation', () => {
           'checkbox',
           'checkbox-checked',
         ],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -418,8 +418,8 @@ describe('form state with schema validation', () => {
     cy.get('input[name="radio"]').blur();
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['radio'],
-        isSubmitted: false,
+        dirtyFields: ['radio'],
+        submitted: false,
         submitCount: 0,
         touched: [
           'firstName',
@@ -429,18 +429,18 @@ describe('form state with schema validation', () => {
           'checkbox-checked',
           'radio',
         ],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
     cy.get('select[name="select"]').select('');
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['radio'],
-        isSubmitted: false,
+        dirtyFields: ['radio'],
+        submitted: false,
         submitCount: 0,
         touched: [
           'firstName',
@@ -450,10 +450,10 @@ describe('form state with schema validation', () => {
           'checkbox-checked',
           'radio',
         ],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('#renderCount').contains('18');
@@ -468,14 +468,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -485,14 +485,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('#renderCount').contains('8');
@@ -507,14 +507,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: ['firstName', 'lastName'],
-        isSubmitted: false,
+        dirtyFields: ['firstName', 'lastName'],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: true,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: true,
+        dirty: true,
+        submitting: false,
+        submitSuccessful: false,
+        valid: true,
       }),
     );
 
@@ -522,14 +522,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: [],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
 
@@ -543,14 +543,14 @@ describe('form state with schema validation', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        dirty: [],
-        isSubmitted: false,
+        dirtyFields: [],
+        submitted: false,
         submitCount: 0,
         touched: ['firstName', 'lastName'],
-        isDirty: false,
-        isSubmitting: false,
-        isSubmitSuccessful: false,
-        isValid: false,
+        dirty: false,
+        submitting: false,
+        submitSuccessful: false,
+        valid: false,
       }),
     );
     cy.get('#renderCount').contains('13');

--- a/cypress/integration/useFormState.ts
+++ b/cypress/integration/useFormState.ts
@@ -20,7 +20,7 @@ describe('useFormState', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
+        dirty: true,
         touched: [
           'nestItem',
           'firstName',
@@ -34,7 +34,7 @@ describe('useFormState', () => {
           'maxDate',
           'minLength',
         ],
-        dirty: [
+        dirtyFields: [
           'firstName',
           'arrayItem',
           'nestItem',
@@ -47,10 +47,10 @@ describe('useFormState', () => {
           'maxDate',
           'minLength',
         ],
-        isSubmitted: true,
-        isSubmitSuccessful: false,
+        submitted: true,
+        submitSuccessful: false,
         submitCount: 0,
-        isValid: false,
+        valid: false,
       }),
     );
 
@@ -64,7 +64,7 @@ describe('useFormState', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
+        dirty: true,
         touched: [
           'nestItem',
           'firstName',
@@ -79,7 +79,7 @@ describe('useFormState', () => {
           'minLength',
           'minRequiredLength',
         ],
-        dirty: [
+        dirtyFields: [
           'firstName',
           'arrayItem',
           'nestItem',
@@ -93,10 +93,10 @@ describe('useFormState', () => {
           'minLength',
           'minRequiredLength',
         ],
-        isSubmitted: true,
-        isSubmitSuccessful: false,
+        submitted: true,
+        submitSuccessful: false,
         submitCount: 0,
-        isValid: true,
+        valid: true,
       }),
     );
 
@@ -104,7 +104,7 @@ describe('useFormState', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: true,
+        dirty: true,
         touched: [
           'nestItem',
           'firstName',
@@ -119,7 +119,7 @@ describe('useFormState', () => {
           'minLength',
           'minRequiredLength',
         ],
-        dirty: [
+        dirtyFields: [
           'firstName',
           'arrayItem',
           'nestItem',
@@ -133,10 +133,10 @@ describe('useFormState', () => {
           'minLength',
           'minRequiredLength',
         ],
-        isSubmitted: true,
-        isSubmitSuccessful: true,
+        submitted: true,
+        submitSuccessful: true,
         submitCount: 1,
-        isValid: true,
+        valid: true,
       }),
     );
 
@@ -144,13 +144,13 @@ describe('useFormState', () => {
 
     cy.get('#state').should(($state) =>
       expect(JSON.parse($state.text())).to.be.deep.equal({
-        isDirty: false,
+        dirty: false,
         touched: [],
-        dirty: [],
-        isSubmitted: false,
-        isSubmitSuccessful: false,
+        dirtyFields: [],
+        submitted: false,
+        submitSuccessful: false,
         submitCount: 0,
-        isValid: true,
+        valid: true,
       }),
     );
 

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -92,8 +92,8 @@ export const Controller: <TFieldValues extends FieldValues = FieldValues, TName 
 // @public (undocumented)
 export type ControllerFieldState = {
     invalid: boolean;
-    isTouched: boolean;
-    isDirty: boolean;
+    touched: boolean;
+    dirty: boolean;
     error?: FieldError;
 };
 
@@ -282,26 +282,26 @@ export type FormProviderProps<TFieldValues extends FieldValues = FieldValues, TC
 
 // @public (undocumented)
 export type FormState<TFieldValues> = {
-    isDirty: boolean;
+    dirty: boolean;
     dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
-    isSubmitted: boolean;
-    isSubmitSuccessful: boolean;
+    submitted: boolean;
+    submitSuccessful: boolean;
     submitCount: number;
     touchedFields: FieldNamesMarkedBoolean<TFieldValues>;
-    isSubmitting: boolean;
-    isValidating: boolean;
-    isValid: boolean;
+    submitting: boolean;
+    validating: boolean;
+    valid: boolean;
     errors: FieldErrors<TFieldValues>;
 };
 
 // @public (undocumented)
 export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
-    isDirty: boolean;
-    isValidating: boolean;
+    dirty: boolean;
+    validating: boolean;
     dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
     touchedFields: FieldNamesMarkedBoolean<TFieldValues>;
     errors: boolean;
-    isValid: boolean;
+    valid: boolean;
 };
 
 // Warning: (ae-forgotten-export) The symbol "Subject" needs to be exported by the entry point index.d.ts
@@ -347,7 +347,7 @@ export type KeepStateOptions = Partial<{
     keepDirty: boolean;
     keepValues: boolean;
     keepDefaultValues: boolean;
-    keepIsSubmitted: boolean;
+    keepSubmitted: boolean;
     keepTouched: boolean;
     keepSubmitCount: boolean;
 }>;
@@ -603,8 +603,8 @@ export const useFormContext: <TFieldValues extends FieldValues>() => UseFormRetu
 // @public (undocumented)
 export type _UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName, formState?: FormState<TFieldValues>) => {
     invalid: boolean;
-    isDirty: boolean;
-    isTouched: boolean;
+    dirty: boolean;
+    touched: boolean;
     error: FieldError;
 };
 
@@ -709,7 +709,7 @@ export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
 export type UseFormTrigger<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[], options?: TriggerConfig) => Promise<boolean>;
 
 // @public (undocumented)
-export type UseFormUnregister<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[], options?: Omit<KeepStateOptions, 'keepIsSubmitted' | 'keepSubmitCount' | 'keepValues' | 'keepDefaultValues' | 'keepErrors'> & {
+export type UseFormUnregister<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[], options?: Omit<KeepStateOptions, 'keepSubmitted' | 'keepSubmitCount' | 'keepValues' | 'keepDefaultValues' | 'keepErrors'> & {
     keepValue?: boolean;
     keepDefaultValue?: boolean;
     keepError?: boolean;

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -708,7 +708,7 @@ describe('Controller', () => {
           render={({ field: props, fieldState }) => (
             <>
               <input {...props} />
-              {fieldState.isTouched && <p>Input is touched.</p>}
+              {fieldState.touched && <p>Input is touched.</p>}
             </>
           )}
           control={control}
@@ -739,7 +739,7 @@ describe('Controller', () => {
           render={({ field: props, fieldState }) => (
             <>
               <input {...props} />
-              {fieldState.isTouched && <p>Input is dirty.</p>}
+              {fieldState.touched && <p>Input is dirty.</p>}
             </>
           )}
           control={control}
@@ -808,7 +808,7 @@ describe('Controller', () => {
           render={({ field: props, fieldState }) => (
             <>
               <input {...props} />
-              {fieldState.isTouched && <p>Input is dirty.</p>}
+              {fieldState.touched && <p>Input is dirty.</p>}
             </>
           )}
           control={control}
@@ -900,7 +900,7 @@ describe('Controller', () => {
     const Component = () => {
       const {
         control,
-        formState: { isValid },
+        formState: { valid },
       } = useForm<{
         test: string;
         test1: string;
@@ -930,7 +930,7 @@ describe('Controller', () => {
             name={'test1'}
             control={control}
           />
-          {isValid ? 'true' : 'false'}
+          {valid ? 'true' : 'false'}
         </>
       );
     };
@@ -968,7 +968,7 @@ describe('Controller', () => {
     const Component = () => {
       const {
         control,
-        formState: { dirtyFields, isDirty },
+        formState: { dirtyFields, dirty },
       } = useForm<FormValues>({
         defaultValues: {
           test: '',
@@ -983,7 +983,7 @@ describe('Controller', () => {
             render={({ field }) => <input {...field} />}
           />
           <p>{JSON.stringify(dirtyFields)}</p>
-          <p>{isDirty ? 'true' : 'false'}</p>
+          <p>{dirty ? 'true' : 'false'}</p>
         </>
       );
     };

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -54,7 +54,7 @@ describe('useController', () => {
     const Test1 = ({ control }: { control: Control<FormValues> }) => {
       const {
         field,
-        fieldState: { isDirty, isTouched },
+        fieldState: { dirty, touched },
       } = useController({
         name: 'test1',
         control,
@@ -65,8 +65,8 @@ describe('useController', () => {
       return (
         <div>
           <input {...field} />
-          {isDirty && <p>isDirty</p>}
-          {isTouched && <p>isTouched</p>}
+          {dirty && <p>dirty</p>}
+          {touched && <p>isTouched</p>}
         </div>
       );
     };
@@ -99,7 +99,7 @@ describe('useController', () => {
       });
     });
 
-    screen.getByText('isDirty');
+    screen.getByText('dirty');
 
     await act(async () => {
       fireEvent.blur(screen.getAllByRole('textbox')[1]);

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -121,7 +121,7 @@ describe('useFieldArray', () => {
         const {
           register,
           control,
-          formState: { isValid, errors },
+          formState: { valid, errors },
         } = useForm<{ test: { value: string }[] }>({
           defaultValues: {
             test: [{ value: 'test' }],
@@ -152,7 +152,7 @@ describe('useFieldArray', () => {
               append
             </button>
 
-            {!isValid && <p>not valid</p>}
+            {!valid && <p>not valid</p>}
             {errors.test && <p>errors</p>}
           </form>
         );
@@ -239,7 +239,7 @@ describe('useFieldArray', () => {
         const {
           register,
           control,
-          formState: { isValid },
+          formState: { valid },
         } = useForm<{
           data: string;
           test: { value: string }[];
@@ -261,7 +261,7 @@ describe('useFieldArray', () => {
               <input key={field.id} {...register(`test.${i}.value` as const)} />
             ))}
             <button onClick={() => append({ value: '' })}>append</button>
-            <span>{isValid && 'valid'}</span>
+            <span>{valid && 'valid'}</span>
           </div>
         );
       };
@@ -325,7 +325,7 @@ describe('useFieldArray', () => {
         const {
           register,
           control,
-          formState: { isValid },
+          formState: { valid },
         } = useForm<FormValues>({
           resolver: (data) => {
             formData = data;
@@ -356,7 +356,7 @@ describe('useFieldArray', () => {
                 </button>
               </fieldset>
             ))}
-            <span>{isValid && 'valid'}</span>
+            <span>{valid && 'valid'}</span>
           </form>
         );
       };
@@ -1013,7 +1013,7 @@ describe('useFieldArray', () => {
   });
 
   describe('with setValue', () => {
-    it.each(['isDirty', 'dirtyFields'])(
+    it.each(['dirty', 'dirtyFields'])(
       'should set name to dirtyFieldRef if array field values are different with default value when formState.%s is defined',
       async (property) => {
         let setValue: any;
@@ -1072,7 +1072,7 @@ describe('useFieldArray', () => {
             test: [{ name: true }, { name: false }, { name: false }],
           });
         } else {
-          expect(formState.isDirty).toBeTruthy();
+          expect(formState.dirty).toBeTruthy();
         }
       },
     );
@@ -1134,7 +1134,7 @@ describe('useFieldArray', () => {
             test: [{ name: true }, { name: false }, { name: false }],
           });
         } else {
-          expect(formState.isDirty).toBeTruthy();
+          expect(formState.dirty).toBeTruthy();
         }
 
         actComponent(() => {
@@ -1158,7 +1158,7 @@ describe('useFieldArray', () => {
             },
           ],
         });
-        expect(formState.isDirty).toBeFalsy();
+        expect(formState.dirty).toBeFalsy();
       },
     );
 

--- a/src/__tests__/useFieldArray/append.test.tsx
+++ b/src/__tests__/useFieldArray/append.test.tsx
@@ -161,7 +161,7 @@ describe('append', () => {
     });
   });
 
-  it.each(['isDirty', 'dirtyFields'])(
+  it.each(['dirty', 'dirtyFields'])(
     'should be dirtyFields when value is appended with %s',
     () => {
       let isDirtyValue;
@@ -171,7 +171,7 @@ describe('append', () => {
         const {
           register,
           control,
-          formState: { isDirty, dirtyFields },
+          formState: { dirty, dirtyFields },
         } = useForm<{
           test: { test: string }[];
         }>();
@@ -180,7 +180,7 @@ describe('append', () => {
           name: 'test',
         });
 
-        isDirtyValue = isDirty;
+        isDirtyValue = dirty;
         dirtyValue = dirtyFields;
 
         return (
@@ -457,7 +457,7 @@ describe('append', () => {
         return { formState, append };
       });
 
-      result.current.formState.isValid;
+      result.current.formState.valid;
 
       await act(async () => {
         result.current.append({ value: '1' });

--- a/src/__tests__/useFieldArray/insert.test.tsx
+++ b/src/__tests__/useFieldArray/insert.test.tsx
@@ -94,7 +94,7 @@ describe('insert', () => {
         return { formState, fields, append, insert };
       });
 
-      result.current.formState.isDirty;
+      result.current.formState.dirty;
       result.current.formState.dirtyFields;
 
       act(() => {
@@ -105,7 +105,7 @@ describe('insert', () => {
         result.current.insert(1, { value1: '3' });
       });
 
-      expect(result.current.formState.isDirty).toBeTruthy();
+      expect(result.current.formState.dirty).toBeTruthy();
       expect(result.current.formState.dirtyFields).toEqual({
         test: [{ value: false }, { value1: true }, { value: true }],
       });
@@ -129,7 +129,7 @@ describe('insert', () => {
         return { formState, fields, append, insert };
       });
 
-      result.current.formState.isDirty;
+      result.current.formState.dirty;
       result.current.formState.dirtyFields;
 
       act(() => {
@@ -140,7 +140,7 @@ describe('insert', () => {
         result.current.insert(1, [{ value1: '3' }, { value2: '4' }]);
       });
 
-      expect(result.current.formState.isDirty).toBeTruthy();
+      expect(result.current.formState.dirty).toBeTruthy();
       expect(result.current.formState.dirtyFields).toEqual({
         test: [
           { value: false },
@@ -605,7 +605,7 @@ describe('insert', () => {
         return { formState, insert };
       });
 
-      result.current.formState.isValid;
+      result.current.formState.valid;
 
       await act(async () => {
         result.current.insert(0, { value: '1' });

--- a/src/__tests__/useFieldArray/move.test.tsx
+++ b/src/__tests__/useFieldArray/move.test.tsx
@@ -40,7 +40,7 @@ describe('swap', () => {
         };
       });
 
-      result.current.formState.isDirty;
+      result.current.formState.dirty;
       result.current.formState.dirtyFields;
 
       act(() => {
@@ -55,7 +55,7 @@ describe('swap', () => {
         result.current.move(0, 1);
       });
 
-      expect(result.current.formState.isDirty).toBeTruthy();
+      expect(result.current.formState.dirty).toBeTruthy();
       expect(result.current.formState.dirtyFields).toEqual({
         test: [{ value: true }, { value: true }, { value: true }],
       });
@@ -300,7 +300,7 @@ describe('swap', () => {
         return { formState, move };
       });
 
-      result.current.formState.isValid;
+      result.current.formState.valid;
 
       await act(async () => {
         result.current.move(0, 1);

--- a/src/__tests__/useFieldArray/prepend.test.tsx
+++ b/src/__tests__/useFieldArray/prepend.test.tsx
@@ -111,7 +111,7 @@ describe('prepend', () => {
         return { register, formState, fields, prepend };
       });
 
-      result.current.formState.isDirty;
+      result.current.formState.dirty;
       result.current.formState.dirtyFields;
 
       act(() => {
@@ -126,7 +126,7 @@ describe('prepend', () => {
         result.current.prepend({ value: 'test2' });
       });
 
-      expect(result.current.formState.isDirty).toBeTruthy();
+      expect(result.current.formState.dirty).toBeTruthy();
       expect(result.current.formState.dirtyFields).toEqual({
         test: [{ value: true }, { value: true }, { value: true }],
       });
@@ -482,7 +482,7 @@ describe('prepend', () => {
         return { formState, prepend };
       });
 
-      result.current.formState.isValid;
+      result.current.formState.valid;
 
       await act(async () => {
         result.current.prepend({ value: '1' });

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -45,7 +45,7 @@ describe('remove', () => {
       });
 
       formState = tempFormState;
-      formState.isDirty;
+      formState.dirty;
 
       return (
         <form>
@@ -74,15 +74,15 @@ describe('remove', () => {
 
     render(<Component />);
 
-    expect(formState.isDirty).toBeFalsy();
+    expect(formState.dirty).toBeFalsy();
 
     fireEvent.click(screen.getByRole('button', { name: /append/i }));
 
-    expect(formState.isDirty).toBeTruthy();
+    expect(formState.dirty).toBeTruthy();
 
     fireEvent.click(screen.getAllByRole('button', { name: /remove/i })[1]);
 
-    expect(formState.isDirty).toBeFalsy();
+    expect(formState.dirty).toBeFalsy();
   });
 
   it('should update isValid formState when item removed', async () => {
@@ -105,7 +105,7 @@ describe('remove', () => {
 
       formState = tempFormState;
 
-      formState.isValid;
+      formState.valid;
 
       return (
         <form>
@@ -131,7 +131,7 @@ describe('remove', () => {
             append
           </button>
 
-          <p>{formState.isValid ? 'isValid' : 'notValid'}</p>
+          <p>{formState.valid ? 'isValid' : 'notValid'}</p>
         </form>
       );
     };
@@ -233,7 +233,7 @@ describe('remove', () => {
     expect(result.current.fields).toEqual([]);
   });
 
-  it.each(['isDirty', 'dirtyFields'])(
+  it.each(['dirty', 'dirtyFields'])(
     'should be dirtyFields when value is remove with %s',
     () => {
       const { result } = renderHook(() => {
@@ -250,7 +250,7 @@ describe('remove', () => {
         return { register, formState, fields, append, remove };
       });
 
-      result.current.formState.isDirty;
+      result.current.formState.dirty;
       result.current.formState.dirtyFields;
 
       act(() => {
@@ -265,7 +265,7 @@ describe('remove', () => {
         result.current.remove(0);
       });
 
-      expect(result.current.formState.isDirty).toBeTruthy();
+      expect(result.current.formState.dirty).toBeTruthy();
       expect(result.current.formState.dirtyFields).toEqual({
         test: [{ value: true }, { value: true }],
       });
@@ -274,7 +274,7 @@ describe('remove', () => {
         result.current.remove();
       });
 
-      expect(result.current.formState.isDirty).toBeTruthy();
+      expect(result.current.formState.dirty).toBeTruthy();
       expect(result.current.formState.dirtyFields).toEqual({
         test: [{ value: true }],
       });
@@ -348,7 +348,7 @@ describe('remove', () => {
         name: 'test',
       });
 
-      formState.isValid;
+      formState.valid;
 
       return (
         <form>
@@ -364,7 +364,7 @@ describe('remove', () => {
           <button type="button" onClick={() => remove(1)}>
             remove
           </button>
-          <p>{formState.isValid ? 'valid' : 'notValid'}</p>
+          <p>{formState.valid ? 'valid' : 'notValid'}</p>
         </form>
       );
     };
@@ -434,7 +434,7 @@ describe('remove', () => {
         control,
         name: 'test',
       });
-      isValid = formState.isValid;
+      isValid = formState.valid;
 
       return (
         <form>
@@ -781,13 +781,13 @@ describe('remove', () => {
     });
 
     result.current.formState.dirtyFields as Record<string, any>;
-    result.current.formState.isDirty;
+    result.current.formState.dirty;
 
     act(() => {
       result.current.append({ value: 'test' });
     });
 
-    expect(result.current.formState.isDirty).toBeTruthy();
+    expect(result.current.formState.dirty).toBeTruthy();
     expect(result.current.formState.dirtyFields).toEqual({
       test: { data: [{ value: false }, { value: true }] },
     });
@@ -796,7 +796,7 @@ describe('remove', () => {
       result.current.remove(1);
     });
 
-    expect(result.current.formState.isDirty).toBeFalsy();
+    expect(result.current.formState.dirty).toBeFalsy();
     expect(result.current.formState.dirtyFields).toEqual({
       test: { data: [{ value: false }] },
     });
@@ -960,7 +960,7 @@ describe('remove', () => {
         return { formState, remove };
       });
 
-      result.current.formState.isValid;
+      result.current.formState.valid;
 
       await act(async () => {
         result.current.remove(0);

--- a/src/__tests__/useFieldArray/swap.test.tsx
+++ b/src/__tests__/useFieldArray/swap.test.tsx
@@ -94,7 +94,7 @@ describe('swap', () => {
         };
       });
 
-      result.current.formState.isDirty;
+      result.current.formState.dirty;
       result.current.formState.dirtyFields;
 
       act(() => {
@@ -109,7 +109,7 @@ describe('swap', () => {
         result.current.swap(0, 1);
       });
 
-      expect(result.current.formState.isDirty).toBeTruthy();
+      expect(result.current.formState.dirty).toBeTruthy();
       expect(result.current.formState.dirtyFields).toEqual({
         test: [{ value: true }, { value: true }, { value: true }],
       });
@@ -325,7 +325,7 @@ describe('swap', () => {
         return { formState, swap };
       });
 
-      result.current.formState.isValid;
+      result.current.formState.valid;
 
       await act(async () => {
         result.current.swap(0, 1);

--- a/src/__tests__/useFieldArray/update.test.tsx
+++ b/src/__tests__/useFieldArray/update.test.tsx
@@ -82,7 +82,7 @@ describe('update', () => {
       const {
         register,
         control,
-        formState: { isDirty, dirtyFields },
+        formState: { dirty, dirtyFields },
       } = useForm<{
         test: { test: string }[];
       }>({
@@ -93,7 +93,7 @@ describe('update', () => {
         name: 'test',
       });
 
-      isDirtyValue = isDirty;
+      isDirtyValue = dirty;
       dirtyValue = dirtyFields;
 
       return (
@@ -424,7 +424,7 @@ describe('update', () => {
         return { formState, update };
       });
 
-      result.current.formState.isValid;
+      result.current.formState.valid;
 
       await act(async () => {
         result.current.update(0, { value: '1' });

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -121,12 +121,12 @@ describe('useForm', () => {
       });
 
       expect(formState.touchedFields.test).toBeDefined();
-      expect(formState.isDirty).toBeFalsy();
+      expect(formState.dirty).toBeFalsy();
 
       unmount();
 
       expect(formState.touchedFields.test).toBeDefined();
-      expect(formState.isDirty).toBeFalsy();
+      expect(formState.dirty).toBeFalsy();
     });
 
     it('should update dirtyFields during unregister', () => {
@@ -137,7 +137,7 @@ describe('useForm', () => {
         }>();
         formState = tempFormState;
 
-        formState.isDirty;
+        formState.dirty;
         formState.dirtyFields;
 
         return <input {...register('test', { required: true })} />;
@@ -151,12 +151,12 @@ describe('useForm', () => {
       });
 
       expect(formState.dirtyFields.test).toBeDefined();
-      expect(formState.isDirty).toBeTruthy();
+      expect(formState.dirty).toBeTruthy();
 
       unmount();
 
       expect(formState.dirtyFields.test).toBeDefined();
-      expect(formState.isDirty).toBeTruthy();
+      expect(formState.dirty).toBeTruthy();
     });
 
     it('should only validate input which are mounted even with unregister: false', async () => {
@@ -508,7 +508,7 @@ describe('useForm', () => {
       const {
         register,
         handleSubmit,
-        formState: { errors, isValid },
+        formState: { errors, valid },
       } = internationalMethods;
       methods = internationalMethods;
 
@@ -522,7 +522,7 @@ describe('useForm', () => {
             {errors?.test?.message && errors.test.message}
           </span>
           <button onClick={handleSubmit(() => {})}>button</button>
-          <p>{isValid ? 'valid' : 'invalid'}</p>
+          <p>{valid ? 'valid' : 'invalid'}</p>
         </div>
       );
     };
@@ -886,7 +886,7 @@ describe('useForm', () => {
 
         render(<Component resolver={resolver} mode="onChange" />);
 
-        methods.formState.isValid;
+        methods.formState.valid;
 
         await actComponent(async () => {
           fireEvent.input(screen.getByRole('textbox'), {
@@ -895,7 +895,7 @@ describe('useForm', () => {
         });
 
         expect(screen.getByRole('alert').textContent).toBe('');
-        expect(methods.formState.isValid).toBeTruthy();
+        expect(methods.formState.valid).toBeTruthy();
 
         await actComponent(async () => {
           fireEvent.input(screen.getByRole('textbox'), {
@@ -905,7 +905,7 @@ describe('useForm', () => {
 
         await waitFor(() => expect(resolver).toHaveBeenCalled());
         expect(screen.getByRole('alert').textContent).toBe('resolver error');
-        expect(methods.formState.isValid).toBeFalsy();
+        expect(methods.formState.valid).toBeFalsy();
       });
 
       it('with sync resolver it should contain error if value is invalid with resolver', async () => {
@@ -925,7 +925,7 @@ describe('useForm', () => {
 
         render(<Component resolver={resolver} mode="onChange" />);
 
-        methods.formState.isValid;
+        methods.formState.valid;
 
         await actComponent(async () => {
           fireEvent.input(screen.getByRole('textbox'), {
@@ -934,7 +934,7 @@ describe('useForm', () => {
         });
 
         expect(screen.getByRole('alert').textContent).toBe('');
-        expect(methods.formState.isValid).toBeTruthy();
+        expect(methods.formState.valid).toBeTruthy();
 
         await actComponent(async () => {
           fireEvent.input(screen.getByRole('textbox'), {
@@ -967,7 +967,7 @@ describe('useForm', () => {
 
         render(<Component resolver={resolver} mode="onChange" />);
 
-        methods.formState.isValid;
+        methods.formState.valid;
 
         await actComponent(async () => {
           fireEvent.input(screen.getByRole('textbox'), {
@@ -976,7 +976,7 @@ describe('useForm', () => {
         });
 
         expect(screen.getByRole('alert').textContent).toBe('');
-        expect(methods.formState.isValid).toBeTruthy();
+        expect(methods.formState.valid).toBeTruthy();
 
         await actComponent(async () => {
           fireEvent.input(screen.getByRole('textbox'), {
@@ -986,7 +986,7 @@ describe('useForm', () => {
 
         await waitFor(() => expect(resolver).toHaveBeenCalled());
         expect(screen.getByRole('alert').textContent).toBe('');
-        expect(methods.formState.isValid).toBeFalsy();
+        expect(methods.formState.valid).toBeFalsy();
       });
 
       it("should call the resolver with the field being validated when an input's value change", async () => {
@@ -1420,7 +1420,7 @@ describe('useForm', () => {
           <>
             <button onClick={() => setToggle(!toggle)}>Toggle</button>
             {toggle && <input id="test" {...register('test')} />}
-            <button disabled={!formState.isValid}>Submit</button>
+            <button disabled={!formState.valid}>Submit</button>
           </>
         );
       };

--- a/src/__tests__/useForm/__snapshots__/reset.test.tsx.snap
+++ b/src/__tests__/useForm/__snapshots__/reset.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`reset should not reset if keepStateOption is specified 1`] = `
 Object {
+  "dirty": true,
   "errors": Object {},
-  "isDirty": true,
   "touchedFields": Object {
     "test": true,
   },
@@ -12,8 +12,8 @@ Object {
 
 exports[`reset should not reset if keepStateOption is specified 2`] = `
 Object {
+  "dirty": true,
   "errors": Object {},
-  "isDirty": true,
   "touchedFields": Object {
     "test": true,
   },

--- a/src/__tests__/useForm/clearErrors.test.tsx
+++ b/src/__tests__/useForm/clearErrors.test.tsx
@@ -223,7 +223,7 @@ describe('clearErrors', () => {
   it('should update isValid to true with setError', async () => {
     const App = () => {
       const {
-        formState: { isValid },
+        formState: { valid },
         setError,
         clearErrors,
       } = useForm({
@@ -247,7 +247,7 @@ describe('clearErrors', () => {
           >
             clearError
           </button>
-          {isValid ? 'yes' : 'no'}
+          {valid ? 'yes' : 'no'}
         </div>
       );
     };

--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -21,7 +21,7 @@ describe('formState', () => {
       const Component = () => {
         const {
           register,
-          formState: { isValid },
+          formState: { valid },
         } = useForm<{ test: string }>({
           mode: 'onChange',
           resolver: async (data) => {
@@ -39,7 +39,7 @@ describe('formState', () => {
           },
         });
 
-        isValidValue = isValid;
+        isValidValue = valid;
         return <input {...register('test')} />;
       };
 
@@ -65,12 +65,12 @@ describe('formState', () => {
     it('should return true for onBlur mode by default', async () => {
       const App = () => {
         const {
-          formState: { isValid },
+          formState: { valid },
         } = useForm<{ test: string }>({
           mode: VALIDATION_MODE.onBlur,
         });
 
-        return <p>{isValid ? 'valid' : 'invalid'}</p>;
+        return <p>{valid ? 'valid' : 'invalid'}</p>;
       };
 
       render(<App />);
@@ -83,12 +83,12 @@ describe('formState', () => {
     it('should return true for onChange mode by default', async () => {
       const App = () => {
         const {
-          formState: { isValid },
+          formState: { valid },
         } = useForm<{ test: string }>({
           mode: VALIDATION_MODE.onChange,
         });
 
-        return <p>{isValid ? 'valid' : 'invalid'}</p>;
+        return <p>{valid ? 'valid' : 'invalid'}</p>;
       };
 
       render(<App />);
@@ -101,12 +101,12 @@ describe('formState', () => {
     it('should return true for all mode by default', async () => {
       const App = () => {
         const {
-          formState: { isValid },
+          formState: { valid },
         } = useForm<{ test: string }>({
           mode: VALIDATION_MODE.all,
         });
 
-        return <p>{isValid ? 'valid' : 'invalid'}</p>;
+        return <p>{valid ? 'valid' : 'invalid'}</p>;
       };
 
       render(<App />);
@@ -122,7 +122,7 @@ describe('formState', () => {
           mode: VALIDATION_MODE.onChange,
         });
 
-        methods.formState.isValid;
+        methods.formState.valid;
 
         return methods;
       });
@@ -132,7 +132,7 @@ describe('formState', () => {
         result.current.setValue('issue', '', { validate: true });
       });
 
-      expect(result.current.formState.isValid).toBeFalsy();
+      expect(result.current.formState.valid).toBeFalsy();
     });
 
     it('should return false when custom register with validation', async () => {
@@ -142,13 +142,13 @@ describe('formState', () => {
         }),
       );
 
-      result.current.formState.isValid;
+      result.current.formState.valid;
 
       await act(async () => {
         result.current.register('issue', { required: true });
       });
 
-      expect(result.current.formState.isValid).toBeFalsy();
+      expect(result.current.formState.valid).toBeFalsy();
     });
 
     it('should update valid when toggle Controller', async () => {
@@ -156,7 +156,7 @@ describe('formState', () => {
         const {
           control,
           watch,
-          formState: { isValid },
+          formState: { valid },
         } = useForm({
           mode: 'onChange',
           unregister: true,
@@ -165,7 +165,7 @@ describe('formState', () => {
 
         return (
           <div>
-            <p>{isValid ? 'valid' : 'invalid'}</p>
+            <p>{valid ? 'valid' : 'invalid'}</p>
             <Controller
               control={control}
               rules={{ required: true }}
@@ -275,7 +275,7 @@ describe('formState', () => {
         const {
           register,
           control,
-          formState: { isValid },
+          formState: { valid },
           reset,
         } = useForm<FormValues>({
           mode: 'onBlur',
@@ -296,7 +296,7 @@ describe('formState', () => {
               render={({ field }) => <input {...field} />}
             />
             <input {...register('foo1', { required: true })} />
-            {isValid ? 'valid' : 'nope'}
+            {valid ? 'valid' : 'nope'}
           </div>
         );
       }
@@ -311,7 +311,7 @@ describe('formState', () => {
         const {
           register,
           control,
-          formState: { isValid },
+          formState: { valid },
           reset,
         } = useForm<FormValues>({
           mode: 'onBlur',
@@ -332,7 +332,7 @@ describe('formState', () => {
               render={({ field }) => <input {...field} />}
             />
             <input {...register('foo1', { required: true })} />
-            {isValid ? 'valid' : 'nope'}
+            {valid ? 'valid' : 'nope'}
           </div>
         );
       }
@@ -352,17 +352,15 @@ describe('formState', () => {
       const {
         register,
         handleSubmit,
-        formState: { isSubmitSuccessful, isSubmitted },
+        formState: { submitSuccessful, submitted },
       } = useForm();
 
       return (
         <form>
           <input {...register('test')} />
-          <p>{isSubmitted ? 'isSubmitted' : 'no'}</p>
+          <p>{submitted ? 'isSubmitted' : 'no'}</p>
           <p>
-            {isSubmitSuccessful
-              ? 'isSubmitSuccessful'
-              : 'isNotSubmitSuccessful'}
+            {submitSuccessful ? 'isSubmitSuccessful' : 'isNotSubmitSuccessful'}
           </p>
           <button
             type={'button'}
@@ -389,7 +387,7 @@ describe('formState', () => {
       const {
         register,
         control,
-        formState: { isValid },
+        formState: { valid },
       } = useForm<{
         list: {
           firstName: string;
@@ -462,7 +460,7 @@ describe('formState', () => {
           >
             append
           </button>
-          <p>{isValid ? 'valid' : 'inValid'}</p>
+          <p>{valid ? 'valid' : 'inValid'}</p>
         </form>
       );
     };
@@ -539,7 +537,7 @@ describe('formState', () => {
       function App() {
         const {
           register,
-          formState: { isValid },
+          formState: { valid },
         } = useForm({
           mode: 'onChange',
         });
@@ -550,7 +548,7 @@ describe('formState', () => {
               {...register('value', { required: true })}
               defaultValue="Any default value!"
             />
-            <p>isValid = {isValid ? 'true' : 'false'}</p>
+            <p>isValid = {valid ? 'true' : 'false'}</p>
           </form>
         );
       }
@@ -566,7 +564,7 @@ describe('formState', () => {
       function App() {
         const {
           control,
-          formState: { isValid },
+          formState: { valid },
         } = useForm({
           mode: 'onChange',
         });
@@ -579,7 +577,7 @@ describe('formState', () => {
               name={'test'}
               defaultValue="Any default value!"
             />
-            <p>isValid = {isValid ? 'true' : 'false'}</p>
+            <p>isValid = {valid ? 'true' : 'false'}</p>
             <button>Submit</button>
           </form>
         );
@@ -789,7 +787,7 @@ describe('formState', () => {
       const App = () => {
         const {
           register,
-          formState: { errors, isValid },
+          formState: { errors, valid },
         } = useForm<{
           test: string;
         }>({
@@ -799,7 +797,7 @@ describe('formState', () => {
 
         return (
           <div>
-            {isValid ? 'valid' : 'inValid'}
+            {valid ? 'valid' : 'inValid'}
             <input
               {...register('test', {
                 required: true,

--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -139,7 +139,7 @@ describe('getFieldState', () => {
           return (
             <form>
               <input {...register('test')} />
-              <p>{_getFieldState('test')?.isTouched ? 'touched' : ''}</p>
+              <p>{_getFieldState('test')?.touched ? 'touched' : ''}</p>
             </form>
           );
         };
@@ -171,7 +171,7 @@ describe('getFieldState', () => {
           return (
             <form>
               <input {...register('test')} />
-              <p>{_getFieldState('test')?.isDirty ? 'dirty' : ''}</p>
+              <p>{_getFieldState('test')?.dirty ? 'dirty' : ''}</p>
             </form>
           );
         };
@@ -285,7 +285,7 @@ describe('getFieldState', () => {
           return (
             <form>
               <NestedInput control={control} />
-              <p>{_getFieldState('nested')?.isTouched ? 'touched' : ''}</p>
+              <p>{_getFieldState('nested')?.touched ? 'touched' : ''}</p>
             </form>
           );
         };
@@ -320,7 +320,7 @@ describe('getFieldState', () => {
           return (
             <form>
               <NestedInput control={control} />
-              <p>{_getFieldState('nested')?.isDirty ? 'dirty' : ''}</p>
+              <p>{_getFieldState('nested')?.dirty ? 'dirty' : ''}</p>
             </form>
           );
         };
@@ -408,12 +408,12 @@ describe('getFieldState', () => {
             },
           });
 
-          const { isTouched } = _getFieldState('test', formState);
+          const { touched } = _getFieldState('test', formState);
 
           return (
             <form>
               <input {...register('test')} />
-              <p>{isTouched ? 'touched' : ''}</p>
+              <p>{touched ? 'touched' : ''}</p>
             </form>
           );
         };
@@ -436,12 +436,12 @@ describe('getFieldState', () => {
             },
           });
 
-          const { isDirty } = _getFieldState('test', formState);
+          const { dirty } = _getFieldState('test', formState);
 
           return (
             <form>
               <input {...register('test')} />
-              <p>{isDirty ? 'dirty' : ''}</p>
+              <p>{dirty ? 'dirty' : ''}</p>
             </form>
           );
         };
@@ -538,12 +538,12 @@ describe('getFieldState', () => {
             },
           });
 
-          const { isTouched } = _getFieldState('nested', formState);
+          const { touched } = _getFieldState('nested', formState);
 
           return (
             <form>
               <NestedInput control={control} />
-              <p>{isTouched ? 'touched' : ''}</p>
+              <p>{touched ? 'touched' : ''}</p>
             </form>
           );
         };
@@ -569,12 +569,12 @@ describe('getFieldState', () => {
             },
           });
 
-          const { isDirty } = _getFieldState('nested', formState);
+          const { dirty } = _getFieldState('nested', formState);
 
           return (
             <form>
               <NestedInput control={control} />
-              <p>{isDirty ? 'dirty' : ''}</p>
+              <p>{dirty ? 'dirty' : ''}</p>
             </form>
           );
         };
@@ -605,16 +605,16 @@ describe('getFieldState', () => {
         });
 
         // @ts-expect-error expected to show type error for field name
-        const { isDirty } = _getFieldState(formState, 'nestedMissing');
+        const { dirty } = _getFieldState(formState, 'nestedMissing');
 
         // @ts-expect-error expected to show type error for field name
-        const { isTouched } = _getFieldState('nestedMissing');
+        const { touched } = _getFieldState('nestedMissing');
 
         return (
           <form>
             <NestedInput control={control} />
-            <p>{isDirty ? 'dirty' : 'notDirty'}</p>
-            <p>{isTouched ? 'touched' : 'notTouched'}</p>
+            <p>{dirty ? 'dirty' : 'notDirty'}</p>
+            <p>{touched ? 'touched' : 'notTouched'}</p>
           </form>
         );
       };

--- a/src/__tests__/useForm/getValues.test.tsx
+++ b/src/__tests__/useForm/getValues.test.tsx
@@ -265,7 +265,7 @@ describe('getValues', () => {
 
     function Form() {
       const { handleSubmit, reset, getValues } = useFormContext();
-      const { isDirty, isValid } = useFormState();
+      const { dirty, valid } = useFormState();
 
       return (
         <form
@@ -282,7 +282,7 @@ describe('getValues', () => {
           >
             getValues
           </button>
-          <button type="submit" disabled={!isDirty || !isValid}>
+          <button type="submit" disabled={!dirty || !valid}>
             submit
           </button>
 

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -54,7 +54,7 @@ describe('register', () => {
         const {
           register,
           watch,
-          formState: { isDirty },
+          formState: { dirty },
         } = useForm<{
           test: string;
         }>({
@@ -68,7 +68,7 @@ describe('register', () => {
         return (
           <form>
             <input type={type} {...register('test')} />
-            <span role="alert">{`${isDirty}`}</span>
+            <span role="alert">{`${dirty}`}</span>
             {test}
           </form>
         );
@@ -138,7 +138,7 @@ describe('register', () => {
       return (
         <div>
           <input {...register('test')} />
-          <span role="alert">{`${formState.isValid}`}</span>
+          <span role="alert">{`${formState.valid}`}</span>
         </div>
       );
     };
@@ -186,7 +186,7 @@ describe('register', () => {
         <div>
           <input {...register('test', { required: true })} />
           <input type="text" {...register('issue', { required: true })} />
-          <button disabled={!formState.isValid}>submit</button>
+          <button disabled={!formState.valid}>submit</button>
         </div>
       );
     };
@@ -205,7 +205,7 @@ describe('register', () => {
       const {
         register,
         setValue,
-        formState: { isValid },
+        formState: { valid },
       } = useForm({
         defaultValues: { a: 'default', b: '' },
         mode: 'onChange',
@@ -234,7 +234,7 @@ describe('register', () => {
               setValue('b', value, { dirty: true, validate: true })
             }
           />
-          <div>{String(isValid)}</div>
+          <div>{String(valid)}</div>
         </form>
       );
     }

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -28,7 +28,7 @@ describe('reset', () => {
     result.current.register('test');
     result.current.setValue('test', 'data');
 
-    expect(result.current.formState.isSubmitted).toBeFalsy();
+    expect(result.current.formState.submitted).toBeFalsy();
     await act(async () => {
       await result.current.handleSubmit((data) => {
         expect(data).toEqual({
@@ -40,9 +40,9 @@ describe('reset', () => {
       } as React.SyntheticEvent);
     });
 
-    expect(result.current.formState.isSubmitted).toBeTruthy();
+    expect(result.current.formState.submitted).toBeTruthy();
     act(() => result.current.reset());
-    expect(result.current.formState.isSubmitted).toBeFalsy();
+    expect(result.current.formState.submitted).toBeFalsy();
   });
 
   it('should reset form value', () => {
@@ -198,7 +198,7 @@ describe('reset', () => {
       const {
         register,
         reset,
-        formState: { isDirty },
+        formState: { dirty },
       } = useForm({
         defaultValues: {
           test: 'test1',
@@ -208,7 +208,7 @@ describe('reset', () => {
       return (
         <>
           <input {...register('test')} />
-          <p>{isDirty ? 'dirty' : ''}</p>
+          <p>{dirty ? 'dirty' : ''}</p>
           <button
             type={'button'}
             onClick={() =>
@@ -261,7 +261,7 @@ describe('reset', () => {
       const {
         register,
         reset,
-        formState: { isDirty, dirtyFields },
+        formState: { dirty, dirtyFields },
       } = useForm({
         defaultValues: {
           firstName: 'test',
@@ -271,7 +271,7 @@ describe('reset', () => {
       return (
         <form>
           <input {...register('firstName')} placeholder="First Name" />
-          <p>{isDirty ? 'dirty' : 'pristine'}</p>
+          <p>{dirty ? 'dirty' : 'pristine'}</p>
           <p>{JSON.stringify(dirtyFields)}</p>
 
           <button
@@ -311,14 +311,14 @@ describe('reset', () => {
         register,
         handleSubmit,
         reset,
-        formState: { touchedFields, errors, isDirty },
+        formState: { touchedFields, errors, dirty },
       } = useForm<{ test: string }>({
         defaultValues: {
           test: '',
         },
       });
 
-      formState = { touchedFields, errors, isDirty };
+      formState = { touchedFields, errors, dirty: dirty };
 
       return (
         <form onSubmit={handleSubmit(() => {})}>
@@ -331,7 +331,7 @@ describe('reset', () => {
                 {
                   keepErrors: true,
                   keepDirty: true,
-                  keepIsSubmitted: true,
+                  keepSubmitted: true,
                   keepTouched: true,
                   keepSubmitCount: true,
                 },
@@ -780,7 +780,7 @@ describe('reset', () => {
       const {
         control,
         reset,
-        formState: { isValid },
+        formState: { valid },
       } = useForm();
 
       mounted.push(control._stateFlags.mount);
@@ -792,7 +792,7 @@ describe('reset', () => {
 
       return (
         <form>
-          <p>{isValid ? 'true' : 'false'}</p>
+          <p>{valid ? 'true' : 'false'}</p>
         </form>
       );
     };
@@ -935,7 +935,7 @@ describe('reset', () => {
         control,
         handleSubmit,
         reset,
-        formState: { isDirty, dirtyFields },
+        formState: { dirty, dirtyFields },
       } = useForm({
         defaultValues: {
           something: 'anything',
@@ -953,7 +953,7 @@ describe('reset', () => {
             reset({ ...data });
           })}
         >
-          <p>is dirty? {isDirty ? 'yes' : 'no'}</p>
+          <p>is dirty? {dirty ? 'yes' : 'no'}</p>
           <p>{JSON.stringify(dirtyFields)}</p>
           <input {...register('something')} />
           <ul>

--- a/src/__tests__/useForm/resetField.test.tsx
+++ b/src/__tests__/useForm/resetField.test.tsx
@@ -96,7 +96,7 @@ describe('resetField', () => {
       const {
         register,
         resetField,
-        formState: { dirtyFields, isDirty },
+        formState: { dirtyFields, dirty },
       } = useForm({
         defaultValues: {
           test: 'test',
@@ -107,7 +107,7 @@ describe('resetField', () => {
         <form>
           <input {...register('test')} />
           <p>{dirtyFields.test ? 'dirty' : 'notDirty'}</p>
-          <p>{isDirty ? 'formDirty' : 'formNotDirty'}</p>
+          <p>{dirty ? 'formDirty' : 'formNotDirty'}</p>
           <button
             type={'button'}
             onClick={() => {
@@ -146,7 +146,7 @@ describe('resetField', () => {
       const {
         register,
         resetField,
-        formState: { errors, isValid },
+        formState: { errors, valid },
       } = useForm({
         defaultValues: {
           test: 'test',
@@ -158,7 +158,7 @@ describe('resetField', () => {
         <form>
           <input {...register('test', { maxLength: 4 })} />
           <p>{errors.test ? 'error' : 'noError'}</p>
-          <p>{isValid ? 'valid' : 'NotValid'}</p>
+          <p>{valid ? 'valid' : 'NotValid'}</p>
           <button
             type={'button'}
             onClick={() => {
@@ -292,7 +292,7 @@ describe('resetField', () => {
         const {
           register,
           resetField,
-          formState: { dirtyFields, isDirty },
+          formState: { dirtyFields, dirty },
         } = useForm({
           defaultValues: {
             test: 'test',
@@ -303,7 +303,7 @@ describe('resetField', () => {
           <form>
             <input {...register('test')} />
             <p>{dirtyFields.test ? 'dirty' : 'notDirty'}</p>
-            <p>{isDirty ? 'formDirty' : 'formNotDirty'}</p>
+            <p>{dirty ? 'formDirty' : 'formNotDirty'}</p>
             <button
               type={'button'}
               onClick={() => {
@@ -342,7 +342,7 @@ describe('resetField', () => {
         const {
           register,
           resetField,
-          formState: { errors, isValid },
+          formState: { errors, valid },
         } = useForm({
           defaultValues: {
             test: 'test',
@@ -354,7 +354,7 @@ describe('resetField', () => {
           <form>
             <input {...register('test', { maxLength: 4 })} />
             <p>{errors.test ? 'error' : 'noError'}</p>
-            <p>{isValid ? 'valid' : 'NotValid'}</p>
+            <p>{valid ? 'valid' : 'NotValid'}</p>
             <button
               type={'button'}
               onClick={() => {

--- a/src/__tests__/useForm/setError.test.tsx
+++ b/src/__tests__/useForm/setError.test.tsx
@@ -56,13 +56,13 @@ describe('setError', () => {
       result.current.setError('input', input);
     });
     expect(result.current.formState.errors).toEqual(output);
-    expect(result.current.formState.isValid).toBeFalsy();
+    expect(result.current.formState.valid).toBeFalsy();
   });
 
   it('should update isValid with setError', async () => {
     const App = () => {
       const {
-        formState: { isValid },
+        formState: { valid },
         setError,
       } = useForm({
         mode: 'onChange',
@@ -78,7 +78,7 @@ describe('setError', () => {
           >
             setError
           </button>
-          {isValid ? 'yes' : 'no'}
+          {valid ? 'yes' : 'no'}
         </div>
       );
     };

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -662,15 +662,15 @@ describe('setValue', () => {
       (property) => {
         const { result } = renderHook(() => useForm<{ test: string }>());
 
-        result.current.formState[property as 'dirtyFields' | 'isDirty'];
-        result.current.formState.isDirty;
+        result.current.formState[property as 'dirtyFields' | 'dirty'];
+        result.current.formState.dirty;
         result.current.formState.dirtyFields;
 
         result.current.register('test');
 
         act(() => result.current.setValue('test', 'test', { dirty: true }));
 
-        expect(result.current.formState.isDirty).toBeTruthy();
+        expect(result.current.formState.dirty).toBeTruthy();
         expect(result.current.formState.dirtyFields).toEqual({ test: true });
       },
     );
@@ -693,8 +693,8 @@ describe('setValue', () => {
           }),
         );
 
-        result.current.formState[property as 'isDirty' | 'dirtyFields'];
-        result.current.formState.isDirty;
+        result.current.formState[property as 'dirty' | 'dirtyFields'];
+        result.current.formState.dirty;
         result.current.formState.dirtyFields;
 
         result.current.register('test.0');
@@ -707,7 +707,7 @@ describe('setValue', () => {
           }),
         );
 
-        expect(result.current.formState.isDirty).toBeTruthy();
+        expect(result.current.formState.dirty).toBeTruthy();
         expect(result.current.formState.dirtyFields).toEqual({
           test: dirtyFields,
         });
@@ -723,13 +723,13 @@ describe('setValue', () => {
           }>(),
         );
 
-        result.current.formState[property as 'isDirty' | 'dirtyFields'];
+        result.current.formState[property as 'dirty' | 'dirtyFields'];
 
         result.current.register('test');
 
         act(() => result.current.setValue('test', 'test', { dirty: false }));
 
-        expect(result.current.formState.isDirty).toBeFalsy();
+        expect(result.current.formState.dirty).toBeFalsy();
         expect(result.current.formState.dirtyFields).toEqual({});
       },
     );
@@ -742,15 +742,15 @@ describe('setValue', () => {
             defaultValues: { test: 'default' },
           }),
         );
-        result.current.formState[property as 'dirtyFields' | 'isDirty'];
-        result.current.formState.isDirty;
+        result.current.formState[property as 'dirtyFields' | 'dirty'];
+        result.current.formState.dirty;
         result.current.formState.dirtyFields;
 
         result.current.register('test');
 
         act(() => result.current.setValue('test', '1', { dirty: true }));
 
-        expect(result.current.formState.isDirty).toBeTruthy();
+        expect(result.current.formState.dirty).toBeTruthy();
         expect(result.current.formState.dirtyFields.test).toBeTruthy();
       },
     );
@@ -763,20 +763,20 @@ describe('setValue', () => {
             defaultValues: { test: 'default' },
           }),
         );
-        result.current.formState[property as 'isDirty' | 'dirtyFields'];
-        result.current.formState.isDirty;
+        result.current.formState[property as 'dirty' | 'dirtyFields'];
+        result.current.formState.dirty;
         result.current.formState.dirtyFields;
 
         result.current.register('test');
 
         act(() => result.current.setValue('test', '1', { dirty: true }));
 
-        expect(result.current.formState.isDirty).toBeTruthy();
+        expect(result.current.formState.dirty).toBeTruthy();
         expect(result.current.formState.dirtyFields.test).toBeTruthy();
 
         act(() => result.current.setValue('test', 'default', { dirty: true }));
 
-        expect(result.current.formState.isDirty).toBeFalsy();
+        expect(result.current.formState.dirty).toBeFalsy();
         expect(result.current.formState.dirtyFields.test).toBeUndefined();
       },
     );
@@ -915,7 +915,7 @@ describe('setValue', () => {
       }),
     );
 
-    result.current.formState.isValid;
+    result.current.formState.valid;
 
     await act(async () => {
       await result.current.register('test.data', { required: true });
@@ -930,7 +930,7 @@ describe('setValue', () => {
       result.current.setValue('test.data', 'test', { validate: true });
     });
 
-    expect(result.current.formState.isValid).toBeFalsy();
+    expect(result.current.formState.valid).toBeFalsy();
 
     await act(async () => {
       await result.current.setValue('test.data1', 'test', {
@@ -938,7 +938,7 @@ describe('setValue', () => {
       });
     });
 
-    expect(result.current.formState.isValid).toBeTruthy();
+    expect(result.current.formState.valid).toBeTruthy();
   });
 
   it('should setValue with valueAs', async () => {
@@ -1314,7 +1314,7 @@ describe('setValue', () => {
     const App = () => {
       const {
         setValue,
-        formState: { isDirty },
+        formState: { dirty },
       } = useForm({
         defaultValues: {
           test: '',
@@ -1325,7 +1325,7 @@ describe('setValue', () => {
         setValue('test', '1234', { dirty: true });
       }, [setValue]);
 
-      return <p>{isDirty ? 'dirty' : 'not'}</p>;
+      return <p>{dirty ? 'dirty' : 'not'}</p>;
     };
 
     render(<App />);

--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -342,7 +342,7 @@ describe('trigger', () => {
       const App = () => {
         const {
           register,
-          formState: { isValid },
+          formState: { valid },
           trigger,
         } = useForm<{ test: string; test1: string }>({
           defaultValues: {
@@ -373,7 +373,7 @@ describe('trigger', () => {
 
         return (
           <div>
-            {isValid ? 'yes' : 'no'}
+            {valid ? 'yes' : 'no'}
             <input {...register('test')} />
             <input {...register('test1')} />
             <button
@@ -423,15 +423,15 @@ describe('trigger', () => {
 
     it('should update isValid for the entire useForm scope', async () => {
       const InputA = () => {
-        const { isValid } = useFormState({ name: 'name' });
+        const { valid } = useFormState({ name: 'name' });
 
-        return <p>{isValid ? 'test: valid' : 'test: invalid'}</p>;
+        return <p>{valid ? 'test: valid' : 'test: invalid'}</p>;
       };
 
       const InputB = () => {
-        const { isValid } = useFormState({ name: 'email' });
+        const { valid } = useFormState({ name: 'email' });
 
-        return <p>{isValid ? 'test1: valid' : 'test1: invalid'}</p>;
+        return <p>{valid ? 'test1: valid' : 'test1: invalid'}</p>;
       };
 
       function App() {
@@ -554,7 +554,7 @@ describe('trigger', () => {
       const {
         register,
         trigger,
-        formState: { isValid },
+        formState: { valid },
       } = useForm();
 
       React.useEffect(() => {
@@ -563,7 +563,7 @@ describe('trigger', () => {
 
       return (
         <div>
-          <p>{isValid ? 'yes' : 'no'}</p>
+          <p>{valid ? 'yes' : 'no'}</p>
           <button
             onClick={() => {
               trigger('test');
@@ -730,7 +730,7 @@ describe('trigger', () => {
       const [isValid, setIsValid] = React.useState(true);
       const { register, trigger, formState } = useForm();
 
-      formState.isValid;
+      formState.valid;
 
       return (
         <div>
@@ -925,7 +925,7 @@ describe('trigger', () => {
       const {
         register,
         trigger,
-        formState: { isValid },
+        formState: { valid },
       } = useForm({
         mode: 'onChange',
       });
@@ -936,7 +936,7 @@ describe('trigger', () => {
 
       return (
         <form>
-          <p>{isValid ? 'valid' : 'invalid'}</p>
+          <p>{valid ? 'valid' : 'invalid'}</p>
           <input
             {...register('test', {
               validate,

--- a/src/__tests__/useForm/watch.test.tsx
+++ b/src/__tests__/useForm/watch.test.tsx
@@ -341,7 +341,7 @@ describe('watch', () => {
     function Component() {
       const {
         register,
-        formState: { isDirty },
+        formState: { dirty },
         watch,
       } = useForm<{
         lastName: string;
@@ -353,7 +353,7 @@ describe('watch', () => {
       return (
         <form>
           <input {...register('lastName')} />
-          <p>{isDirty ? 'True' : 'False'}</p>
+          <p>{dirty ? 'True' : 'False'}</p>
         </form>
       );
     }

--- a/src/__tests__/useFormContext.test.tsx
+++ b/src/__tests__/useFormContext.test.tsx
@@ -55,9 +55,9 @@ describe('FormProvider', () => {
     };
 
     const TestFormState = () => {
-      const { isDirty } = useFormState();
+      const { dirty } = useFormState();
 
-      return <div>{isDirty ? 'yes' : 'no'}</div>;
+      return <div>{dirty ? 'yes' : 'no'}</div>;
     };
 
     const Component = () => {

--- a/src/__tests__/useFormState.test.tsx
+++ b/src/__tests__/useFormState.test.tsx
@@ -23,13 +23,13 @@ describe('useFormState', () => {
         test: string;
       }>;
     }) => {
-      const { isDirty, dirtyFields, touchedFields } = useFormState({
+      const { dirty, dirtyFields, touchedFields } = useFormState({
         control,
       });
 
       return (
         <>
-          <div>{isDirty ? 'isDirty' : ''}</div>
+          <div>{dirty ? 'isDirty' : ''}</div>
           <div>{dirtyFields['test'] ? 'dirty field' : ''}</div>
           <div>{touchedFields['test'] ? 'isTouched' : ''}</div>
         </>
@@ -71,14 +71,14 @@ describe('useFormState', () => {
   it('should render correct isolated errors message', async () => {
     let count = 0;
     const Test = ({ control }: { control: Control }) => {
-      const { errors, isValid } = useFormState({
+      const { errors, valid } = useFormState({
         control,
       });
 
       return (
         <>
           <div>{errors['test'] ? 'error' : 'valid'}</div>
-          <div>{isValid ? 'yes' : 'no'}</div>
+          <div>{valid ? 'yes' : 'no'}</div>
         </>
       );
     };
@@ -130,7 +130,7 @@ describe('useFormState', () => {
     let test1Count = 0;
 
     const Test1 = ({ control }: { control: Control }) => {
-      const { isDirty, dirtyFields } = useFormState({
+      const { dirty, dirtyFields } = useFormState({
         control,
       });
 
@@ -141,7 +141,7 @@ describe('useFormState', () => {
           <div>
             {dirtyFields['test'] ? 'hasDirtyField' : 'notHasDirtyField'}
           </div>
-          <div>{isDirty ? 'isDirty' : 'notDirty'}</div>
+          <div>{dirty ? 'isDirty' : 'notDirty'}</div>
         </>
       );
     };
@@ -216,13 +216,13 @@ describe('useFormState', () => {
   it('should render correct submit state', async () => {
     let count = 0;
     const Test = ({ control }: { control: Control }) => {
-      const { isSubmitted, submitCount } = useFormState({
+      const { submitted, submitCount } = useFormState({
         control,
       });
 
       return (
         <>
-          <div>{isSubmitted ? 'isSubmitted' : ''}</div>
+          <div>{submitted ? 'isSubmitted' : ''}</div>
           <div>{submitCount}</div>
         </>
       );

--- a/src/__typetests__/types/form.test-d.ts
+++ b/src/__typetests__/types/form.test-d.ts
@@ -38,8 +38,8 @@ import { useForm } from '../../useForm';
 
     expectType<{
       invalid: boolean;
-      isDirty: boolean;
-      isTouched: boolean;
+      dirty: boolean;
+      touched: boolean;
       error: FieldError;
     }>(_getFieldState('test'));
   }
@@ -54,8 +54,8 @@ import { useForm } from '../../useForm';
 
     expectType<{
       invalid: boolean;
-      isDirty: boolean;
-      isTouched: boolean;
+      dirty: boolean;
+      touched: boolean;
       error: FieldError;
     }>(_getFieldState('test', formState));
   }

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -100,15 +100,15 @@ export function createFormControl<
     ...props,
   };
   let _formState: FormState<TFieldValues> = {
-    isDirty: false,
-    isValidating: false,
+    dirty: false,
+    validating: false,
     dirtyFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
-    isSubmitted: false,
+    submitted: false,
     submitCount: 0,
     touchedFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
-    isSubmitting: false,
-    isSubmitSuccessful: false,
-    isValid: false,
+    submitting: false,
+    submitSuccessful: false,
+    valid: false,
     errors: {} as FieldErrors<TFieldValues>,
   };
   let _fields = {};
@@ -129,11 +129,11 @@ export function createFormControl<
   let timer = 0;
   let validateFields: Record<InternalFieldName, number> = {};
   const _proxyFormState = {
-    isDirty: false,
+    dirty: false,
     dirtyFields: false,
     touchedFields: false,
-    isValidating: false,
-    isValid: false,
+    validating: false,
+    valid: false,
     errors: false,
   };
   const _subjects: Subjects<TFieldValues> = {
@@ -155,22 +155,22 @@ export function createFormControl<
     };
 
   const _updateValid = async (shouldSkipRender?: boolean) => {
-    let isValid = false;
+    let valid = false;
 
-    if (_proxyFormState.isValid) {
-      isValid = _options.resolver
+    if (_proxyFormState.valid) {
+      valid = _options.resolver
         ? isEmptyObject((await _executeSchema()).errors)
         : await executeBuildInValidation(_fields, true);
 
-      if (!shouldSkipRender && isValid !== _formState.isValid) {
-        _formState.isValid = isValid;
+      if (!shouldSkipRender && valid !== _formState.valid) {
+        _formState.valid = valid;
         _subjects.state.next({
-          isValid,
+          valid: valid,
         });
       }
     }
 
-    return isValid;
+    return valid;
   };
 
   const _updateFieldArray: BatchFieldArrayUpdate = (
@@ -215,10 +215,10 @@ export function createFormControl<
     }
 
     _subjects.state.next({
-      isDirty: _getDirty(name, values),
+      dirty: _getDirty(name, values),
       dirtyFields: _formState.dirtyFields,
       errors: _formState.errors,
-      isValid: _formState.isValid,
+      valid: _formState.valid,
     });
   };
 
@@ -265,7 +265,7 @@ export function createFormControl<
     shouldDirty?: boolean,
     shouldRender?: boolean,
   ): Partial<
-    Pick<FormState<TFieldValues>, 'dirtyFields' | 'isDirty' | 'touchedFields'>
+    Pick<FormState<TFieldValues>, 'dirtyFields' | 'dirty' | 'touchedFields'>
   > => {
     let isFieldDirty = false;
     const output: Partial<FormState<TFieldValues>> & { name: string } = {
@@ -273,11 +273,11 @@ export function createFormControl<
     };
     const isPreviousFieldTouched = get(_formState.touchedFields, name);
 
-    if (_proxyFormState.isDirty) {
-      const isPreviousFormDirty = _formState.isDirty;
+    if (_proxyFormState.dirty) {
+      const isPreviousFormDirty = _formState.dirty;
 
-      _formState.isDirty = output.isDirty = _getDirty();
-      isFieldDirty = isPreviousFormDirty !== output.isDirty;
+      _formState.dirty = output.dirty = _getDirty();
+      isFieldDirty = isPreviousFormDirty !== output.dirty;
     }
 
     if (_proxyFormState.dirtyFields && (!isBlurEvent || shouldDirty)) {
@@ -313,17 +313,17 @@ export function createFormControl<
   const shouldRenderByError = async (
     shouldSkipRender: boolean,
     name: InternalFieldName,
-    isValid: boolean,
+    valid: boolean,
     error?: FieldError,
     fieldState?: {
-      dirty?: FieldNamesMarkedBoolean<TFieldValues>;
+      dirtyFields?: FieldNamesMarkedBoolean<TFieldValues>;
       isDirty?: boolean;
       touched?: FieldNamesMarkedBoolean<TFieldValues>;
     },
   ): Promise<void> => {
     const previousFieldError = get(_formState.errors, name);
     const shouldUpdateValid =
-      _proxyFormState.isValid && _formState.isValid !== isValid;
+      _proxyFormState.valid && _formState.valid !== valid;
 
     if (props.delayError && error) {
       delayErrorCallback =
@@ -344,7 +344,7 @@ export function createFormControl<
     ) {
       const updatedFormState = {
         ...fieldState,
-        ...(shouldUpdateValid ? { isValid } : {}),
+        ...(shouldUpdateValid ? { valid } : {}),
         errors: _formState.errors,
         name,
       };
@@ -359,9 +359,9 @@ export function createFormControl<
 
     validateFields[name]--;
 
-    if (_proxyFormState.isValidating && !validateFields[name]) {
+    if (_proxyFormState.validating && !validateFields[name]) {
       _subjects.state.next({
-        isValidating: false,
+        validating: false,
       });
       validateFields = {};
     }
@@ -601,7 +601,7 @@ export function createFormControl<
       });
 
       if (
-        (_proxyFormState.isDirty || _proxyFormState.dirtyFields) &&
+        (_proxyFormState.dirty || _proxyFormState.dirtyFields) &&
         options.dirty
       ) {
         _formState.dirtyFields = getDirtyFields(_defaultValues, _formValues);
@@ -609,7 +609,7 @@ export function createFormControl<
         _subjects.state.next({
           name,
           dirtyFields: _formState.dirtyFields,
-          isDirty: _getDirty(name, value),
+          dirty: _getDirty(name, value),
         });
       }
     } else {
@@ -631,7 +631,7 @@ export function createFormControl<
 
     if (field) {
       let error;
-      let isValid;
+      let valid;
       const fieldValue = target.type
         ? getFieldValue(field._f)
         : getEventValue(event);
@@ -644,7 +644,7 @@ export function createFormControl<
         skipValidation(
           isBlurEvent,
           get(_formState.touchedFields, name),
-          _formState.isSubmitted,
+          _formState.submitted,
           validationModeAfterSubmit,
           validationModeBeforeSubmit,
         );
@@ -684,9 +684,9 @@ export function createFormControl<
 
       validateFields[name] = validateFields[name] ? +1 : 1;
 
-      _proxyFormState.isValidating &&
+      _proxyFormState.validating &&
         _subjects.state.next({
-          isValidating: true,
+          validating: true,
         });
 
       if (_options.resolver) {
@@ -705,7 +705,7 @@ export function createFormControl<
         error = errorLookupResult.error;
         name = errorLookupResult.name;
 
-        isValid = isEmptyObject(errors);
+        valid = isEmptyObject(errors);
       } else {
         error = (
           await validateField(
@@ -716,22 +716,22 @@ export function createFormControl<
           )
         )[name];
 
-        isValid = await _updateValid(true);
+        valid = await _updateValid(true);
       }
 
       field._f.deps && trigger(field._f.deps as FieldPath<TFieldValues>[]);
 
-      shouldRenderByError(false, name, isValid, error, fieldState);
+      shouldRenderByError(false, name, valid, error, fieldState);
     }
   };
 
   const trigger: UseFormTrigger<TFieldValues> = async (name, options = {}) => {
-    let isValid;
+    let valid;
     let validationResult;
     const fieldNames = convertToArrayPayload(name) as InternalFieldName[];
 
     _subjects.state.next({
-      isValidating: true,
+      validating: true,
     });
 
     if (_options.resolver) {
@@ -739,10 +739,10 @@ export function createFormControl<
         isUndefined(name) ? name : fieldNames,
       );
 
-      isValid = isEmptyObject(errors);
+      valid = isEmptyObject(errors);
       validationResult = name
         ? !fieldNames.some((name) => get(errors, name))
-        : isValid;
+        : valid;
     } else if (name) {
       validationResult = (
         await Promise.all(
@@ -754,19 +754,19 @@ export function createFormControl<
           }),
         )
       ).every(Boolean);
-      !(!validationResult && !_formState.isValid) && _updateValid();
+      !(!validationResult && !_formState.valid) && _updateValid();
     } else {
-      validationResult = isValid = await executeBuildInValidation(_fields);
+      validationResult = valid = await executeBuildInValidation(_fields);
     }
 
     _subjects.state.next({
       ...(!isString(name) ||
-      (_proxyFormState.isValid && isValid !== _formState.isValid)
+      (_proxyFormState.valid && valid !== _formState.valid)
         ? {}
         : { name }),
-      ...(_options.resolver ? { isValid } : {}),
+      ...(_options.resolver ? { valid } : {}),
       errors: _formState.errors,
-      isValidating: false,
+      validating: false,
     });
 
     options.focus &&
@@ -802,8 +802,8 @@ export function createFormControl<
     formState,
   ) => ({
     invalid: !!get((formState || _formState).errors, name),
-    isDirty: get((formState || _formState).dirtyFields, name),
-    isTouched: get((formState || _formState).touchedFields, name),
+    dirty: get((formState || _formState).dirtyFields, name),
+    touched: get((formState || _formState).touchedFields, name),
     error: get((formState || _formState).errors, name),
   });
 
@@ -830,7 +830,7 @@ export function createFormControl<
     _subjects.state.next({
       name,
       errors: _formState.errors,
-      isValid: false,
+      valid: false,
     });
 
     options && options.focus && ref && ref.focus && ref.focus();
@@ -891,7 +891,7 @@ export function createFormControl<
       ...(!options.keepDirty ? {} : { isDirty: _getDirty() }),
     });
 
-    _proxyFormState.isValid && _updateValid();
+    _proxyFormState.valid && _updateValid();
   };
 
   const register: UseFormRegister<TFieldValues> = (name, options = {}) => {
@@ -995,7 +995,7 @@ export function createFormControl<
         : { ..._formValues };
 
       _subjects.state.next({
-        isSubmitting: true,
+        submitting: true,
       });
 
       try {
@@ -1013,7 +1013,7 @@ export function createFormControl<
         ) {
           _subjects.state.next({
             errors: {} as FieldErrors<TFieldValues>,
-            isSubmitting: true,
+            submitting: true,
           });
           await onValid(fieldValues, e);
         } else {
@@ -1029,11 +1029,11 @@ export function createFormControl<
         hasNoPromiseError = false;
         throw err;
       } finally {
-        _formState.isSubmitted = true;
+        _formState.submitted = true;
         _subjects.state.next({
-          isSubmitted: true,
-          isSubmitting: false,
-          isSubmitSuccessful:
+          submitted: true,
+          submitting: false,
+          submitSuccessful:
             isEmptyObject(_formState.errors) && hasNoPromiseError,
           submitCount: _formState.submitCount + 1,
           errors: _formState.errors,
@@ -1056,14 +1056,14 @@ export function createFormControl<
 
       if (!options.keepDirty) {
         unset(_formState.dirtyFields, name);
-        _formState.isDirty = options.defaultValue
+        _formState.dirty = options.defaultValue
           ? _getDirty(name, get(_defaultValues, name))
           : _getDirty();
       }
 
       if (!options.keepError) {
         unset(_formState.errors, name);
-        _proxyFormState.isValid && _updateValid();
+        _proxyFormState.valid && _updateValid();
       }
 
       _subjects.state.next({ ..._formState });
@@ -1129,7 +1129,7 @@ export function createFormControl<
       focus: '',
     };
 
-    _stateFlags.mount = !_proxyFormState.isValid;
+    _stateFlags.mount = !_proxyFormState.valid;
 
     _stateFlags.watch = !!props.unregister;
 
@@ -1137,14 +1137,12 @@ export function createFormControl<
       submitCount: keepStateOptions.keepSubmitCount
         ? _formState.submitCount
         : 0,
-      isDirty: keepStateOptions.keepDirty
-        ? _formState.isDirty
+      dirty: keepStateOptions.keepDirty
+        ? _formState.dirty
         : keepStateOptions.keepDefaultValues
         ? !deepEqual(formValues, _defaultValues)
         : false,
-      isSubmitted: keepStateOptions.keepIsSubmitted
-        ? _formState.isSubmitted
-        : false,
+      submitted: keepStateOptions.keepSubmitted ? _formState.submitted : false,
       dirtyFields: keepStateOptions.keepDirty
         ? _formState.dirtyFields
         : ((keepStateOptions.keepDefaultValues && formValues
@@ -1162,8 +1160,8 @@ export function createFormControl<
       errors: keepStateOptions.keepErrors
         ? _formState.errors
         : ({} as FieldErrors<TFieldValues>),
-      isSubmitting: false,
-      isSubmitSuccessful: false,
+      submitting: false,
+      submitSuccessful: false,
     });
   };
 

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -15,8 +15,8 @@ import {
 
 export type ControllerFieldState = {
   invalid: boolean;
-  isTouched: boolean;
-  isDirty: boolean;
+  touched: boolean;
+  dirty: boolean;
   error?: FieldError;
 };
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -105,26 +105,26 @@ export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<
 >;
 
 export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
-  isDirty: boolean;
-  isValidating: boolean;
+  dirty: boolean;
+  validating: boolean;
   dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
   touchedFields: FieldNamesMarkedBoolean<TFieldValues>;
   errors: boolean;
-  isValid: boolean;
+  valid: boolean;
 };
 
 export type ReadFormState = { [K in keyof FormStateProxy]: boolean | 'all' };
 
 export type FormState<TFieldValues> = {
-  isDirty: boolean;
+  dirty: boolean;
   dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
-  isSubmitted: boolean;
-  isSubmitSuccessful: boolean;
+  submitted: boolean;
+  submitSuccessful: boolean;
   submitCount: number;
   touchedFields: FieldNamesMarkedBoolean<TFieldValues>;
-  isSubmitting: boolean;
-  isValidating: boolean;
-  isValid: boolean;
+  submitting: boolean;
+  validating: boolean;
+  valid: boolean;
   errors: FieldErrors<TFieldValues>;
 };
 
@@ -133,7 +133,7 @@ export type KeepStateOptions = Partial<{
   keepDirty: boolean;
   keepValues: boolean;
   keepDefaultValues: boolean;
-  keepIsSubmitted: boolean;
+  keepSubmitted: boolean;
   keepTouched: boolean;
   keepSubmitCount: boolean;
 }>;
@@ -186,8 +186,8 @@ export type _UseFormGetFieldState<TFieldValues extends FieldValues> = <
   formState?: FormState<TFieldValues>,
 ) => {
   invalid: boolean;
-  isDirty: boolean;
-  isTouched: boolean;
+  dirty: boolean;
+  touched: boolean;
   error: FieldError;
 };
 
@@ -245,7 +245,7 @@ export type UseFormUnregister<TFieldValues extends FieldValues> = (
     | readonly FieldPath<TFieldValues>[],
   options?: Omit<
     KeepStateOptions,
-    | 'keepIsSubmitted'
+    | 'keepSubmitted'
     | 'keepSubmitCount'
     | 'keepValues'
     | 'keepDefaultValues'

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -115,8 +115,8 @@ export function useController<
     formState,
     fieldState: {
       invalid: !!get(formState.errors, name),
-      isDirty: get(formState.dirtyFields, name),
-      isTouched: get(formState.touchedFields, name),
+      dirty: get(formState.dirtyFields, name),
+      touched: get(formState.touchedFields, name),
       error: get(formState.errors, name),
     },
   };

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -286,7 +286,7 @@ export const useFieldArray = <
 
     control._names.focus = '';
 
-    control._proxyFormState.isValid && control._updateValid();
+    control._proxyFormState.valid && control._updateValid();
   }, [fields, name, control]);
 
   React.useEffect(() => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -23,15 +23,15 @@ export function useForm<
     UseFormReturn<TFieldValues, TContext> | undefined
   >();
   const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
-    isDirty: false,
-    isValidating: false,
+    dirty: false,
+    validating: false,
     dirtyFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
-    isSubmitted: false,
+    submitted: false,
     submitCount: 0,
     touchedFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
-    isSubmitting: false,
-    isSubmitSuccessful: false,
-    isValid: false,
+    submitting: false,
+    submitSuccessful: false,
+    valid: false,
     errors: {} as FieldErrors<TFieldValues>,
   });
 
@@ -67,7 +67,7 @@ export function useForm<
 
   React.useEffect(() => {
     if (!control._stateFlags.mount) {
-      control._proxyFormState.isValid && control._updateValid();
+      control._proxyFormState.valid && control._updateValid();
       control._stateFlags.mount = true;
     }
     if (control._stateFlags.watch) {

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -6,6 +6,7 @@ import shouldSubscribeByName from './logic/shouldSubscribeByName';
 import {
   FieldValues,
   InternalFieldName,
+  ReadFormState,
   UseFormStateProps,
   UseFormStateReturn,
 } from './types';
@@ -18,12 +19,12 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
   const methods = useFormContext<TFieldValues>();
   const { control = methods.control, disabled, name, exact } = props || {};
   const [formState, updateFormState] = React.useState(control._formState);
-  const _localProxyFormState = React.useRef({
-    isDirty: false,
+  const _localProxyFormState = React.useRef<ReadFormState>({
+    dirty: false,
     dirtyFields: false,
     touchedFields: false,
-    isValidating: false,
-    isValid: false,
+    validating: false,
+    valid: false,
     errors: false,
   });
   const _name = React.useRef(name);


### PR DESCRIPTION
remove `is*` prefix

`isValid` -> `valid`
`isTouched` -> `touched`
`isDirty` -> `dirty`
`isSubmitted` -> `submitted`
`isSubmitSuccessful` -> `submitSuccessful`
`keepIsSubmitted` -> `keepSubmitted`
`keepIsSubmitSuccessful` -> `keepIsSubmitSuccessful`