### PR TITLE
fix: don't expose internal state in handleSubmit

### DIFF
--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -87,6 +87,38 @@ describe('handleSubmit', () => {
     });
   });
 
+  it('should not provide reference to _formValues as data', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ test: string; deep: { values: string } }>({
+        mode: VALIDATION_MODE.onSubmit,
+        defaultValues: {
+          test: 'data',
+          deep: {
+            values: '5',
+          },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleSubmit((data: any) => {
+        data.deep.values = '12';
+      })({
+        preventDefault: () => {},
+        persist: () => {},
+      } as React.SyntheticEvent);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit((data: any) => {
+        expect(data.deep).toEqual({ values: '5' });
+      })({
+        preventDefault: () => {},
+        persist: () => {},
+      } as React.SyntheticEvent);
+    });
+  });
+
   it('should not invoke callback when there are errors', async () => {
     const { result } = renderHook(() => useForm<{ test: string }>());
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1010,9 +1010,7 @@ export function createFormControl<
         e.persist && e.persist();
       }
       let hasNoPromiseError = true;
-      let fieldValues: any = _options.shouldUnregister
-        ? cloneObject(_formValues)
-        : { ..._formValues };
+      let fieldValues: any = cloneObject(_formValues);
 
       _subjects.state.next({
         isSubmitting: true,


### PR DESCRIPTION
Fixes #7703.

Create a deep clone of `formValues` before passing them on as the `data` argument to `handleSubmit`. Otherwise nested objects directly reference the internal `_formValues` state.