### PR TITLE
Prevent error on setFocus for unfocusable inputs

### DIFF
--- a/app/src/setFocus.tsx
+++ b/app/src/setFocus.tsx
@@ -7,6 +7,8 @@ type FormValues = {
   selectInputContent: string;
   focusTextarea: string;
   selectTextareaContent: string;
+  focusUnfocusable: number;
+  selectUnfocusable: number;
 };
 
 const defaultValues: DefaultValues<FormValues> = {
@@ -14,10 +16,12 @@ const defaultValues: DefaultValues<FormValues> = {
   selectInputContent: 'Content should be selected',
   focusTextarea: 'Textarea should be focused',
   selectTextareaContent: 'Content should be selected',
+  focusUnfocusable: 1,
+  selectUnfocusable: 1,
 };
 
 const SetFocus = () => {
-  const { register, setFocus } = useForm<FormValues>({
+  const { register, watch, setValue, setFocus } = useForm<FormValues>({
     defaultValues,
   });
 
@@ -64,6 +68,45 @@ const SetFocus = () => {
           }
         >
           Select Textarea Content
+        </button>
+      </fieldset>
+      <fieldset>
+        <legend>Don't focus unfocusable input</legend>
+        <label htmlFor="focusUnfocusable">Unfocusable Input</label>
+        <div>Value: {watch('focusUnfocusable')}</div>
+        <a
+          id="focusUnfocusable"
+          href="#"
+          onClick={(event) => {
+            event.preventDefault();
+            setValue('focusUnfocusable', watch('focusUnfocusable') + 1);
+          }}
+        >
+          Click to increment
+        </a>
+        <button type="button" onClick={() => setFocus('focusUnfocusable')}>
+          Do Not Focus
+        </button>
+      </fieldset>
+      <fieldset>
+        <legend>Don't select unfocusable input</legend>
+        <label htmlFor="selectUnfocusable">Unfocusable Input</label>
+        <div>Value: {watch('selectUnfocusable')}</div>
+        <a
+          id="selectUnfocusable"
+          href="#"
+          onClick={(event) => {
+            event.preventDefault();
+            setValue('selectUnfocusable', watch('selectUnfocusable') + 1);
+          }}
+        >
+          Click to increment
+        </a>
+        <button
+          type="button"
+          onClick={() => setFocus('focusUnfocusable', { shouldSelect: true })}
+        >
+          Do Not Select
         </button>
       </fieldset>
     </form>

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -61,3 +61,6 @@ input[type='submit']:active {
   transition: 0.3s all;
   top: 2px;
 }
+a {
+  color: white;
+}

--- a/cypress/integration/setFocus.ts
+++ b/cypress/integration/setFocus.ts
@@ -26,4 +26,14 @@ describe('form setFocus', () => {
       .type('New Value')
       .should('have.value', 'New Value');
   });
+
+  it('should not focus unfocusable input', () => {
+    cy.visit('http://localhost:3000/setFocus');
+    cy.get('button:contains("Do Not Focus")').click();
+  });
+
+  it('should not select unfocusable input', () => {
+    cy.visit('http://localhost:3000/setFocus');
+    cy.get('button:contains("Do Not Select")').click();
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1197,9 +1197,11 @@ export function createFormControl<
   };
 
   const setFocus: UseFormSetFocus<TFieldValues> = (name, options = {}) => {
-    const field = get(_fields, name)._f;
-    const fieldRef = field.refs ? field.refs[0] : field.ref;
-    options.shouldSelect ? fieldRef.select() : fieldRef.focus();
+    const field = get(_fields, name)?._f;
+    const fieldRef = field?.refs ? field?.refs[0] : field?.ref;
+    options.shouldSelect
+      ? fieldRef?.select()
+      : fieldRef?.focus && fieldRef?.focus();
   };
 
   return {


### PR DESCRIPTION
If we call `setFocus` on a field that doesn't have a regular input associated with it, it will now fail silently.

That's useful in case we have a generic focus management function that tries to focus fields regardless of their input type.

I'm using react-hook-form under the hood on [Remix Forms](https://remix-forms.seasoned.cc/), and I came across this issue when writing a custom HTML field with it.