### PR TITLE
Enforce stricter type for controller on change callback

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -6,6 +6,7 @@
 
 /// <reference types="react" />
 
+import { ChangeEvent } from 'react';
 import { JSXElementConstructor } from 'react';
 import { default as React_2 } from 'react';
 import * as React_3 from 'react';
@@ -93,7 +94,7 @@ export type ControllerProps<TFieldValues extends FieldValues = FieldValues, TNam
 
 // @public (undocumented)
 export type ControllerRenderProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> = {
-    onChange: (...event: any[]) => void;
+    onChange: (event: ChangeEvent | FieldPathValue<TFieldValues, TName>) => void;
     onBlur: Noop;
     value: FieldPathValue<TFieldValues, TName>;
     name: TName;

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -8,23 +8,24 @@ import {
 } from '@testing-library/react';
 
 import { Controller } from '../controller';
-import { ControllerRenderProps, FieldValues } from '../types';
 import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 import { FormProvider } from '../useFormContext';
 import { useWatch } from '../useWatch';
 
-function Input<TFieldValues extends FieldValues>({
+function Input({
   onChange,
   onBlur,
   placeholder,
-}: Pick<ControllerRenderProps<TFieldValues>, 'onChange' | 'onBlur'> & {
+}: {
+  onChange: (newValue: string) => void;
+  onBlur: () => void;
   placeholder?: string;
 }) {
   return (
     <input
       placeholder={placeholder}
-      onChange={() => onChange(1)}
+      onChange={(event) => onChange(event.target.value)}
       onBlur={() => onBlur()}
     />
   );
@@ -378,7 +379,7 @@ describe('Controller', () => {
     expect(onChange).toBeCalled();
   });
 
-  it('should invoke custom onChange method', () => {
+  it('should invoke custom onBlur method', () => {
     const onBlur = jest.fn();
     const Component = () => {
       const { control } = useForm();

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -146,7 +146,7 @@ describe('useController', () => {
       const watchResult: unknown[] = [];
       const Component = () => {
         const { control, watch } = useForm<{
-          test: string;
+          test: boolean;
         }>();
 
         watchResult.push(watch());
@@ -154,7 +154,6 @@ describe('useController', () => {
         const { field } = useController({
           name: 'test',
           control,
-          defaultValue: '',
         });
 
         return (
@@ -183,7 +182,7 @@ describe('useController', () => {
       const watchResult: unknown[] = [];
       const Component = () => {
         const { control, watch } = useForm<{
-          test: string;
+          test: string | boolean;
         }>();
 
         watchResult.push(watch());

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 
 import { RegisterOptions } from './validator';
 import {
@@ -23,7 +23,7 @@ export type ControllerRenderProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
-  onChange: (...event: any[]) => void;
+  onChange: (event: ChangeEvent | FieldPathValue<TFieldValues, TName>) => void;
   onBlur: Noop;
   value: FieldPathValue<TFieldValues, TName>;
   name: TName;


### PR DESCRIPTION
When using Controller field onChange fn, you were able to pass any value you want (because it was typed as any), even when it mismatches the type defined on the form.

So if form has defined type
```
{
  fieldName: number
}
```

You could pass

```
controllerProps.field.onChange('hello')
```

This is a huge typesafety hole, and I have patches my projects to have such behaviour. After this change a lot of error were exposed.

This implementation is still not 100% typesafe, because it still accepts event, for backwards compatibility reasons. But when event is passed, it suffer from safe issue - types can mismatch.

Ideally I would opt to either remove option to pass event at all (but this would hurt DX), or provide additional typesafe onChange which allows to pass just the exact type value