### PR TITLE
add react v16 and 17 job to unit test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,37 @@ name: Unit Test / Lint
 on: [pull_request]
 
 jobs:
-  build:
+  react-16-17:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        react-version: [^16.8.0, ^17]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Install deps and build (with cache)
+        uses: bahmutov/npm-install@v1
+
+      - name: Install React v${{ matrix.react-version }}
+        run: |
+          yarn add --dev \
+            react@${{ matrix.react-version }} \
+            react-dom@${{ matrix.react-version }} \
+            react-test-renderer@${{ matrix.react-version }} \
+            @testing-library/react@12
+
+      - name: Lint
+        run: |
+          yarn lint
+          yarn type
+
+      - name: Test
+        run: |
+          yarn test --ci
+          yarn tsd
+  react-18:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Since RHF continues to support React ^16.8.0 and 17, it is better to test with them.
Cypress should be tested as well, but should be considered due to its long execution time.