### PR TITLE
fix: `trigger` should use passed names to construct resolver options

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1165,8 +1165,8 @@ describe('useForm', () => {
 
         expect(resolver).toHaveBeenCalledWith(defaultValues, undefined, {
           criteriaMode: undefined,
-          fields,
-          names: ['test.sub', 'test1'],
+          fields: { test: fields.test },
+          names: ['test.sub'],
         });
 
         await act(async () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -392,7 +392,7 @@ export function createFormControl<
     );
 
   const executeSchemaAndUpdateState = async (names?: InternalFieldName[]) => {
-    const { errors } = await _executeSchema();
+    const { errors } = await _executeSchema(names);
 
     if (names) {
       for (const name of names) {


### PR DESCRIPTION
Documentation states that passing a name or names is a way to select what fields are getting validated, but builder for resolver options does not receive those names, always producing full fields and all names, so resolver cannot skip unrequested checks. 