### PR TITLE
fix: default for isLoading form state

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1907,6 +1907,14 @@ describe('useForm', () => {
     });
   });
 
+  it('should not update isLoading when literal defaultValues are provided', async () => {
+    const { result } = renderHook(() =>
+      useForm({ defaultValues: { test: 'default' } }),
+    );
+
+    expect(result.current.formState.isLoading).toBe(false);
+  });
+
   it('should update isValidating to true when using with resolver', async () => {
     jest.useFakeTimers();
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -101,7 +101,7 @@ export function createFormControl<
   let _formState: FormState<TFieldValues> = {
     submitCount: 0,
     isDirty: false,
-    isLoading: true,
+    isLoading: isFunction(_options.defaultValues),
     isValidating: false,
     isSubmitted: false,
     isSubmitting: false,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -55,7 +55,7 @@ export function useForm<
   const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
     isDirty: false,
     isValidating: false,
-    isLoading: true,
+    isLoading: isFunction(props.defaultValues),
     isSubmitted: false,
     isSubmitting: false,
     isSubmitSuccessful: false,


### PR DESCRIPTION
Mentioned here https://github.com/react-hook-form/react-hook-form/issues/9934.

This pull request fixes an issue with the `isLoading` functionality. Currently, the default value for `defaultValues` is always set to `true`, even if it's a static value. I have a component abstraction that subscribes to `isLoading` to display a loading state, but the default value was causing issues with the component's behaviour.

To address this, I've updated the `defaultValues` default to `true` only if it's a function, which allows the component to support both async and static `defaultValues` without any unexpected behaviour.