### PR TITLE
close #8653 when useFormContext provide no generic for type check

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -554,7 +554,7 @@ export function useForm<TFieldValues extends FieldValues = FieldValues, TContext
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[]) => void;
 
 // @public
-export const useFormContext: <TFieldValues extends FieldValues>() => UseFormReturn<TFieldValues, any>;
+export const useFormContext: <TFieldValues extends FieldValues = FieldValues>() => UseFormReturn<TFieldValues, any>;
 
 // @public
 export type UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName, formState?: FormState<TFieldValues>) => {

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -35,7 +35,7 @@ const HookFormContext = React.createContext<UseFormReturn | null>(null);
  * ```
  */
 export const useFormContext = <
-  TFieldValues extends FieldValues,
+  TFieldValues extends FieldValues = FieldValues,
 >(): UseFormReturn<TFieldValues> =>
   React.useContext(HookFormContext) as unknown as UseFormReturn<TFieldValues>;
 


### PR DESCRIPTION
ref: https://codesandbox.io/s/react-hook-form-chakra-ui-forked-0kcquv?file=/src/App.tsx

related: #8652 #8619

Prevent compile error when user not provide generic for context