### PR TITLE
fix: clone object which have functions

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -74,7 +74,6 @@ describe('setValue', () => {
       0: file,
       1: file,
       length: 2,
-      item: () => file,
     } as any as FileList;
 
     act(() => result.current.setValue('test', fileList));

--- a/src/__tests__/utils/cloneObject.test.ts
+++ b/src/__tests__/utils/cloneObject.test.ts
@@ -82,19 +82,30 @@ describe('clone', () => {
     expect(copy.items).toEqual([2]);
   });
 
-  it('should skip clone if a node contains function', () => {
+  it('should skip clone if a node is instance of Blob', () => {
     function testFunction() {}
 
-    const test = {
-      data: {
+    const data = {
+      test: {
         testFunction,
+        test: 'inner-string',
+        deep: {
+          test: 'deep-string',
+        },
       },
       other: 'string',
     };
 
-    expect(cloneObject(test)).toEqual({
-      data: {
+    const copy = cloneObject(data);
+    data.test.deep.test = 'changed-deep-string';
+
+    expect(copy).toEqual({
+      test: {
         testFunction,
+        test: 'inner-string',
+        deep: {
+          test: 'deep-string',
+        },
       },
       other: 'string',
     });

--- a/src/__tests__/utils/cloneObject.test.ts
+++ b/src/__tests__/utils/cloneObject.test.ts
@@ -101,7 +101,6 @@ describe('clone', () => {
 
     expect(copy).toEqual({
       test: {
-        testFunction,
         test: 'inner-string',
         deep: {
           test: 'deep-string',

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -9,10 +9,6 @@ export default function cloneObject<T>(data: T): T {
     copy = new Date(data);
   } else if (data instanceof Set) {
     copy = new Set(data);
-  } else if (globalThis.Blob && data instanceof Blob) {
-    copy = data;
-  } else if (globalThis.FileList && data instanceof FileList) {
-    copy = data;
   } else if (isArray || isObject(data)) {
     copy = isArray ? [] : {};
     for (const key in data) {

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -9,9 +9,9 @@ export default function cloneObject<T>(data: T): T {
     copy = new Date(data);
   } else if (data instanceof Set) {
     copy = new Set(data);
-  } else if (data instanceof Blob) {
+  } else if (globalThis.Blob && data instanceof Blob) {
     copy = data;
-  } else if (data instanceof FileList) {
+  } else if (globalThis.FileList && data instanceof FileList) {
     copy = data;
   } else if (isArray || isObject(data)) {
     copy = isArray ? [] : {};

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -11,6 +11,8 @@ export default function cloneObject<T>(data: T): T {
     copy = new Set(data);
   } else if (globalThis.Blob && data instanceof Blob) {
     copy = data;
+  } else if (globalThis.FileList && data instanceof FileList) {
+    copy = data;
   } else if (isArray || isObject(data)) {
     copy = isArray ? [] : {};
     for (const key in data) {

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -1,3 +1,4 @@
+import isFunction from './isFunction';
 import isObject from './isObject';
 
 export default function cloneObject<T>(data: T): T {
@@ -13,7 +14,9 @@ export default function cloneObject<T>(data: T): T {
   } else if (isArray || isObject(data)) {
     copy = isArray ? [] : {};
     for (const key in data) {
-      copy[key] = cloneObject(data[key]);
+      if (!isFunction(data[key])) {
+        copy[key] = cloneObject(data[key]);
+      }
     }
   } else {
     return data;

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -1,4 +1,3 @@
-import isFunction from './isFunction';
 import isObject from './isObject';
 
 export default function cloneObject<T>(data: T): T {
@@ -9,13 +8,11 @@ export default function cloneObject<T>(data: T): T {
     copy = new Date(data);
   } else if (data instanceof Set) {
     copy = new Set(data);
+  } else if (globalThis.Blob && data instanceof Blob) {
+    copy = data;
   } else if (isArray || isObject(data)) {
     copy = isArray ? [] : {};
     for (const key in data) {
-      if (isFunction(data[key])) {
-        copy = data;
-        break;
-      }
       copy[key] = cloneObject(data[key]);
     }
   } else {

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -9,6 +9,8 @@ export default function cloneObject<T>(data: T): T {
     copy = new Date(data);
   } else if (data instanceof Set) {
     copy = new Set(data);
+  } else if (data instanceof Blob) {
+    copy = data;
   } else if (data instanceof FileList) {
     copy = data;
   } else if (isArray || isObject(data)) {

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -9,6 +9,8 @@ export default function cloneObject<T>(data: T): T {
     copy = new Date(data);
   } else if (data instanceof Set) {
     copy = new Set(data);
+  } else if (data instanceof FileList) {
+    copy = data;
   } else if (isArray || isObject(data)) {
     copy = isArray ? [] : {};
     for (const key in data) {


### PR DESCRIPTION
Above all, I don't think I understand the context of this library properly. **If there is any problem that my code will cause, please let me know**.

I think you decided not to just clone an object that contains a function in order not to create a new File object(maybe..?). But I think it's an error that when a user puts a function in defaultValues, the object itself containing the function is not copied.

So I changed cloneObject like below.

```javascript
let copy: any;
const isArray = Array.isArray(data);

if (data instanceof Date) {
  copy = new Date(data);
} else if (data instanceof Set) {
  copy = new Set(data);
} else if (globalThis.Blob && data instanceof Blob) { // check it is Blob
  copy = data;
} else if (isArray || isObject(data)) {
  copy = isArray ? [] : {};
  for (const key in data) { // dont check data[key] is function or not
    copy[key] = cloneObject(data[key]); // process clone
  }
} else {
  return data;
}

return copy;
```

This code prevent a bug(maybe..) below.

```javascript
function DefaultValues() {
  const defaultValues = {
    testFunction: () => { console.log('this is function'); },
    test: 'test',
    checkbox: ['1', '2'],
    test1: {
      firstName: 'firstName',
      lastName: ['lastName0', 'lastName1'],
      deep: {
        nest: 'nest',
      },
    },
  }
  const { register, handleSubmit, getValues } = useForm<{
    testFunction: () => void;
    test: string;
    test1: {
      firstName: string;
      lastName: string[];
      deep: {
        nest: string;
      };
    };
    checkbox: NestedValue<string[]>;
  }>({
    defaultValues,
  });
  const [show, setShow] = React.useState(true);

  const onSubmit = (data: any) => {
    defaultValues.test = 'another-test-string'; // this change the result of `getValues()`;
    console.log(getValues());
  }

  return (
    <>
      {show ? (
        <form onSubmit={handleSubmit(onSubmit)}>
          <input {...register('test')} />
          <input {...register('test1.firstName')} />
          <input {...register('test1.deep.nest')} />
          <input {...register('test1.deep.nest')} />
          <input {...register('test1.lastName.0')} />
          <input {...register('test1.lastName.1')} />
          <input type="checkbox" value={'1'} {...register('checkbox')} />
          <input type="checkbox" value={'2'} {...register('checkbox')} />
          <button type="submit">SUBMIT</button>
        </form>
      ) : null}
      <button type={'button'} id={'toggle'} onClick={() => setShow(!show)}>
        toggle
      </button>
    </>
  );
}

export default DefaultValues;
```

If we skip clone an object which has a function, the result of `getValues().test` will be `another-test-string`.  

