### PR TITLE
feature: field path by value generic implementation

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -218,6 +218,11 @@ export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<
 export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
 
 // @public
+export type FieldPathByValue<TFieldValues extends FieldValues, TValue> = {
+    [Key in FieldPath<TFieldValues>]: FieldPathValue<TFieldValues, Key> extends TValue ? Key : never;
+}[FieldPath<TFieldValues>];
+
+// @public
 export type FieldPathValue<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = PathValue<TFieldValues, TFieldPath>;
 
 // @public

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -140,3 +140,25 @@ export type FieldPathValues<
     TPath[K] & FieldPath<TFieldValues>
   >;
 };
+
+/**
+ * Type which eagerly collects all paths through a fieldType that matches a give type
+ * @typeParam TFieldValues - field values which are indexed by the paths
+ * @typeParam TValue       - the value you want to match into each type
+ * @example
+ * ```typescript
+ * FieldPathByValue<{foo: {bar: number}, baz: number, bar: string}, number>
+ *   = 'foo.bar' | 'baz'
+ * ```
+ */
+export type FieldPathByValue<
+  TFieldValues extends FieldValues,
+  TValue,
+> = {
+  [Key in FieldPath<TFieldValues>]: FieldPathValue<
+    TFieldValues,
+    Key
+  > extends TValue
+    ? Key
+    : never;
+}[FieldPath<TFieldValues>];

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -151,10 +151,7 @@ export type FieldPathValues<
  *   = 'foo.bar' | 'baz'
  * ```
  */
-export type FieldPathByValue<
-  TFieldValues extends FieldValues,
-  TValue,
-> = {
+export type FieldPathByValue<TFieldValues extends FieldValues, TValue> = {
   [Key in FieldPath<TFieldValues>]: FieldPathValue<
     TFieldValues,
     Key

--- a/src/types/path/index.ts
+++ b/src/types/path/index.ts
@@ -6,6 +6,7 @@ export {
   FieldArrayPath,
   FieldArrayPathValue,
   FieldPath,
+  FieldPathByValue,
   FieldPathValue,
   FieldPathValues,
   Path,


### PR DESCRIPTION
I came to this solution after a discussion on the discord support channel. related to: https://github.com/react-hook-form/react-hook-form/discussions/8557

The purpose of the `FieldPathByValue` is to return a union with all available paths that match the passed value. This is really helpful to have strongly type custom components using the `ControllerApi`. As e.g.:

```jsx
import {
  FieldPathByValue,
  FieldValues,
  Control,
  useController,
  useForm
} from "react-hook-form";

// this component uses a date value
function SomeCustomFormComponent<
    TFieldValues extends FieldValues,
    TPath extends FieldPathByValue<TFieldValues, Date>
>({
    control,
    name
}: {
    control: Control<TFieldValues>,
    name: TPath
}) {
    const { field } = useController({
      control,
      name,
    });

    // rest of components rules
}

function ExampleOfUsage () {
    const {control} = useForm<{
        foo: Date;
        baz: string;
        bar: {
            baz: Date;
        }
    }>()

    return (
      <>
        <SomeCustomFormComponent control={control} name="foo" /> {/* throw no error */}
        <SomeCustomFormComponent control={control} name="baz" /> {/*  throw an error since baz is string */}
        <SomeCustomFormComponent control={control} name="bar.baz" /> {/* throw no error */}
      </>
    );
}
```