### PR TITLE
#8020 Make handleSubmit return void instead of Promise<void>

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -620,7 +620,7 @@ export type UseFormHandleSubmit<
     ? SubmitHandler<TTransformedValues>
     : SubmitHandler<TFieldValues>,
   onInvalid?: SubmitErrorHandler<TFieldValues>,
-) => (e?: React.BaseSyntheticEvent) => Promise<void>;
+) => (e?: React.BaseSyntheticEvent) => void;
 
 /**
  * Reset a field state and reference.


### PR DESCRIPTION
This PR makes handleSubmit return void instead of Promise<void>, but the tests are breaking, because they assume handleSubmit should reject a Promise instead.

How this should be handled needs to be decided by the maintainers. Either:

1. Update docs, so they catch consistently
  - i.e. `<form onSubmit={handleSubmit((data) => console.log(data))}>` would become `<form onSubmit={() => handleSubmit((data) => console.log(data))().catch(() => {})}>`
2. Update the tests, so they don't catch at all
3. Pass a rejectionHandler which is called in the `catch`-part of my PR