### PR TITLE
close #8619 return errors as any if generic is not provided

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -197,7 +197,7 @@ export type FieldError = {
 };
 
 // @public (undocumented)
-export type FieldErrors<T extends FieldValues = FieldValues> = FieldErrorsImpl<DeepRequired<T>>;
+export type FieldErrors<T extends FieldValues = FieldValues> = IsAny<T> extends true ? T : FieldErrorsImpl<DeepRequired<T>>;
 
 // @public (undocumented)
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {

--- a/src/__typetest__/errors.test-d.ts
+++ b/src/__typetest__/errors.test-d.ts
@@ -16,4 +16,10 @@ import { _ } from './__fixtures__';
       test1?: FieldError;
     }>(actual);
   }
+
+  /** it should return any if any provided */
+  {
+    const actual = _ as FieldErrors<any>;
+    expectType<any>(actual);
+  }
 }

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -718,7 +718,7 @@ export function createFormControl<
           name,
         );
         const errorLookupResult = schemaErrorLookup(
-          errors,
+          errors as FieldErrors<TFieldValues>,
           _fields,
           previousErrorLookupResult.name || name,
         );

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,5 +1,5 @@
 import { FieldValues, InternalFieldName, Ref } from './fields';
-import { LiteralUnion, Merge } from './utils';
+import { IsAny, LiteralUnion, Merge } from './utils';
 import { RegisterOptions, ValidateResult } from './validator';
 
 export type Message = string;
@@ -33,9 +33,8 @@ export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
     : FieldError;
 };
 
-export type FieldErrors<T extends FieldValues = FieldValues> = FieldErrorsImpl<
-  DeepRequired<T>
->;
+export type FieldErrors<T extends FieldValues = FieldValues> =
+  IsAny<T> extends true ? T : FieldErrorsImpl<DeepRequired<T>>;
 
 export type InternalFieldErrors = Partial<
   Record<InternalFieldName, FieldError>


### PR DESCRIPTION
couldn't be fixed as `useFormContext` do require a generic, most users reported issue because generic were missing in the first place.