### PR TITLE
Validation bug for dropdown in onChange mode

### DIFF
--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -69,7 +69,7 @@ export default async <T extends FieldValues>(
     ((valueAsNumber || isFileInput(ref)) &&
       isUndefined(ref.value) &&
       isUndefined(inputValue)) ||
-    (isHTMLElement(ref) && ref.value === '') ||
+    (isHTMLElement(ref) && ref.value === '' && inputValue === '') ||
     inputValue === '' ||
     (Array.isArray(inputValue) && !inputValue.length);
   const appendErrorsCurry = appendErrors.bind(


### PR DESCRIPTION
When using a dropdown component in mode: onChange 
I would need to change the dropdown's value twice to remove the validation messages.

There appears to be a logical bug in the `isEmpty` conditions

Essentially, before the fix, we get this:

```
const isEmpty =
/*condition #1*/    ((valueAsNumber || isFileInput(ref)) && isUndefined(ref.value) && isUndefined(inputValue)) ||
/*condition #2*/    (isHTMLElement(ref) && ref.value === '') ||
/*condition #3*/    (isHTMLElement(ref) && ref.value === '') ||
/*condition #4*/    inputValue === '' ||
/*condition #5*/    (Array.isArray(inputValue) && !inputValue.length);
```

After clearing the value on my dropdown condition#4 would get flagged to mark the field as `isEmpty`
After setting a value in the dropdown condition#4 would now be false but condition#3 is true, flagging the field as `isEmpty`
Which is inconsistent, in my opinion :-)

So with this version of the code, everything works PERFECTLY
```
const isEmpty =
/*condition #1*/    ((valueAsNumber || isFileInput(ref)) && isUndefined(ref.value) && isUndefined(inputValue)) ||
/*condition #2*/    (isHTMLElement(ref) && ref.value === '') ||
/*condition #3*/    (isHTMLElement(ref) && ref.value === '' && inputValue === '') ||
/*condition #4*/    inputValue === '' ||
/*condition #5*/    (Array.isArray(inputValue) && !inputValue.length);
```

Thanks for a GREAT library.
And thanks for reviewing this PR