### PR TITLE
sync defaultValues of the form in watch and getValues

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -491,10 +491,11 @@ export function createFormControl<
       names,
       _names,
       {
+        ..._defaultValues,
         ...(_state.mount
           ? _formValues
           : isUndefined(defaultValue)
-          ? _defaultValues
+          ? {}
           : isString(names)
           ? { [names]: defaultValue }
           : defaultValue),


### PR DESCRIPTION
Synchronize the way of `getValues` generating formValues with the way of `watch` generating formValues. The difference is  that in the current `watch`, formValue does not merging with defaultValue, while the current `getValues` does. This leads [issue:10140](https://github.com/react-hook-form/react-hook-form/issues/10140) happen.