### PR TITLE
simple fix to allow numeric fields to use regex patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form",
   "description": "Performant, flexible and extensible forms library for React Hooks",
-  "version": "7.42.1",
+  "version": "7.42.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.mjs",
   "umd:main": "dist/index.umd.js",

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -207,7 +207,12 @@ export default async <T extends FieldValues>(
   if (pattern && !isEmpty && (isString(inputValue) || valueAsNumber)) {
     const { value: patternValue, message } = getValueAndMessage(pattern);
 
-    if (isRegex(patternValue) && !(isString(inputValue) ? inputValue : String(inputValue)).match(patternValue)) {
+    if (
+      isRegex(patternValue) &&
+      !(isString(inputValue) ? inputValue : String(inputValue))?.match(
+        patternValue,
+      )
+    ) {
       error[name] = {
         type: INPUT_VALIDATION_RULES.pattern,
         message,

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -207,7 +207,7 @@ export default async <T extends FieldValues>(
   if (pattern && !isEmpty && (isString(inputValue) || valueAsNumber)) {
     const { value: patternValue, message } = getValueAndMessage(pattern);
 
-    if (isRegex(patternValue) && !String(inputValue).match(patternValue)) {
+    if (isRegex(patternValue) && !(isString(inputValue) ? inputValue : String(inputValue)).match(patternValue)) {
       error[name] = {
         type: INPUT_VALIDATION_RULES.pattern,
         message,

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -204,10 +204,10 @@ export default async <T extends FieldValues>(
     }
   }
 
-  if (pattern && !isEmpty && isString(inputValue)) {
+  if (pattern && !isEmpty && (isString(inputValue) || valueAsNumber)) {
     const { value: patternValue, message } = getValueAndMessage(pattern);
 
-    if (isRegex(patternValue) && !inputValue.match(patternValue)) {
+    if (isRegex(patternValue) && !String(inputValue).match(patternValue)) {
       error[name] = {
         type: INPUT_VALIDATION_RULES.pattern,
         message,


### PR DESCRIPTION
I saw you added external validation functions a few days ago but it seemed to me a less confusing path to simply treat numbers as strings if the user wants to use a pattern.