### PR TITLE
Fix incorrect test case in useController.test.tsx

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -301,6 +301,7 @@ describe('useController', () => {
       const { field } = useController({
         control,
         name: 'test',
+        defaultValue: '',
       });
 
       return (
@@ -315,15 +316,15 @@ describe('useController', () => {
           </button>
         </div>
       );
-
-      render(<App />);
-
-      fireEvent.click(screen.getByRole('button'));
-
-      expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
-        'data',
-      );
     };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toEqual(
+      'data',
+    );
   });
 
   it('should be able to setValue after reset', async () => {


### PR DESCRIPTION
I noticed that one of the test cases in `useController.test.tsx` was not correctly set up, causing it to be not executed as expected.
In the original setup, the test runner function was incorrectly nested inside the App component, resulting in the test not being executed as expected.

I've fixed the nesting issue and revised the test case.

In the revised test case, I've moved the test runner function out of the App component. Additionally, to eliminate the warning about an input changing from uncontrolled to controlled, I added defaultValue: '' to the options passed to useController.

These changes should make the test run correctly and remove the warning.