### PR TITLE
getNodeParentName missing case(s)

### DIFF
--- a/src/__tests__/logic/getNodeParentName.test.ts
+++ b/src/__tests__/logic/getNodeParentName.test.ts
@@ -6,6 +6,7 @@ describe('getNodeParentName', () => {
     expect(getNodeParentName('test1.1')).toBe('test1');
     expect(getNodeParentName('test.0.data.0')).toBe('test');
     expect(getNodeParentName('test.data.0')).toBe('test.data');
+    expect(getNodeParentName('test.1st')).toBe('test.1st');
   });
 
   it('should return empty string when name is not field array', () => {

--- a/src/logic/getNodeParentName.ts
+++ b/src/logic/getNodeParentName.ts
@@ -1,1 +1,2 @@
-export default (name: string) => name.substring(0, name.search(/\.\d/)) || name;
+export default (name: string) =>
+  name.substring(0, name.search(/\.\d+(\.|$)/)) || name;

--- a/src/logic/isNameInFieldArray.ts
+++ b/src/logic/isNameInFieldArray.ts
@@ -3,4 +3,4 @@ import { InternalFieldName } from '../types';
 import getNodeParentName from './getNodeParentName';
 
 export default (names: Set<InternalFieldName>, name: InternalFieldName) =>
-  [...names].some((current) => getNodeParentName(name) === current);
+  names.has(getNodeParentName(name));


### PR DESCRIPTION
In reference to [this pull request](https://github.com/react-hook-form/react-hook-form/pull/8167):

The merged expression does not consider object keys that start with a digit "test.1st". I have altered the expression to make sure that the key is a positive amount of digits that either (1) ends with a period or (2) is at end of field name.

_Field names using square brackets, ie "test[0]", were removed from tests and are not supported at all now. Have they been deprecated?_

Another small optimization: Using Set.has in isNameInFieldArray has better performance than spreading the set into an array.

