### PR TITLE
Keep track of traversed types to avoid self-referencing while constructing paths for a type

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -13,17 +13,10 @@ import { ReactElement } from 'react';
 // @public (undocumented)
 export const appendErrors: (name: InternalFieldName, validateAllFieldCriteria: boolean, errors: InternalFieldErrors, type: string, message: ValidateResult) => {};
 
-// Warning: (ae-forgotten-export) The symbol "IsTuple" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "TupleKeys" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ArrayPathImpl" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ArrayKey" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ArrayPathInternal" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type ArrayPath<T, TraversedTypes = never> = T extends ReadonlyArray<infer V> ? IsTuple<T> extends true ? {
-    [K in TupleKeys<T>]-?: ArrayPathImpl<K & string, T[K], TraversedTypes>;
-}[TupleKeys<T>] : ArrayPathImpl<ArrayKey, V, TraversedTypes> : {
-    [K in keyof T]-?: ArrayPathImpl<K & string, T[K], TraversedTypes>;
-}[keyof T];
+export type ArrayPath<T> = T extends any ? ArrayPathInternal<T> : never;
 
 // @public (undocumented)
 export type BatchFieldArrayUpdate = <T extends Function, TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>>(name: InternalFieldName, updatedFieldArrayValues?: Partial<FieldArray<TFieldValues, TFieldArrayName>>[], method?: T, args?: Partial<{
@@ -75,7 +68,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
 };
 
 // @public
-export const Controller: <TFieldValues extends FieldValues = FieldValues, TName extends Path<UnPackAsyncDefaultValues<TFieldValues>, never> = Path<UnPackAsyncDefaultValues<TFieldValues>, never>>(props: ControllerProps<TFieldValues, TName>) => ReactElement<any, string | JSXElementConstructor<any>>;
+export const Controller: <TFieldValues extends FieldValues = FieldValues, TName extends Path<UnPackAsyncDefaultValues<TFieldValues>> = Path<UnPackAsyncDefaultValues<TFieldValues>>>(props: ControllerProps<TFieldValues, TName>) => ReactElement<any, string | JSXElementConstructor<any>>;
 
 // @public (undocumented)
 export type ControllerFieldState = {
@@ -299,6 +292,9 @@ export type InternalNameSet = Set<InternalFieldName>;
 // @public
 export type IsAny<T> = 0 extends 1 & T ? true : false;
 
+// @public
+export type IsEqual<T1, T2> = T1 extends T2 ? (<G>() => G extends T1 ? 1 : 2) extends <G>() => G extends T2 ? 1 : 2 ? true : false : false;
+
 // @public (undocumented)
 export type IsFlatObject<T extends object> = Extract<Exclude<T[keyof T], NestedValue | Date | FileList_2>, any[] | object> extends never ? true : false;
 
@@ -365,18 +361,16 @@ export type NonUndefined<T> = T extends undefined ? never : T;
 // @public (undocumented)
 export type Noop = () => void;
 
-// Warning: (ae-forgotten-export) The symbol "PathImpl" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "PathInternal" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type Path<T, TraversedTypes = never> = T extends ReadonlyArray<infer V> ? IsTuple<T> extends true ? {
-    [K in TupleKeys<T>]-?: PathImpl<K & string, T[K], TraversedTypes>;
-}[TupleKeys<T>] : PathImpl<ArrayKey, V, TraversedTypes> : {
-    [K in keyof T]-?: PathImpl<K & string, T[K], TraversedTypes>;
-}[keyof T];
+export type Path<T> = T extends any ? PathInternal<T> : never;
 
 // @public
 export type PathString = string;
 
+// Warning: (ae-forgotten-export) The symbol "ArrayKey" needs to be exported by the entry point index.d.ts
+//
 // @public
 export type PathValue<T, P extends Path<T> | ArrayPath<T>> = T extends any ? P extends `${infer K}.${infer R}` ? K extends keyof T ? R extends Path<T[K]> ? PathValue<T[K], R> : never : K extends `${ArrayKey}` ? T extends ReadonlyArray<infer V> ? PathValue<V, R & Path<V>> : never : never : P extends keyof T ? T[P] : P extends `${ArrayKey}` ? T extends ReadonlyArray<infer V> ? V : never : never : never;
 

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -19,10 +19,10 @@ export const appendErrors: (name: InternalFieldName, validateAllFieldCriteria: b
 // Warning: (ae-forgotten-export) The symbol "ArrayKey" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type ArrayPath<T> = T extends ReadonlyArray<infer V> ? IsTuple<T> extends true ? {
-    [K in TupleKeys<T>]-?: ArrayPathImpl<K & string, T[K]>;
-}[TupleKeys<T>] : ArrayPathImpl<ArrayKey, V> : {
-    [K in keyof T]-?: ArrayPathImpl<K & string, T[K]>;
+export type ArrayPath<T, TraversedTypes = never> = T extends ReadonlyArray<infer V> ? IsTuple<T> extends true ? {
+    [K in TupleKeys<T>]-?: ArrayPathImpl<K & string, T[K], TraversedTypes>;
+}[TupleKeys<T>] : ArrayPathImpl<ArrayKey, V, TraversedTypes> : {
+    [K in keyof T]-?: ArrayPathImpl<K & string, T[K], TraversedTypes>;
 }[keyof T];
 
 // @public (undocumented)
@@ -75,7 +75,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
 };
 
 // @public
-export const Controller: <TFieldValues extends FieldValues = FieldValues, TName extends Path<UnPackAsyncDefaultValues<TFieldValues>> = Path<UnPackAsyncDefaultValues<TFieldValues>>>(props: ControllerProps<TFieldValues, TName>) => ReactElement<any, string | JSXElementConstructor<any>>;
+export const Controller: <TFieldValues extends FieldValues = FieldValues, TName extends Path<UnPackAsyncDefaultValues<TFieldValues>, never> = Path<UnPackAsyncDefaultValues<TFieldValues>, never>>(props: ControllerProps<TFieldValues, TName>) => ReactElement<any, string | JSXElementConstructor<any>>;
 
 // @public (undocumented)
 export type ControllerFieldState = {
@@ -368,10 +368,10 @@ export type Noop = () => void;
 // Warning: (ae-forgotten-export) The symbol "PathImpl" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type Path<T> = T extends ReadonlyArray<infer V> ? IsTuple<T> extends true ? {
-    [K in TupleKeys<T>]-?: PathImpl<K & string, T[K]>;
-}[TupleKeys<T>] : PathImpl<ArrayKey, V> : {
-    [K in keyof T]-?: PathImpl<K & string, T[K]>;
+export type Path<T, TraversedTypes = never> = T extends ReadonlyArray<infer V> ? IsTuple<T> extends true ? {
+    [K in TupleKeys<T>]-?: PathImpl<K & string, T[K], TraversedTypes>;
+}[TupleKeys<T>] : PathImpl<ArrayKey, V, TraversedTypes> : {
+    [K in keyof T]-?: PathImpl<K & string, T[K], TraversedTypes>;
 }[keyof T];
 
 // @public

--- a/src/__tests__/type.test.tsx
+++ b/src/__tests__/type.test.tsx
@@ -60,7 +60,7 @@ test('should not throw type error with optional array fields', () => {
 
         {fields.map((field, index) => (
           <div key={field.id}>
-            <input {...register(`things.${index}.name`)} />
+            <input {...register(`things.${index}.name` as const)} />
           </div>
         ))}
         {fieldArray.fields.map((item) => {

--- a/src/__typetest__/path/eager.test-d.ts
+++ b/src/__typetest__/path/eager.test-d.ts
@@ -23,6 +23,25 @@ import { _, Depth3Type } from '../__fixtures__';
     const actual = _ as Path<{ foo: string[] }>;
     expectType<'foo' | `foo.${number}`>(actual);
   }
+
+  /** it should be able to avoid self-referencing/recursion, not crashing on self-referencing types. */ {
+    type Foo = { foo: Foo };
+    const actual = _ as Path<Foo>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not erroneously match subtypes as traversed */ {
+    type Foo =
+      | {
+          foo?: Foo;
+          bar?: {
+            baz: 1;
+          };
+        }
+      | {};
+    const actual = _ as Path<Foo>;
+    expectType<'foo' | 'bar' | 'bar.baz'>(actual);
+  }
 }
 
 /** {@link ArrayPath} */ {
@@ -41,6 +60,25 @@ import { _, Depth3Type } from '../__fixtures__';
   /** it should include paths through arrays */ {
     const actual = _ as ArrayPath<{ foo: string[][][] }>;
     expectType<'foo' | `foo.${number}`>(actual);
+  }
+
+  /** it should be able to avoid self-referencing/recursion, not crashing on self-referencing types. */ {
+    type Foo = { foo: Foo[] };
+    const actual = _ as ArrayPath<Foo>;
+    expectType<'foo'>(actual);
+  }
+
+  /** it should not erroneously match subtypes as traversed */ {
+    type Foo =
+      | {
+          bar?: {
+            baz?: 1;
+            fooArr?: Foo[];
+          };
+        }
+      | {};
+    const actual = _ as ArrayPath<Foo>;
+    expectType<'bar.fooArr'>(actual);
   }
 }
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -82,17 +82,17 @@ export type IsNever<T> = [T] extends [never] ? true : false;
  * @typeParam T1 - type to check
  * @typeParam T2 - type to check against
  * ```
- * IsExactlyAssignable<string, string> = true
- * IsExactlyAssignable<'foo', 'foo'> = true
- * IsExactlyAssignable<string, number> = false
- * IsExactlyAssignable<string, number> = false
- * IsExactlyAssignable<string, 'foo'> = false
- * IsExactlyAssignable<'foo', string> = false
- * IsExactlyAssignable<'foo' | 'bar', 'foo'> = boolean // 'foo' is assignable, but 'bar' is not (true | false) -> boolean
+ * IsEqual<string, string> = true
+ * IsEqual<'foo', 'foo'> = true
+ * IsEqual<string, number> = false
+ * IsEqual<string, number> = false
+ * IsEqual<string, 'foo'> = false
+ * IsEqual<'foo', string> = false
+ * IsEqual<'foo' | 'bar', 'foo'> = boolean // 'foo' is assignable, but 'bar' is not (true | false) -> boolean
  * ```
  */
-export type IsExactlyAssignable<T1, T2> = T1 extends T2
-  ? T1 extends Extract<T2, T1>
+export type IsEqual<T1, T2> = T1 extends T2
+  ? (<G>() => G extends T1 ? 1 : 2) extends <G>() => G extends T2 ? 1 : 2
     ? true
     : false
   : false;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -77,6 +77,26 @@ export type IsAny<T> = 0 extends 1 & T ? true : false;
  */
 export type IsNever<T> = [T] extends [never] ? true : false;
 
+/**
+ * Checks whether T1 can be exactly (mutually) assigned to T2
+ * @typeParam T1 - type to check
+ * @typeParam T2 - type to check against
+ * ```
+ * IsExactlyAssignable<string, string> = true
+ * IsExactlyAssignable<'foo', 'foo'> = true
+ * IsExactlyAssignable<string, number> = false
+ * IsExactlyAssignable<string, number> = false
+ * IsExactlyAssignable<string, 'foo'> = false
+ * IsExactlyAssignable<'foo', string> = false
+ * IsExactlyAssignable<'foo' | 'bar', 'foo'> = boolean // 'foo' is assignable, but 'bar' is not (true | false) -> boolean
+ * ```
+ */
+export type IsExactlyAssignable<T1, T2> = T1 extends T2
+  ? T1 extends Extract<T2, T1>
+    ? true
+    : false
+  : false;
+
 export type DeepMap<T, TValue> = IsAny<T> extends true
   ? any
   : T extends BrowserNativeObject | NestedValue


### PR DESCRIPTION
[Link to TS Playground showing off what purpose this PR has](https://www.typescriptlang.org/play?ssl=11&ssc=1&pln=12&pc=1#code/C4TwDgpgBAShDGBXATgZwJYDcIBVzQF4oBvAKCijGXQFt1gsIB+ALigDtEaAjCZAbnKVqdBtgCCyZKw5deyANoBdQRSq16jHIjAAbZmwWcefFUID23AFYyyFCpasAFEW2PzV9xy9qTkbuT5lTwdrHxptPQhDd1NPAF9PRz9bIVCrP3CAkwEheOChZAQUDHN2GTgkNC18QUTSUlBIKABRAA8AQxoopw7gAAsoIgAxdAhdABNegYAeSpKayAA+QSbodq6ovw6QacGRscnt3b7+ueLq7DxlwQaAegAqJ+eX19e70keoXuQGDt0oBAOgBzPgAOmAqCgDw+jze8LeH0+T3IDygAAlxpBkFA1lAAGbmHFFKoYbC6EBQeBlVDAZCIeAMdjAyinKEDZDmRDAwYdXH4MGoqAAZQg0GIAAFdOh2ABrb6neKoj54vYASW6uhmAGlAW1gBB2BMobTqMyoAAfWQ5AA0UAAanacMgOtg0BAJtcIKglkMHXqDUbUEIreFNNgQ1AAEKcgDuqD4ADk+owAPLWBDAIRMKAAAwAJMRtfFc0I2PaA4bjVBna6+AnPfhgxQcwp2nSOoyZo6ay63Q2vT6lJWg1A2-qXV3a-2PYO7falko0lAcwWiyXl2w18Xc5a84Xi2DC3tu06+-XZ029wuNxQtweS3vt-Ej8QTz3pxfG5AoVab7nbjhIUvSgWN+nQeBBiBUFkApKlzF0fRGShf4ATANlcX6TluV5flICFCU1h+LoaygABaPDoDAiDBlQfouUmKBeCgGU6XMVBIEZD0CKIjoXRoXs63db9vXIyioWoyCoH6OsoH+IoOgmSleENXFz2E3FzDkzBzHQCYWPYfEZXoCAhRJBYygIiBOk1UzoTzXNS3sk9iEJcw2GIbg+LYU0ZWBeJ4l9IgAHI3OCvdQvMcwwS85BgqFRynJhUhrLAIlgEohVZhwM8hIHK8iHYCA3SC0jrMDas4EUsoKWOGYZXxPgHSWbMoDVVBIn0GYcF9cqq3Zek7PsHM7HsMaFF1GUax0fRtQgEBUG6xcyJkdVNR1KAADIoF85knQmpRcpnESfRCex8k6iA5oWpalzGtg1r0GZjmu+cjq-QcWrvEhlwoCaDKgWV5vMfEayUFaHtODUnt1bbduBfbtUOwTjs+s78iBkAQbBwCUXs0VxSlGV5T2JVoQ+VL0sy0ZximU5uppyZ7X+RBRL60dGYmZndFZn0-RPIQAFV2F6eBZXEVAQHYeAABEIHxDpEF0YBud5hnDi5lnvRalZ7jxtFMV0bFMsJYkLjJcZKWpdhTQZJkWXQgZ2SwrkeTkyjBXxsUSCJuUoGOUnlUafB-akHZHq1XV2ereG91iZA3pRj6m1Kito+bPcwzEIarRjcx4yTFNsHTKxM1aoq3TLf109gIEJhqkA6oaprBa+lcoEFkdqyzxg9zzgvkGTbOS7LsacwrvhN2r-V+qT4TB2XVt20nYBTzn-Kf0XLuoXHDsp3UjfvXnRdfvbifkFP+9113K1n1fAP6Y-A-Lx-a8llvewr53J8H3vsOTlmE-PKL9RJ-nfk5KA5Zt7rxARnJeE5OyryAajFOw4a67xXt1Z+J1j53WGhwYqk97r7nXH-F0ACzjIOTq-MBH8v4vkLA-QB7155XloQBPWDxgIh0klBEEfA4LUkQpmFCiFWRO0wthN2fI8S8MoLpdgGVgBaQ6OwOS-8hRrE9miQi+BiICRwGJWR4EpJ0QYvpZirFOQcUzNxeyujID6JgSdIxV45EyWwHJXQCklJMTFGojsx1NLaV0vpBqxkDRmXNugSy9jrKbH0AlRyQoXJuQ8rFHydI-LKDtF5AAXtkeQygAqlUitFWK4UrRlJih0PJ8V7KJSDpTX4mUmFnBys4wcfpz6lUMTXKq9d2C1X-jMIQzccT2lIG3HM7VLpLWgXSVmi8fpjXGpNNRl1rqLR6uDGQbToaRy2jtLJe0awHRYYfU6p8LozSuvNbZJ9iH7PWi9eaidPysM3lXUaayAaY2xjgXZbBnkwyOfDRGyMPmXN1mNDGwNQaAtxlwr2hNpR+zaWTZKzSlEh05m09WtNVZsxnhzDWRK+ZEHxULEWnZxaS2lnLBWSsVZa22ZzclOskUIgRLCNEapEwABl+UtDagAWScKmGAOBhTk2RNynlKU2hpRaXidlrK-SVCJBMGY4K5LsBALrbFrT-7XW6YEXIRq8SzNud1aBAyG51VUQa0q8doE4AUMFfQzIBjBTwTmBWugExV0WRAQQlqQ6bPuba-pdcHUjKdUsUq7R4A8wmBAUZFB-kIptEILNeqQDKCmWGpVVNVQiHDIQSMnBEKRkQEaeWMo7F7nhlW81kZuBRX0KoyMkseAIXbegYErFi3Kpxc0fuCZB5FwgCPRkfoZZ9GgFaUY+gBXoFpHuFdobFWjsysLUWdKpay3lorZW5KCVM1ZUFIQOA1U82JRVKEAAKAAlEMX0LhzB0ATPVQyLdfQ5k7mwW9ZLWWCCAA)

Using this library in conjunction with other libraries such as Firebase Firestore, which sometimes have recursive structures (in my case `DocumentReference->parent->parent->parent->parent->[...]`) can be rather frustrating due to the eager unpacking of path keys.

My proposed solution is to pass along a union of all traversed types, and see if the type we're about to go deeper into has already been included in the current stack of traversals.