### PR TITLE
fix(types): UseFieldArray Append, Prepend, Insert, Replace

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -566,16 +566,16 @@ export type UseControllerReturn<TFieldValues extends FieldValues = FieldValues, 
 export function useFieldArray<TFieldValues extends FieldValues = FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>, TKeyName extends string = 'id'>(props: UseFieldArrayProps<TFieldValues, TFieldArrayName, TKeyName>): UseFieldArrayReturn<TFieldValues, TFieldArrayName, TKeyName>;
 
 // @public
-export type UseFieldArrayAppend<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: FieldArray<TFieldValues, TFieldArrayName> | FieldArray<TFieldValues, TFieldArrayName>[], options?: FieldArrayMethodProps) => void;
+export type UseFieldArrayAppend<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<FieldArray<TFieldValues, TFieldArrayName>> | Partial<FieldArray<TFieldValues, TFieldArrayName>>[], options?: FieldArrayMethodProps) => void;
 
 // @public
-export type UseFieldArrayInsert<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (index: number, value: FieldArray<TFieldValues, TFieldArrayName> | FieldArray<TFieldValues, TFieldArrayName>[], options?: FieldArrayMethodProps) => void;
+export type UseFieldArrayInsert<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (index: number, value: Partial<FieldArray<TFieldValues, TFieldArrayName>> | Partial<FieldArray<TFieldValues, TFieldArrayName>>[], options?: FieldArrayMethodProps) => void;
 
 // @public
 export type UseFieldArrayMove = (indexA: number, indexB: number) => void;
 
 // @public
-export type UseFieldArrayPrepend<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: FieldArray<TFieldValues, TFieldArrayName> | FieldArray<TFieldValues, TFieldArrayName>[], options?: FieldArrayMethodProps) => void;
+export type UseFieldArrayPrepend<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<FieldArray<TFieldValues, TFieldArrayName>> | Partial<FieldArray<TFieldValues, TFieldArrayName>>[], options?: FieldArrayMethodProps) => void;
 
 // @public (undocumented)
 export type UseFieldArrayProps<TFieldValues extends FieldValues = FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>, TKeyName extends string = 'id'> = {
@@ -592,7 +592,7 @@ export type UseFieldArrayProps<TFieldValues extends FieldValues = FieldValues, T
 export type UseFieldArrayRemove = (index?: number | number[]) => void;
 
 // @public
-export type UseFieldArrayReplace<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: FieldArray<TFieldValues, TFieldArrayName> | FieldArray<TFieldValues, TFieldArrayName>[]) => void;
+export type UseFieldArrayReplace<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (value: Partial<FieldArray<TFieldValues, TFieldArrayName>> | Partial<FieldArray<TFieldValues, TFieldArrayName>>[]) => void;
 
 // @public (undocumented)
 export type UseFieldArrayReturn<TFieldValues extends FieldValues = FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>, TKeyName extends string = 'id'> = {

--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -111,8 +111,8 @@ export type UseFieldArrayPrepend<
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = (
   value:
-    | FieldArray<TFieldValues, TFieldArrayName>
-    | FieldArray<TFieldValues, TFieldArrayName>[],
+    | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+    | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
   options?: FieldArrayMethodProps,
 ) => void;
 
@@ -142,8 +142,8 @@ export type UseFieldArrayAppend<
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = (
   value:
-    | FieldArray<TFieldValues, TFieldArrayName>
-    | FieldArray<TFieldValues, TFieldArrayName>[],
+    | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+    | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
   options?: FieldArrayMethodProps,
 ) => void;
 
@@ -196,8 +196,8 @@ export type UseFieldArrayInsert<
 > = (
   index: number,
   value:
-    | FieldArray<TFieldValues, TFieldArrayName>
-    | FieldArray<TFieldValues, TFieldArrayName>[],
+    | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+    | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
   options?: FieldArrayMethodProps,
 ) => void;
 
@@ -249,8 +249,8 @@ export type UseFieldArrayReplace<
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
 > = (
   value:
-    | FieldArray<TFieldValues, TFieldArrayName>
-    | FieldArray<TFieldValues, TFieldArrayName>[],
+    | Partial<FieldArray<TFieldValues, TFieldArrayName>>
+    | Partial<FieldArray<TFieldValues, TFieldArrayName>>[],
 ) => void;
 
 export type UseFieldArrayReturn<


### PR DESCRIPTION
Fix types of `UseFieldArray{Append, Prepend, Insert, Replace}` so they match those of https://github.com/react-hook-form/react-hook-form/blob/97a4ed9d90f3bbeb2f397f5a07fa43d292f8f0a3/src/useFieldArray.ts.

This PR allows these functions to be used with partial objects, so it should not break existing code unless one depends on the argument type of these functions directly.