### PR TITLE
chore: improve error when not passing `control` to `useController`

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -1012,4 +1012,24 @@ describe('useController', () => {
       }),
     );
   });
+
+  it("should throw a meaningful error if the control prop isn't passed", async () => {
+    const Component = () => {
+      useController({
+        name: 'test',
+        defaultValue: '',
+      });
+
+      return null;
+    };
+
+    // Don't log the thrown error to the console
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() => render(<Component />)).toThrow(
+      'useController: missing `control`. Pass `control` as a prop or provide it via FormProvider.',
+    );
+
+    spy.mockRestore();
+  });
 });

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -53,7 +53,19 @@ export function useController<
   props: UseControllerProps<TFieldValues, TName>,
 ): UseControllerReturn<TFieldValues, TName> {
   const methods = useFormContext<TFieldValues>();
-  const { name, disabled, control = methods.control, shouldUnregister } = props;
+  const {
+    name,
+    disabled,
+    control = methods?.control,
+    shouldUnregister,
+  } = props;
+
+  if (!control) {
+    throw new Error(
+      'useController: missing `control`. Pass `control` as a prop or provide it via FormProvider.',
+    );
+  }
+
   const isArrayField = isNameInFieldArray(control._names.array, name);
   const value = useWatch({
     control,


### PR DESCRIPTION
## Proposed Changes

This PR improves the message of the error that is generated when you don't pass `control` to `Controller` or `useController`. This error occurs if you neither pass `control` as a prop directly nor provide `control` via `FormProvider`.

Currently, you would get a rather cryptic "methods is null" error:

![image](https://github.com/react-hook-form/react-hook-form/assets/11708035/86a075a9-5546-4626-8389-d69fe99e34fa)

After this PR, you get a more informative error:

<img width="939" alt="Screenshot 2023-10-10 at 19 03 48" src="https://github.com/react-hook-form/react-hook-form/assets/11708035/943c3855-3dde-455c-8109-fadd623c2d9d">

Interestingly, while the console stack trace is able to pinpoint `useController` as the source for both errors, Next.js can only understand that this error happens in the code of the library if it's explicitly thrown. Before this PR, Next.js thinks that the error happens in my code.

While to most users of the library it should be obvious that you need to somehow pass `control` to `Controller`, when developing you can easily get tunnel vision and forget about basic mechanisms, as happened to me. This PR should help developers get back on track without having to spend a lot of time understanding what they did wrong.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
