### PR TITLE
fix type for defaultValues

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -86,7 +86,7 @@ export type DelayCallback = (wait: number) => void;
 
 type AsyncDefaultValues<TFieldValues> = (
   payload?: unknown,
-) => Promise<TFieldValues>;
+) => Promise<DeepPartial<TFieldValues>>;
 
 export type UseFormProps<
   TFieldValues extends FieldValues = FieldValues,


### PR DESCRIPTION
fixes #9915 by wrapping `AsyncDefaultValues` in `DeepPartial` as already done in `DefaultValues`