### PR TITLE
Fix output types of transformed values onSubmit

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -550,7 +550,7 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
 };
 
 // @public
-export type UseFormHandleSubmit<TFieldValues extends FieldValues> = <_>(onValid: SubmitHandler<TFieldValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
+export type UseFormHandleSubmit<TFieldValues extends FieldValues> = <TSubmitFieldValues = TFieldValues>(onValid: SubmitHandler<TSubmitFieldValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
 
 // @public (undocumented)
 export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContext extends object = object> = Partial<{

--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -349,6 +349,34 @@ describe('handleSubmit', () => {
       });
       expect(callback.mock.calls[0][0]).toEqual({ test: 'test' });
     });
+
+    it('should transform input values and return correct output types', async () => {
+      const resolver = async () => {
+        return {
+          values: { count: 0 },
+          errors: {},
+        };
+      };
+
+      const { result } = renderHook(() =>
+        useForm<{ count: string }>({
+          mode: VALIDATION_MODE.onSubmit,
+          resolver,
+        }),
+      );
+
+      result.current.register('count', { required: true });
+
+      const callback = jest.fn();
+
+      await act(async () => {
+        await result.current.handleSubmit(callback)({
+          preventDefault: () => {},
+          persist: () => {},
+        } as React.SyntheticEvent);
+      });
+      expect(callback.mock.calls[0][0]).toEqual({ count: 0 });
+    });
   });
 
   describe('with onInvalid callback', () => {

--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -367,15 +367,16 @@ describe('handleSubmit', () => {
 
       result.current.register('count', { required: true });
 
-      const callback = jest.fn();
-
       await act(async () => {
-        await result.current.handleSubmit(callback)({
+        await result.current.handleSubmit((data: { count: number }) => {
+          expect(data).toEqual({
+            count: 0,
+          });
+        })({
           preventDefault: () => {},
           persist: () => {},
         } as React.SyntheticEvent);
       });
-      expect(callback.mock.calls[0][0]).toEqual({ count: 0 });
     });
   });
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -582,10 +582,9 @@ export type UseFormUnregister<TFieldValues extends FieldValues> = (
  * <form onSubmit={handleSubmit(onSubmit, onError)} />
  * ```
  */
-export type UseFormHandleSubmit<TFieldValues extends FieldValues> = <
-  TSubmitFieldValues = TFieldValues,
->(
-  onValid: SubmitHandler<TSubmitFieldValues>,
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type UseFormHandleSubmit<TFieldValues extends FieldValues> = <_>(
+  onValid: SubmitHandler<TFieldValues>,
   onInvalid?: SubmitErrorHandler<TFieldValues>,
 ) => (e?: React.BaseSyntheticEvent) => Promise<void>;
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -582,9 +582,10 @@ export type UseFormUnregister<TFieldValues extends FieldValues> = (
  * <form onSubmit={handleSubmit(onSubmit, onError)} />
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type UseFormHandleSubmit<TFieldValues extends FieldValues> = <_>(
-  onValid: SubmitHandler<TFieldValues>,
+export type UseFormHandleSubmit<TFieldValues extends FieldValues> = <
+  TSubmitFieldValues = TFieldValues,
+>(
+  onValid: SubmitHandler<TSubmitFieldValues>,
   onInvalid?: SubmitErrorHandler<TFieldValues>,
 ) => (e?: React.BaseSyntheticEvent) => Promise<void>;
 


### PR DESCRIPTION
## Summary

This fixes a typing/validation issue when using a resolver that transforms the form input types into different output types.

Example using zod:
```typescript

import { useForm } from "react-hook-form";
import { z } from "zod";
import { zodResolver } from "@hookform/resolvers/zod";

const countSchema = z.object({
  count: z.string().transform(val => Number(val)),
});

type CountForm = z.input<typeof countSchema>; // input type is inferred => string
type CountSchema = z.infer<typeof countSchema>; // output type is inferred => number

export default function App() {
  const { register, handleSubmit } = useForm<CountForm>({resolver: zodResolver(countSchema)});
  const onSubmit = (data: CountSchema) => console.log(data);

  return (
    <div>
      ...
      // Error: Type '{ count: string; }' is not assignable to type '{ count: number; }'.
      <form onSubmit={handleSubmit(onSubmit)}>
        <input {...register("count")} placeholder="Count" />
        <input type="submit" />
      </form>
    </div>
  );
}
```
Error was also reproduced here: https://codesandbox.io/s/ecstatic-pine-brxt1?file=/src/App.tsx:0-892

### Version

7.26.1



