### PR TITLE
v6 - Add types to exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "./package.json": "./package.json",
     ".": {
       "import": "./dist/index.esm.js",
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js"
     },
     "./dist/index.ie11": {
       "import": "./dist/index.ie11.js",
+      "types": "./dist/index.ie11.d.ts",
       "require": "./dist/index.ie11.js"
     }
   },


### PR DESCRIPTION
It's not possible to use typescript v5 and moduleResolution="bundler" without this change.
V7 has the same settings.