### PR TITLE
Native form reset isn't executed if first fieldReference isn't a HTMLElement

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1134,7 +1134,7 @@ export function createFormControl<
                 : field._f.ref;
 
               try {
-                if(isHTMLElement(fieldReference)){
+                if (isHTMLElement(fieldReference)) {
                   fieldReference.closest('form')!.reset();
                   break;
                 }

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1134,9 +1134,10 @@ export function createFormControl<
                 : field._f.ref;
 
               try {
-                isHTMLElement(fieldReference) &&
+                if(isHTMLElement(fieldReference)){
                   fieldReference.closest('form')!.reset();
-                break;
+                  break;
+                }
               } catch {}
             }
           }


### PR DESCRIPTION
If the first field evaluated in `isHTMLElement(fieldReference)` returns `false` then loop is skipped and native reset is not executed.