### PR TITLE
🗑 remove reference for Blob and FileList

### DIFF
--- a/src/__tests__/useForm/getValues.test.tsx
+++ b/src/__tests__/useForm/getValues.test.tsx
@@ -204,7 +204,6 @@ describe('getValues', () => {
             firstName: 'test',
             lastName: 'test',
             time: new Date('1999-09-09'),
-            file: new File([''], 'filename'),
           },
         },
       });
@@ -234,7 +233,6 @@ describe('getValues', () => {
         firstName: 'test',
         lastName: 'test',
         time: new Date('1999-09-09'),
-        file: new File([''], 'filename'),
       },
     });
 

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -63,33 +63,6 @@ describe('setValue', () => {
     });
   });
 
-  it('should set value of file input correctly if value is FileList', async () => {
-    const { result } = renderHook(() => useForm<{ test: FileList }>());
-
-    result.current.register('test');
-
-    const blob = new Blob([''], { type: 'image/png', lastModified: 1 } as any);
-    const file = blob as File;
-    const fileList = {
-      0: file,
-      1: file,
-      length: 2,
-    } as any as FileList;
-
-    act(() => result.current.setValue('test', fileList));
-
-    await act(async () => {
-      await result.current.handleSubmit((data) => {
-        expect(data).toEqual({
-          test: fileList,
-        });
-      })({
-        preventDefault: () => {},
-        persist: () => {},
-      } as React.SyntheticEvent);
-    });
-  });
-
   it('should set value of multiple checkbox input correctly', async () => {
     const { result } = renderHook(() => useForm<{ test: string[] }>());
 

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -9,10 +9,6 @@ export default function cloneObject<T>(data: T): T {
     copy = new Date(data);
   } else if (data instanceof Set) {
     copy = new Set(data);
-  } else if (globalThis.Blob && data instanceof Blob) {
-    copy = data;
-  } else if (globalThis.FileList && data instanceof FileList) {
-    copy = data;
   } else if (isArray || isObject(data)) {
     copy = isArray ? [] : {};
     for (const key in data) {


### PR DESCRIPTION
we don't support blob and filelist as defaultValues, hence remove those unit tests coverage and include clone object method.