### PR TITLE
fix typo in useForm.ts

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -14,7 +14,7 @@ import {
 import { useSubscribe } from './useSubscribe';
 
 /**
- * Custom hook to mange the entire form.
+ * Custom hook to manage the entire form.
  *
  * @remarks
  * [API](https://react-hook-form.com/api/useform) • [Demo](https://codesandbox.io/s/react-hook-form-get-started-ts-5ksmm) • [Video](https://www.youtube.com/watch?v=RkXv4AXXC_4)


### PR DESCRIPTION
This PR fixes a typo in `useForm.ts`.
I think it is probably a typo in `manage`.


---

Thank you for your awesome work!

Best regards.