### PR TITLE
Fix formState.invalid not works at first render.

### DIFF
--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -634,6 +634,35 @@ describe('Controller', () => {
     await waitFor(() => expect(currentErrors.test).toBeUndefined());
   });
 
+  it('should show invalid input when there is an error in first render', async () => {
+    const Component = () => {
+      const { control } = useForm({
+        mode: 'onChange',
+      });
+
+      return (
+        <Controller
+          defaultValue=""
+          name="test"
+          render={({ field: props, fieldState }) => (
+            <>
+              <input {...props} />
+              {fieldState.invalid && <p>Input is invalid.</p>}
+            </>
+          )}
+          control={control}
+          rules={{
+            required: true,
+          }}
+        />
+      );
+    };
+
+    render(<Component />);
+
+    expect(await screen.findByText('Input is invalid.')).toBeVisible();
+  });
+
   it('should show invalid input when there is an error', async () => {
     const Component = () => {
       const { control } = useForm({

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -832,7 +832,7 @@ export function createFormControl<
     name,
     formState,
   ) => ({
-    invalid: !!get((formState || _formState).errors, name),
+    invalid: !get((formState || _formState).isValid, name),
     isDirty: !!get((formState || _formState).dirtyFields, name),
     isTouched: !!get((formState || _formState).touchedFields, name),
     error: get((formState || _formState).errors, name),

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -13,12 +13,6 @@ import {
 } from './';
 
 export type ControllerFieldState = {
-  /**
-   * @deprecated check `fieldState.error` instead
-   * ```jsx
-   * {fieldState.error && <p>{fieldState.error.message}</p>}
-   * ```
-   */
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -333,13 +333,7 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <
 >(
   name: TFieldName,
   formState?: FormState<TFieldValues>,
-) => {
-  /**
-   * @deprecated check `fieldState.error` instead
-   * ```jsx
-   * {fieldState.error && <p>{fieldState.error.message}</p>}
-   * ```
-   */
+) => {  
   invalid: boolean;
   isDirty: boolean;
   isTouched: boolean;

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -144,7 +144,7 @@ export function useController<
       {
         invalid: {
           enumerable: true,
-          get: () => !!get(formState.errors, name),
+          get: () => !get(formState.isValid, name),
         },
         isDirty: {
           enumerable: true,


### PR DESCRIPTION
https://github.com/react-hook-form/react-hook-form/discussions/9750

formState.invalid should be classified by whether the field is valid or not, not by error.

Now, We're setting this standard by an error right now. 
The error value changes only when there is an action, So invalid value is not correct at initial render.

By not using the invalid value through error, This value will be normal.

I don't think it needs to be deprecated anymore because this value is normal.