### PR TITLE
fix: make useController fieldState properties enumerable

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -145,15 +145,19 @@ export function useController<
       {},
       {
         invalid: {
+          enumerable: true,
           get: () => !!get(formState.errors, name),
         },
         isDirty: {
+          enumerable: true,
           get: () => !!get(formState.dirtyFields, name),
         },
         isTouched: {
+          enumerable: true,
           get: () => !!get(formState.touchedFields, name),
         },
         error: {
+          enumerable: true,
           get: () => get(formState.errors, name),
         },
       },


### PR DESCRIPTION
Fixes [react-hook-form/react-hook-form#8919](https://github.com/react-hook-form/react-hook-form/issues/8919)