### PR TITLE
🚚 fix reset test route typo

### DIFF
--- a/app/src/welcome/index.tsx
+++ b/app/src/welcome/index.tsx
@@ -99,7 +99,7 @@ const items: Item[] = [
   {
     title: 'Reset',
     description: 'Should be able to re-populate the form while reset',
-    slugs: ['/rest'],
+    slugs: ['/reset'],
   },
   {
     title: 'ReValidateMode',


### PR DESCRIPTION
I was trying to manually check out the reset functionality and couldn't see the reset route going from the list of routes via the link.