### PR TITLE
fix(path): keys of `Date | FileList | File` shouldn't be add to the `PathImpl`

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -31,6 +31,12 @@ export type BatchFieldArrayUpdate = <T extends Function, TFieldValues extends Fi
     argB: unknown;
 }>, shouldSetValue?: boolean, shouldUpdateFieldsAndErrors?: boolean) => void;
 
+// Warning: (ae-forgotten-export) The symbol "FileList" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "File" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type BrowserNativeObject = Date | FileList_2 | File_2;
+
 // @public (undocumented)
 export type ChangeHandler = (event: {
     target: any;
@@ -110,28 +116,25 @@ export type CustomElement<TFieldValues extends FieldValues> = {
     focus?: Noop;
 };
 
-// Warning: (ae-forgotten-export) The symbol "FileList" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "File" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends Date | FileList_2 | File_2 | NestedValue ? TValue : T extends object ? {
+export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends BrowserNativeObject | NestedValue ? TValue : T extends object ? {
     [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue>;
 } : TValue;
 
 // @public (undocumented)
-export type DeepPartial<T> = T extends Date | FileList_2 | File_2 | NestedValue ? T : {
+export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue ? T : {
     [K in keyof T]?: DeepPartial<T[K]>;
 };
 
 // @public (undocumented)
-export type DeepPartialSkipArrayKey<T> = T extends Date | FileList_2 | File_2 | NestedValue ? T : T extends ReadonlyArray<any> ? {
+export type DeepPartialSkipArrayKey<T> = T extends BrowserNativeObject | NestedValue ? T : T extends ReadonlyArray<any> ? {
     [K in keyof T]: DeepPartialSkipArrayKey<T[K]>;
 } : {
     [K in keyof T]?: DeepPartialSkipArrayKey<T[K]>;
 };
 
 // @public (undocumented)
-export type DeepRequired<T> = T extends Date | FileList | File | Blob ? T : {
+export type DeepRequired<T> = T extends BrowserNativeObject | Blob ? T : {
     [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
 };
 
@@ -202,7 +205,7 @@ export type FieldErrors<T extends FieldValues = FieldValues> = FieldErrorsImpl<D
 
 // @public (undocumented)
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-    [K in keyof T]?: T[K] extends Date | FileList | File | Blob ? FieldError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
+    [K in keyof T]?: T[K] extends BrowserNativeObject | Blob ? FieldError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
 };
 
 // @public (undocumented)

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,5 +1,5 @@
 import { FieldValues, InternalFieldName, Ref } from './fields';
-import { LiteralUnion, Merge } from './utils';
+import { BrowserNativeObject, LiteralUnion, Merge } from './utils';
 import { RegisterOptions, ValidateResult } from './validator';
 
 export type Message = string;
@@ -24,14 +24,14 @@ export type ErrorOption = {
   types?: MultipleFieldErrors;
 };
 
-export type DeepRequired<T> = T extends Date | FileList | File | Blob
+export type DeepRequired<T> = T extends BrowserNativeObject | Blob
   ? T
   : {
       [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
     };
 
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-  [K in keyof T]?: T[K] extends Date | FileList | File | Blob
+  [K in keyof T]?: T[K] extends BrowserNativeObject | Blob
     ? FieldError
     : T[K] extends object
     ? Merge<FieldError, FieldErrorsImpl<T[K]>>

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -1,5 +1,5 @@
 import { FieldValues } from '../fields';
-import { Primitive } from '../utils';
+import { BrowserNativeObject, Primitive } from '../utils';
 
 import { ArrayKey, IsTuple, TupleKeys } from './common';
 
@@ -9,9 +9,7 @@ import { ArrayKey, IsTuple, TupleKeys } from './common';
  */
 type PathImpl<K extends string | number, V> = V extends
   | Primitive
-  | Date
-  | FileList
-  | File
+  | BrowserNativeObject
   ? `${K}`
   : `${K}` | `${K}.${Path<V>}`;
 
@@ -44,12 +42,10 @@ export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
  */
 type ArrayPathImpl<K extends string | number, V> = V extends
   | Primitive
-  | Date
-  | FileList
-  | File
+  | BrowserNativeObject
   ? never
   : V extends ReadonlyArray<infer U>
-  ? U extends Primitive | Date | FileList | File
+  ? U extends Primitive | BrowserNativeObject
     ? never
     : `${K}` | `${K}.${ArrayPath<V>}`
   : `${K}.${ArrayPath<V>}`;

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -7,7 +7,11 @@ import { ArrayKey, IsTuple, TupleKeys } from './common';
  * Helper type for recursively constructing paths through a type.
  * See {@link Path}
  */
-type PathImpl<K extends string | number, V> = V extends Primitive
+type PathImpl<K extends string | number, V> = V extends
+  | Primitive
+  | Date
+  | FileList
+  | File
   ? `${K}`
   : `${K}` | `${K}.${Path<V>}`;
 
@@ -38,10 +42,14 @@ export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
  * Helper type for recursively constructing paths through a type.
  * See {@link ArrayPath}
  */
-type ArrayPathImpl<K extends string | number, V> = V extends Primitive
+type ArrayPathImpl<K extends string | number, V> = V extends
+  | Primitive
+  | Date
+  | FileList
+  | File
   ? never
   : V extends ReadonlyArray<infer U>
-  ? U extends Primitive
+  ? U extends Primitive | Date | FileList | File
     ? never
     : `${K}` | `${K}.${ArrayPath<V>}`
   : `${K}.${ArrayPath<V>}`;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -31,6 +31,8 @@ export type Primitive =
   | symbol
   | bigint;
 
+export type BrowserNativeObject = Date | FileList | File;
+
 export type EmptyObject = { [K in string | number]: never };
 
 export type NonUndefined<T> = T extends undefined ? never : T;
@@ -39,14 +41,12 @@ export type LiteralUnion<T extends U, U extends Primitive> =
   | T
   | (U & { _?: never });
 
-export type DeepPartial<T> = T extends Date | FileList | File | NestedValue
+export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue
   ? T
   : { [K in keyof T]?: DeepPartial<T[K]> };
 
 export type DeepPartialSkipArrayKey<T> = T extends
-  | Date
-  | FileList
-  | File
+  | BrowserNativeObject
   | NestedValue
   ? T
   : T extends ReadonlyArray<any>
@@ -76,7 +76,7 @@ export type IsNever<T> = [T] extends [never] ? true : false;
 
 export type DeepMap<T, TValue> = IsAny<T> extends true
   ? any
-  : T extends Date | FileList | File | NestedValue
+  : T extends BrowserNativeObject | NestedValue
   ? TValue
   : T extends object
   ? { [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue> }


### PR DESCRIPTION
keys of `Date | FileList | File` shouldn't be add to the `PathImpl`

If using `Path<{foo: {bar: File}}>`, the pahs of File keys shouldn't be include.