### PR TITLE
errors: include received and expected (build-in validation)

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -189,6 +189,8 @@ export type FieldError = {
     ref?: Ref;
     types?: MultipleFieldErrors;
     message?: Message;
+    received?: unknown;
+    expected?: unknown;
 };
 
 // @public (undocumented)

--- a/src/__tests__/logic/__snapshots__/validateField.test.tsx.snap
+++ b/src/__tests__/logic/__snapshots__/validateField.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`validateField should handle pattern with g flag 1`] = `
 Object {
   "test": Object {
+    "expected": 10,
     "message": "",
     "received": "a",
     "ref": Object {
@@ -21,6 +22,7 @@ Object {
 exports[`validateField should handle pattern with g flag 2`] = `
 Object {
   "test": Object {
+    "expected": 10,
     "message": "",
     "received": "a",
     "ref": Object {
@@ -39,6 +41,7 @@ Object {
 exports[`validateField should return all validation error messages 1`] = `
 Object {
   "test": Object {
+    "expected": true,
     "message": "test",
     "received": "",
     "ref": Object {
@@ -59,6 +62,7 @@ Object {
 exports[`validateField should return all validation error messages 2`] = `
 Object {
   "test": Object {
+    "expected": 10,
     "message": "minLength",
     "received": "bil",
     "ref": Object {
@@ -80,6 +84,7 @@ Object {
 exports[`validateField should return all validation error messages 3`] = `
 Object {
   "test": Object {
+    "expected": 10,
     "message": "minLength",
     "received": "bil",
     "ref": Object {
@@ -101,6 +106,7 @@ Object {
 exports[`validateField should return all validation errors 1`] = `
 Object {
   "test": Object {
+    "expected": true,
     "message": "",
     "received": "",
     "ref": Object {
@@ -119,6 +125,7 @@ Object {
 exports[`validateField should return all validation errors 2`] = `
 Object {
   "test": Object {
+    "expected": 10,
     "message": "",
     "received": "123",
     "ref": Object {

--- a/src/__tests__/logic/__snapshots__/validateField.test.tsx.snap
+++ b/src/__tests__/logic/__snapshots__/validateField.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`validateField should handle pattern with g flag 1`] = `
 Object {
   "test": Object {
     "message": "",
+    "received": "a",
     "ref": Object {
       "name": "test",
       "type": "text",
@@ -21,6 +22,7 @@ exports[`validateField should handle pattern with g flag 2`] = `
 Object {
   "test": Object {
     "message": "",
+    "received": "a",
     "ref": Object {
       "name": "test",
       "type": "text",
@@ -38,6 +40,7 @@ exports[`validateField should return all validation error messages 1`] = `
 Object {
   "test": Object {
     "message": "test",
+    "received": "",
     "ref": Object {
       "name": "test",
       "type": "text",
@@ -57,6 +60,7 @@ exports[`validateField should return all validation error messages 2`] = `
 Object {
   "test": Object {
     "message": "minLength",
+    "received": "bil",
     "ref": Object {
       "name": "test",
       "type": "text",
@@ -77,6 +81,7 @@ exports[`validateField should return all validation error messages 3`] = `
 Object {
   "test": Object {
     "message": "minLength",
+    "received": "bil",
     "ref": Object {
       "name": "test",
       "type": "text",
@@ -97,6 +102,7 @@ exports[`validateField should return all validation errors 1`] = `
 Object {
   "test": Object {
     "message": "",
+    "received": "",
     "ref": Object {
       "name": "test",
       "type": "text",
@@ -114,6 +120,7 @@ exports[`validateField should return all validation errors 2`] = `
 Object {
   "test": Object {
     "message": "",
+    "received": "123",
     "ref": Object {
       "name": "test",
       "type": "text",

--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -30,6 +30,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        received: '',
         ref: { type: 'text', value: '', name: 'test' },
         message: '',
         type: 'required',
@@ -53,6 +54,7 @@ describe('validateField', () => {
       test: {
         ref: { type: 'text', value: '', name: 'test' },
         message: 'required',
+        received: '',
         type: 'required',
       },
     });
@@ -74,6 +76,7 @@ describe('validateField', () => {
       test: {
         ref: { type: 'text', value: '', name: 'test' },
         message: 'required',
+        received: '',
         type: 'required',
       },
     });
@@ -99,6 +102,7 @@ describe('validateField', () => {
         ref: { type: 'text', value: '', name: 'test' },
         message: 'required',
         type: 'required',
+        received: '',
       },
     });
 
@@ -123,6 +127,7 @@ describe('validateField', () => {
         ref: { type: 'text', value: '', name: 'test' },
         message: 'required',
         type: 'required',
+        received: '',
       },
     });
 
@@ -161,6 +166,7 @@ describe('validateField', () => {
       test: {
         message: '',
         type: 'required',
+        received: false,
         ref: { type: 'radio', name: 'test' },
       },
     });
@@ -182,6 +188,7 @@ describe('validateField', () => {
       test: {
         message: 'test',
         type: 'required',
+        received: '',
         ref: { type: 'text', name: 'test', value: '' },
       },
     });
@@ -203,6 +210,7 @@ describe('validateField', () => {
       test: {
         message: 'test',
         type: 'required',
+        received: '',
         ref: { type: 'radio', name: 'test', value: '' },
       },
     });
@@ -224,6 +232,7 @@ describe('validateField', () => {
       test: {
         message: 'test',
         type: 'required',
+        received: false,
         ref: { type: 'checkbox', name: 'test' },
       },
     });
@@ -283,6 +292,7 @@ describe('validateField', () => {
       test: {
         type: 'required',
         message: '',
+        received: '',
         ref: {
           name: 'test',
           value: '',
@@ -308,6 +318,7 @@ describe('validateField', () => {
       test: {
         type: 'required',
         message: '',
+        received: '',
         ref: {
           type: 'file',
           name: 'test',
@@ -335,6 +346,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        received: 10,
         type: 'max',
         message: '',
         ref: { type: 'number', name: 'test', valueAsNumber: 10 },
@@ -362,6 +374,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'max',
+        received: 10,
         message: 'max',
         ref: { type: 'number', name: 'test', valueAsNumber: 10 },
       },
@@ -388,6 +401,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'max',
+        received: 10,
         message: 'max',
         ref: { type: 'number', name: 'test', valueAsNumber: 10 },
       },
@@ -427,6 +441,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'max',
+        received: 10,
         message: '',
         ref: { type: 'number', name: 'test', valueAsNumber: 10 },
         types: {
@@ -453,6 +468,7 @@ describe('validateField', () => {
       test: {
         type: 'required',
         message: '',
+        received: '',
         ref: { type: 'custom', name: 'test', valueAsNumber: NaN },
       },
     });
@@ -510,6 +526,7 @@ describe('validateField', () => {
       test: {
         type: 'required',
         message: '',
+        received: null,
         ref: { type: 'custom', name: 'test', valueAsNumber: NaN },
       },
     });
@@ -552,6 +569,7 @@ describe('validateField', () => {
       test: {
         type: 'max',
         message: '',
+        received: '2019-2-13',
         ref: {
           type: 'date',
           name: 'test',
@@ -579,6 +597,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'min',
+        received: -1,
         message: '',
         ref: { type: 'number', name: 'test', valueAsNumber: -1 },
       },
@@ -605,6 +624,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'min',
+        received: -1,
         message: 'min',
         ref: { type: 'number', name: 'test', valueAsNumber: -1 },
       },
@@ -631,6 +651,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'min',
+        received: -1,
         message: 'min',
         ref: { type: 'number', name: 'test', valueAsNumber: -1 },
       },
@@ -655,6 +676,7 @@ describe('validateField', () => {
       test: {
         type: 'min',
         message: '',
+        received: 10,
         ref: { type: 'number', name: 'test', valueAsNumber: 10 },
       },
     });
@@ -682,6 +704,7 @@ describe('validateField', () => {
       test: {
         type: 'min',
         message: '',
+        received: '2019-2-12',
         ref: {
           type: 'date',
           name: 'test',
@@ -715,6 +738,7 @@ describe('validateField', () => {
       test: {
         type: 'min',
         message: 'min',
+        received: '2019-2-12',
         ref: {
           type: 'date',
           name: 'test',
@@ -748,6 +772,7 @@ describe('validateField', () => {
       test: {
         type: 'min',
         message: 'min',
+        received: '2019-2-12',
         ref: {
           type: 'date',
           name: 'test',
@@ -778,6 +803,7 @@ describe('validateField', () => {
         type: 'min',
         message: '',
         ref: { type: '', name: 'test' },
+        received: '1',
       },
     });
 
@@ -800,6 +826,7 @@ describe('validateField', () => {
       test: {
         type: 'max',
         message: '',
+        received: '4',
         ref: { type: '', name: 'test' },
       },
     });
@@ -827,6 +854,7 @@ describe('validateField', () => {
       test: {
         type: 'max',
         message: '',
+        received: '2019-2-12',
         ref: {
           type: '',
           name: 'test',
@@ -861,6 +889,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: '',
         type: 'maxLength',
       },
@@ -893,6 +922,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: 'maxLength',
         type: 'maxLength',
       },
@@ -925,6 +955,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: 'maxLength',
         type: 'maxLength',
       },
@@ -956,6 +987,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: '',
         type: 'minLength',
       },
@@ -988,6 +1020,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: 'minLength',
         type: 'minLength',
       },
@@ -1020,6 +1053,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: 'minLength',
         type: 'minLength',
       },
@@ -1054,6 +1088,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: '',
         type: 'pattern',
       },
@@ -1086,6 +1121,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: 'regex failed',
         type: 'pattern',
       },
@@ -1118,6 +1154,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        received: 'This is a long text input',
         message: 'regex failed',
         type: 'pattern',
       },

--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -30,6 +30,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: true,
         received: '',
         ref: { type: 'text', value: '', name: 'test' },
         message: '',
@@ -54,6 +55,7 @@ describe('validateField', () => {
       test: {
         ref: { type: 'text', value: '', name: 'test' },
         message: 'required',
+        expected: true,
         received: '',
         type: 'required',
       },
@@ -76,6 +78,7 @@ describe('validateField', () => {
       test: {
         ref: { type: 'text', value: '', name: 'test' },
         message: 'required',
+        expected: true,
         received: '',
         type: 'required',
       },
@@ -102,6 +105,7 @@ describe('validateField', () => {
         ref: { type: 'text', value: '', name: 'test' },
         message: 'required',
         type: 'required',
+        expected: true,
         received: '',
       },
     });
@@ -126,6 +130,7 @@ describe('validateField', () => {
       test: {
         ref: { type: 'text', value: '', name: 'test' },
         message: 'required',
+        expected: true,
         type: 'required',
         received: '',
       },
@@ -166,6 +171,7 @@ describe('validateField', () => {
       test: {
         message: '',
         type: 'required',
+        expected: true,
         received: false,
         ref: { type: 'radio', name: 'test' },
       },
@@ -187,6 +193,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         message: 'test',
+        expected: true,
         type: 'required',
         received: '',
         ref: { type: 'text', name: 'test', value: '' },
@@ -209,6 +216,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         message: 'test',
+        expected: true,
         type: 'required',
         received: '',
         ref: { type: 'radio', name: 'test', value: '' },
@@ -232,6 +240,7 @@ describe('validateField', () => {
       test: {
         message: 'test',
         type: 'required',
+        expected: true,
         received: false,
         ref: { type: 'checkbox', name: 'test' },
       },
@@ -290,6 +299,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: true,
         type: 'required',
         message: '',
         received: '',
@@ -317,6 +327,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'required',
+        expected: true,
         message: '',
         received: '',
         ref: {
@@ -346,6 +357,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: 0,
         received: 10,
         type: 'max',
         message: '',
@@ -373,6 +385,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: 0,
         type: 'max',
         received: 10,
         message: 'max',
@@ -400,6 +413,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: 0,
         type: 'max',
         received: 10,
         message: 'max',
@@ -440,6 +454,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: 8,
         type: 'max',
         received: 10,
         message: '',
@@ -466,6 +481,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: true,
         type: 'required',
         message: '',
         received: '',
@@ -493,7 +509,9 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: true,
         type: 'required',
+        received: undefined,
         message: '',
         ref: {
           type: 'custom',
@@ -524,6 +542,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: true,
         type: 'required',
         message: '',
         received: null,
@@ -567,6 +586,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: '2019-1-12',
         type: 'max',
         message: '',
         received: '2019-2-13',
@@ -596,6 +616,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: 0,
         type: 'min',
         received: -1,
         message: '',
@@ -624,6 +645,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'min',
+        expected: 0,
         received: -1,
         message: 'min',
         ref: { type: 'number', name: 'test', valueAsNumber: -1 },
@@ -651,6 +673,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'min',
+        expected: 0,
         received: -1,
         message: 'min',
         ref: { type: 'number', name: 'test', valueAsNumber: -1 },
@@ -675,6 +698,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'min',
+        expected: 12,
         message: '',
         received: 10,
         ref: { type: 'number', name: 'test', valueAsNumber: 10 },
@@ -703,6 +727,7 @@ describe('validateField', () => {
     ).toEqual({
       test: {
         type: 'min',
+        expected: '2019-3-12',
         message: '',
         received: '2019-2-12',
         ref: {
@@ -736,6 +761,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: '2019-3-12',
         type: 'min',
         message: 'min',
         received: '2019-2-12',
@@ -772,6 +798,7 @@ describe('validateField', () => {
       test: {
         type: 'min',
         message: 'min',
+        expected: '2019-3-12',
         received: '2019-2-12',
         ref: {
           type: 'date',
@@ -802,6 +829,7 @@ describe('validateField', () => {
       test: {
         type: 'min',
         message: '',
+        expected: '4',
         ref: { type: '', name: 'test' },
         received: '1',
       },
@@ -824,6 +852,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: '2',
         type: 'max',
         message: '',
         received: '4',
@@ -852,6 +881,7 @@ describe('validateField', () => {
       ),
     ).toEqual({
       test: {
+        expected: '2019-1-12',
         type: 'max',
         message: '',
         received: '2019-2-12',
@@ -889,6 +919,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        expected: 12,
         received: 'This is a long text input',
         message: '',
         type: 'maxLength',
@@ -922,6 +953,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        expected: 12,
         received: 'This is a long text input',
         message: 'maxLength',
         type: 'maxLength',
@@ -955,6 +987,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        expected: 12,
         received: 'This is a long text input',
         message: 'maxLength',
         type: 'maxLength',
@@ -988,6 +1021,7 @@ describe('validateField', () => {
           name: 'test',
         },
         received: 'This is a long text input',
+        expected: 200,
         message: '',
         type: 'minLength',
       },
@@ -1020,6 +1054,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        expected: 200,
         received: 'This is a long text input',
         message: 'minLength',
         type: 'minLength',
@@ -1053,6 +1088,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        expected: 200,
         received: 'This is a long text input',
         message: 'minLength',
         type: 'minLength',
@@ -1088,6 +1124,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        expected: emailRegex,
         received: 'This is a long text input',
         message: '',
         type: 'pattern',
@@ -1121,6 +1158,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        expected: emailRegex,
         received: 'This is a long text input',
         message: 'regex failed',
         type: 'pattern',
@@ -1154,6 +1192,7 @@ describe('validateField', () => {
           type: 'text',
           name: 'test',
         },
+        expected: emailRegex,
         received: 'This is a long text input',
         message: 'regex failed',
         type: 'pattern',

--- a/src/__tests__/useForm/__snapshots__/clearErrors.test.tsx.snap
+++ b/src/__tests__/useForm/__snapshots__/clearErrors.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`clearErrors should remove deep nested error and set it to undefined 1`]
 Object {
   "test": Object {
     "data": Object {
+      "expected": true,
       "message": "",
       "received": "",
       "ref": <input

--- a/src/__tests__/useForm/__snapshots__/clearErrors.test.tsx.snap
+++ b/src/__tests__/useForm/__snapshots__/clearErrors.test.tsx.snap
@@ -5,6 +5,7 @@ Object {
   "test": Object {
     "data": Object {
       "message": "",
+      "received": "",
       "ref": <input
         name="test.data"
         type="text"

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -58,7 +58,6 @@ export default async <T extends NativeFieldValue>(
   const error: InternalFieldErrors = {};
   const isRadio = isRadioInput(ref);
   const isCheckBox = isCheckBoxInput(ref);
-  const isRadioOrCheckbox = isRadio || isCheckBox;
   const isEmpty =
     ((valueAsNumber || isFileInput(ref)) && !ref.value) ||
     inputValue === '' ||
@@ -81,13 +80,14 @@ export default async <T extends NativeFieldValue>(
       type: exceedMax ? maxType : minType,
       message,
       ref,
+      received: inputValue,
       ...appendErrorsCurry(exceedMax ? maxType : minType, message),
     };
   };
 
   if (
     required &&
-    ((!isRadioOrCheckbox && (isEmpty || isNullOrUndefined(inputValue))) ||
+    ((!(isRadio || isCheckBox) && (isEmpty || isNullOrUndefined(inputValue))) ||
       (isBoolean(inputValue) && !inputValue) ||
       (isCheckBox && !getCheckboxValue(refs).isValid) ||
       (isRadio && !getRadioValue(refs).isValid))
@@ -101,6 +101,7 @@ export default async <T extends NativeFieldValue>(
         type: INPUT_VALIDATION_RULES.required,
         message,
         ref: inputRef,
+        received: inputValue,
         ...appendErrorsCurry(INPUT_VALIDATION_RULES.required, message),
       };
       if (!validateAllFieldCriteria) {
@@ -116,16 +117,7 @@ export default async <T extends NativeFieldValue>(
     const maxOutput = getValueAndMessage(max);
     const minOutput = getValueAndMessage(min);
 
-    if (!isNaN(inputValue as number)) {
-      const valueNumber =
-        (ref as HTMLInputElement).valueAsNumber || +inputValue;
-      if (!isNullOrUndefined(maxOutput.value)) {
-        exceedMax = valueNumber > maxOutput.value;
-      }
-      if (!isNullOrUndefined(minOutput.value)) {
-        exceedMin = valueNumber < minOutput.value;
-      }
-    } else {
+    if (isNaN(inputValue as number)) {
       const valueDate =
         (ref as HTMLInputElement).valueAsDate || new Date(inputValue as string);
       if (isString(maxOutput.value)) {
@@ -133,6 +125,15 @@ export default async <T extends NativeFieldValue>(
       }
       if (isString(minOutput.value)) {
         exceedMin = valueDate < new Date(minOutput.value);
+      }
+    } else {
+      const valueNumber =
+        (ref as HTMLInputElement).valueAsNumber || +inputValue;
+      if (!isNullOrUndefined(maxOutput.value)) {
+        exceedMax = valueNumber > maxOutput.value;
+      }
+      if (!isNullOrUndefined(minOutput.value)) {
+        exceedMin = valueNumber < minOutput.value;
       }
     }
 
@@ -182,6 +183,7 @@ export default async <T extends NativeFieldValue>(
         type: INPUT_VALIDATION_RULES.pattern,
         message,
         ref,
+        received: inputValue,
         ...appendErrorsCurry(INPUT_VALIDATION_RULES.pattern, message),
       };
       if (!validateAllFieldCriteria) {

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -15,6 +15,8 @@ export type FieldError = {
   ref?: Ref;
   types?: MultipleFieldErrors;
   message?: Message;
+  received?: unknown;
+  expected?: unknown;
 };
 
 export type ErrorOption = {


### PR DESCRIPTION
```diff
export type FieldError = {
  type: LiteralUnion<keyof RegisterOptions, string>;
  ref?: Ref;
  types?: MultipleFieldErrors;
  message?: Message;
+ received?: unknown;
+ expected?: unknown;
};
```

close [#3950](https://github.com/react-hook-form/react-hook-form/issues/3950)