### PR TITLE
🐞 fix #10139 `useFieldArray` array error not updating in some cases

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -323,18 +323,12 @@ export function useFieldArray<
       if (control._options.resolver) {
         control._executeSchema([name]).then((result) => {
           const error = get(result.errors, name);
-          const existingError = get(control._formState.errors, name);
-
-          if (
-            existingError ? !error && existingError.type : error && error.type
-          ) {
-            error
-              ? set(control._formState.errors, name, error)
-              : unset(control._formState.errors, name);
-            control._subjects.state.next({
-              errors: control._formState.errors as FieldErrors<TFieldValues>,
-            });
-          }
+          error
+            ? set(control._formState.errors, name, error)
+            : unset(control._formState.errors, name);
+          control._subjects.state.next({
+            errors: control._formState.errors as FieldErrors<TFieldValues>,
+          });
         });
       } else {
         const field: Field = get(control._fields, name);


### PR DESCRIPTION
This PR fixes issue #10139, which causes the error state of a `useFieldArray` array to not update on append/remove/etc. actions on the array if any of the fields of the array already had an error. It also fixes another issue I discovered while testing, which is that the error will not update from one error to another.

The issue is caused by this code:

https://github.com/react-hook-form/react-hook-form/blob/20d897b4d957e0e59692612c9339731199aaa985/src/useFieldArray.ts#L328-L330

which appears to be an optimization to avoid unnecessarily setting or unsetting the error state of the array after a resolver validates. However, this check does not account for the possibility of going from no error to error (or vice versa) while one of the fields already has an error, nor does it account for the array error changing from one error directly to another.

I fixed the issue by simply removing the `if` statement that attempts to avoid setting or unsetting the error state. This will make the error state update after every resolver validation. It is possible that this may hurt performance in some cases, but the Git history does not show that the check was added for this reason.

I added a test that ensures these issues are resolved.