### PR TITLE
fix #8584: handle nullable nested properties

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -132,7 +132,7 @@ export type DeepPartialSkipArrayKey<T> = T extends Date | FileList_2 | File_2 | 
 
 // @public (undocumented)
 export type DeepRequired<T> = {
-    [K in keyof T]-?: DeepRequired<T[K]>;
+    [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
 };
 
 // @public (undocumented)

--- a/src/__tests__/type.test.tsx
+++ b/src/__tests__/type.test.tsx
@@ -231,3 +231,36 @@ test('should support optional field errors', () => {
 
   errors;
 });
+
+test('should support nullable field errors', () => {
+  type Errors = FieldErrors<{
+    steps?: { action: string }[] | null;
+    foo: {
+      bar: string;
+    } | null;
+    baz: { action: string };
+  }>;
+
+  const error = {
+    type: 'test',
+    message: 'test',
+  };
+
+  let errors: Errors = {
+    steps: error,
+    foo: error,
+    baz: error,
+  };
+
+  errors = {
+    steps: [{ action: error }],
+    foo: {
+      bar: error,
+    },
+    baz: {
+      action: error,
+    },
+  };
+
+  errors;
+});

--- a/src/__typetest__/errors.test-d.ts
+++ b/src/__typetest__/errors.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 
-import { FieldError, FieldErrors } from '../types';
+import { FieldError, FieldErrors, Merge } from '../types';
 
 import { _ } from './__fixtures__';
 
@@ -10,10 +10,18 @@ import { _ } from './__fixtures__';
     const actual = _ as FieldErrors<{
       test?: string;
       test1?: string;
+      attachment: {
+        data: string;
+        data1: string;
+      };
     }>;
     expectType<{
       test?: FieldError;
       test1?: FieldError;
+      attachment?: Merge<FieldError, {
+        data?: FieldError;
+        data1?: FieldError;
+      }>;
     }>(actual);
   }
 
@@ -22,12 +30,18 @@ import { _ } from './__fixtures__';
     const actual = _ as FieldErrors<{
       test?: string;
       test1?: string | null;
-      test2: string | null;
+      attachment: {
+        data: string;
+        data1: string;
+      } | null;
     }>;
     expectType<{
       test?: FieldError;
       test1?: FieldError;
-      test2?: FieldError;
+      attachment?: Merge<FieldError, {
+        data?: FieldError;
+        data1?: FieldError;
+      }>;
     }>(actual);
   }
 }

--- a/src/__typetest__/errors.test-d.ts
+++ b/src/__typetest__/errors.test-d.ts
@@ -18,10 +18,13 @@ import { _ } from './__fixtures__';
     expectType<{
       test?: FieldError;
       test1?: FieldError;
-      attachment?: Merge<FieldError, {
-        data?: FieldError;
-        data1?: FieldError;
-      }>;
+      attachment?: Merge<
+        FieldError,
+        {
+          data?: FieldError;
+          data1?: FieldError;
+        }
+      >;
     }>(actual);
   }
 
@@ -38,10 +41,13 @@ import { _ } from './__fixtures__';
     expectType<{
       test?: FieldError;
       test1?: FieldError;
-      attachment?: Merge<FieldError, {
-        data?: FieldError;
-        data1?: FieldError;
-      }>;
+      attachment?: Merge<
+        FieldError,
+        {
+          data?: FieldError;
+          data1?: FieldError;
+        }
+      >;
     }>(actual);
   }
 }

--- a/src/__typetest__/errors.test-d.ts
+++ b/src/__typetest__/errors.test-d.ts
@@ -16,4 +16,18 @@ import { _ } from './__fixtures__';
       test1?: FieldError;
     }>(actual);
   }
+
+  /** it should support nullable record fields */
+  {
+    const actual = _ as FieldErrors<{
+      test?: string;
+      test1?: string | null;
+      test2: string | null;
+    }>;
+    expectType<{
+      test?: FieldError;
+      test1?: FieldError;
+      test2?: FieldError;
+    }>(actual);
+  }
 }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -25,7 +25,7 @@ export type ErrorOption = {
 };
 
 export type DeepRequired<T> = {
-  [K in keyof T]-?: DeepRequired<T[K]>;
+  [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
 };
 
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {


### PR DESCRIPTION
Fix errors for nullable nested properties: https://github.com/react-hook-form/react-hook-form/issues/8584#issuecomment-1189843605

- [x] type test