### PR TITLE
fix(reset): set isSubmitted to formState value if keepIsSubmitted is true

### DIFF
--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -1361,4 +1361,31 @@ describe('reset', () => {
       (screen.getAllByRole('textbox')[2] as HTMLInputElement).value,
     ).toEqual('3');
   });
+
+  it('should keep isSubmitted value when keepIsSubmitted is true', async () => {
+    const { result } = renderHook(() => useForm<{ test: string }>());
+
+    expect(result.current.formState.isSubmitted).toBeFalsy();
+
+    await act(() => result.current.reset(undefined, { keepIsSubmitted: true }));
+    expect(result.current.formState.isSubmitted).toBeFalsy();
+
+    result.current.register('test');
+    result.current.setValue('test', 'data');
+
+    await act(async () => {
+      await result.current.handleSubmit((data) => {
+        expect(data).toEqual({
+          test: 'data',
+        });
+      })({
+        preventDefault: () => {},
+        persist: () => {},
+      } as React.SyntheticEvent);
+    });
+
+    expect(result.current.formState.isSubmitted).toBeTruthy();
+    await act(() => result.current.reset(undefined, { keepIsSubmitted: true }));
+    expect(result.current.formState.isSubmitted).toBeTruthy();
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1186,7 +1186,9 @@ export function createFormControl<
               keepStateOptions.keepDefaultValues &&
               !deepEqual(formValues, _defaultValues)
             ),
-      isSubmitted: !!keepStateOptions.keepIsSubmitted,
+      isSubmitted: keepStateOptions.keepIsSubmitted
+        ? _formState.isSubmitted
+        : false,
       dirtyFields:
         keepStateOptions.keepDirty || keepStateOptions.keepDirtyValues
           ? _formState.dirtyFields

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1186,9 +1186,7 @@ export function createFormControl<
               keepStateOptions.keepDefaultValues &&
               !deepEqual(formValues, _defaultValues)
             ),
-      isSubmitted: keepStateOptions.keepIsSubmitted
-        ? _formState.isSubmitted
-        : false,
+      isSubmitted: keepStateOptions.keepIsSubmitted && _formState.isSubmitted,
       dirtyFields:
         keepStateOptions.keepDirty || keepStateOptions.keepDirtyValues
           ? _formState.dirtyFields

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1186,7 +1186,9 @@ export function createFormControl<
               keepStateOptions.keepDefaultValues &&
               !deepEqual(formValues, _defaultValues)
             ),
-      isSubmitted: keepStateOptions.keepIsSubmitted && _formState.isSubmitted,
+      isSubmitted: keepStateOptions.keepIsSubmitted
+        ? _formState.isSubmitted
+        : false,
       dirtyFields:
         keepStateOptions.keepDirty || keepStateOptions.keepDirtyValues
           ? _formState.dirtyFields


### PR DESCRIPTION
https://github.com/react-hook-form/react-hook-form/pull/8237 introduced a bug where `isSubmitted` would be set to the value of `keepIsSubmitted` (not the `isSubmitted` value that was in form state).