### PR TITLE
🐞 fix: add exact option for array name in useWatch.

### DIFF
--- a/src/logic/shouldSubscribeByName.ts
+++ b/src/logic/shouldSubscribeByName.ts
@@ -7,9 +7,11 @@ export default <T extends string | string[] | undefined>(
 ) =>
   exact && signalName
     ? name === signalName ||
-      convertToArrayPayload(name).some(
-        (currentName) => currentName && exact && currentName === signalName,
-      )
+      (typeof name !== 'string' &&
+        Array.isArray(name) &&
+        name.some(
+          (currentName) => currentName && exact && currentName === signalName,
+        ))
     : !name ||
       !signalName ||
       name === signalName ||

--- a/src/logic/shouldSubscribeByName.ts
+++ b/src/logic/shouldSubscribeByName.ts
@@ -6,7 +6,10 @@ export default <T extends string | string[] | undefined>(
   exact?: boolean,
 ) =>
   exact && signalName
-    ? name === signalName
+    ? name === signalName ||
+      convertToArrayPayload(name).some(
+        (currentName) => currentName && exact && currentName === signalName,
+      )
     : !name ||
       !signalName ||
       name === signalName ||

--- a/src/logic/shouldSubscribeByName.ts
+++ b/src/logic/shouldSubscribeByName.ts
@@ -7,8 +7,7 @@ export default <T extends string | string[] | undefined>(
 ) =>
   exact && signalName
     ? name === signalName ||
-      (typeof name !== 'string' &&
-        Array.isArray(name) &&
+      (Array.isArray(name) &&
         name.some(
           (currentName) => currentName && exact && currentName === signalName,
         ))


### PR DESCRIPTION
An unwanted update occurred when using useWatch as the array name. So I used the exact option, but it didn't work with the array name. The current exact option only works when it is not an array, so the condition has been changed to work on the array. Please review the corresponding update. Thank you.