### PR TITLE
fix: remove direct delete operator

### DIFF
--- a/src/utils/omit.ts
+++ b/src/utils/omit.ts
@@ -1,4 +1,4 @@
-export default <Key extends string, T extends Record<Key, any>>(
+export default <Key extends string| number| symbol, T extends Record<Key, any>>(
   source: T,
   key: Key,
 ): Omit<T, Key> => {
@@ -7,3 +7,4 @@ export default <Key extends string, T extends Record<Key, any>>(
 
   return copy;
 };
+

--- a/src/utils/unset.ts
+++ b/src/utils/unset.ts
@@ -2,6 +2,7 @@ import isEmptyObject from './isEmptyObject';
 import isKey from './isKey';
 import isObject from './isObject';
 import isUndefined from './isUndefined';
+import omit from './omit';
 import stringToPath from './stringToPath';
 
 function baseGet(object: any, updatePath: (string | number)[]) {
@@ -30,20 +31,17 @@ export default function unset(object: any, path: string | (string | number)[]) {
     : isKey(path)
     ? [path]
     : stringToPath(path);
-
-  const childObject = paths.length === 1 ? object : baseGet(object, paths);
-
+    
   const index = paths.length - 1;
   const key = paths[index];
-
-  if (childObject) {
-    delete childObject[key];
-  }
+  
+  const sourceObject = paths.length === 1 ? object : baseGet(object, paths);
+  const unsetObject = omit(sourceObject, String(key));
 
   if (
     index !== 0 &&
-    ((isObject(childObject) && isEmptyObject(childObject)) ||
-      (Array.isArray(childObject) && isEmptyArray(childObject)))
+    ((isObject(unsetObject) && isEmptyObject(unsetObject)) ||
+      (Array.isArray(unsetObject) && isEmptyArray(unsetObject)))
   ) {
     unset(object, paths.slice(0, -1));
   }


### PR DESCRIPTION

- enables to delete non-configurable key reference 
  - avoiding error:  `Uncaught TypeError: Cannot delete property {} of #<Object>`