### PR TITLE
Catch errors in handleSubmit's onValid callback and reflect state

### DIFF
--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -524,4 +524,28 @@ describe('handleSubmit', () => {
 
     await waitFor(() => expect(onSubmit).toBeCalled());
   });
+
+  it('should set isSubmitting back to false if onValid throws an error', async () => {
+    const { result } = renderHook(() =>
+      useForm<{
+        test: string;
+      }>(),
+    );
+
+    const callback = () => {
+      throw new Error('test');
+    };
+
+    result.current.formState;
+
+    await act(async () => {
+      await result.current.handleSubmit(callback)({
+        preventDefault: () => {},
+        persist: () => {},
+      } as React.SyntheticEvent);
+    });
+
+    expect(result.current.control._formState.isSubmitting).toEqual(false);
+    expect(result.current.control._formState.isSubmitSuccessful).toEqual(false);
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1047,7 +1047,15 @@ export function createFormControl<
         _subjects.state.next({
           errors: {},
         });
-        await onValid(fieldValues as TFieldValues, e);
+        try {
+          await onValid(fieldValues as TFieldValues, e);
+        } catch (error) {
+          _subjects.state.next({
+            isSubmitting: false,
+            isSubmitSuccessful: false,
+          });
+          return;
+        }
       } else {
         if (onInvalid) {
           await onInvalid({ ..._formState.errors }, e);


### PR DESCRIPTION
This PR handles cases where the async function provided to `handleSubmit` throws an error, setting `isSubmitting` back to `false` and without increasing `submitCount.`

I stumbled upon a similar scenario when the API returned a 500 code, keeping the form's 'Submit' button disabled (since `isSubmitting = false`) and preventing the user from retrying. 