### PR TITLE
fix: clear error on remove if field array is empty

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -189,7 +189,6 @@ export function createFormControl<
       }
 
       if (
-        _proxyFormState.errors &&
         shouldUpdateFieldsAndState &&
         Array.isArray(get(_formState.errors, name))
       ) {

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -339,7 +339,12 @@ export function useFieldArray<
         });
       } else {
         const field: Field = get(control._fields, name);
-        if (field && field._f) {
+        if (Array.isArray(field) && field.length === 0) {
+          unset(control._formState.errors, name);
+          control._subjects.state.next({
+            errors: control._formState.errors as FieldErrors<TFieldValues>,
+          });
+        } else if (field && field._f) {
           validateField(
             field,
             get(control._formValues, name),

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -339,12 +339,7 @@ export function useFieldArray<
         });
       } else {
         const field: Field = get(control._fields, name);
-        if (Array.isArray(field) && field.length === 0) {
-          unset(control._formState.errors, name);
-          control._subjects.state.next({
-            errors: control._formState.errors as FieldErrors<TFieldValues>,
-          });
-        } else if (field && field._f) {
+        if (field && field._f) {
           validateField(
             field,
             get(control._formValues, name),


### PR DESCRIPTION
**Root cause**

Field array errors are not cleared in case method "remove" is triggered on one last remaining item.

Fixes #9383 