### PR TITLE
Revert "🤯 use input reference instead custom object (#9132)"

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -124,11 +124,17 @@ export function useController<
           }),
         [name, control],
       ),
-      ref: (ref) => {
+      ref: (elm) => {
         const field = get(control._fields, name);
 
-        if (field && ref) {
-          field._f.ref = ref;
+        if (field && elm) {
+          field._f.ref = {
+            focus: () => elm.focus(),
+            select: () => elm.select(),
+            setCustomValidity: (message: string) =>
+              elm.setCustomValidity(message),
+            reportValidity: () => elm.reportValidity(),
+          };
         }
       },
     },


### PR DESCRIPTION
This reverts commit e83b9234edf1723cc5f41ba0d27a4c213a41cc0e.

close #9310

follow up

- [ ] unit test coverage