### PR TITLE
🔍 fix issues with` null` or `undefined` cases caught by TS ^4.8

### DIFF
--- a/src/logic/getFieldValueAs.ts
+++ b/src/logic/getFieldValueAs.ts
@@ -1,4 +1,5 @@
 import { Field, NativeFieldValue } from '../types';
+import isNullOrUndefined from '../utils/isNullOrUndefined';
 import isString from '../utils/isString';
 import isUndefined from '../utils/isUndefined';
 
@@ -9,7 +10,7 @@ export default <T extends NativeFieldValue>(
   isUndefined(value)
     ? value
     : valueAsNumber
-    ? value === ''
+    ? value === '' || isNullOrUndefined(value)
       ? NaN
       : +value
     : valueAsDate && isString(value)

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -116,7 +116,7 @@ export default async <T extends NativeFieldValue>(
     const maxOutput = getValueAndMessage(max);
     const minOutput = getValueAndMessage(min);
 
-    if (!isNaN(inputValue as number)) {
+    if (!isNullOrUndefined(inputValue) && !isNaN(inputValue as number)) {
       const valueNumber =
         (ref as HTMLInputElement).valueAsNumber || +inputValue;
       if (!isNullOrUndefined(maxOutput.value)) {


### PR DESCRIPTION
related to #8484

```
src/logic/getFieldValueAs.ts:14:10 - error TS2533: Object is possibly 'null' or 'undefined'.

14       : +value
            ~~~~~

src/logic/validateField.ts:121:53 - error TS2533: Object is possibly 'null' or 'undefined'.

121         (ref as HTMLInputElement).valueAsNumber || +inputValue;
                                                        ~~~~~~~~~~


Found 2 errors in 2 files.

Errors  Files
     1  src/logic/getFieldValueAs.ts:14
     1  src/logic/validateField.ts:121
```