### PR TITLE
fix bugs that occur in the presence of Array polyfills

### DIFF
--- a/src/__tests__/utils/cloneObject.test.ts
+++ b/src/__tests__/utils/cloneObject.test.ts
@@ -114,4 +114,23 @@ describe('clone', () => {
       other: 'string',
     });
   });
+
+  describe('in presence of Array polyfills', () => {
+    beforeAll(() => {
+      // @ts-expect-error
+      Array.prototype.somePolyfill = () => 123;
+    });
+
+    it('should skip polyfills while cloning', () => {
+      const data = [1];
+      const copy = cloneObject(data);
+
+      expect(Object.hasOwn(copy, 'somePolyfill')).toBe(false);
+    });
+
+    afterAll(() => {
+      // @ts-expect-error
+      delete Array.prototype.somePolyfill;
+    });
+  });
 });

--- a/src/__tests__/utils/unset.test.ts
+++ b/src/__tests__/utils/unset.test.ts
@@ -311,4 +311,25 @@ describe('unset', () => {
       expect(test.test.root).toBeDefined();
     });
   });
+
+  describe('in presence of Array polyfills', () => {
+    beforeAll(() => {
+      // @ts-expect-error
+      Array.prototype.somePolyfill = () => 123;
+    });
+
+    it('should delete empty arrays', () => {
+      const data = {
+        prop: [],
+      };
+      unset(data, 'prop.0');
+
+      expect(data.prop).toBeUndefined();
+    });
+
+    afterAll(() => {
+      // @ts-expect-error
+      delete Array.prototype.somePolyfill;
+    });
+  });
 });

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -16,11 +16,13 @@ export default function cloneObject<T>(data: T): T {
   ) {
     copy = isArray ? [] : {};
 
-    if (!Array.isArray(data) && !isPlainObject(data)) {
+    if (!isArray && !isPlainObject(data)) {
       copy = data;
     } else {
       for (const key in data) {
-        copy[key] = cloneObject(data[key]);
+        if (Object.hasOwn(data, key)) {
+          copy[key] = cloneObject(data[key]);
+        }
       }
     }
   } else {

--- a/src/utils/unset.ts
+++ b/src/utils/unset.ts
@@ -17,7 +17,7 @@ function baseGet(object: any, updatePath: (string | number)[]) {
 
 function isEmptyArray(obj: unknown[]) {
   for (const key in obj) {
-    if (!isUndefined(obj[key])) {
+    if (Object.hasOwn(obj, key) && !isUndefined(obj[key])) {
       return false;
     }
   }


### PR DESCRIPTION
Fixes #9037

Currently if `Array.prototype` is patched (for polyfilling reasons, for example), it completely breaks `react-hook-form`. This is very inconvenient and something the consumer doesn't necessarily has control over (the patching might be done by a third-party script embedded outside of the consumer app).

The underlying reason is that current version of the code doesn't use the recommended `Object.hasOwn` checks inside `for..in` loops, hence iterating over properties added to the prototype and breaking the rest of the library code. This PR adds some tests to enforce the correct behaviour and fixes the underlying issue.