### PR TITLE
Add formState.invalidFields property

### DIFF
--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -634,6 +634,35 @@ describe('Controller', () => {
     await waitFor(() => expect(currentErrors.test).toBeUndefined());
   });
 
+  it('should show invalid input when there is an error in first render', async () => {
+    const Component = () => {
+      const { control } = useForm({
+        mode: 'onChange',
+      });
+
+      return (
+        <Controller
+          defaultValue=""
+          name="test"
+          render={({ field: props, fieldState }) => (
+            <>
+              <input {...props} />
+              {fieldState.invalid && <p>Input is invalid.</p>}
+            </>
+          )}
+          control={control}
+          rules={{
+            required: true,
+          }}
+        />
+      );
+    };
+
+    render(<Component />);
+
+    expect(await screen.findByText('Input is invalid.')).toBeVisible();
+  });
+
   it('should show invalid input when there is an error', async () => {
     const Component = () => {
       const { control } = useForm({

--- a/src/logic/getInvalidFields.ts
+++ b/src/logic/getInvalidFields.ts
@@ -1,0 +1,35 @@
+import { FieldRefs, FieldValues } from '../types';
+
+import validateField from './validateField';
+
+async function getInvalidFields<T extends FieldValues>(
+  fields: FieldRefs,
+  formValues: T,
+  validateAllFieldCriteria: boolean,
+) {
+  const invalidFields: any = {};
+
+  for (const name in fields) {
+    const field = fields[name];
+
+    if (field) {
+      const { _f } = field;
+
+      if (_f) {
+        const fieldError = await validateField(
+          field,
+          formValues,
+          validateAllFieldCriteria,
+        );
+
+        if (fieldError[_f.name]) {
+          invalidFields[_f.name] = _f;
+        }
+      }
+    }
+  }
+
+  return invalidFields;
+}
+
+export default getInvalidFields;

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -13,12 +13,6 @@ import {
 } from './';
 
 export type ControllerFieldState = {
-  /**
-   * @deprecated check `fieldState.error` instead
-   * ```jsx
-   * {fieldState.error && <p>{fieldState.error.message}</p>}
-   * ```
-   */
   invalid: boolean;
   isTouched: boolean;
   isDirty: boolean;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -134,6 +134,7 @@ export type FormState<TFieldValues extends FieldValues> = {
   defaultValues?: undefined | Readonly<DeepPartial<TFieldValues>>;
   dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
   touchedFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
+  invalidFields: Partial<Readonly<FieldNamesMarkedBoolean<TFieldValues>>>;
   errors: FieldErrors<TFieldValues>;
 };
 
@@ -334,12 +335,6 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <
   name: TFieldName,
   formState?: FormState<TFieldValues>,
 ) => {
-  /**
-   * @deprecated check `fieldState.error` instead
-   * ```jsx
-   * {fieldState.error && <p>{fieldState.error.message}</p>}
-   * ```
-   */
   invalid: boolean;
   isDirty: boolean;
   isTouched: boolean;

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -144,7 +144,7 @@ export function useController<
       {
         invalid: {
           enumerable: true,
-          get: () => !!get(formState.errors, name),
+          get: () => !!get(formState.invalidFields, name),
         },
         isDirty: {
           enumerable: true,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -57,6 +57,7 @@ export function useForm<
     submitCount: 0,
     dirtyFields: {},
     touchedFields: {},
+    invalidFields: {},
     errors: {},
     defaultValues: isFunction(props.defaultValues)
       ? undefined

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -54,6 +54,7 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
     isLoading: false,
     dirtyFields: false,
     touchedFields: false,
+    invalidFields: false,
     isValidating: false,
     isValid: false,
     errors: false,


### PR DESCRIPTION
formState.invalid should be classified by whether the field is valid or not, not by error.

Now, We're setting this standard by an error right now.
The error value changes only when there is an action, So invalid value is not correct at initial render.

By not using the invalid value through error, This value will be normal.

So, i add formState.invalidFields and calculate fieldState.invalid with that.
https://github.com/react-hook-form/react-hook-form/pull/9753#discussion_r1067029226

But there is one problem in my work. In useFieldArray, the function I added doesn't work properly. I would appreciate your help on this part.

Also, there seems to be some deficiencies in the code. I would appreciate your help in this part, too.

Thanks :) 

related PR: https://github.com/react-hook-form/react-hook-form/pull/9753
discussion: https://github.com/react-hook-form/react-hook-form/discussions/9750