### PR TITLE
🧪 POC: support async defaultValues

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -258,6 +258,7 @@ export type FormState<TFieldValues extends FieldValues> = {
     isSubmitting: boolean;
     isValidating: boolean;
     isValid: boolean;
+    isLoading: boolean;
     errors: FieldErrors<TFieldValues>;
 };
 
@@ -590,7 +591,7 @@ export type UseFormHandleSubmit<TFieldValues extends FieldValues> = (onValid: Su
 export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContext = any> = Partial<{
     mode: Mode;
     reValidateMode: Exclude<Mode, 'onTouched' | 'all'>;
-    defaultValues: DefaultValues<TFieldValues>;
+    defaultValues: DefaultValues<TFieldValues> | AsyncDefaultValues<TFieldValues>;
     resolver: Resolver<TFieldValues, TContext>;
     context: TContext;
     shouldFocusError: boolean;
@@ -768,7 +769,8 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:417:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:102:3 - (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:427:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1723,7 +1723,10 @@ describe('useForm', () => {
     }
 
     const App = () => {
-      const { register } = useForm<{ test: string }>({
+      const {
+        register,
+        formState: { isLoading },
+      } = useForm<{ test: string }>({
         defaultValues: async () => {
           await sleep(100);
 
@@ -1735,15 +1738,28 @@ describe('useForm', () => {
         },
       });
 
-      return <input {...register('test')} />;
+      return (
+        <form>
+          <input {...register('test')} />
+          <p>{isLoading ? 'loading...' : 'done'}</p>
+        </form>
+      );
     };
 
     render(<App />);
 
     await waitFor(() => {
+      screen.getByText('loading...');
+    });
+
+    await waitFor(() => {
       expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
         'test',
       );
+    });
+
+    await waitFor(() => {
+      screen.getByText('done');
     });
   });
 });

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1716,4 +1716,34 @@ describe('useForm', () => {
     screen.getByText('isValidating: false');
     screen.getByText('stateValidation: false');
   });
+
+  it('should update defaultValues async', async () => {
+    function sleep(ms: number) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
+    const App = () => {
+      const { register } = useForm<{ test: string }>({
+        defaultValues: async () => {
+          await sleep(100);
+
+          return {
+            values: {
+              test: 'test',
+            },
+          };
+        },
+      });
+
+      return <input {...register('test')} />;
+    };
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
+        'test',
+      );
+    });
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -56,6 +56,7 @@ import isFunction from '../utils/isFunction';
 import isHTMLElement from '../utils/isHTMLElement';
 import isMultipleSelect from '../utils/isMultipleSelect';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
+import isObject from '../utils/isObject';
 import isPrimitive from '../utils/isPrimitive';
 import isRadioOrCheckbox from '../utils/isRadioOrCheckbox';
 import isString from '../utils/isString';
@@ -111,7 +112,10 @@ export function createFormControl<
     errors: {} as FieldErrors<TFieldValues>,
   };
   let _fields = {};
-  let _defaultValues = cloneObject(_options.defaultValues) || {};
+  let _defaultValues = isObject(_options.defaultValues)
+    ? cloneObject(_options.defaultValues) || {}
+    : {};
+
   let _formValues = _options.shouldUnregister
     ? {}
     : cloneObject(_defaultValues);
@@ -1213,6 +1217,12 @@ export function createFormControl<
     fieldRef.focus();
     options.shouldSelect && fieldRef.select();
   };
+
+  if (isFunction(_options.defaultValues)) {
+    _options
+      .defaultValues()
+      .then(({ values, resetOptions }) => reset(values, resetOptions));
+  }
 
   return {
     control: {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -108,6 +108,7 @@ export function createFormControl<
     touchedFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
     isSubmitting: false,
     isSubmitSuccessful: false,
+    isLoading: true,
     isValid: false,
     errors: {} as FieldErrors<TFieldValues>,
   };
@@ -1219,9 +1220,12 @@ export function createFormControl<
   };
 
   if (isFunction(_options.defaultValues)) {
-    _options
-      .defaultValues()
-      .then(({ values, resetOptions }) => reset(values, resetOptions));
+    _options.defaultValues().then(({ values, resetOptions }) => {
+      reset(values, resetOptions);
+      _subjects.state.next({
+        isLoading: false,
+      });
+    });
   }
 
   return {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -84,13 +84,22 @@ export type ChangeHandler = (event: {
 
 export type DelayCallback = (wait: number) => void;
 
+type AsyncDefaultValuesReturn<TFieldValues> = {
+  values: TFieldValues;
+  resetOptions?: KeepStateOptions;
+};
+
+type AsyncDefaultValues<TFieldValues> = () => Promise<
+  AsyncDefaultValuesReturn<TFieldValues>
+>;
+
 export type UseFormProps<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
 > = Partial<{
   mode: Mode;
   reValidateMode: Exclude<Mode, 'onTouched' | 'all'>;
-  defaultValues: DefaultValues<TFieldValues>;
+  defaultValues: DefaultValues<TFieldValues> | AsyncDefaultValues<TFieldValues>;
   resolver: Resolver<TFieldValues, TContext>;
   context: TContext;
   shouldFocusError: boolean;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -135,6 +135,7 @@ export type FormState<TFieldValues extends FieldValues> = {
   isSubmitting: boolean;
   isValidating: boolean;
   isValid: boolean;
+  isLoading: boolean;
   errors: FieldErrors<TFieldValues>;
 };
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -60,6 +60,7 @@ export function useForm<
     touchedFields: {} as FieldNamesMarkedBoolean<TFieldValues>,
     isSubmitting: false,
     isSubmitSuccessful: false,
+    isLoading: true,
     isValid: false,
     errors: {} as FieldErrors<TFieldValues>,
   });


### PR DESCRIPTION
RFC: https://github.com/react-hook-form/react-hook-form/discussions/9046

## Proposal Syntax

The following syntax will support async `defaultValues`, so we will manage the `reset` form internally and update `isLoading` `formState` accordingly.


```tsx
const fetchFormValues = () => {
  const values = fetch('API')

  return {
    values,
    resetOptions: {
       keepDirtyValues: true,
    }
  }
}

const { formState: { isLoading } } = useForm({
  defaultValues: fetchFormValues
})

// you can display a loading content or disable the form for better UX
if (isLoading) {
  return <div>Loading...</div>;
}

return <form />
```