### PR TITLE
feat: Add trigger to ControllerRenderProps

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -98,6 +98,7 @@ export type ControllerRenderProps<TFieldValues extends FieldValues = FieldValues
     value: FieldPathValue<TFieldValues, TName>;
     name: TName;
     ref: RefCallBack;
+    trigger: () => Promise<boolean>;
 };
 
 // @public (undocumented)

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -28,6 +28,7 @@ export type ControllerRenderProps<
   value: FieldPathValue<TFieldValues, TName>;
   name: TName;
   ref: RefCallBack;
+  trigger: () => Promise<boolean>;
 };
 
 export type UseControllerProps<

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -150,6 +150,7 @@ export function useController<
           };
         }
       },
+      trigger: () => methods.trigger(name),
     },
     formState,
     fieldState: Object.defineProperties(


### PR DESCRIPTION
For some fields, we need a method to trigger a revalidation `onChange`, while the form's mode is `onSubmit`.
This is very helpful since we can't dynamically change the `mode` of the form: