### PR TITLE
🧑‍💻 Support TypeScript 4.7+ ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "./package.json": "./package.json",
     ".": {
       "import": "./dist/index.esm.mjs",
-      "require": "./dist/index.cjs.js"
+      "require": "./dist/index.cjs.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Addresses https://github.com/react-hook-form/react-hook-form/issues/8388

The next version of TypeScript supports the `exports` field, causing the currently-specified `types` field to be hidden. This PR adds the types path to the `exports` map, allowing TypeScript 4.7 to find it successfully.