### PR TITLE
fix(types): async defaultValues await promise value

### DIFF
--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -11,6 +11,7 @@ import SetValue from './setValue';
 import FormState from './formState';
 import ManualRegisterForm from './manualRegisterForm';
 import DefaultValues from './defaultValues';
+import DefaultValuesAsync from './defaultValuesAsync';
 import WatchDefaultValues from './watchDefaultValues';
 import Reset from './reset';
 import TriggerValidation from './triggerValidation';
@@ -93,6 +94,7 @@ const App: React.FC = () => {
         />
         <Route path="/isValid/:mode/:defaultValues" element={<IsValid />} />
         <Route path="/default-values" element={<DefaultValues />} />
+        <Route path="/default-values-async" element={<DefaultValuesAsync />} />
         <Route path="/trigger-validation" element={<TriggerValidation />} />
         <Route path="/watch-default-values" element={<WatchDefaultValues />} />
         <Route path="/watch-field-array/:mode" element={<WatchFieldArray />} />

--- a/app/src/defaultValuesAsync.tsx
+++ b/app/src/defaultValuesAsync.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
+const sleep = <T,>(data: T, ms: number) =>
+  new Promise<T>((res) => setTimeout(() => res(data), ms));
+
+function DefaultValues() {
+  const { register } = useForm({
+    defaultValues: async () =>
+      sleep(
+        {
+          test: 'test',
+          checkbox: ['1', '2'],
+          test1: {
+            firstName: 'firstName',
+            lastName: ['lastName0', 'lastName1'],
+            deep: {
+              nest: 'nest',
+            },
+          },
+        },
+        10,
+      ),
+  });
+  const [show, setShow] = React.useState(true);
+
+  return (
+    <>
+      {show ? (
+        <form>
+          <input {...register('test')} />
+          <input {...register('test1.firstName')} />
+          <input {...register('test1.deep.nest')} />
+          <input {...register('test1.deep.nest')} />
+          <input {...register('test1.lastName.0')} />
+          <input {...register('test1.lastName.1')} />
+          <input type="checkbox" value={'1'} {...register('checkbox')} />
+          <input type="checkbox" value={'2'} {...register('checkbox')} />
+        </form>
+      ) : null}
+      <button type={'button'} id={'toggle'} onClick={() => setShow(!show)}>
+        toggle
+      </button>
+    </>
+  );
+}
+
+export default DefaultValues;

--- a/app/src/welcome/index.tsx
+++ b/app/src/welcome/index.tsx
@@ -54,7 +54,7 @@ const items: Item[] = [
   {
     title: 'DefaultValues',
     description: 'Should populate defaultValue for inputs',
-    slugs: ['/default-values'],
+    slugs: ['/default-values', '/default-values-async'],
   },
   {
     title: 'FormState',

--- a/cypress/e2e/defaultValuesAsync.cy.ts
+++ b/cypress/e2e/defaultValuesAsync.cy.ts
@@ -1,0 +1,28 @@
+describe('defaultValues async', () => {
+  it('should populate defaultValue async for inputs', () => {
+    cy.visit('http://localhost:3000/default-values-async');
+
+    cy.wait(10);
+
+    cy.get('input[name="test"]').should('have.value', 'test');
+    cy.get('input[name="test1.firstName"]').should('have.value', 'firstName');
+    cy.get('input[name="test1.lastName.0"]').should('have.value', 'lastName0');
+    cy.get('input[name="test1.lastName.1"]').should('have.value', 'lastName1');
+    cy.get('input[name="checkbox"]').eq(0).should('have.checked');
+    cy.get('input[name="checkbox"]').eq(1).should('have.checked');
+
+    cy.get('input[name="checkbox"]').eq(0).click();
+    cy.get('#toggle').click();
+    cy.get('#toggle').click();
+
+    cy.get('input[name="checkbox"]').eq(0).should('not.have.checked');
+    cy.get('input[name="checkbox"]').eq(1).should('have.checked');
+    cy.get('input[name="checkbox"]').eq(1).click();
+
+    cy.get('#toggle').click();
+    cy.get('#toggle').click();
+
+    cy.get('input[name="checkbox"]').eq(0).should('not.have.checked');
+    cy.get('input[name="checkbox"]').eq(1).should('not.have.checked');
+  });
+});

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -136,8 +136,10 @@ export type DeepRequired<T> = T extends BrowserNativeObject | Blob ? T : {
     [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
 };
 
+// Warning: (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export type DefaultValues<TFieldValues> = DeepPartial<TFieldValues>;
+export type DefaultValues<TFieldValues> = TFieldValues extends AsyncDefaultValues<TFieldValues> ? DeepPartial<Awaited<TFieldValues>> : DeepPartial<TFieldValues>;
 
 // @public (undocumented)
 export type DelayCallback = (wait: number) => void;
@@ -826,8 +828,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:105:3 - (ae-forgotten-export) The symbol "AsyncDefaultValues" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:428:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:431:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -41,7 +41,10 @@ export type UnpackNestedValue<T> = T extends NestedValue<infer U>
   ? { [K in keyof T]: UnpackNestedValue<T[K]> }
   : T;
 
-export type DefaultValues<TFieldValues> = DeepPartial<TFieldValues>;
+export type DefaultValues<TFieldValues> =
+  TFieldValues extends AsyncDefaultValues<TFieldValues>
+    ? DeepPartial<Awaited<TFieldValues>>
+    : DeepPartial<TFieldValues>;
 
 export type InternalNameSet = Set<InternalFieldName>;
 


### PR DESCRIPTION
Closes #10625 

Previously, when an async `defaultValues` was passed, the field type was inferred as follows:
```ts
useForm<() => Promise<{ firstName: string, lastName: string }>>
```

This caused a problem with the form methods because it treated the type as an async function instead of the value type. This pull request fixes the async `defaultValues` to return the value directly, similar to the behavior of non-async `defaultValues`.

```ts
useForm<{ firstName: string, lastName: string }>
```