### PR TITLE
fix valueAsNumber with whitespace input returning 0 instead of NaN

### DIFF
--- a/src/__tests__/logic/getFieldValueAs.test.ts
+++ b/src/__tests__/logic/getFieldValueAs.test.ts
@@ -13,4 +13,28 @@ describe('getFieldValueAs', () => {
       }),
     ).toBeUndefined();
   });
+  it('should return NaN when value is empty string ""', () => {
+    expect(
+      getFieldValueAs('', {
+        ref: {
+          name: 'test',
+        },
+        name: 'test',
+        valueAsNumber: true,
+        valueAsDate: false,
+      }),
+    ).toBeNaN();
+  });
+  it('should return NaN when value is whitespace string " "', () => {
+    expect(
+      getFieldValueAs(' ', {
+        ref: {
+          name: 'test',
+        },
+        name: 'test',
+        valueAsNumber: true,
+        valueAsDate: false,
+      }),
+    ).toBeNaN();
+  });
 });

--- a/src/logic/getFieldValueAs.ts
+++ b/src/logic/getFieldValueAs.ts
@@ -9,7 +9,7 @@ export default <T extends NativeFieldValue>(
   isUndefined(value)
     ? value
     : valueAsNumber
-    ? value === ''
+    ? isString(value) && value.trim() === ''
       ? NaN
       : value
       ? +value


### PR DESCRIPTION
This change makes whitespace inputs convert to NaN instead of 0, when using valueAsNumber.

Currently, an empty input converts to NaN (as expected) but any whitespace converts to the number 0, which is confusing at best and can cause serious problems at worse. No user would expect a spacebar entered in a form to result in the number 0 sent to an API or elsewhere.

Also, 2 test are added for empty string and whitespace, when using valueAsNumber.


This issue can currently be replicated here: https://codesandbox.io/s/react-hook-form-js-forked-8dynim which is a fork of the form on the landing page.

Screenshot with nothing entered and hitting submit:
![image](https://user-images.githubusercontent.com/39016062/198903777-44ed07f9-9b6f-4cf8-9896-6ab0fc631e74.png)

Screenshot with whitespace entered and hitting submit:
![image](https://user-images.githubusercontent.com/39016062/198903810-2cbf92f7-84d4-47ec-8f35-45f9de3e59b6.png)
