### PR TITLE
fix: DeepMap infers types correctly when using union types

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -116,9 +116,11 @@ export type CustomElement<TFieldValues extends FieldValues> = {
     focus?: Noop;
 };
 
+// Warning: (ae-forgotten-export) The symbol "UnionToIntersection" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends BrowserNativeObject | NestedValue ? TValue : T extends object ? {
-    [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue>;
+export type DeepMap<T, TValue> = IsAny<T> extends true ? any : [T] extends [BrowserNativeObject | NestedValue] ? TValue : [T] extends [object] ? {
+    [K in keyof UnionToIntersection<T>]: DeepMap<NonUndefined<UnionToIntersection<T>[K]>, TValue>;
 } : TValue;
 
 // @public (undocumented)

--- a/src/__typetest__/form.test-d.ts
+++ b/src/__typetest__/form.test-d.ts
@@ -60,3 +60,69 @@ import { useForm } from '../useForm';
     }>(getFieldState('test', formState));
   }
 }
+
+/** {@link FieldNamesMarkedBoolean} */ {
+  /** It should infer the correct types if there is an union type */ {
+    type FormWithUnion = {
+      always: string;
+      nested: {
+        foo: number;
+        bar: {
+          foo: boolean;
+          bar: boolean;
+        };
+      };
+      union:
+        | {
+            data: 'A';
+            data1: string;
+          }
+        | {
+            data: 'B';
+            data2: string;
+          };
+    };
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const {
+      formState: { touchedFields },
+    } = useForm<FormWithUnion>({
+      defaultValues: {
+        always: '',
+        nested: {
+          foo: 0,
+          bar: {
+            foo: true,
+            bar: false,
+          },
+        },
+        union: {
+          data: 'A',
+          data1: '',
+        },
+      },
+    });
+
+    expectType<{
+      always?: boolean;
+      nested?: {
+        foo?: boolean;
+        bar?: {
+          foo?: boolean;
+          bar?: boolean;
+        };
+      };
+      union?: {
+        data?: boolean;
+        data1?: boolean;
+        data2?: boolean;
+      };
+    }>(touchedFields);
+    expectType<boolean | undefined>(touchedFields.always);
+    expectType<boolean | undefined>(touchedFields.nested?.foo);
+    expectType<boolean | undefined>(touchedFields.nested?.bar?.foo);
+    expectType<boolean | undefined>(touchedFields.nested?.bar?.bar);
+    expectType<boolean | undefined>(touchedFields.union?.data);
+    expectType<boolean | undefined>(touchedFields.union?.data1);
+    expectType<boolean | undefined>(touchedFields.union?.data2);
+  }
+}

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -213,7 +213,12 @@ export function createFormControl<
           args.argA,
           args.argB,
         );
-        shouldSetValues && set(_formState.touchedFields, name, touchedFields);
+        shouldSetValues &&
+          set(
+            _formState.touchedFields as unknown as TFieldValues,
+            name,
+            touchedFields,
+          );
       }
 
       if (_proxyFormState.dirtyFields) {
@@ -298,7 +303,7 @@ export function createFormControl<
 
       isCurrentFieldPristine
         ? unset(_formState.dirtyFields, name)
-        : set(_formState.dirtyFields as TFieldValues, name, true);
+        : set(_formState.dirtyFields as unknown as TFieldValues, name, true);
       output.dirtyFields = _formState.dirtyFields;
       isFieldDirty =
         isFieldDirty ||
@@ -306,7 +311,11 @@ export function createFormControl<
     }
 
     if (isBlurEvent && !isPreviousFieldTouched) {
-      set(_formState.touchedFields as TFieldValues, name, isBlurEvent);
+      set(
+        _formState.touchedFields as unknown as TFieldValues,
+        name,
+        isBlurEvent,
+      );
       output.touchedFields = _formState.touchedFields;
       isFieldDirty =
         isFieldDirty ||

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,3 +1,4 @@
+import { UnionToIntersection } from './path/common';
 import { NestedValue } from './form';
 
 /*
@@ -76,10 +77,15 @@ export type IsNever<T> = [T] extends [never] ? true : false;
 
 export type DeepMap<T, TValue> = IsAny<T> extends true
   ? any
-  : T extends BrowserNativeObject | NestedValue
+  : [T] extends [BrowserNativeObject | NestedValue]
   ? TValue
-  : T extends object
-  ? { [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue> }
+  : [T] extends [object]
+  ? {
+      [K in keyof UnionToIntersection<T>]: DeepMap<
+        NonUndefined<UnionToIntersection<T>[K]>,
+        TValue
+      >;
+    }
   : TValue;
 
 export type IsFlatObject<T extends object> = Extract<


### PR DESCRIPTION
Fixes #8815

This fixes DeepMap not applying to union types using a combination of `UnionToIntersection` and avoiding distributivity on conditional types (`[T] extends [...]`) 

I am not entirely sure this is the correct approach, please let me know what you think about this solution.

I'm still figuring out a fix for `FieldErrorsImpl` but wanted to check with you this one first