### PR TITLE
:poop: close #8624 add chrome devtools extension support

### DIFF
--- a/src/types/extensionMessage.ts
+++ b/src/types/extensionMessage.ts
@@ -1,0 +1,37 @@
+export type UpdatePayload<
+  TFieldValues extends Record<string, any> = Record<string, any>,
+> = {
+  id: string;
+  data: {
+    formValues: TFieldValues;
+    formState: {
+      errors: Record<keyof TFieldValues, { type?: string; message?: string }>;
+      dirtyFields: Record<keyof TFieldValues, boolean>;
+      touchedFields: Record<keyof TFieldValues, boolean>;
+      submitCount: number;
+      isSubmitted: boolean;
+      isSubmitting: boolean;
+      isSubmitSuccessful: boolean;
+      isValid: boolean;
+      isValidating: boolean;
+      isDirty: boolean;
+    };
+  };
+};
+
+type InitMessageData = {
+  source: string;
+  type: 'INIT' | 'WELCOME';
+};
+
+type UpdateMessageData<
+  TFieldValues extends Record<string, any> = Record<string, any>,
+> = {
+  source: string;
+  type: 'UPDATE';
+  payload: UpdatePayload<TFieldValues>;
+};
+
+export type MessageData<
+  TFieldValues extends Record<string, any> = Record<string, any>,
+> = InitMessageData | UpdateMessageData<TFieldValues>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -98,6 +98,7 @@ export type UseFormProps<
   shouldUseNativeValidation: boolean;
   criteriaMode: CriteriaMode;
   delayError: number;
+  debug: boolean;
 }>;
 
 export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<


### PR DESCRIPTION
@bluebill1049 
- [ ] `{ debug: boolean }` prop
- [ ] generate id must be outside `useForm` ( idk why but if you make it inside, it will generate another id after you submit )
- [ ] Some code needs to be optimized
- [ ] `native` or `custom`

close #8624