### PR TITLE
Forward custom props from Controller to render

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -85,10 +85,11 @@ export type ControllerFieldState = {
 
 // @public
 export type ControllerProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> = {
-    render: ({ field, fieldState, formState, }: {
+    render: ({ field, fieldState, formState, customProps, }: {
         field: ControllerRenderProps<TFieldValues, TName>;
         fieldState: ControllerFieldState;
         formState: UseFormStateReturn<TFieldValues>;
+        customProps: Record<string, any>;
     }) => React_2.ReactElement;
 } & UseControllerProps<TFieldValues, TName>;
 
@@ -499,6 +500,7 @@ export type UseControllerProps<TFieldValues extends FieldValues = FieldValues, T
     shouldUnregister?: boolean;
     defaultValue?: FieldPathValue<TFieldValues, TName>;
     control?: Control<TFieldValues>;
+    customProps?: Record<string, any>;
 };
 
 // @public (undocumented)
@@ -506,6 +508,7 @@ export type UseControllerReturn<TFieldValues extends FieldValues = FieldValues, 
     field: ControllerRenderProps<TFieldValues, TName>;
     formState: UseFormStateReturn<TFieldValues>;
     fieldState: ControllerFieldState;
+    customProps: Record<string, any>;
 };
 
 // @public

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -8,7 +8,11 @@ import {
 } from '@testing-library/react';
 
 import { Controller } from '../controller';
-import { ControllerRenderProps, FieldValues } from '../types';
+import {
+  ControllerRenderProps,
+  FieldValues,
+  UseControllerReturn,
+} from '../types';
 import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 import { FormProvider } from '../useFormContext';
@@ -1428,5 +1432,35 @@ describe('Controller', () => {
     expect(getValueFn).toBeCalledWith({
       show: false,
     });
+  });
+
+  it('should render correctly with custom props', () => {
+    const dataCp = 'test-cp';
+    const Wrapped = ({
+      field,
+      customProps,
+    }: UseControllerReturn<FieldValues, any>) => {
+      return <input {...field} data-cp={customProps.cp} />;
+    };
+
+    const Component = () => {
+      const { control } = useForm();
+      return (
+        <Controller
+          defaultValue=""
+          name="test"
+          render={Wrapped}
+          control={control}
+          customProps={{ cp: dataCp }}
+        />
+      );
+    };
+
+    render(<Component />);
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+
+    expect(input).toBeVisible();
+    expect(input.dataset.cp).toBe(dataCp);
   });
 });

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -48,6 +48,7 @@ export type UseControllerProps<
   shouldUnregister?: boolean;
   defaultValue?: FieldPathValue<TFieldValues, TName>;
   control?: Control<TFieldValues>;
+  customProps?: Record<string, any>;
 };
 
 export type UseControllerReturn<
@@ -57,6 +58,7 @@ export type UseControllerReturn<
   field: ControllerRenderProps<TFieldValues, TName>;
   formState: UseFormStateReturn<TFieldValues>;
   fieldState: ControllerFieldState;
+  customProps: Record<string, any>;
 };
 
 /**
@@ -66,15 +68,16 @@ export type UseControllerReturn<
  *
  * @example
  * ```tsx
- * const { field, fieldState, formState } = useController();
+ * const { field, fieldState, formState, customProps } = useController();
  *
  * <Controller
- *   render={({ field, formState, fieldState }) => ({
+ *   render={({ field, formState, fieldState, customProps }) => ({
  *     <input
  *       onChange={field.onChange}
  *       onBlur={field.onBlur}
  *       name={field.name}
  *       ref={field.ref} // optional for focus management
+ *       data-foo={customProps.foo} // optional to pass down props
  *     />
  *   })}
  * />
@@ -88,9 +91,11 @@ export type ControllerProps<
     field,
     fieldState,
     formState,
+    customProps,
   }: {
     field: ControllerRenderProps<TFieldValues, TName>;
     fieldState: ControllerFieldState;
     formState: UseFormStateReturn<TFieldValues>;
+    customProps: Record<string, any>;
   }) => React.ReactElement;
 } & UseControllerProps<TFieldValues, TName>;

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -98,6 +98,8 @@ export function useController<
     };
   }, [name, control, isArrayField, shouldUnregister]);
 
+  const customProps = props.customProps || {};
+
   return {
     field: {
       name,
@@ -162,5 +164,6 @@ export function useController<
         },
       },
     ) as ControllerFieldState,
+    customProps,
   };
 }


### PR DESCRIPTION
I have this situation where I need to wrap inputs inside a Controller depending on any parent prop Eg:

```javascript
export function Foo({error}) {
  {/* ... */}
  const WrappedComponent = ({ field }) => {
    return (
      <TextField
        error={error}
        {/* ... */}
      />
    );
  };

  return (
    <Controller
      name="firstName"
      control={control}
      render={WrappedComponent}
    />
  );
}
```

And creating components inside components without memoization leads to the nested component and all its children being recreated during each re-render. A property to pass down custom properties could prevent this behavior

something like this:

```javascript
const WrappedComponent = ({ field, customProps }) => {
  return (
    <TextField
      error={customProps.error}
      {/* ... */}
    />
  );
};

export function Foo({error}) {
  ...
  return (
    <Controller
      name="firstName"
      control={control}
      render={WrappedComponent}
      customProps={{ error }}
    />
  );
}
```