### PR TITLE
fix: useFieldArray example crash

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -35,7 +35,7 @@ import { useSubscribe } from './useSubscribe';
  * A custom hook that exposes convenient methods to perform operations with a list of dynamic inputs that need to be appended, updated, removed etc.
  *
  * @remarks
- * [API](https://react-hook-form.com/api/usefieldarray) • [Demo](https://codesandbox.io/s/react-hook-form-usefieldarray-ssugn)
+ * [API](https://react-hook-form.com/api/usefieldarray) • [Demo](https://codesandbox.io/s/react-hook-form-usefieldarray-forked-31u8q8)
  *
  * @param props - useFieldArray props
  *


### PR DESCRIPTION
Summary of fixes
1. Null-safe item key
2. Remove unused `useWatch` import
3. Remove unused `watch` destruct

Crash happens when swapping/moving with initial values
<img width="958" alt="Screen Shot 2022-03-03 at 19 30 28" src="https://user-images.githubusercontent.com/15677820/156639655-c35573e1-3327-49e0-8156-9ce2021c80fe.png">


Original sandbox: https://codesandbox.io/s/react-hook-form-usefieldarray-ssugn?file=/src/index.js
Forked sandbox: https://codesandbox.io/s/react-hook-form-usefieldarray-forked-31u8q8
diff: https://www.diffchecker.com/mEwLVofv
