### PR TITLE
feat #10248 `useWatch` return value which has been updated by `useSubscribe` in all render.

### DIFF
--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -777,6 +777,7 @@ describe('useWatch', () => {
             <input
               {...register(`labels.${itemIndex}.displayName` as const)}
               defaultValue={actualValue}
+              role="input"
             />
             <button type="button" onClick={() => remove(itemIndex)}>
               Remove
@@ -827,13 +828,30 @@ describe('useWatch', () => {
 
       render(<Component />);
 
+      // remove element by `remove`
       expect(inputValues).toEqual(['Type', 'Number', 'Totals']);
-
       inputValues.length = 0; // clear array
-
-      fireEvent.click(screen.getAllByRole('button')[1]);
-
+      const secondButton = screen.getAllByRole('button')[1];
+      fireEvent.click(secondButton);
       expect(inputValues).toEqual(['Type', 'Totals']);
+
+      // change second element value
+      const secondInputElement = screen.getAllByRole('input')[1];
+      expect(secondInputElement).toHaveValue('Totals');
+      inputValues.length = 0; // clear array
+      fireEvent.change(secondInputElement, {
+        target: { value: 'Number' },
+      });
+      expect(secondInputElement).toHaveValue('Number');
+      expect(inputValues).toEqual(['Number']);
+
+      // change second element value with the same value
+      inputValues.length = 0; // clear array
+      fireEvent.change(secondInputElement, {
+        target: { value: 'Number' },
+      });
+      expect(secondInputElement).toHaveValue('Number');
+      expect(inputValues).toEqual([]);
     });
 
     it('should return shallow merged watch values', () => {

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -827,17 +827,13 @@ describe('useWatch', () => {
 
       render(<Component />);
 
+      expect(inputValues).toEqual(['Type', 'Number', 'Totals']);
+
+      inputValues.length = 0; // clear array
+
       fireEvent.click(screen.getAllByRole('button')[1]);
 
-      expect(inputValues).toEqual([
-        'Type',
-        'Number',
-        'Totals',
-        'Type',
-        'Totals',
-        'Type',
-        'Totals',
-      ]);
+      expect(inputValues).toEqual(['Type', 'Totals']);
     });
 
     it('should return shallow merged watch values', () => {

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -152,8 +152,25 @@ export function useWatch<TFieldValues extends FieldValues>(
     exact,
   } = props || {};
   const _name = React.useRef(name);
+  const _value = React.useRef(
+    control._getWatch(
+      name as InternalFieldName,
+      defaultValue as DeepPartialSkipArrayKey<TFieldValues>,
+    ),
+  );
+  const [, set] = React.useState({});
+  const forceRender = () => {
+    set({});
+  };
 
   _name.current = name;
+
+  const updateValue = (value: any) => {
+    if (_value.current !== value) {
+      _value.current = value;
+      forceRender();
+    }
+  };
 
   useSubscribe({
     disabled,
@@ -181,14 +198,7 @@ export function useWatch<TFieldValues extends FieldValues>(
     },
   });
 
-  const [value, updateValue] = React.useState(
-    control._getWatch(
-      name as InternalFieldName,
-      defaultValue as DeepPartialSkipArrayKey<TFieldValues>,
-    ),
-  );
-
   React.useEffect(() => control._removeUnmounted());
 
-  return value;
+  return _value.current;
 }


### PR DESCRIPTION
close  #10248

In certain situations (e.g. #10248), rendering after `setState` does not always reflect that value.
This results in this issue #10248.
`useController` call `register` in every render and `register` is passed the return value of `useWatch`.
After calling `reset`, once `register` is called with an old value before being updated by `useSubscribe`'s callback., `_fromValue` is registered with that old value. 

In this PR, `useWatch` return value which has been updated by `useSubscribe` in all render.
However, a render is to be triggered as before.
