### PR TITLE
💁‍♂️ close #9684 revert `UnPackAsyncDefaultValues` to avoid TS breaking change

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -75,7 +75,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
 };
 
 // @public
-export const Controller: <TFieldValues extends FieldValues = FieldValues, TName extends Path<UnPackAsyncDefaultValues<TFieldValues>> = Path<UnPackAsyncDefaultValues<TFieldValues>>>(props: ControllerProps<TFieldValues, TName>) => ReactElement<any, string | JSXElementConstructor<any>>;
+export const Controller: <TFieldValues extends FieldValues = FieldValues, TName extends Path<TFieldValues> = Path<TFieldValues>>(props: ControllerProps<TFieldValues, TName>) => ReactElement<any, string | JSXElementConstructor<any>>;
 
 // @public (undocumented)
 export type ControllerFieldState = {
@@ -182,10 +182,10 @@ export type FieldArrayMethodProps = {
 };
 
 // @public
-export type FieldArrayPath<TFieldValues extends FieldValues> = ArrayPath<UnPackAsyncDefaultValues<TFieldValues>>;
+export type FieldArrayPath<TFieldValues extends FieldValues> = ArrayPath<TFieldValues>;
 
 // @public
-export type FieldArrayPathValue<TFieldValues extends FieldValues, TFieldArrayPath extends FieldArrayPath<TFieldValues>> = PathValue<UnPackAsyncDefaultValues<TFieldValues>, TFieldArrayPath>;
+export type FieldArrayPathValue<TFieldValues extends FieldValues, TFieldArrayPath extends FieldArrayPath<TFieldValues>> = PathValue<TFieldValues, TFieldArrayPath>;
 
 // @public
 export type FieldArrayWithId<TFieldValues extends FieldValues = FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>, TKeyName extends string = 'id'> = FieldArray<TFieldValues, TFieldArrayName> & Record<TKeyName, string>;
@@ -203,7 +203,7 @@ export type FieldError = {
 };
 
 // @public (undocumented)
-export type FieldErrors<T extends FieldValues = FieldValues> = Partial<FieldValues extends IsAny<FieldValues> ? any : FieldErrorsImpl<DeepRequired<UnPackAsyncDefaultValues<T>>>>;
+export type FieldErrors<T extends FieldValues = FieldValues> = Partial<FieldValues extends IsAny<FieldValues> ? any : FieldErrorsImpl<DeepRequired<T>>>;
 
 // @public (undocumented)
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
@@ -217,7 +217,7 @@ export type FieldName<TFieldValues extends FieldValues> = IsFlatObject<TFieldVal
 export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<DeepPartial<TFieldValues>, boolean>;
 
 // @public
-export type FieldPath<TFieldValues extends FieldValues> = Path<UnPackAsyncDefaultValues<TFieldValues>>;
+export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
 
 // @public
 export type FieldPathByValue<TFieldValues extends FieldValues, TValue> = {
@@ -225,7 +225,7 @@ export type FieldPathByValue<TFieldValues extends FieldValues, TValue> = {
 }[FieldPath<TFieldValues>];
 
 // @public
-export type FieldPathValue<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = PathValue<UnPackAsyncDefaultValues<TFieldValues>, TFieldPath>;
+export type FieldPathValue<TFieldValues extends FieldValues, TFieldPath extends FieldPath<TFieldValues>> = PathValue<TFieldValues, TFieldPath>;
 
 // @public
 export type FieldPathValues<TFieldValues extends FieldValues, TPath extends FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[]> = {} & {
@@ -259,9 +259,9 @@ export type FormState<TFieldValues extends FieldValues> = {
     isValidating: boolean;
     isValid: boolean;
     submitCount: number;
-    defaultValues?: UnPackAsyncDefaultValues<TFieldValues> | undefined | Readonly<DeepPartial<TFieldValues>>;
-    dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<UnPackAsyncDefaultValues<TFieldValues>>>>;
-    touchedFields: Partial<Readonly<FieldNamesMarkedBoolean<UnPackAsyncDefaultValues<TFieldValues>>>>;
+    defaultValues?: undefined | Readonly<DeepPartial<TFieldValues>>;
+    dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
+    touchedFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
     errors: FieldErrors<TFieldValues>;
 };
 
@@ -488,9 +488,6 @@ export type TriggerConfig = Partial<{
     shouldFocus: boolean;
 }>;
 
-// @public (undocumented)
-export type UnPackAsyncDefaultValues<TFieldValues> = TFieldValues extends () => Promise<infer U> ? U : TFieldValues;
-
 // @public @deprecated (undocumented)
 export type UnpackNestedValue<T> = T extends NestedValue<infer U> ? U : T extends Date | FileList | File | Blob ? T : T extends object ? {
     [K in keyof T]: UnpackNestedValue<T[K]>;
@@ -594,7 +591,7 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
 export type UseFormHandleSubmit<TFieldValues extends FieldValues> = (onValid: SubmitHandler<TFieldValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
 
 // @public (undocumented)
-export type UseFormProps<TFieldValues extends UnPackAsyncDefaultValues<FieldValues> = UnPackAsyncDefaultValues<FieldValues>, TContext = any> = Partial<{
+export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContext = any> = Partial<{
     mode: Mode;
     reValidateMode: Exclude<Mode, 'onTouched' | 'all'>;
     defaultValues: DefaultValues<TFieldValues> | AsyncDefaultValues<TFieldValues>;
@@ -779,7 +776,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 // Warnings were encountered during analysis:
 //
 // src/types/form.ts:97:3 - (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:432:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:425:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/type.test.tsx
+++ b/src/__tests__/type.test.tsx
@@ -287,6 +287,14 @@ test('should work with generic component path assertion', () => {
 });
 
 test('should infer async default values', () => {
+  const formValues = {
+    test: 'test',
+    test1: {
+      nested: 'test',
+    },
+    fieldArray: [{ test: '' }],
+  };
+
   function App() {
     const {
       register,
@@ -302,15 +310,9 @@ test('should infer async default values', () => {
       setFocus,
       trigger,
       setError,
-    } = useForm({
+    } = useForm<typeof formValues>({
       defaultValues: async () => {
-        return {
-          test: 'test',
-          test1: {
-            nested: 'test',
-          },
-          fieldArray: [{ test: '' }],
-        };
+        return formValues;
       },
     });
     useFieldArray({
@@ -334,7 +336,9 @@ test('should infer async default values', () => {
     setValue('test1.nested', 'data');
     reset({
       test: 'test',
-      test1: 'test1',
+      test1: {
+        nested: 'test1',
+      },
     });
 
     watch('test');

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1724,7 +1724,9 @@ describe('useForm', () => {
       const {
         register,
         formState: { isLoading },
-      } = useForm({
+      } = useForm<{
+        test: string;
+      }>({
         defaultValues: async () => {
           await sleep(100);
 
@@ -1761,7 +1763,9 @@ describe('useForm', () => {
 
   it('should update async default values for controlled components', async () => {
     const App = () => {
-      const { control } = useForm({
+      const { control } = useForm<{
+        test: string;
+      }>({
         defaultValues: async () => {
           await sleep(100);
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -20,7 +20,6 @@ import {
   SetFieldValue,
   SetValueConfig,
   Subjects,
-  UnPackAsyncDefaultValues,
   UseFormClearErrors,
   UseFormGetFieldState,
   UseFormGetValues,
@@ -585,8 +584,7 @@ export function createFormControl<
         true,
       );
 
-    options.shouldValidate &&
-      trigger(name as Path<UnPackAsyncDefaultValues<TFieldValues>>);
+    options.shouldValidate && trigger(name as Path<TFieldValues>);
   };
 
   const setValues = <

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,11 +1,5 @@
 import { FieldValues, InternalFieldName, Ref } from './fields';
-import {
-  BrowserNativeObject,
-  IsAny,
-  LiteralUnion,
-  Merge,
-  UnPackAsyncDefaultValues,
-} from './utils';
+import { BrowserNativeObject, IsAny, LiteralUnion, Merge } from './utils';
 import { RegisterOptions, ValidateResult } from './validator';
 
 export type Message = string;
@@ -47,7 +41,7 @@ export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
 export type FieldErrors<T extends FieldValues = FieldValues> = Partial<
   FieldValues extends IsAny<FieldValues>
     ? any
-    : FieldErrorsImpl<DeepRequired<UnPackAsyncDefaultValues<T>>>
+    : FieldErrorsImpl<DeepRequired<T>>
 >;
 
 export type InternalFieldErrors = Partial<

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -18,7 +18,7 @@ import {
   FieldPathValues,
 } from './path';
 import { Resolver } from './resolvers';
-import { DeepMap, DeepPartial, Noop, UnPackAsyncDefaultValues } from './utils';
+import { DeepMap, DeepPartial, Noop } from './utils';
 import { RegisterOptions } from './validator';
 
 declare const $NestedValue: unique symbol;
@@ -89,7 +89,7 @@ type AsyncDefaultValues<TFieldValues> = (
 ) => Promise<TFieldValues>;
 
 export type UseFormProps<
-  TFieldValues extends UnPackAsyncDefaultValues<FieldValues> = UnPackAsyncDefaultValues<FieldValues>,
+  TFieldValues extends FieldValues = FieldValues,
   TContext = any,
 > = Partial<{
   mode: Mode;
@@ -131,16 +131,9 @@ export type FormState<TFieldValues extends FieldValues> = {
   isValidating: boolean;
   isValid: boolean;
   submitCount: number;
-  defaultValues?:
-    | UnPackAsyncDefaultValues<TFieldValues>
-    | undefined
-    | Readonly<DeepPartial<TFieldValues>>;
-  dirtyFields: Partial<
-    Readonly<FieldNamesMarkedBoolean<UnPackAsyncDefaultValues<TFieldValues>>>
-  >;
-  touchedFields: Partial<
-    Readonly<FieldNamesMarkedBoolean<UnPackAsyncDefaultValues<TFieldValues>>>
-  >;
+  defaultValues?: undefined | Readonly<DeepPartial<TFieldValues>>;
+  dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
+  touchedFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
   errors: FieldErrors<TFieldValues>;
 };
 

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -1,9 +1,5 @@
 import { FieldValues } from '../fields';
-import {
-  BrowserNativeObject,
-  Primitive,
-  UnPackAsyncDefaultValues,
-} from '../utils';
+import { BrowserNativeObject, Primitive } from '../utils';
 
 import { ArrayKey, IsTuple, TupleKeys } from './common';
 
@@ -38,9 +34,7 @@ export type Path<T> = T extends ReadonlyArray<infer V>
 /**
  * See {@link Path}
  */
-export type FieldPath<TFieldValues extends FieldValues> = Path<
-  UnPackAsyncDefaultValues<TFieldValues>
->;
+export type FieldPath<TFieldValues extends FieldValues> = Path<TFieldValues>;
 
 /**
  * Helper type for recursively constructing paths through a type.
@@ -78,9 +72,8 @@ export type ArrayPath<T> = T extends ReadonlyArray<infer V>
 /**
  * See {@link ArrayPath}
  */
-export type FieldArrayPath<TFieldValues extends FieldValues> = ArrayPath<
-  UnPackAsyncDefaultValues<TFieldValues>
->;
+export type FieldArrayPath<TFieldValues extends FieldValues> =
+  ArrayPath<TFieldValues>;
 
 /**
  * Type to evaluate the type which the given path points to.
@@ -118,7 +111,7 @@ export type PathValue<T, P extends Path<T> | ArrayPath<T>> = T extends any
 export type FieldPathValue<
   TFieldValues extends FieldValues,
   TFieldPath extends FieldPath<TFieldValues>,
-> = PathValue<UnPackAsyncDefaultValues<TFieldValues>, TFieldPath>;
+> = PathValue<TFieldValues, TFieldPath>;
 
 /**
  * See {@link PathValue}
@@ -126,7 +119,7 @@ export type FieldPathValue<
 export type FieldArrayPathValue<
   TFieldValues extends FieldValues,
   TFieldArrayPath extends FieldArrayPath<TFieldValues>,
-> = PathValue<UnPackAsyncDefaultValues<TFieldValues>, TFieldArrayPath>;
+> = PathValue<TFieldValues, TFieldArrayPath>;
 
 /**
  * Type to evaluate the type which the given paths point to.

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -53,9 +53,6 @@ export type DeepPartialSkipArrayKey<T> = T extends
   ? { [K in keyof T]: DeepPartialSkipArrayKey<T[K]> }
   : { [K in keyof T]?: DeepPartialSkipArrayKey<T[K]> };
 
-export type UnPackAsyncDefaultValues<TFieldValues> =
-  TFieldValues extends () => Promise<infer U> ? U : TFieldValues;
-
 /**
  * Checks whether the type is any
  * See {@link https://stackoverflow.com/a/49928360/3406963}


### PR DESCRIPTION
Revert `UnPackAsyncDefaultValues` as this may lead to TS breaking change, the downside would mean users will have to manually provide form value generic (async default values) in order for us to do the type check.