### PR TITLE
WIP: Add isValidating to true before validation and to false after on handleSubmit

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1024,6 +1024,10 @@ export function createFormControl<
       let fieldValues: any = cloneObject(_formValues);
 
       try {
+        _subjects.state.next({
+          isValidating: true,
+        });
+
         if (_options.resolver) {
           const { errors, values } = await _executeSchema();
           _formState.errors = errors as FieldErrors<TFieldValues>;
@@ -1031,6 +1035,11 @@ export function createFormControl<
         } else {
           await executeBuiltInValidation(_fields);
         }
+
+        _subjects.state.next({
+          // TODO: Discss if this is the ideal placement for setting the flag back to false
+          isValidating: false,
+        });
 
         if (isEmptyObject(_formState.errors)) {
           _subjects.state.next({


### PR DESCRIPTION
Relates to #8854

Latest update: 
- Waiting to see if more people need `isValidating` set to true while the submission is happening.
- For the submission flow, the `isSubmitting` flag is set to true, which can be used instead of the `isUpdating` flag.

Demo of fixed local version and remote version with the bug
https://www.loom.com/share/e871bea4ec5d48d39850086378355587

Need help with:
- pointers to where to set the `isValidating` flag back to false in the `handleSubmit` method
- where/how to write a test for this, if needed

Notes:
- there is a failing test on master right now, related to `setValueAsyncStrictMode.cy.ts`. This fails when running the clean react-hook-form project without any changes on my local machine. 
