### PR TITLE
check submitters `formNoValidate` property on `handleSubmit`

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -353,6 +353,13 @@ export type Names = {
 };
 
 // @public (undocumented)
+export type NativeEventWithSubmitter = {
+    submitter: React.ReactNode & {
+        formNoValidate?: boolean;
+    };
+};
+
+// @public (undocumented)
 export type NativeFieldValue = string | number | boolean | null | undefined | unknown[];
 
 // @public @deprecated (undocumented)

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -15,6 +15,7 @@ import {
   GetIsDirty,
   InternalFieldName,
   Names,
+  NativeEventWithSubmitter,
   Path,
   Ref,
   SetFieldValue,
@@ -1040,12 +1041,16 @@ export function createFormControl<
       let hasNoPromiseError = true;
       let fieldValues: any = cloneObject(_formValues);
 
+      const submitter = (e?.nativeEvent as NativeEventWithSubmitter)?.submitter;
+      const noValidate = submitter?.formNoValidate;
+
       _subjects.state.next({
         isSubmitting: true,
       });
 
       try {
-        if (_options.resolver) {
+        if (noValidate) {
+        } else if (_options.resolver) {
           const { errors, values } = await _executeSchema();
           _formState.errors = errors;
           fieldValues = values;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -23,3 +23,10 @@ export type EventType =
   | 'error'
   | 'progress'
   | 'custom';
+
+// the nativeEvent is not included in the type definition of synthetic events
+export type NativeEventWithSubmitter = {
+  submitter: React.ReactNode & {
+    formNoValidate?: boolean;
+  };
+};


### PR DESCRIPTION
> First I thought I was opening this PR onto my fork's `master`. We can close it until we see if #9389 is upvoted.
Meanwhile I just wanted to check if this is answering my problems on my app (it does).

It's a simple validation bypass, but I needed to type the `nativeEvent` properly to get access to the submitter and its props.
It is (on purpose?) not well typed in React.

I also didn't find where to update the documentation.
