### PR TITLE
chore: adding link to v7 examples folder in readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 You can view the source code for most examples within their folder, or visit Code Sandbox to see how the example works live.
 
-- V7
+- [V7](/examples/V7)
 - [V6](/examples/V6)
 
 ## Web


### PR DESCRIPTION
Noticed that the examples has a link to V6 but not to V7, this change just adds a link to the v7 folder in the examples readme.

(super simple change, I know, thought that I'd fix it when I noticed it).