### PR TITLE
🚂 feature: `reset` to support callback syntax

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -31,8 +31,8 @@ export type BatchFieldArrayUpdate = <T extends Function, TFieldValues extends Fi
     argB: unknown;
 }>, shouldSetValue?: boolean, shouldUpdateFieldsAndErrors?: boolean) => void;
 
-// Warning: (ae-forgotten-export) The symbol "FileList_2" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "File_2" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "FileList" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "File" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type BrowserNativeObject = Date | FileList_2 | File_2;

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -31,8 +31,8 @@ export type BatchFieldArrayUpdate = <T extends Function, TFieldValues extends Fi
     argB: unknown;
 }>, shouldSetValue?: boolean, shouldUpdateFieldsAndErrors?: boolean) => void;
 
-// Warning: (ae-forgotten-export) The symbol "FileList" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "File" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "FileList_2" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "File_2" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type BrowserNativeObject = Date | FileList_2 | File_2;
@@ -618,8 +618,10 @@ export type UseFormRegisterReturn<TFieldName extends InternalFieldName = Interna
     disabled?: boolean;
 };
 
+// Warning: (ae-forgotten-export) The symbol "ResetAction" needs to be exported by the entry point index.d.ts
+//
 // @public
-export type UseFormReset<TFieldValues extends FieldValues> = (values?: DefaultValues<TFieldValues> | TFieldValues, keepStateOptions?: KeepStateOptions) => void;
+export type UseFormReset<TFieldValues extends FieldValues> = (values?: DefaultValues<TFieldValues> | TFieldValues | ResetAction<TFieldValues>, keepStateOptions?: KeepStateOptions) => void;
 
 // @public
 export type UseFormResetField<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(name: TFieldName, options?: Partial<{

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -42,7 +42,7 @@ describe('reset', () => {
 
   it('should reset form value', () => {
     let methods: any;
-    const Component = () => {
+    const App = () => {
       methods = useForm<{
         test: string;
       }>();
@@ -52,7 +52,7 @@ describe('reset', () => {
         </form>
       );
     };
-    render(<Component />);
+    render(<App />);
 
     actComponent(() =>
       methods.reset({
@@ -65,8 +65,39 @@ describe('reset', () => {
     });
   });
 
+  it('should reset the form with callback action', () => {
+    const App = () => {
+      const { register, reset } = useForm({
+        defaultValues: {
+          test: '',
+        },
+      });
+
+      React.useEffect(() => {
+        reset((formValues) => {
+          return {
+            ...formValues,
+            test: 'test',
+          };
+        });
+      }, [reset]);
+
+      return (
+        <form>
+          <input {...register('test')} />
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
+      'test',
+    );
+  });
+
   it('should set array value of multiple checkbox inputs correctly', async () => {
-    const Component = () => {
+    const App = () => {
       const { register } = useForm<{
         test: string[];
       }>({
@@ -83,7 +114,7 @@ describe('reset', () => {
       );
     };
 
-    render(<Component />);
+    render(<App />);
 
     screen
       .getAllByRole('checkbox')
@@ -97,13 +128,13 @@ describe('reset', () => {
     let methods: UseFormReturn<{
       test: string;
     }>;
-    const Component = () => {
+    const App = () => {
       methods = useForm<{
         test: string;
       }>();
       return <input {...methods.register('test')} />;
     };
-    render(<Component />);
+    render(<App />);
 
     actComponent(() => methods.reset());
 
@@ -151,7 +182,7 @@ describe('reset', () => {
   });
 
   it('should not reset form values when keepValues is specified', () => {
-    const Component = () => {
+    const App = () => {
       const { register, reset } = useForm();
 
       return (
@@ -171,7 +202,7 @@ describe('reset', () => {
       );
     };
 
-    render(<Component />);
+    render(<App />);
 
     fireEvent.change(screen.getByRole('textbox'), {
       target: {
@@ -187,7 +218,7 @@ describe('reset', () => {
   });
 
   it('should not reset form defaultValues when keepDefaultValues is specified', async () => {
-    const Component = () => {
+    const App = () => {
       const {
         register,
         reset,
@@ -216,7 +247,7 @@ describe('reset', () => {
       );
     };
 
-    render(<Component />);
+    render(<App />);
 
     fireEvent.change(screen.getByRole('textbox'), {
       target: {
@@ -371,7 +402,7 @@ describe('reset', () => {
 
   it('should reset field array fine with empty value', async () => {
     let data: unknown;
-    const Component = () => {
+    const App = () => {
       const { control, register, reset, handleSubmit } = useForm<{
         test: {
           firstName: string;
@@ -419,7 +450,7 @@ describe('reset', () => {
       );
     };
 
-    render(<Component />);
+    render(<App />);
 
     const resetButton = screen.getByRole('button', { name: 'reset' });
     const submitButton = screen.getByRole('button', { name: 'submit' });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1100,7 +1100,7 @@ export function createFormControl<
     }
   };
 
-  const reset: UseFormReset<TFieldValues> = (
+  const _reset: UseFormReset<TFieldValues> = (
     formValues,
     keepStateOptions = {},
   ) => {
@@ -1206,6 +1206,14 @@ export function createFormControl<
       isSubmitSuccessful: false,
     });
   };
+
+  const reset: UseFormReset<TFieldValues> = (formValues, keepStateOptions) =>
+    _reset(
+      isFunction(formValues)
+        ? formValues(_formValues as TFieldValues)
+        : formValues,
+      keepStateOptions,
+    );
 
   const setFocus: UseFormSetFocus<TFieldValues> = (name, options = {}) => {
     const field = get(_fields, name)._f;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -626,6 +626,8 @@ export type UseFormResetField<TFieldValues extends FieldValues> = <
   }>,
 ) => void;
 
+type ResetAction<TFieldValues> = (formValues: TFieldValues) => TFieldValues;
+
 /**
  * Reset at the entire form state.
  *
@@ -661,7 +663,10 @@ export type UseFormResetField<TFieldValues extends FieldValues> = <
  * ```
  */
 export type UseFormReset<TFieldValues extends FieldValues> = (
-  values?: DefaultValues<TFieldValues> | TFieldValues,
+  values?:
+    | DefaultValues<TFieldValues>
+    | TFieldValues
+    | ResetAction<TFieldValues>,
   keepStateOptions?: KeepStateOptions,
 ) => void;
 


### PR DESCRIPTION
## Context

There is a lot of use case, in which we observe users are reset with partial form values and required to invoke `getValues` at the same time.

```tsx
reset({
  ...getValues(),
  partialData: 'onlyChangeThis'
})
```

## Prospal API

This following API eliminates the need to forward the getValues method and also type safe with the callback payload. This also align with React's core `useState/setState` callback syntax.

```tsx
reset((formValues) => {
  return {
    ...formValues,
    partialData: 'onlyChangeThis'
  }
})
```

## Todos

- [x] code implementation
- [x] unit tests
- [x] doc update