### PR TITLE
fix(typo): remove duplicated 'the' from messages.default's comment

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -289,7 +289,7 @@
        */
       "default": {
         /**
-         * Specifies whether the message should be written to the the tool's output log.  Note that
+         * Specifies whether the message should be written to the tool's output log.  Note that
          * the "addToApiReportFile" property may supersede this option.
          *
          * Possible values: "error", "warning", "none"


### PR DESCRIPTION
This PR is for fix json's comment. so it doesn't affect app's function.