### PR TITLE
Fix FieldErrors not distributing over union types. Fixes #8584

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -191,9 +191,11 @@ export type FieldError = {
     message?: Message;
 };
 
+// Warning: (ae-forgotten-export) The symbol "FieldErrorsRecursiveStep" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export type FieldErrors<T extends FieldValues = FieldValues> = {
-    [K in keyof T]?: T[K] extends object ? Merge<FieldError, FieldErrors<T[K]>> : FieldError;
+    [K in keyof T]?: FieldErrorsRecursiveStep<T[K]>;
 };
 
 // @public (undocumented)

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,3 +1,4 @@
+import { UnionToIntersection } from './path/common';
 import { FieldValues, InternalFieldName, Ref } from './fields';
 import { LiteralUnion, Merge } from './utils';
 import { RegisterOptions, ValidateResult } from './validator';
@@ -23,10 +24,12 @@ export type ErrorOption = {
   types?: MultipleFieldErrors;
 };
 
+type FieldErrorsRecursiveStep<T> = UnionToIntersection<
+  T extends object ? Merge<FieldError, FieldErrors<T>> : FieldError
+>;
+
 export type FieldErrors<T extends FieldValues = FieldValues> = {
-  [K in keyof T]?: T[K] extends object
-    ? Merge<FieldError, FieldErrors<T[K]>>
-    : FieldError;
+  [K in keyof T]?: FieldErrorsRecursiveStep<T[K]>;
 };
 
 export type InternalFieldErrors = Partial<


### PR DESCRIPTION
The conditional type check in `FieldErrors` didn't distribute over `T[K]` as it is not a bare generic. That resulted in the type evaluating to just `FieldError` for properties which were unions.

I moved that check into its own helper type to have a bare generic to distribute over. `UnionToIntersection` is required to merge the resulting union into a type which has all the properties of its constituants.