### PR TITLE
Support field array parents with numbers in name

### DIFF
--- a/src/__tests__/logic/getNodeParentName.test.ts
+++ b/src/__tests__/logic/getNodeParentName.test.ts
@@ -3,11 +3,14 @@ import getFieldArrayParentName from '../../logic/getNodeParentName';
 describe('getFieldArrayParentName', () => {
   it('should return parent name when name is field array', () => {
     expect(getFieldArrayParentName('test.0')).toBe('test');
+    expect(getFieldArrayParentName('test[0]')).toBe('test');
     expect(getFieldArrayParentName('test.0.data.0')).toBe('test');
     expect(getFieldArrayParentName('test.data.0')).toBe('test.data');
   });
 
   it('should return empty string when name is not field array', () => {
     expect(getFieldArrayParentName('test')).toBe('test');
+    expect(getFieldArrayParentName('test0')).toBe('test0');
+    expect(getFieldArrayParentName('te1st')).toBe('te1st');
   });
 });

--- a/src/__tests__/logic/getNodeParentName.test.ts
+++ b/src/__tests__/logic/getNodeParentName.test.ts
@@ -1,16 +1,16 @@
-import getFieldArrayParentName from '../../logic/getNodeParentName';
+import getNodeParentName from '../../logic/getNodeParentName';
 
-describe('getFieldArrayParentName', () => {
+describe('getNodeParentName', () => {
   it('should return parent name when name is field array', () => {
-    expect(getFieldArrayParentName('test.0')).toBe('test');
-    expect(getFieldArrayParentName('test[0]')).toBe('test');
-    expect(getFieldArrayParentName('test.0.data.0')).toBe('test');
-    expect(getFieldArrayParentName('test.data.0')).toBe('test.data');
+    expect(getNodeParentName('test.0')).toBe('test');
+    expect(getNodeParentName('test1.1')).toBe('test1');
+    expect(getNodeParentName('test.0.data.0')).toBe('test');
+    expect(getNodeParentName('test.data.0')).toBe('test.data');
   });
 
   it('should return empty string when name is not field array', () => {
-    expect(getFieldArrayParentName('test')).toBe('test');
-    expect(getFieldArrayParentName('test0')).toBe('test0');
-    expect(getFieldArrayParentName('te1st')).toBe('te1st');
+    expect(getNodeParentName('test')).toBe('test');
+    expect(getNodeParentName('test0')).toBe('test0');
+    expect(getNodeParentName('te1st')).toBe('te1st');
   });
 });

--- a/src/logic/getNodeParentName.ts
+++ b/src/logic/getNodeParentName.ts
@@ -1,2 +1,1 @@
-export default (name: string) =>
-  name.substring(0, name.search(/(\[\d+\])|(\.\d+(\.|$))/)) || name;
+export default (name: string) => name.substring(0, name.search(/\.\d/)) || name;

--- a/src/logic/getNodeParentName.ts
+++ b/src/logic/getNodeParentName.ts
@@ -1,1 +1,2 @@
-export default (name: string) => name.substring(0, name.search(/.\d/)) || name;
+export default (name: string) =>
+  name.substring(0, name.search(/(\[\d+\])|(\.\d+(\.|$))/)) || name;


### PR DESCRIPTION
**Describe the bug**
Field arrays with names containing numbers (for example "address1") currently break down when using "shouldUnregister: true" on the form level.

**To Reproduce**
[This sandbox](https://codesandbox.io/s/react-hook-form-usefieldarray-forked-855mle?file=/src/index.js) demonstrates the bug:

1. Append a row and alter its value.
2. Delete the first row.
3. The remaining field is reset to its initial value (empty string in this case).

See it working as intended by removing the "1" from the arrayName constant at line 9.

**Codesandbox link (Required)**
https://codesandbox.io/s/react-hook-form-usefieldarray-forked-855mle?file=/src/index.js

**Expected behavior**
The remaining fields should have unaltered values.

**Solution**
The expression used in "getNodeParentName" splits the field name at any digit instead of checking for an all-digit fragment.

I have modified the expression used by getNodeParentName to look for explicit numerical indices, either of the form "fieldName[123]" or "fieldName.123"
