### PR TITLE
Typo in UseFieldArray `replace` type declaration

### DIFF
--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -238,7 +238,7 @@ export type UseFieldArrayUpdate<
  * ```tsx
  * <button
  *   type="button"
- *   onClick={() => update([{ name: "data" }, { name: "data" }])}
+ *   onClick={() => replace([{ name: "data" }, { name: "data" }])}
  * >
  *   Replace
  * </button>


### PR DESCRIPTION
Hi there, just suggesting a tiny correction in the type declarations for UseFieldArray. Looks like a copy/paste error coming from the type above.

Pretty minor, but it confused me for a second!

Thanks for this great library.