### PR TITLE
Funnel along appropriate constraints for (upcoming) TypeScript 4.8

### DIFF
--- a/app/src/crossFrameForm.tsx
+++ b/app/src/crossFrameForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {useForm} from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 
 const FRAME_CONTENT = `
   <style>
@@ -24,7 +24,10 @@ const CrossFrameForm: React.FC = () => {
   const ref = React.useRef<HTMLIFrameElement>(null);
 
   function renderFormInFrame() {
-    ReactDOM.render(<FrameForm/>, ref.current!.contentDocument!.getElementById('inner-root'));
+    ReactDOM.render(
+      <FrameForm />,
+      ref.current!.contentDocument!.getElementById('inner-root'),
+    );
   }
 
   return (
@@ -38,36 +41,43 @@ const CrossFrameForm: React.FC = () => {
 };
 
 const FrameForm: React.FC = () => {
-  const {
-    register,
-    watch,
-  } = useForm();
+  const { register, watch } = useForm();
 
   const value = watch();
 
-  return <>
-    <form>
-      <label>
-        Free text
-        <input type="text" {...register('input', {required: true})}/>
-      </label>
+  return (
+    <>
+      <form>
+        <label>
+          Free text
+          <input type="text" {...register('input', { required: true })} />
+        </label>
+
+        <label>
+          <input
+            type="radio"
+            value="a"
+            {...register('radio', { required: true })}
+          />
+          Choice A
+        </label>
+
+        <label>
+          <input
+            type="radio"
+            value="b"
+            {...register('radio', { required: true })}
+          />
+          Choice B
+        </label>
+      </form>
 
       <label>
-        <input type="radio" value="a" {...register('radio', {required: true})}/>
-        Choice A
+        Form value
+        <pre>{JSON.stringify(value)}</pre>
       </label>
-
-      <label>
-        <input type="radio" value="b" {...register('radio', {required: true})}/>
-        Choice B
-      </label>
-    </form>
-
-    <label>
-      Form value
-      <pre>{JSON.stringify(value)}</pre>
-    </label>
-  </>;
-}
+    </>
+  );
+};
 
 export default CrossFrameForm;

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -26,7 +26,7 @@ export type ArrayPath<T> = T extends ReadonlyArray<infer V> ? IsTuple<T> extends
 }[keyof T];
 
 // @public (undocumented)
-export type BatchFieldArrayUpdate = <T extends Function, TFieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>>(name: InternalFieldName, updatedFieldArrayValues?: Partial<FieldArray<TFieldValues, TFieldArrayName>>[], method?: T, args?: Partial<{
+export type BatchFieldArrayUpdate = <T extends Function, TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>>(name: InternalFieldName, updatedFieldArrayValues?: Partial<FieldArray<TFieldValues, TFieldArrayName>>[], method?: T, args?: Partial<{
     argA: unknown;
     argB: unknown;
 }>, shouldSetValue?: boolean, shouldUpdateFieldsAndErrors?: boolean) => void;
@@ -229,7 +229,7 @@ export type FormProviderProps<TFieldValues extends FieldValues = FieldValues, TC
 } & UseFormReturn<TFieldValues, TContext>;
 
 // @public (undocumented)
-export type FormState<TFieldValues> = {
+export type FormState<TFieldValues extends FieldValues> = {
     isDirty: boolean;
     dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
     isSubmitted: boolean;
@@ -255,7 +255,7 @@ export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
 // Warning: (ae-forgotten-export) The symbol "Subject" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type FormStateSubjectRef<TFieldValues> = Subject<Partial<FormState<TFieldValues>> & {
+export type FormStateSubjectRef<TFieldValues extends FieldValues> = Subject<Partial<FormState<TFieldValues>> & {
     name?: InternalFieldName;
 }>;
 
@@ -397,7 +397,7 @@ export type ResolverError<TFieldValues extends FieldValues = FieldValues> = {
 };
 
 // @public (undocumented)
-export interface ResolverOptions<TFieldValues> {
+export interface ResolverOptions<TFieldValues extends FieldValues> {
     // (undocumented)
     criteriaMode?: CriteriaMode;
     // (undocumented)
@@ -421,7 +421,7 @@ export type ResolverSuccess<TFieldValues extends FieldValues = FieldValues> = {
 export function set(object: FieldValues, path: string, value?: unknown): FieldValues;
 
 // @public (undocumented)
-export type SetFieldValue<TFieldValues> = FieldValue<TFieldValues>;
+export type SetFieldValue<TFieldValues extends FieldValues> = FieldValue<TFieldValues>;
 
 // @public (undocumented)
 export type SetFocusOptions = Partial<{
@@ -488,16 +488,16 @@ export type UseControllerReturn<TFieldValues extends FieldValues = FieldValues, 
 export function useFieldArray<TFieldValues extends FieldValues = FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>, TKeyName extends string = 'id'>(props: UseFieldArrayProps<TFieldValues, TFieldArrayName, TKeyName>): UseFieldArrayReturn<TFieldValues, TFieldArrayName, TKeyName>;
 
 // @public
-export type UseFieldArrayAppend<TFieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>> | Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>>[], options?: FieldArrayMethodProps) => void;
+export type UseFieldArrayAppend<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>> | Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>>[], options?: FieldArrayMethodProps) => void;
 
 // @public
-export type UseFieldArrayInsert<TFieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (index: number, value: Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>> | Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>>[], options?: FieldArrayMethodProps) => void;
+export type UseFieldArrayInsert<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (index: number, value: Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>> | Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>>[], options?: FieldArrayMethodProps) => void;
 
 // @public
 export type UseFieldArrayMove = (indexA: number, indexB: number) => void;
 
 // @public
-export type UseFieldArrayPrepend<TFieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>> | Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>>[], options?: FieldArrayMethodProps) => void;
+export type UseFieldArrayPrepend<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>> | Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>>[], options?: FieldArrayMethodProps) => void;
 
 // @public (undocumented)
 export type UseFieldArrayProps<TFieldValues extends FieldValues = FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>, TKeyName extends string = 'id'> = {
@@ -511,7 +511,7 @@ export type UseFieldArrayProps<TFieldValues extends FieldValues = FieldValues, T
 export type UseFieldArrayRemove = (index?: number | number[]) => void;
 
 // @public
-export type UseFieldArrayReplace<TFieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>> | Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>>[]) => void;
+export type UseFieldArrayReplace<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>> | Partial<UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>>[]) => void;
 
 // @public (undocumented)
 export type UseFieldArrayReturn<TFieldValues extends FieldValues = FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>, TKeyName extends string = 'id'> = {
@@ -530,7 +530,7 @@ export type UseFieldArrayReturn<TFieldValues extends FieldValues = FieldValues, 
 export type UseFieldArraySwap = (indexA: number, indexB: number) => void;
 
 // @public
-export type UseFieldArrayUpdate<TFieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (index: number, value: UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>) => void;
+export type UseFieldArrayUpdate<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (index: number, value: UnpackNestedValue<FieldArray<TFieldValues, TFieldArrayName>>) => void;
 
 // @public
 export function useForm<TFieldValues extends FieldValues = FieldValues, TContext = any>(props?: UseFormProps<TFieldValues, TContext>): UseFormReturn<TFieldValues, TContext>;
@@ -636,7 +636,7 @@ export type UseFormSetValue<TFieldValues extends FieldValues> = <TFieldName exte
 export function useFormState<TFieldValues extends FieldValues = FieldValues>(props?: UseFormStateProps<TFieldValues>): UseFormStateReturn<TFieldValues>;
 
 // @public (undocumented)
-export type UseFormStateProps<TFieldValues> = Partial<{
+export type UseFormStateProps<TFieldValues extends FieldValues> = Partial<{
     control?: Control<TFieldValues>;
     disabled?: boolean;
     name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[];
@@ -644,7 +644,7 @@ export type UseFormStateProps<TFieldValues> = Partial<{
 }>;
 
 // @public (undocumented)
-export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
+export type UseFormStateReturn<TFieldValues extends FieldValues> = FormState<TFieldValues>;
 
 // @public
 export type UseFormTrigger<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[], options?: TriggerConfig) => Promise<boolean>;
@@ -733,7 +733,7 @@ export type ValidationValueMessage<TValidationValue extends ValidationValue = Va
 export type WatchInternal<TFieldValues> = (fieldNames?: InternalFieldName | InternalFieldName[], defaultValue?: UnpackNestedValue<DeepPartial<TFieldValues>>, isMounted?: boolean, isGlobal?: boolean) => FieldPathValue<FieldValues, InternalFieldName> | FieldPathValues<FieldValues, InternalFieldName[]>;
 
 // @public (undocumented)
-export type WatchObserver<TFieldValues> = (value: UnpackNestedValue<DeepPartial<TFieldValues>>, info: {
+export type WatchObserver<TFieldValues extends FieldValues> = (value: UnpackNestedValue<DeepPartial<TFieldValues>>, info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;
     value?: unknown;
@@ -741,7 +741,7 @@ export type WatchObserver<TFieldValues> = (value: UnpackNestedValue<DeepPartial<
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:412:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:413:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -8,13 +8,13 @@ import {
 } from '@testing-library/react';
 
 import { Controller } from '../controller';
-import { ControllerRenderProps, NestedValue } from '../types';
+import { ControllerRenderProps, FieldValues, NestedValue } from '../types';
 import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 import { FormProvider } from '../useFormContext';
 import { useWatch } from '../useWatch';
 
-function Input<TFieldValues>({
+function Input<TFieldValues extends FieldValues>({
   onChange,
   onBlur,
   placeholder,

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { Controller } from '../controller';
-import { Control, FieldPath } from '../types';
+import { Control, FieldPath, FieldValues } from '../types';
 import { useController } from '../useController';
 import { useForm } from '../useForm';
 import { FormProvider, useFormContext } from '../useFormContext';
@@ -554,7 +554,7 @@ describe('useController', () => {
   it('should remount with input with current formValue', () => {
     let data: unknown;
 
-    function Input<T>({
+    function Input<T extends FieldValues>({
       control,
       name,
     }: {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -584,7 +584,7 @@ export function createFormControl<
   const setValues = <
     T extends InternalFieldName,
     K extends SetFieldValue<TFieldValues>,
-    U,
+    U extends SetValueConfig,
   >(
     name: T,
     value: K,

--- a/src/logic/getProxyFormState.ts
+++ b/src/logic/getProxyFormState.ts
@@ -1,7 +1,7 @@
 import { VALIDATION_MODE } from '../constants';
-import { FormState, ReadFormState } from '../types';
+import { FieldValues, FormState, ReadFormState } from '../types';
 
-export default <TFieldValues>(
+export default <TFieldValues extends FieldValues>(
   formState: FormState<TFieldValues>,
   _proxyFormState: ReadFormState,
   localProxyFormState?: ReadFormState,

--- a/src/logic/getResolverOptions.ts
+++ b/src/logic/getResolverOptions.ts
@@ -3,12 +3,13 @@ import {
   Field,
   FieldName,
   FieldRefs,
+  FieldValues,
   InternalFieldName,
 } from '../types';
 import { get } from '../utils';
 import set from '../utils/set';
 
-export default <TFieldValues>(
+export default <TFieldValues extends FieldValues>(
   fieldsNames: Set<InternalFieldName> | InternalFieldName[],
   _fields: FieldRefs,
   criteriaMode?: CriteriaMode,

--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -95,7 +95,7 @@ export type UseFieldArrayMove = (indexA: number, indexB: number) => void;
  * ```
  */
 export type UseFieldArrayPrepend<
-  TFieldValues,
+  TFieldValues extends FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = (
   value:
@@ -126,7 +126,7 @@ export type UseFieldArrayPrepend<
  * ```
  */
 export type UseFieldArrayAppend<
-  TFieldValues,
+  TFieldValues extends FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = (
   value:
@@ -179,7 +179,7 @@ export type UseFieldArrayRemove = (index?: number | number[]) => void;
  * ```
  */
 export type UseFieldArrayInsert<
-  TFieldValues,
+  TFieldValues extends FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = (
   index: number,
@@ -210,7 +210,7 @@ export type UseFieldArrayInsert<
  * ```
  */
 export type UseFieldArrayUpdate<
-  TFieldValues,
+  TFieldValues extends FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = (
   index: number,
@@ -236,7 +236,7 @@ export type UseFieldArrayUpdate<
  * ```
  */
 export type UseFieldArrayReplace<
-  TFieldValues,
+  TFieldValues extends FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = (
   value:

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -137,7 +137,8 @@ export type KeepStateOptions = Partial<{
   keepSubmitCount: boolean;
 }>;
 
-export type SetFieldValue<TFieldValues extends FieldValues> = FieldValue<TFieldValues>;
+export type SetFieldValue<TFieldValues extends FieldValues> =
+  FieldValue<TFieldValues>;
 
 export type RefCallBack = (instance: any) => void;
 
@@ -791,7 +792,8 @@ export type UseFormStateProps<TFieldValues extends FieldValues> = Partial<{
   exact?: boolean;
 }>;
 
-export type UseFormStateReturn<TFieldValues extends FieldValues> = FormState<TFieldValues>;
+export type UseFormStateReturn<TFieldValues extends FieldValues> =
+  FormState<TFieldValues>;
 
 export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
   defaultValue?: unknown;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -112,7 +112,7 @@ export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
 
 export type ReadFormState = { [K in keyof FormStateProxy]: boolean | 'all' };
 
-export type FormState<TFieldValues> = {
+export type FormState<TFieldValues extends FieldValues> = {
   isDirty: boolean;
   dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
   isSubmitted: boolean;
@@ -137,7 +137,7 @@ export type KeepStateOptions = Partial<{
   keepSubmitCount: boolean;
 }>;
 
-export type SetFieldValue<TFieldValues> = FieldValue<TFieldValues>;
+export type SetFieldValue<TFieldValues extends FieldValues> = FieldValue<TFieldValues>;
 
 export type RefCallBack = (instance: any) => void;
 
@@ -674,7 +674,7 @@ export type GetIsDirty = <TName extends InternalFieldName, TData>(
   data?: TData,
 ) => boolean;
 
-export type FormStateSubjectRef<TFieldValues> = Subject<
+export type FormStateSubjectRef<TFieldValues extends FieldValues> = Subject<
   Partial<FormState<TFieldValues>> & { name?: InternalFieldName }
 >;
 
@@ -702,7 +702,7 @@ export type Names = {
 
 export type BatchFieldArrayUpdate = <
   T extends Function,
-  TFieldValues,
+  TFieldValues extends FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 >(
   name: InternalFieldName,
@@ -751,7 +751,7 @@ export type Control<
   getFieldState: UseFormGetFieldState<TFieldValues>;
 };
 
-export type WatchObserver<TFieldValues> = (
+export type WatchObserver<TFieldValues extends FieldValues> = (
   value: UnpackNestedValue<DeepPartial<TFieldValues>>,
   info: {
     name?: FieldPath<TFieldValues>;
@@ -781,7 +781,7 @@ export type UseFormReturn<
   setFocus: UseFormSetFocus<TFieldValues>;
 };
 
-export type UseFormStateProps<TFieldValues> = Partial<{
+export type UseFormStateProps<TFieldValues extends FieldValues> = Partial<{
   control?: Control<TFieldValues>;
   disabled?: boolean;
   name?:
@@ -791,7 +791,7 @@ export type UseFormStateProps<TFieldValues> = Partial<{
   exact?: boolean;
 }>;
 
-export type UseFormStateReturn<TFieldValues> = FormState<TFieldValues>;
+export type UseFormStateReturn<TFieldValues extends FieldValues> = FormState<TFieldValues>;
 
 export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
   defaultValue?: unknown;

--- a/src/types/resolvers.ts
+++ b/src/types/resolvers.ts
@@ -16,7 +16,7 @@ export type ResolverResult<TFieldValues extends FieldValues = FieldValues> =
   | ResolverSuccess<TFieldValues>
   | ResolverError<TFieldValues>;
 
-export interface ResolverOptions<TFieldValues> {
+export interface ResolverOptions<TFieldValues extends FieldValues> {
   criteriaMode?: CriteriaMode;
   fields: Record<InternalFieldName, Field['_f']>;
   names?: FieldName<TFieldValues>[];

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -144,7 +144,9 @@ export function useWatch<
  * })
  * ```
  */
-export function useWatch<TFieldValues extends FieldValues>(props?: UseWatchProps<TFieldValues>) {
+export function useWatch<TFieldValues extends FieldValues>(
+  props?: UseWatchProps<TFieldValues>,
+) {
   const methods = useFormContext();
   const {
     control = methods.control,

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -144,7 +144,7 @@ export function useWatch<
  * })
  * ```
  */
-export function useWatch<TFieldValues>(props?: UseWatchProps<TFieldValues>) {
+export function useWatch<TFieldValues extends FieldValues>(props?: UseWatchProps<TFieldValues>) {
   const methods = useFormContext();
   const {
     control = methods.control,


### PR DESCRIPTION
Hi there! 👋

TypeScript recently added some stricter checking around

* unconstrained generics being incompatible with emptyish object types.
* narrowing on generic values

The changes are only in nightly versions of TypeScript right now, but we've been exploring how open-source projects have been impacted [here](https://github.com/microsoft/TypeScript/issues/49461). 

These are some of the changes necessary for react-hook-form to build cleanly, though there are two left that require manual intervention from a maintainer.

```
src/logic/getFieldValueAs.ts:14:10 - error TS2533: Object is possibly 'null' or 'undefined'.

14       : +value
            ~~~~~

src/logic/validateField.ts:121:53 - error TS2533: Object is possibly 'null' or 'undefined'.

121         (ref as HTMLInputElement).valueAsNumber || +inputValue;
                                                        ~~~~~~~~~~


Found 2 errors in 2 files.

Errors  Files
     1  src/logic/getFieldValueAs.ts:14
     1  src/logic/validateField.ts:121
```

These seem like legitimate errors, and would have been caught if `value` and `inputValue` were not declared as generics. In fact, I don't think they need to be declared as generics.