### PR TITLE
Set defaultValue in state when initialized in useController

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -295,6 +295,86 @@ describe('useController', () => {
     );
   });
 
+  it('should not be dirty when initializing field with controller defaultValue', async () => {
+    const App = () => {
+      const {
+        control,
+        formState: { isDirty },
+      } = useForm();
+
+      return (
+        <div>
+          <p>Form dirty: {isDirty.toString()}</p>
+          <Controller
+            render={({ field }) => {
+              return <input {...field} />;
+            }}
+            control={control}
+            name="test"
+            defaultValue="luo"
+          />
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    const input = screen.getByRole('textbox');
+
+    expect(input).toHaveValue('luo');
+    expect(screen.getByText('Form dirty: false')).toBeVisible();
+
+    fireEvent.change(input, { target: { value: 'Bill' } });
+
+    expect(screen.getByText('Form dirty: true')).toBeVisible();
+
+    fireEvent.change(input, { target: { value: 'luo' } });
+
+    expect(screen.getByText('Form dirty: false')).toBeVisible();
+  });
+
+  it('should be dirty when initializing field with controller and useForm defaultValue', async () => {
+    const App = () => {
+      const {
+        control,
+        formState: { isDirty },
+      } = useForm({
+        defaultValues: {
+          test: 'Bill',
+        },
+      });
+
+      return (
+        <div>
+          <p>Form dirty: {isDirty.toString()}</p>
+          <Controller
+            render={({ field }) => {
+              return <input {...field} />;
+            }}
+            control={control}
+            name="test"
+            defaultValue="luo"
+          />
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    const input = screen.getByRole('textbox');
+
+    expect(input).toHaveValue('Bill');
+    expect(screen.getByText('Form dirty: false')).toBeVisible();
+
+    fireEvent.change(input, { target: { value: 'luo' } });
+
+    expect(screen.getByText('Form dirty: true')).toBeVisible();
+
+    fireEvent.change(input, { target: { value: 'Bill' } });
+
+    expect(screen.getByText('Form dirty: false')).toBeVisible();
+  });
+
   it('should be able to update input value without ref', () => {
     const App = () => {
       const { control, setValue } = useForm();

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import getEventValue from './logic/getEventValue';
 import isNameInFieldArray from './logic/isNameInFieldArray';
@@ -17,6 +17,7 @@ import {
 import { useFormContext } from './useFormContext';
 import { useFormState } from './useFormState';
 import { useWatch } from './useWatch';
+import { set } from './utils';
 
 /**
  * Custom hook to work with controlled component, this function provide you with both form and field level state. Re-render is isolated at the hook level.
@@ -65,6 +66,18 @@ export function useController<
     control,
     name,
   });
+
+  const defaultValueRef = useRef(props.defaultValue);
+
+  useEffect(() => {
+    // Set the defaultValue only if there is no already defined one
+    if (
+      control._defaultValues[name] === undefined &&
+      defaultValueRef.current !== undefined
+    ) {
+      set(control._defaultValues, name, defaultValueRef.current);
+    }
+  }, [control, name]);
 
   const _registerProps = React.useRef(
     control.register(name, {


### PR DESCRIPTION
Hello :)

**Explanation**
Currently, there is a behavior difference:
- if we initialize a field directly in `useForm` with the prop `defaultValues` 
- if we initialize a controlled field in `useController` with the prop `defaultValue`

We can see the difference with the `isDirty` value.
_Initialized with `useForm`_ : https://codesandbox.io/s/rhf-initialized-with-useform-s7cl3y?file=/src/App.js
_Initialized with `useController`_: https://codesandbox.io/s/rhf-initialized-with-useform-forked-ch10pd?file=/src/App.js

In the case of the intialization with `useForm`, if we touch the input the form (field) stays pristine. Unlike when initializing with `useController` which becomes `dirty`.

**Research**
I did some research about this difference, but did not find anything in the documentation, issues, discussions and tests. I don't know if it's something wanted.
Therefore, I propose this PR that unifies the behavior.

**What I did?**
I just initialized the field with `useController` id it has not been initialized with `useForm`. If the user change the `defaultValue` after the first render, I do nothing.
The use of `useRef` is only here to satisfy the eslint `react-hooks/exhaustive-deps` rule.

If you have some questions about my changes let me know :)