### PR TITLE
Don't expose internal errors reference in handleSubmit

### DIFF
--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -395,6 +395,33 @@ describe('handleSubmit', () => {
     });
   });
 
+  it('should not provide internal errors reference to onInvalid callback', async () => {
+    const { result } = renderHook(() =>
+      useForm<{
+        test: string;
+      }>(),
+    );
+    result.current.register('test', { required: true });
+
+    await act(async () => {
+      await result.current.handleSubmit(
+        () => {},
+        (errors) => {
+          Object.freeze(errors);
+        },
+      )({
+        preventDefault: () => {},
+        persist: () => {},
+      } as React.SyntheticEvent);
+    });
+
+    await act(async () => {
+      expect(() =>
+        result.current.setError('test', { message: 'Not enough', type: 'min' }),
+      ).not.toThrow();
+    });
+  });
+
   it('should be able to submit correctly when errors contains empty array object', async () => {
     const onSubmit = jest.fn();
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1035,7 +1035,10 @@ export function createFormControl<
           });
           await onValid(fieldValues, e);
         } else {
-          onInvalid && (await onInvalid(_formState.errors, e));
+          if (onInvalid) {
+            await onInvalid({ ..._formState.errors }, e);
+          }
+
           _options.shouldFocusError &&
             focusFieldBy(
               _fields,


### PR DESCRIPTION
Fixes #7717

`_formState.errors` are cloned before passing them on to `onInvalid` handler.

This requires a change in the `cloneObject` method:

On the web context we have lots of references on a `HTMLElement` which would already slow the method down. On top of that, a `HTMLInputElement` has a reference to the form, which itself references it's inputs again, causing an infinite loop.

Because of that we now ignore `HTMLElement`s on the web and accordingly `Component`s when using `react-native` and instead pass those on without cloning.