### PR TITLE
Added TTransformedValues to FormProvider

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -280,12 +280,12 @@ export type FormProps<TFieldValues extends FieldValues, TTransformedValues exten
 }>);
 
 // @public
-export const FormProvider: <TFieldValues extends FieldValues, TContext = any>(props: FormProviderProps<TFieldValues, TContext>) => JSX.Element;
+export const FormProvider: <TFieldValues extends FieldValues, TContext = any, TTransformedValues extends FieldValues | undefined = undefined>(props: FormProviderProps<TFieldValues, TContext, TTransformedValues>) => JSX.Element;
 
 // @public (undocumented)
-export type FormProviderProps<TFieldValues extends FieldValues = FieldValues, TContext = any> = {
+export type FormProviderProps<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues extends FieldValues | undefined = undefined> = {
     children: React_2.ReactNode | React_2.ReactNode[];
-} & UseFormReturn<TFieldValues, TContext>;
+} & UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
 // @public (undocumented)
 export type FormState<TFieldValues extends FieldValues> = {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -833,6 +833,7 @@ export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
 export type FormProviderProps<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
+  TTransformedValues extends FieldValues | undefined = undefined,
 > = {
   children: React.ReactNode | React.ReactNode[];
-} & UseFormReturn<TFieldValues, TContext>;
+} & UseFormReturn<TFieldValues, TContext, TTransformedValues>;

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -73,12 +73,16 @@ export const useFormContext = <
  * }
  * ```
  */
-export const FormProvider = <TFieldValues extends FieldValues, TContext = any>(
-  props: FormProviderProps<TFieldValues, TContext>,
+export const FormProvider = <
+  TFieldValues extends FieldValues,
+  TContext = any,
+  TTransformedValues extends FieldValues | undefined = undefined,
+>(
+  props: FormProviderProps<TFieldValues, TContext, TTransformedValues>,
 ) => {
   const { children, ...data } = props;
   return (
-    <HookFormContext.Provider value={data as UseFormReturn}>
+    <HookFormContext.Provider value={data as unknown as UseFormReturn}>
       {children}
     </HookFormContext.Provider>
   );


### PR DESCRIPTION
First of all, thank you so much for this wonderful library!

I am not sure if this pull request is suitable for the problem I was facing, and I may be missing something here, so I hope you can guide me further on this if needed.

The fix proposed relates to pull request #9735.

Say we have this example, inspired by the one you gave in the aforementioned pull request.

```typescript
import { Form, FormProvider, useForm } from "react-hook-form";

const defaultValues = { test: "test" };

type FormValues = typeof defaultValues;
type TransformedFormValue = {
  test: number;
};

const Test = () => {
  const methods = useForm<FormValues, unknown, TransformedFormValue>({
    defaultValues: { test: "test" }
  });
  const { control } = methods;

  return (
    <FormProvider {...methods}>
      <Form<FormValues, TransformedFormValue>
        onSubmit={(data) => {
          console.log(data); // data.test -> number
        }}
        control={control} // optional if not using context
      >
        <input />
      </Form>
    </FormProvider>
  );
};
```

https://codesandbox.io/s/naughty-worker-35iqq0?file=/src/App.tsx

`FormProvider` would give a type error since it expects `props` of type `UseFormReturn<FormValues, any, undefined>` while `formMethods` is of type `UseFormReturn<FormValues, any, TransformedValue>`.

Thank you again!