### PR TITLE
test(generated-id): setting window performance undefined without ts-ignore

### DIFF
--- a/src/__tests__/logic/generateId.test.ts
+++ b/src/__tests__/logic/generateId.test.ts
@@ -6,8 +6,10 @@ describe('generateId', () => {
   });
 
   it('should fallback to current date if performance is undefined', () => {
-    // @ts-ignore
-    delete window.performance;
+    Object.defineProperty(window, 'performance', {
+      value: undefined,
+    });
+
     expect(/\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}/i.test(generateId())).toBeTruthy();
   });
 });


### PR DESCRIPTION
Setting window performance undefined without ts-ignore