### PR TITLE
fix: add exact option for array name in useWatch.

### DIFF
--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -552,6 +552,88 @@ describe('useWatch', () => {
       expect(childCount).toBe(1);
     });
 
+    it('should partial re-render with array name and exact option', async () => {
+      type FormInputs = {
+        child: string;
+        childSecond: string;
+        parent: string;
+      };
+
+      let childCount = 0;
+      let childSecondCount = 0;
+      const Child = ({
+        register,
+        control,
+      }: Pick<UseFormReturn<FormInputs>, 'register' | 'control'>) => {
+        useWatch({ name: ['childSecond'], control });
+        childCount++;
+        return <input {...register('child')} />;
+      };
+
+      const ChildSecond = ({
+        register,
+        control,
+      }: Pick<UseFormReturn<FormInputs>, 'register' | 'control'>) => {
+        useWatch({ name: ['childSecond'], control, exact: true });
+        childSecondCount++;
+        return <input {...register('childSecond')} />;
+      };
+
+      let parentCount = 0;
+      const Parent = () => {
+        const {
+          register,
+          handleSubmit,
+          control,
+          formState: { errors },
+        } = useForm<FormInputs>();
+        parentCount++;
+        return (
+          <form onSubmit={handleSubmit(() => {})}>
+            <>
+              <input {...register('parent')} />
+              <Child register={register} control={control} />
+              <ChildSecond register={register} control={control} />
+              {errors.parent}
+              <button>submit</button>
+            </>
+          </form>
+        );
+      };
+
+      render(<Parent />);
+
+      const childInput = screen.getAllByRole('textbox')[1];
+
+      fireEvent.input(childInput, {
+        target: { value: 'test' },
+      });
+
+      expect(parentCount).toBe(1);
+      expect(childCount).toBe(2);
+      expect(childSecondCount).toBe(1);
+
+      parentCount = 0;
+      childCount = 0;
+      childSecondCount = 0;
+
+      fireEvent.submit(screen.getByRole('button', { name: /submit/i }));
+
+      await waitFor(() => expect(parentCount).toBe(1));
+      expect(childCount).toBe(1);
+      expect(childSecondCount).toBe(1);
+
+      parentCount = 0;
+      childCount = 0;
+      childSecondCount = 0;
+
+      fireEvent.input(childInput, { target: { value: 'test1' } });
+
+      expect(parentCount).toBe(0);
+      expect(childCount).toBe(1);
+      expect(childSecondCount).toBe(0);
+    });
+
     it('should only subscribe change at useWatch level instead of useForm', () => {
       type FormValues = {
         test: string;

--- a/src/logic/shouldSubscribeByName.ts
+++ b/src/logic/shouldSubscribeByName.ts
@@ -13,6 +13,8 @@ export default <T extends string | string[] | undefined>(
       convertToArrayPayload(name).some(
         (currentName) =>
           currentName &&
-          (currentName.startsWith(signalName) ||
-            signalName.startsWith(currentName)),
+          ((!exact &&
+            (currentName.startsWith(signalName) ||
+              signalName.startsWith(currentName))) ||
+            (exact && currentName === signalName)),
       );


### PR DESCRIPTION
An unwanted update occurred when using useWatch as the array name. So I used the exact option, but it didn't work with the array name. The current exact option only works when it is not an array, so the condition has been changed to work on the array. Please review the corresponding update. Thank you.