### PR TITLE
fix: Set errors formState if defaultValues fail resolver validation

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -51,7 +51,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
     _getDirty: GetIsDirty;
     _resetDefaultValues: Noop;
     _formState: FormState<TFieldValues>;
-    _updateValid: (shouldUpdateValid?: boolean) => void;
+    _updateValidErrors: (shouldUpdateValid?: boolean) => void;
     _updateFormState: (formState: Partial<FormState<TFieldValues>>) => void;
     _fields: FieldRefs;
     _formValues: FieldValues;

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -181,6 +181,42 @@ describe('register', () => {
     expect(screen.getByRole('alert').textContent).toBe('false');
   });
 
+  it('should populate errors if defaultValues are passed with a resolver', async () => {
+    const message = 'error in test';
+
+    const Component = () => {
+      const { register, formState } = useForm<{ test: string }>({
+        defaultValues: {
+          test: 'invalid',
+        },
+        resolver: async (data) => {
+          return {
+            values: data,
+            errors: {
+              test: {
+                type: 'test',
+              },
+            },
+          };
+        },
+      });
+
+      return (
+        <div>
+          <input {...register('test')} />
+          <span role="alert">{`${formState.isValid}`}</span>
+          <p>{formState.errors.test && message}</p>
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    await waitFor(() =>
+      expect(screen.queryByText(message)).toBeInTheDocument(),
+    );
+  });
+
   it('should be set default value when item is remounted again', async () => {
     const { result, unmount } = renderHook(() => useForm<{ test: string }>());
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -766,7 +766,7 @@ export type Control<
   _getDirty: GetIsDirty;
   _resetDefaultValues: Noop;
   _formState: FormState<TFieldValues>;
-  _updateValid: (shouldUpdateValid?: boolean) => void;
+  _updateValidErrors: (shouldUpdateValid?: boolean) => void;
   _updateFormState: (formState: Partial<FormState<TFieldValues>>) => void;
   _fields: FieldRefs;
   _formValues: FieldValues;

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -378,7 +378,7 @@ export function useFieldArray<
 
     control._names.focus = '';
 
-    control._updateValid();
+    control._updateValidErrors();
     _actioned.current = false;
   }, [fields, name, control]);
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -112,7 +112,7 @@ export function useForm<
 
   React.useEffect(() => {
     if (!control._state.mount) {
-      control._updateValid();
+      control._updateValidErrors();
       control._state.mount = true;
     }
 

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -88,7 +88,7 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
 
   React.useEffect(() => {
     _mounted.current = true;
-    _localProxyFormState.current.isValid && control._updateValid(true);
+    _localProxyFormState.current.isValid && control._updateValidErrors(true);
 
     return () => {
       _mounted.current = false;


### PR DESCRIPTION
Validation errors weren't propagated to the form consumer if default values failed validation.

This PR changes the concern of `_updateValid` to also consider if errors should be set on `formState`. I presume `_updateValid` is a private interface hence the rename.

The provided resolver was invoked already, but the errors would be ignored, leaving registered inputs as if they would not be in an error state.