### PR TITLE
fix: compare html elements against correct global

### DIFF
--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -4,6 +4,7 @@ import AutoUnregister from './autoUnregister';
 import Basic from './basic';
 import Watch from './watch';
 import BasicSchemaValidation from './basicSchemaValidation';
+import CrossFrameForm from './crossFrameForm';
 import SetError from './setError';
 import SetFocus from './setFocus';
 import SetValue from './setValue';
@@ -51,6 +52,7 @@ const App: React.FC = () => {
           path="/re-validate-mode/:mode/:reValidateMode"
           element={<ReValidateMode />}
         />
+        <Route path="/crossFrameForm" element={<CrossFrameForm />} />
         <Route path="/manual-register-form" element={<ManualRegisterForm />} />
         <Route path="/watch" element={<Watch />} />
         <Route

--- a/app/src/crossFrameForm.tsx
+++ b/app/src/crossFrameForm.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {useForm} from 'react-hook-form';
+
+const FRAME_CONTENT = `
+  <style>
+    label {display: block; margin-bottom: .5em}
+    form {margin-bottom: 2em}
+    input {margin: 0 1em}
+  </style>
+
+  <div id='inner-root'>
+    Loading content...
+  </div>
+`;
+
+const FRAME_STYLE = {
+  width: '640px',
+  height: '480px',
+  background: 'white',
+};
+
+const CrossFrameForm: React.FC = () => {
+  const ref = React.useRef<HTMLIFrameElement>(null);
+
+  function renderFormInFrame() {
+    ReactDOM.render(<FrameForm/>, ref.current!.contentDocument!.getElementById('inner-root'));
+  }
+
+  return (
+    <iframe
+      ref={ref}
+      style={FRAME_STYLE}
+      srcDoc={FRAME_CONTENT}
+      onLoad={renderFormInFrame}
+    />
+  );
+};
+
+const FrameForm: React.FC = () => {
+  const {
+    register,
+    watch,
+  } = useForm();
+
+  const value = watch();
+
+  return <>
+    <form>
+      <label>
+        Free text
+        <input type="text" {...register('input', {required: true})}/>
+      </label>
+
+      <label>
+        <input type="radio" value="a" {...register('radio', {required: true})}/>
+        Choice A
+      </label>
+
+      <label>
+        <input type="radio" value="b" {...register('radio', {required: true})}/>
+        Choice B
+      </label>
+    </form>
+
+    <label>
+      Form value
+      <pre>{JSON.stringify(value)}</pre>
+    </label>
+  </>;
+}
+
+export default CrossFrameForm;

--- a/cypress/integration/crossFrameRendering.ts
+++ b/cypress/integration/crossFrameRendering.ts
@@ -1,0 +1,21 @@
+function getIframe() {
+  return cy
+    .get('iframe')
+    .its('0.contentDocument')
+    .should('exist')
+    .its('body')
+    .should('not.be.undefined')
+    .then(cy.wrap);
+}
+
+describe('Cross-Frame rendering', () => {
+  it('should work correctly when rendering inside frames', () => {
+    cy.visit('http://localhost:3000/crossFrameForm');
+    getIframe().find('input[type="text"]').type('test');
+    getIframe().find('input[type="radio"][value="a"]').click();
+    getIframe().find('input[type="radio"][value="b"]').click();
+    getIframe()
+      .find('pre')
+      .should('contain.text', '{"input":"test","radio":"b"}');
+  });
+});

--- a/src/__tests__/utils/isHTMLElement.test.ts
+++ b/src/__tests__/utils/isHTMLElement.test.ts
@@ -4,4 +4,14 @@ describe('isHTMLElement', () => {
   it('should return true when value is HTMLElement', () => {
     expect(isHTMLElement(document.createElement('input'))).toBeTruthy();
   });
+
+  it('should return true when HTMLElement is inside an iframe', () => {
+    const iframe = document.createElement('iframe');
+    document.body.append(iframe);
+
+    const iframeDocument = iframe.contentDocument!;
+    const input = iframeDocument.createElement('input');
+    iframeDocument.body.append(input);
+    expect(isHTMLElement(input)).toBeTruthy();
+  });
 });

--- a/src/utils/isHTMLElement.ts
+++ b/src/utils/isHTMLElement.ts
@@ -1,2 +1,6 @@
-export default (value: unknown): value is HTMLElement =>
-  value instanceof HTMLElement;
+export default (value: unknown): value is HTMLElement => {
+  const ElementClass =
+    (value as HTMLElement)?.ownerDocument?.defaultView?.HTMLElement ??
+    HTMLElement;
+  return value instanceof ElementClass;
+};

--- a/src/utils/isHTMLElement.ts
+++ b/src/utils/isHTMLElement.ts
@@ -1,6 +1,7 @@
 export default (value: unknown): value is HTMLElement => {
-  const ElementClass =
-    (value as HTMLElement)?.ownerDocument?.defaultView?.HTMLElement ??
-    HTMLElement;
+  const owner = (value as HTMLElement).ownerDocument;
+  const ElementClass = owner.defaultView
+    ? owner.defaultView.HTMLElement
+    : HTMLElement;
   return value instanceof ElementClass;
 };

--- a/src/utils/isHTMLElement.ts
+++ b/src/utils/isHTMLElement.ts
@@ -1,7 +1,6 @@
 export default (value: unknown): value is HTMLElement => {
   const owner = value ? ((value as HTMLElement).ownerDocument as Document) : 0;
-  const ElementClass = owner && owner.defaultView
-    ? owner.defaultView.HTMLElement
-    : HTMLElement;
+  const ElementClass =
+    owner && owner.defaultView ? owner.defaultView.HTMLElement : HTMLElement;
   return value instanceof ElementClass;
 };

--- a/src/utils/isHTMLElement.ts
+++ b/src/utils/isHTMLElement.ts
@@ -1,6 +1,6 @@
 export default (value: unknown): value is HTMLElement => {
-  const owner = (value as HTMLElement).ownerDocument;
-  const ElementClass = owner.defaultView
+  const owner = value ? ((value as HTMLElement).ownerDocument as Document) : 0;
+  const ElementClass = owner && owner.defaultView
     ? owner.defaultView.HTMLElement
     : HTMLElement;
   return value instanceof ElementClass;


### PR DESCRIPTION
When checking whether a value is an instance of HTMLElement,
the reference class must be owned by the same window which
owns the value, or the comparison will fail.