### PR TITLE
Require index/indices for useFieldArray#remove

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -187,7 +187,7 @@ export function useFieldArray<
     });
   };
 
-  const remove = (index?: number | number[]) => {
+  const remove = (index: number | number[]) => {
     const updatedFieldArrayValues: Partial<
       FieldArrayWithId<TFieldValues, TFieldArrayName, TKeyName>
     >[] = removeArrayAt(control._getFieldArray(name), index);


### PR DESCRIPTION
It's unclear to me what the use case is for calling `remove` without a specific index or set of indices.

Requiring this parameter can prevent the very easy mistake to make of binding `remove` directly to a handler without passing `index` from the field.