### PR TITLE
Update package.json exports rule to allow importing specific file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     ".": {
       "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js"
-    }
+    },
+    "./dist/": "./dist/"
   },
   "scripts": {
     "clean": "rimraf dist",


### PR DESCRIPTION
When building our code using react-hook-form as an external library, some are shipped using esm and some are using cjs, which causes useFormContext to return null. See https://github.com/react-hook-form/react-hook-form/discussions/3894

In one of the replies https://github.com/react-hook-form/react-hook-form/discussions/3894#discussioncomment-2135181 it mentioned the cause is due to the mixed usage of esm and cjs.

Currently the import esm or cjs module is automatically determined and the system may not be very smart. It always causes some problem.

This pull request changes the package.json to allow directly selecting of module type during import by forcing a filename.