### PR TITLE
infer type from async defaultValues

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -258,7 +258,7 @@ export type FormState<TFieldValues extends FieldValues> = {
     isValidating: boolean;
     isValid: boolean;
     submitCount: number;
-    defaultValues?: (TFieldValues extends () => Promise<any> ? Awaited<ReturnType<TFieldValues>> : TFieldValues) | undefined | Readonly<DeepPartial<TFieldValues>>;
+    defaultValues?: UnPackDefaultValues<TFieldValues> | undefined | Readonly<DeepPartial<TFieldValues>>;
     dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
     touchedFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
     errors: FieldErrors<TFieldValues>;
@@ -488,7 +488,7 @@ export type TriggerConfig = Partial<{
 }>;
 
 // @public (undocumented)
-export type UnPackDefaultValues<TFieldValues> = TFieldValues extends () => Promise<any> ? Awaited<ReturnType<TFieldValues>> : TFieldValues;
+export type UnPackDefaultValues<TFieldValues> = TFieldValues extends () => Promise<infer U> ? U : TFieldValues;
 
 // @public @deprecated (undocumented)
 export type UnpackNestedValue<T> = T extends NestedValue<infer U> ? U : T extends Date | FileList | File | Blob ? T : T extends object ? {
@@ -778,7 +778,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:95:3 - (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:97:3 - (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
 // src/types/form.ts:427:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -75,7 +75,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
 };
 
 // @public
-export const Controller: <TFieldValues extends FieldValues = FieldValues, TName extends Path<TFieldValues> = Path<TFieldValues>>(props: ControllerProps<TFieldValues, TName>) => ReactElement<any, string | JSXElementConstructor<any>>;
+export const Controller: <TFieldValues extends FieldValues = FieldValues, TName extends Path<UnPackDefaultValues<TFieldValues>> = Path<UnPackDefaultValues<TFieldValues>>>(props: ControllerProps<TFieldValues, TName>) => ReactElement<any, string | JSXElementConstructor<any>>;
 
 // @public (undocumented)
 export type ControllerFieldState = {
@@ -217,7 +217,7 @@ export type FieldName<TFieldValues extends FieldValues> = IsFlatObject<TFieldVal
 export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<DeepPartial<TFieldValues>, boolean>;
 
 // @public
-export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
+export type FieldPath<TFieldValues extends FieldValues> = Path<UnPackDefaultValues<TFieldValues>>;
 
 // @public
 export type FieldPathByValue<TFieldValues extends FieldValues, TValue> = {
@@ -225,7 +225,7 @@ export type FieldPathByValue<TFieldValues extends FieldValues, TValue> = {
 }[FieldPath<TFieldValues>];
 
 // @public
-export type FieldPathValue<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = PathValue<TFieldValues, TFieldPath>;
+export type FieldPathValue<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = PathValue<UnPackDefaultValues<TFieldValues>, TFieldPath>;
 
 // @public
 export type FieldPathValues<TFieldValues extends FieldValues, TPath extends FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[]> = {} & {
@@ -258,7 +258,7 @@ export type FormState<TFieldValues extends FieldValues> = {
     isValidating: boolean;
     isValid: boolean;
     submitCount: number;
-    defaultValues?: Readonly<DeepPartial<TFieldValues>> | TFieldValues | undefined;
+    defaultValues?: (TFieldValues extends () => Promise<any> ? Awaited<ReturnType<TFieldValues>> : TFieldValues) | undefined | Readonly<DeepPartial<TFieldValues>>;
     dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
     touchedFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
     errors: FieldErrors<TFieldValues>;
@@ -487,6 +487,9 @@ export type TriggerConfig = Partial<{
     shouldFocus: boolean;
 }>;
 
+// @public (undocumented)
+export type UnPackDefaultValues<TFieldValues> = TFieldValues extends () => Promise<any> ? Awaited<ReturnType<TFieldValues>> : TFieldValues;
+
 // @public @deprecated (undocumented)
 export type UnpackNestedValue<T> = T extends NestedValue<infer U> ? U : T extends Date | FileList | File | Blob ? T : T extends object ? {
     [K in keyof T]: UnpackNestedValue<T[K]>;
@@ -590,7 +593,7 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
 export type UseFormHandleSubmit<TFieldValues extends FieldValues> = (onValid: SubmitHandler<TFieldValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
 
 // @public (undocumented)
-export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContext = any> = Partial<{
+export type UseFormProps<TFieldValues extends UnPackDefaultValues<FieldValues> = UnPackDefaultValues<FieldValues>, TContext = any> = Partial<{
     mode: Mode;
     reValidateMode: Exclude<Mode, 'onTouched' | 'all'>;
     defaultValues: DefaultValues<TFieldValues> | AsyncDefaultValues<TFieldValues>;
@@ -776,7 +779,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 // Warnings were encountered during analysis:
 //
 // src/types/form.ts:95:3 - (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:425:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:427:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1724,7 +1724,7 @@ describe('useForm', () => {
     }
 
     const App = () => {
-      const { register } = useForm<{ test: string }>({
+      const { register } = useForm({
         defaultValues: async () => {
           await sleep(100);
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -21,6 +21,7 @@ import {
   SetFieldValue,
   SetValueConfig,
   Subjects,
+  UnPackDefaultValues,
   UseFormClearErrors,
   UseFormGetFieldState,
   UseFormGetValues,
@@ -591,7 +592,8 @@ export function createFormControl<
         true,
       );
 
-    options.shouldValidate && trigger(name as Path<TFieldValues>);
+    options.shouldValidate &&
+      trigger(name as Path<UnPackDefaultValues<TFieldValues>>);
   };
 
   const setValues = <

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -129,9 +129,7 @@ export type FormState<TFieldValues extends FieldValues> = {
   isValid: boolean;
   submitCount: number;
   defaultValues?:
-    | (TFieldValues extends () => Promise<any>
-        ? Awaited<ReturnType<TFieldValues>>
-        : TFieldValues)
+    | UnPackDefaultValues<TFieldValues>
     | undefined
     | Readonly<DeepPartial<TFieldValues>>;
   dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -18,7 +18,7 @@ import {
   FieldPathValues,
 } from './path';
 import { Resolver } from './resolvers';
-import { DeepMap, DeepPartial, Noop } from './utils';
+import { DeepMap, DeepPartial, Noop, UnPackDefaultValues } from './utils';
 import { RegisterOptions } from './validator';
 
 declare const $NestedValue: unique symbol;
@@ -87,7 +87,7 @@ export type DelayCallback = (wait: number) => void;
 type AsyncDefaultValues<TFieldValues> = () => Promise<TFieldValues>;
 
 export type UseFormProps<
-  TFieldValues extends FieldValues = FieldValues,
+  TFieldValues extends UnPackDefaultValues<FieldValues> = UnPackDefaultValues<FieldValues>,
   TContext = any,
 > = Partial<{
   mode: Mode;
@@ -129,9 +129,11 @@ export type FormState<TFieldValues extends FieldValues> = {
   isValid: boolean;
   submitCount: number;
   defaultValues?:
-    | Readonly<DeepPartial<TFieldValues>>
-    | TFieldValues
-    | undefined;
+    | (TFieldValues extends () => Promise<any>
+        ? Awaited<ReturnType<TFieldValues>>
+        : TFieldValues)
+    | undefined
+    | Readonly<DeepPartial<TFieldValues>>;
   dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
   touchedFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
   errors: FieldErrors<TFieldValues>;

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -1,5 +1,5 @@
 import { FieldValues } from '../fields';
-import { BrowserNativeObject, Primitive } from '../utils';
+import { BrowserNativeObject, Primitive, UnPackDefaultValues } from '../utils';
 
 import { ArrayKey, IsTuple, TupleKeys } from './common';
 
@@ -34,7 +34,9 @@ export type Path<T> = T extends ReadonlyArray<infer V>
 /**
  * See {@link Path}
  */
-export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
+export type FieldPath<TFieldValues extends FieldValues> = Path<
+  UnPackDefaultValues<TFieldValues>
+>;
 
 /**
  * Helper type for recursively constructing paths through a type.
@@ -111,7 +113,7 @@ export type PathValue<T, P extends Path<T> | ArrayPath<T>> = T extends any
 export type FieldPathValue<
   TFieldValues extends FieldValues,
   TFieldPath extends FieldPath<TFieldValues>,
-> = PathValue<TFieldValues, TFieldPath>;
+> = PathValue<UnPackDefaultValues<TFieldValues>, TFieldPath>;
 
 /**
  * See {@link PathValue}

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -53,6 +53,11 @@ export type DeepPartialSkipArrayKey<T> = T extends
   ? { [K in keyof T]: DeepPartialSkipArrayKey<T[K]> }
   : { [K in keyof T]?: DeepPartialSkipArrayKey<T[K]> };
 
+export type UnPackDefaultValues<TFieldValues> =
+  TFieldValues extends () => Promise<any>
+    ? Awaited<ReturnType<TFieldValues>>
+    : TFieldValues;
+
 /**
  * Checks whether the type is any
  * See {@link https://stackoverflow.com/a/49928360/3406963}

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -54,9 +54,7 @@ export type DeepPartialSkipArrayKey<T> = T extends
   : { [K in keyof T]?: DeepPartialSkipArrayKey<T[K]> };
 
 export type UnPackDefaultValues<TFieldValues> =
-  TFieldValues extends () => Promise<any>
-    ? Awaited<ReturnType<TFieldValues>>
-    : TFieldValues;
+  TFieldValues extends () => Promise<infer U> ? U : TFieldValues;
 
 /**
  * Checks whether the type is any


### PR DESCRIPTION
The aim is to infer an async return for the defaultValue type definition.

```diff
const App = () => {
-  const { register } = useForm<{test: string}>({
+  const { register } = useForm({
    defaultValues: async () => {
      await sleep(100);

      return {
        test: 'test',
      };
    },
  });

  return (
    <form>
      <input {...register('test')} />
    </form>
  );
};
```
