### PR TITLE
Feature/#7683

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1222,6 +1222,59 @@ describe('useForm', () => {
 
       expect(screen.queryByText('This is required.')).toBeInTheDocument();
     });
+
+    it('should validate onFocusout event', async () => {
+      const Component = () => {
+        const {
+          register,
+          formState: { errors },
+        } = useForm<{
+          test: string;
+        }>({
+          mode: 'onTouched',
+        });
+
+        return (
+          <>
+            <input
+              type="text"
+              {...register('test', { required: 'This is required.' })}
+            />
+            {errors.test?.message}
+          </>
+        );
+      };
+
+      render(<Component />);
+
+      screen.getByRole('textbox').focus();
+
+      await actComponent(async () => {
+        fireEvent.focusOut(screen.getByRole('textbox'));
+      });
+
+      expect(screen.queryByText('This is required.')).toBeInTheDocument();
+
+      await actComponent(async () => {
+        fireEvent.input(screen.getByRole('textbox'), {
+          target: {
+            value: 'test',
+          },
+        });
+      });
+
+      expect(screen.queryByText('This is required.')).not.toBeInTheDocument();
+
+      await actComponent(async () => {
+        fireEvent.input(screen.getByRole('textbox'), {
+          target: {
+            value: '',
+          },
+        });
+      });
+
+      expect(screen.queryByText('This is required.')).toBeInTheDocument();
+    });
   });
 
   describe('with schema validation', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ import { ValidationMode } from './types';
 
 export const EVENTS = {
   BLUR: 'blur',
+  FOCUS_OUT: 'focusout',
   CHANGE: 'change',
 };
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -655,7 +655,7 @@ export function createFormControl<
       const fieldValue = target.type
         ? getFieldValue(field._f)
         : getEventValue(event);
-      const isBlurEvent = 
+      const isBlurEvent =
         event.type === EVENTS.BLUR || event.type === EVENTS.FOCUS_OUT;
       const shouldSkipValidation =
         (!hasValidation(field._f) &&

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -653,7 +653,9 @@ export function createFormControl<
       const fieldValue = target.type
         ? getFieldValue(field._f)
         : getEventValue(event);
-      const isBlurEvent = [EVENTS.BLUR, EVENTS.FOCUS_OUT].some(eventType => event.type === eventType);
+      const isBlurEvent = [EVENTS.BLUR, EVENTS.FOCUS_OUT].some(
+        (eventType) => event.type === eventType,
+      );
       const shouldSkipValidation =
         (!hasValidation(field._f) &&
           !_options.resolver &&

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -655,9 +655,7 @@ export function createFormControl<
       const fieldValue = target.type
         ? getFieldValue(field._f)
         : getEventValue(event);
-      const isBlurEvent = [EVENTS.BLUR, EVENTS.FOCUS_OUT].some(
-        (eventType) => event.type === eventType,
-      );
+      const isBlurEvent = [EVENTS.BLUR, EVENTS.FOCUS_OUT].includes(event.type);
       const shouldSkipValidation =
         (!hasValidation(field._f) &&
           !_options.resolver &&

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -655,7 +655,7 @@ export function createFormControl<
       const fieldValue = target.type
         ? getFieldValue(field._f)
         : getEventValue(event);
-      const isBlurEvent = [EVENTS.BLUR, EVENTS.FOCUS_OUT].includes(event.type);
+      const isBlurEvent = event.type === EVENTS.BLUR || event.type === EVENTS.FOCUS_OUT;
       const shouldSkipValidation =
         (!hasValidation(field._f) &&
           !_options.resolver &&

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -655,7 +655,8 @@ export function createFormControl<
       const fieldValue = target.type
         ? getFieldValue(field._f)
         : getEventValue(event);
-      const isBlurEvent = event.type === EVENTS.BLUR || event.type === EVENTS.FOCUS_OUT;
+      const isBlurEvent = 
+        event.type === EVENTS.BLUR || event.type === EVENTS.FOCUS_OUT;
       const shouldSkipValidation =
         (!hasValidation(field._f) &&
           !_options.resolver &&

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -653,7 +653,7 @@ export function createFormControl<
       const fieldValue = target.type
         ? getFieldValue(field._f)
         : getEventValue(event);
-      const isBlurEvent = event.type === EVENTS.BLUR;
+      const isBlurEvent = [EVENTS.BLUR, EVENTS.FOCUS_OUT].some(eventType => event.type === eventType);
       const shouldSkipValidation =
         (!hasValidation(field._f) &&
           !_options.resolver &&


### PR DESCRIPTION
Ref: #7683
In case you wanna support [the `focusout` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusout_event)
As RHF doesn't officially support anything non-React, IDK if we wanna have tests with Preact.
Please, let me know, what you think.

_P.S. my 5 cents, RHF should support native Web event types as it's the Web API_ 