### PR TITLE
Revert breaking type change in #10342

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -6,7 +6,6 @@
 
 /// <reference types="react" />
 
-import { ChangeEvent } from 'react';
 import { JSXElementConstructor } from 'react';
 import { default as React_2 } from 'react';
 import { ReactElement } from 'react';
@@ -93,7 +92,7 @@ export type ControllerProps<TFieldValues extends FieldValues = FieldValues, TNam
 
 // @public (undocumented)
 export type ControllerRenderProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> = {
-    onChange: (event: ChangeEvent | FieldPathValue<TFieldValues, TName>) => void;
+    onChange: (...event: any[]) => void;
     onBlur: Noop;
     value: FieldPathValue<TFieldValues, TName>;
     name: TName;

--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -8,24 +8,23 @@ import {
 } from '@testing-library/react';
 
 import { Controller } from '../controller';
+import { ControllerRenderProps, FieldValues } from '../types';
 import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 import { FormProvider } from '../useFormContext';
 import { useWatch } from '../useWatch';
 
-function Input({
+function Input<TFieldValues extends FieldValues>({
   onChange,
   onBlur,
   placeholder,
-}: {
-  onChange: (newValue: string) => void;
-  onBlur: () => void;
+}: Pick<ControllerRenderProps<TFieldValues>, 'onChange' | 'onBlur'> & {
   placeholder?: string;
 }) {
   return (
     <input
       placeholder={placeholder}
-      onChange={(event) => onChange(event.target.value)}
+      onChange={() => onChange(1)}
       onBlur={() => onBlur()}
     />
   );

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -146,7 +146,7 @@ describe('useController', () => {
       const watchResult: unknown[] = [];
       const Component = () => {
         const { control, watch } = useForm<{
-          test: boolean;
+          test: string;
         }>();
 
         watchResult.push(watch());
@@ -154,6 +154,7 @@ describe('useController', () => {
         const { field } = useController({
           name: 'test',
           control,
+          defaultValue: '',
         });
 
         return (
@@ -182,7 +183,7 @@ describe('useController', () => {
       const watchResult: unknown[] = [];
       const Component = () => {
         const { control, watch } = useForm<{
-          test: string | boolean;
+          test: string;
         }>();
 
         watchResult.push(watch());

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React from 'react';
 
 import { RegisterOptions } from './validator';
 import {
@@ -23,7 +23,7 @@ export type ControllerRenderProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
-  onChange: (event: ChangeEvent | FieldPathValue<TFieldValues, TName>) => void;
+  onChange: (...event: any[]) => void;
   onBlur: Noop;
   value: FieldPathValue<TFieldValues, TName>;
   name: TName;


### PR DESCRIPTION
This PR reverts the type changes introduced in https://github.com/react-hook-form/react-hook-form/pull/10342.

The type changes are positive, but releasing it in a minor release have led to large issues for many consumers.  I suggest reverting the changes for now and introducing them in the next major release.

See the discussion in https://github.com/react-hook-form/react-hook-form/pull/10342 for more details.