### PR TITLE
fix(appendErrors): can take an array of errors

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -752,7 +752,7 @@ export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
 export type Validate<TFieldValue, TFormValues> = (value: TFieldValue, formValues: TFormValues) => ValidateResult | Promise<ValidateResult>;
 
 // @public (undocumented)
-export type ValidateResult = Message | boolean | undefined;
+export type ValidateResult = Message | Message[] | boolean | undefined;
 
 // @public (undocumented)
 export type ValidationMode = {

--- a/src/__tests__/logic/appendErrors.test.ts
+++ b/src/__tests__/logic/appendErrors.test.ts
@@ -60,5 +60,27 @@ describe('appendErrors', () => {
         undefined: true,
       },
     });
+
+    errors.test.types = {
+      ...errors.test.types,
+      undefined: true,
+    };
+    expect(
+      appendErrors('test', true, errors, 'invalid_string', [
+        'uppercase',
+        'lowercase',
+        'number',
+      ]),
+    ).toEqual({
+      message: 'test',
+      type: 'required',
+      types: {
+        required: 'test',
+        min: 'test',
+        max: 'test',
+        undefined: true,
+        invalid_string: ['uppercase', 'lowercase', 'number'],
+      },
+    });
   });
 });

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -15,7 +15,7 @@ export type ValidationValueMessage<
   message: Message;
 };
 
-export type ValidateResult = Message | boolean | undefined;
+export type ValidateResult = Message | Message[] | boolean | undefined;
 
 export type Validate<TFieldValue, TFormValues> = (
   value: TFieldValue,


### PR DESCRIPTION
As discussed, `appendErrors` is used by resolvers and need to pass en array of errors (`Record<string, string[]>`) when `validateAllCriteria: true`. This PR fix the type and add a test for the case