### PR TITLE
🥅 prevent reset from throwing without form element

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1116,7 +1116,7 @@ export function createFormControl<
 
             try {
               isHTMLElement(fieldReference) &&
-                fieldReference.closest('form')!.reset();
+                fieldReference.closest('form')?.reset();
               break;
             } catch {}
           }


### PR DESCRIPTION
Atm, the [`reset` form method](https://react-hook-form.com/api/useform/reset/#main) throws
```cmd
TypeError: can't access property "reset", fieldReference.closest(...) is null
```
if there were no `values` provided _(i.e. `reset(defaultValues)`)_ and no `form` element is present. The optional catch binding in `try...catch` block swallows the error and the `non-null assertion operator` prevents TS from whining about possible `null` value. It might be appropriate to use `optional chaining` instead to avoid calling `.closest()` when no form element is present.