### PR TITLE
Fix: Add missing blur method to field ref

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -135,6 +135,7 @@ export function useController<
               setCustomValidity: (message: string) =>
                 elm.setCustomValidity(message),
               reportValidity: () => elm.reportValidity(),
+              blur: () => elm.blur(),
             };
           }
         },


### PR DESCRIPTION
Adding a missing `blur` method to field ref in `useController` hook.