### PR TITLE
feat: add validation error prop in FieldError

### DIFF
--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -10,12 +10,12 @@ export type MultipleFieldErrors = {
   [key: string]: ValidateResult;
 };
 
-export type FieldError = {
+export type FieldError<T = unknown> = {
   type: LiteralUnion<keyof RegisterOptions, string>;
   ref?: Ref;
   types?: MultipleFieldErrors;
   message?: Message;
-  validationError?: unknown;
+  validationError?: T;
 };
 
 export type ErrorOption = {

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -15,6 +15,7 @@ export type FieldError = {
   ref?: Ref;
   types?: MultipleFieldErrors;
   message?: Message;
+  validationError?: unknown;
 };
 
 export type ErrorOption = {


### PR DESCRIPTION
This follows up a discussion [here](https://github.com/react-hook-form/react-hook-form/discussions/3808#discussioncomment-261851).

When dealing with validation libraries like `yup` and `zod` it is convenient to have the possibility to be able to access the original error thrown by the validation library outside the context of react hook form. 

This tiny change would allow a standardised param where we can retrieve the original error from the validation library we are using.

This is the only change that is needed in this package, and it's backwards compatible. We can then add the original error in the resolver packages, for example [here for Zod](https://github.com/react-hook-form/resolvers/blob/master/zod/src/zod.ts#L29).