### PR TITLE
Ensure field is focused when selected

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -665,7 +665,6 @@ describe('useController', () => {
       });
 
       React.useEffect(() => {
-        setFocus('test');
         setFocus('test', { shouldSelect: true });
       }, [setFocus]);
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1204,7 +1204,8 @@ export function createFormControl<
   const setFocus: UseFormSetFocus<TFieldValues> = (name, options = {}) => {
     const field = get(_fields, name)._f;
     const fieldRef = field.refs ? field.refs[0] : field.ref;
-    options.shouldSelect ? fieldRef.select() : fieldRef.focus();
+    fieldRef.focus();
+    options.shouldSelect && fieldRef.select();
   };
 
   return {


### PR DESCRIPTION
As [noted by MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select#notes), calling `element.select()` doesn’t necessarily focus the element. As such, they recommend calling `element.focus()` too.

I believe the expectation when calling `setFocus(name, { shouldSelect: true })` is that the field would be both selected _and_ focused.