### PR TITLE
feat: make UseFormRegisterReturn generic over TFieldName

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -574,14 +574,14 @@ export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContex
 }>;
 
 // @public
-export type UseFormRegister<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(name: TFieldName, options?: RegisterOptions<TFieldValues, TFieldName>) => UseFormRegisterReturn;
+export type UseFormRegister<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(name: TFieldName, options?: RegisterOptions<TFieldValues, TFieldName>) => UseFormRegisterReturn<TFieldName>;
 
 // @public (undocumented)
-export type UseFormRegisterReturn = {
+export type UseFormRegisterReturn<TFieldName extends InternalFieldName = InternalFieldName> = {
     onChange: ChangeHandler;
     onBlur: ChangeHandler;
     ref: RefCallBack;
-    name: InternalFieldName;
+    name: TFieldName;
     min?: string | number;
     max?: string | number;
     maxLength?: number;
@@ -741,7 +741,7 @@ export type WatchObserver<TFieldValues> = (value: UnpackNestedValue<DeepPartial<
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:410:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:412:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -141,11 +141,13 @@ export type SetFieldValue<TFieldValues> = FieldValue<TFieldValues>;
 
 export type RefCallBack = (instance: any) => void;
 
-export type UseFormRegisterReturn = {
+export type UseFormRegisterReturn<
+  TFieldName extends InternalFieldName = InternalFieldName,
+> = {
   onChange: ChangeHandler;
   onBlur: ChangeHandler;
   ref: RefCallBack;
-  name: InternalFieldName;
+  name: TFieldName;
   min?: string | number;
   max?: string | number;
   maxLength?: number;
@@ -193,7 +195,7 @@ export type UseFormRegister<TFieldValues extends FieldValues> = <
 >(
   name: TFieldName,
   options?: RegisterOptions<TFieldValues, TFieldName>,
-) => UseFormRegisterReturn;
+) => UseFormRegisterReturn<TFieldName>;
 
 export type SetFocusOptions = Partial<{
   shouldSelect: boolean;


### PR DESCRIPTION
Improve the type for `UseFormRegisterReturn.name`