### PR TITLE
improve error handle with handleSubmit callback

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -490,7 +490,7 @@ export type Subjects<TFieldValues extends FieldValues = FieldValues> = {
 };
 
 // @public (undocumented)
-export type SubmitErrorHandler<TFieldValues extends FieldValues> = (errors: FieldErrors<TFieldValues>, event?: React_2.BaseSyntheticEvent) => any | Promise<any>;
+export type SubmitErrorHandler<TFieldValues extends FieldValues> = (errors: FieldErrors<TFieldValues>, event?: React_2.BaseSyntheticEvent, error?: unknown) => any | Promise<any>;
 
 // @public (undocumented)
 export type SubmitHandler<TFieldValues extends FieldValues> = (data: TFieldValues, event?: React_2.BaseSyntheticEvent) => any | Promise<any>;
@@ -787,8 +787,8 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:97:3 - (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:419:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:98:3 - (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:420:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -346,7 +346,7 @@ describe('formState', () => {
           </p>
           <button
             type={'button'}
-            onClick={() => handleSubmit(rejectPromiseFn)().catch(() => {})}
+            onClick={() => handleSubmit(rejectPromiseFn)()}
           >
             Submit
           </button>
@@ -356,9 +356,14 @@ describe('formState', () => {
 
     render(<App />);
 
-    fireEvent.click(screen.getByRole('button'));
+    act(() => {
+      fireEvent.click(screen.getByRole('button'));
+    });
 
-    expect(screen.getByText('isNotSubmitSuccessful')).toBeVisible();
+    await waitFor(async () => {
+      screen.getByText('isSubmitted');
+      screen.getByText('isNotSubmitSuccessful');
+    });
   });
 
   it('should update isValid even with mode set to onSubmit', async () => {

--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -268,9 +268,9 @@ describe('handleSubmit', () => {
           <button
             type={'button'}
             onClick={() =>
-              handleSubmit(rejectPromiseFn)().catch((err) =>
-                setError(err.message),
-              )
+              handleSubmit(rejectPromiseFn, (_, __, err) => {
+                setError((err as Error).message);
+              })()
             }
           >
             Submit

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1051,9 +1051,7 @@ export function createFormControl<
           });
           await onValid(fieldValues as TFieldValues, e);
         } else {
-          if (onInvalid) {
-            await onInvalid({ ..._formState.errors }, e);
-          }
+          onInvalid && onInvalid(_formState.errors, e);
           _focusError();
         }
       } catch (error) {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1059,15 +1059,15 @@ export function createFormControl<
       } catch (error) {
         onInvalid && onInvalid(_formState.errors, e, error);
         runTimeError = true;
-      } finally {
-        _subjects.state.next({
-          isSubmitted: true,
-          isSubmitting: false,
-          isSubmitSuccessful: isEmptyObject(_formState.errors) && !runTimeError,
-          submitCount: _formState.submitCount + 1,
-          errors: _formState.errors,
-        });
       }
+
+      _subjects.state.next({
+        isSubmitted: true,
+        isSubmitting: false,
+        isSubmitSuccessful: isEmptyObject(_formState.errors) && !runTimeError,
+        submitCount: _formState.submitCount + 1,
+        errors: _formState.errors,
+      });
     };
 
   const resetField: UseFormResetField<TFieldValues> = (name, options = {}) => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1028,40 +1028,46 @@ export function createFormControl<
         e.persist && e.persist();
       }
       let fieldValues = cloneObject(_formValues);
+      let runTimeError = false;
 
       _subjects.state.next({
         isSubmitting: true,
       });
 
-      if (_options.resolver) {
-        const { errors, values } = await _executeSchema();
-        _formState.errors = errors;
-        fieldValues = values;
-      } else {
-        await executeBuiltInValidation(_fields);
-      }
-
-      unset(_formState.errors, 'root');
-
-      if (isEmptyObject(_formState.errors)) {
-        _subjects.state.next({
-          errors: {},
-        });
-        await onValid(fieldValues as TFieldValues, e);
-      } else {
-        if (onInvalid) {
-          await onInvalid({ ..._formState.errors }, e);
+      try {
+        if (_options.resolver) {
+          const { errors, values } = await _executeSchema();
+          _formState.errors = errors;
+          fieldValues = values;
+        } else {
+          await executeBuiltInValidation(_fields);
         }
-        _focusError();
-      }
 
-      _subjects.state.next({
-        isSubmitted: true,
-        isSubmitting: false,
-        isSubmitSuccessful: isEmptyObject(_formState.errors),
-        submitCount: _formState.submitCount + 1,
-        errors: _formState.errors,
-      });
+        unset(_formState.errors, 'root');
+
+        if (isEmptyObject(_formState.errors)) {
+          _subjects.state.next({
+            errors: {},
+          });
+          await onValid(fieldValues as TFieldValues, e);
+        } else {
+          if (onInvalid) {
+            await onInvalid({ ..._formState.errors }, e);
+          }
+          _focusError();
+        }
+      } catch (error) {
+        onInvalid && onInvalid(_formState.errors, e, error);
+        runTimeError = true;
+      } finally {
+        _subjects.state.next({
+          isSubmitted: true,
+          isSubmitting: false,
+          isSubmitSuccessful: isEmptyObject(_formState.errors) && !runTimeError,
+          submitCount: _formState.submitCount + 1,
+          errors: _formState.errors,
+        });
+      }
     };
 
   const resetField: UseFormResetField<TFieldValues> = (name, options = {}) => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1051,11 +1051,11 @@ export function createFormControl<
           });
           await onValid(fieldValues as TFieldValues, e);
         } else {
-          onInvalid && onInvalid(_formState.errors, e);
+          onInvalid && onInvalid({ ..._formState.errors }, e);
           _focusError();
         }
       } catch (error) {
-        onInvalid && onInvalid(_formState.errors, e, error);
+        onInvalid && onInvalid({ ..._formState.errors }, e, error);
         runTimeError = true;
       }
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -65,6 +65,7 @@ export type SubmitHandler<TFieldValues extends FieldValues> = (
 export type SubmitErrorHandler<TFieldValues extends FieldValues> = (
   errors: FieldErrors<TFieldValues>,
   event?: React.BaseSyntheticEvent,
+  error?: unknown,
 ) => any | Promise<any>;
 
 export type SetValueConfig = Partial<{


### PR DESCRIPTION
This PR is trying to address the handleSubmit runtime error.

```tsx
const onSubmit = () => {
  throw new Error('data')
}

const onError = (error, e, runTimeError) => {
  console.log(runTimeError)
}

handleSubmit(onSubmit, onError)
```

`isSubmitSuccessful` will return false if any runtime error 
`isSubmitting` wouldn't be stuck at true.

Somewhat related to this: #9844