### PR TITLE
fix: getFieldState - error might be undefined

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -519,7 +519,7 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName
     invalid: boolean;
     isDirty: boolean;
     isTouched: boolean;
-    error: FieldError;
+    error?: FieldError;
 };
 
 // @public (undocumented)

--- a/src/__tests__/types/form.test-d.ts
+++ b/src/__tests__/types/form.test-d.ts
@@ -27,7 +27,7 @@ import { useForm } from '../../useForm';
   }
 }
 
-/** {@link _UseFormGetFieldState} */ {
+/** {@link UseFormGetFieldState} */ {
   /** it should return associated field state */ {
     /* eslint-disable react-hooks/rules-of-hooks */
     const { getFieldState } = useForm({
@@ -40,7 +40,7 @@ import { useForm } from '../../useForm';
       invalid: boolean;
       isDirty: boolean;
       isTouched: boolean;
-      error: FieldError;
+      error?: FieldError;
     }>(getFieldState('test'));
   }
 
@@ -56,7 +56,7 @@ import { useForm } from '../../useForm';
       invalid: boolean;
       isDirty: boolean;
       isTouched: boolean;
-      error: FieldError;
+      error?: FieldError;
     }>(getFieldState('test', formState));
   }
 }

--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -204,7 +204,11 @@ describe('getFieldState', () => {
           return (
             <form>
               <input {...register('test')} />
-              <p>{getFieldState('test')?.error === undefined ? 'error undefined' : ''}</p>
+              <p>
+                {getFieldState('test').error === undefined
+                  ? 'error undefined'
+                  : ''}
+              </p>
             </form>
           );
         };
@@ -383,7 +387,11 @@ describe('getFieldState', () => {
           return (
             <form>
               <NestedInput control={control} />
-              <p>{getFieldState('nested')?.error === undefined ? 'error undefined' : ''}</p>
+              <p>
+                {getFieldState('nested').error === undefined
+                  ? 'error undefined'
+                  : ''}
+              </p>
             </form>
           );
         };

--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -186,6 +186,33 @@ describe('getFieldState', () => {
 
         screen.getByText('dirty');
       });
+
+      it('should not have error', () => {
+        const App = () => {
+          const {
+            register,
+            getFieldState,
+            formState: { dirtyFields },
+          } = useForm({
+            defaultValues: {
+              test: '',
+            },
+          });
+
+          dirtyFields;
+
+          return (
+            <form>
+              <input {...register('test')} />
+              <p>{getFieldState('test')?.error === undefined ? 'error undefined' : ''}</p>
+            </form>
+          );
+        };
+
+        render(<App />);
+
+        screen.getByText('error undefined');
+      });
     });
 
     describe('when input is nested data type', () => {
@@ -335,6 +362,36 @@ describe('getFieldState', () => {
 
         screen.getByText('dirty');
       });
+
+      it('should not have error', () => {
+        const App = () => {
+          const {
+            control,
+            getFieldState,
+            formState: { dirtyFields },
+          } = useForm<FormValues>({
+            defaultValues: {
+              nested: {
+                first: '',
+                last: '',
+              },
+            },
+          });
+
+          dirtyFields;
+
+          return (
+            <form>
+              <NestedInput control={control} />
+              <p>{getFieldState('nested')?.error === undefined ? 'error undefined' : ''}</p>
+            </form>
+          );
+        };
+
+        render(<App />);
+
+        screen.getByText('error undefined');
+      });
     });
   });
 
@@ -455,6 +512,29 @@ describe('getFieldState', () => {
         });
 
         screen.getByText('dirty');
+      });
+
+      it('should not have error', () => {
+        const App = () => {
+          const { register, getFieldState, formState } = useForm({
+            defaultValues: {
+              test: '',
+            },
+          });
+
+          const { error } = getFieldState('test', formState);
+
+          return (
+            <form>
+              <input {...register('test')} />
+              <p>{error === undefined ? 'error undefined' : ''}</p>
+            </form>
+          );
+        };
+
+        render(<App />);
+
+        screen.getByText('error undefined');
       });
     });
 
@@ -589,6 +669,32 @@ describe('getFieldState', () => {
 
         screen.getByText('dirty');
       });
+
+      it('should not have error', () => {
+        const App = () => {
+          const { control, getFieldState, formState } = useForm<FormValues>({
+            defaultValues: {
+              nested: {
+                first: '',
+                last: '',
+              },
+            },
+          });
+
+          const { error } = getFieldState('nested', formState);
+
+          return (
+            <form>
+              <NestedInput control={control} />
+              <p>{error === undefined ? 'error undefined' : ''}</p>
+            </form>
+          );
+        };
+
+        render(<App />);
+
+        screen.getByText('error undefined');
+      });
     });
   });
 
@@ -605,16 +711,17 @@ describe('getFieldState', () => {
         });
 
         // @ts-expect-error expected to show type error for field name
-        const { isDirty } = getFieldState(formState, 'nestedMissing');
+        const { isDirty } = getFieldState('nestedMissing', formState);
 
         // @ts-expect-error expected to show type error for field name
-        const { isTouched } = getFieldState('nestedMissing');
+        const { isTouched, error } = getFieldState('nestedMissing');
 
         return (
           <form>
             <NestedInput control={control} />
             <p>{isDirty ? 'dirty' : 'notDirty'}</p>
             <p>{isTouched ? 'touched' : 'notTouched'}</p>
+            <p>{error === undefined ? 'error undefined' : 'error defined'}</p>
           </form>
         );
       };
@@ -629,6 +736,7 @@ describe('getFieldState', () => {
 
       screen.getByText('notDirty');
       screen.getByText('notTouched');
+      screen.getByText('error undefined');
     });
   });
 });

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -189,7 +189,7 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <
   invalid: boolean;
   isDirty: boolean;
   isTouched: boolean;
-  error: FieldError;
+  error?: FieldError;
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {


### PR DESCRIPTION
Fix to the feature introduced in 7.25.0

when the form is not validated yet or field is valid the `error` field is `undefined`

todo:
- [x] test to cover the fix