### PR TITLE
fix issue #8256

### DIFF
--- a/src/logic/isNameInFieldArray.ts
+++ b/src/logic/isNameInFieldArray.ts
@@ -3,4 +3,4 @@ import { InternalFieldName } from '../types';
 import getNodeParentName from './getNodeParentName';
 
 export default (names: Set<InternalFieldName>, name: InternalFieldName) =>
-  names.has(getNodeParentName(name));
+  names.has(name ? getNodeParentName(name) : name);


### PR DESCRIPTION
Hi @bluebill1049 , firstly I want to apologize that there's some problem for me to share the code snippet to show you the issue I've met, but when I looked at the board I found that issue https://github.com/react-hook-form/react-hook-form/issues/8256 is exactly what I encountered. 

I checked the according PR and found the cause of the issue. Just in terms of javascript, this update has its potential issue:

old:
```js
export default (names: Set<InternalFieldName>, name: InternalFieldName) =>
  [...names].some((current) => getNodeParentName(name) === current);
```
new:
```js
export default (names: Set<InternalFieldName>, name: InternalFieldName) =>
  names.has(getNodeParentName(name));
```

When the `names` is empty and `name` is `undefined`, the old way worked as expected because there's no iteration if the array is empty, so the function `getNodeParentName(name)` will never be called. 
But for the new one, the `getNodeParentName(name)` will always be called, and if it's undefined, it will break the whole thing.

So I added the condition to check if the name is valid, if yes, then we can do next thing, if not, just check if its origin value is in the set.

Please review this PR, let me know if this is correct way to do it, thanks!