### PR TITLE
Fix: removed code from the README updater which was trying to read a …

### DIFF
--- a/scripts/README/Data.js
+++ b/scripts/README/Data.js
@@ -7,6 +7,4 @@ const readYAML = async (path) => parse(await readTextFile(path));
 
 const { individuals, companies } = await readYAML(Files.sponsors);
 
-export const helpers = await readYAML(Files.helpers);
-
-export default { individuals, companies, helpers };
+export default { individuals, companies };


### PR DESCRIPTION
…non-existent `docs/Helpers.yaml`. This was causing the corresponding build job to fail. For reference, this file was removed in commit b93c873603de9d68b9e4601723614d5997eed354 as part of a README cleanup effort.