### PR TITLE
feat: add options to clearErrors

### DIFF
--- a/src/__tests__/useForm/clearErrors.test.tsx
+++ b/src/__tests__/useForm/clearErrors.test.tsx
@@ -277,4 +277,76 @@ describe('clearErrors', () => {
 
     render(<App />);
   });
+
+  it('should update isValid to true with options for clearErrors', async () => {
+    const App = () => {
+      const {
+        register,
+        formState: { isValid },
+        setError,
+        clearErrors,
+      } = useForm();
+      return (
+        <div>
+          <input
+            {...register('name', { required: 'Required' })}
+            placeholder="Name"
+            role="input"
+          />
+          <button
+            onClick={() => {
+              setError('root.test', { type: 'test', message: 'test' });
+            }}
+          >
+            setError
+          </button>
+
+          <button
+            onClick={() => {
+              clearErrors('root.test', {
+                shouldValidate: true,
+              });
+            }}
+          >
+            clearError
+          </button>
+          {isValid ? 'yes' : 'no'}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    expect(await screen.findByText('no')).toBeVisible();
+
+    const inputElement = screen.getByRole('input');
+
+    fireEvent.input(inputElement, {
+      target: {
+        value: 'test text',
+      },
+    });
+
+    expect(await screen.findByText('yes')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'setError' }));
+
+    expect(await screen.findByText('no')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'clearError' }));
+
+    expect(await screen.findByText('yes')).toBeVisible();
+
+    fireEvent.input(inputElement, {
+      target: {
+        value: '',
+      },
+    });
+
+    expect(await screen.findByText('no')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'clearError' }));
+
+    expect(await screen.findByText('no')).toBeVisible();
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -858,18 +858,16 @@ export function createFormControl<
     if (!Object.keys(_formState.errors).length) {
       return;
     }
-    if (typeof name === 'undefined') {
-      name = 'root';
-    }
     name &&
       convertToArrayPayload(name).forEach((inputName) => {
         unset(_formState.errors, inputName);
-        options.shouldValidate && trigger(inputName as Path<TFieldValues>);
       });
 
     _subjects.state.next({
-      errors: _formState.errors,
+      errors: name ? _formState.errors : {},
     });
+
+    options.shouldValidate && trigger(name as Path<TFieldValues>);
   };
   const setError: UseFormSetError<TFieldValues> = (name, error, options) => {
     const ref = (get(_fields, name, { _f: {} })._f || {}).ref;

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -851,17 +851,26 @@ export function createFormControl<
     error: get((formState || _formState).errors, name),
   });
 
-  const clearErrors: UseFormClearErrors<TFieldValues> = (name) => {
+  const clearErrors: UseFormClearErrors<TFieldValues> = (
+    name,
+    options = {},
+  ) => {
+    if (!Object.keys(_formState.errors).length) {
+      return;
+    }
+    if (typeof name === 'undefined') {
+      name = 'root';
+    }
     name &&
-      convertToArrayPayload(name).forEach((inputName) =>
-        unset(_formState.errors, inputName),
-      );
+      convertToArrayPayload(name).forEach((inputName) => {
+        unset(_formState.errors, inputName);
+        options.shouldValidate && trigger(inputName as Path<TFieldValues>);
+      });
 
     _subjects.state.next({
-      errors: name ? _formState.errors : {},
+      errors: _formState.errors,
     });
   };
-
   const setError: UseFormSetError<TFieldValues> = (name, error, options) => {
     const ref = (get(_fields, name, { _f: {} })._f || {}).ref;
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -858,10 +858,11 @@ export function createFormControl<
     if (!Object.keys(_formState.errors).length) {
       return;
     }
+
     name &&
-      convertToArrayPayload(name).forEach((inputName) => {
-        unset(_formState.errors, inputName);
-      });
+      convertToArrayPayload(name).forEach((inputName) =>
+        unset(_formState.errors, inputName),
+      );
 
     _subjects.state.next({
       errors: name ? _formState.errors : {},

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -489,6 +489,9 @@ export type UseFormClearErrors<TFieldValues extends FieldValues> = (
     | readonly FieldPath<TFieldValues>[]
     | `root.${string}`
     | 'root',
+  options?: {
+    shouldValidate?: boolean;
+  },
 ) => void;
 
 /**


### PR DESCRIPTION
Add `options` to `clearErrors`  that, similar to setValue, include `shouldValidate` to determine if the current behavior triggers form validation.

#10689