### PR TITLE
fix: compare html elements against correct global

### DIFF
--- a/src/utils/isHTMLElement.ts
+++ b/src/utils/isHTMLElement.ts
@@ -1,2 +1,6 @@
-export default (value: unknown): value is HTMLElement =>
-  value instanceof HTMLElement;
+export default (value: unknown): value is HTMLElement => {
+  const ElementClass =
+    (value as HTMLElement)?.ownerDocument?.defaultView?.HTMLElement ??
+    HTMLElement;
+  return value instanceof ElementClass;
+};


### PR DESCRIPTION
When checking whether a value is an instance of HTMLElement,
the reference class must be owned by the same window which
owns the value, or the comparison will fail.