### PR TITLE
fix: validateField "isEmpty" for MultiSelect cases

### DIFF
--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -1,12 +1,22 @@
 import getCheckboxValue from '../../logic/getCheckboxValue';
 import getRadioValue from '../../logic/getRadioValue';
 import validateField from '../../logic/validateField';
+import * as isHTMLElement from '../../utils/isHTMLElement';
 
 jest.mock('../../logic/getRadioValue');
 jest.mock('../../logic/getCheckboxValue');
 
+jest.mock('../../utils/isHTMLElement', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 describe('validateField', () => {
   it('should return required true when input not filled with required', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     (getRadioValue as jest.Mock).mockImplementation(() => ({
       value: '2',
     }));
@@ -389,6 +399,10 @@ describe('validateField', () => {
   });
 
   it('should return max error', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -720,6 +734,10 @@ describe('validateField', () => {
   });
 
   it('should return min error', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -999,6 +1017,10 @@ describe('validateField', () => {
   });
 
   it('should return min and max error for custom input', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -1084,6 +1106,10 @@ describe('validateField', () => {
   });
 
   it('should return max length error ', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -1185,6 +1211,10 @@ describe('validateField', () => {
   });
 
   it('should return min length error ', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -1286,6 +1316,10 @@ describe('validateField', () => {
   });
 
   it('should return pattern error when not matching', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     const emailRegex =
       /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 
@@ -1434,6 +1468,10 @@ describe('validateField', () => {
   });
 
   it('should validate for custom validation', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -1622,6 +1660,10 @@ describe('validateField', () => {
   });
 
   it('should return error message when it is defined', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -1698,6 +1740,10 @@ describe('validateField', () => {
   });
 
   it('should return result or empty string when validate has error', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -1760,6 +1806,10 @@ describe('validateField', () => {
   });
 
   it('if undefined returned from validate, no error is reported', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -1783,6 +1833,14 @@ describe('validateField', () => {
   });
 
   it('should do nothing when validate is not an object nor function', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -1805,6 +1863,10 @@ describe('validateField', () => {
   });
 
   it('should return all validation errors', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     (getRadioValue as jest.Mock).mockImplementation(() => ({
       value: '',
     }));
@@ -1880,6 +1942,10 @@ describe('validateField', () => {
   });
 
   it('should handle pattern with g flag', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     const reusedRe = /a/g;
 
     (getRadioValue as jest.Mock).mockImplementation(() => ({
@@ -1955,6 +2021,10 @@ describe('validateField', () => {
   });
 
   it('should return all validation error messages', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     (getRadioValue as jest.Mock).mockImplementation(() => ({
       value: '',
     }));
@@ -2100,6 +2170,10 @@ describe('validateField', () => {
   });
 
   describe('with Browser native validation', () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     it('should invoke setCustomValidity for invalid input', () => {
       const setCustomValidity = jest.fn();
       const reportValidity = jest.fn();
@@ -2215,6 +2289,10 @@ describe('validateField', () => {
   });
 
   it('should validate field array with required attribute', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return false;
+    });
+
     expect(
       await validateField(
         {
@@ -2329,6 +2407,35 @@ describe('validateField', () => {
         false,
         false,
         true,
+      ),
+    ).toEqual({});
+  });
+
+  /**
+   * In a custom built multislect, the value is an array of objects. But the referenced element does not necessarily have a value attribute.
+   */
+  it('should not detect isEmpty when handling a custom built multi select', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return true;
+    });
+
+    expect(
+      await validateField(
+        {
+          _f: {
+            mount: true,
+            name: 'test',
+            ref: { value: '', name: 'test' },
+            required: true,
+          },
+        },
+        {
+          test: [
+            { label: 'Blackberry', value: 'blackberry' },
+            { label: 'Banana', value: 'banana' },
+          ],
+        },
+        false,
       ),
     ).toEqual({});
   });

--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -1,22 +1,12 @@
 import getCheckboxValue from '../../logic/getCheckboxValue';
 import getRadioValue from '../../logic/getRadioValue';
 import validateField from '../../logic/validateField';
-import * as isHTMLElement from '../../utils/isHTMLElement';
 
 jest.mock('../../logic/getRadioValue');
 jest.mock('../../logic/getCheckboxValue');
 
-jest.mock('../../utils/isHTMLElement', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
 describe('validateField', () => {
   it('should return required true when input not filled with required', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     (getRadioValue as jest.Mock).mockImplementation(() => ({
       value: '2',
     }));
@@ -399,10 +389,6 @@ describe('validateField', () => {
   });
 
   it('should return max error', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -734,10 +720,6 @@ describe('validateField', () => {
   });
 
   it('should return min error', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1017,10 +999,6 @@ describe('validateField', () => {
   });
 
   it('should return min and max error for custom input', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1106,10 +1084,6 @@ describe('validateField', () => {
   });
 
   it('should return max length error ', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1211,10 +1185,6 @@ describe('validateField', () => {
   });
 
   it('should return min length error ', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1316,10 +1286,6 @@ describe('validateField', () => {
   });
 
   it('should return pattern error when not matching', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     const emailRegex =
       /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 
@@ -1468,10 +1434,6 @@ describe('validateField', () => {
   });
 
   it('should validate for custom validation', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1660,10 +1622,6 @@ describe('validateField', () => {
   });
 
   it('should return error message when it is defined', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1740,10 +1698,6 @@ describe('validateField', () => {
   });
 
   it('should return result or empty string when validate has error', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1806,10 +1760,6 @@ describe('validateField', () => {
   });
 
   it('if undefined returned from validate, no error is reported', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1833,14 +1783,6 @@ describe('validateField', () => {
   });
 
   it('should do nothing when validate is not an object nor function', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -1863,10 +1805,6 @@ describe('validateField', () => {
   });
 
   it('should return all validation errors', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     (getRadioValue as jest.Mock).mockImplementation(() => ({
       value: '',
     }));
@@ -1942,10 +1880,6 @@ describe('validateField', () => {
   });
 
   it('should handle pattern with g flag', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     const reusedRe = /a/g;
 
     (getRadioValue as jest.Mock).mockImplementation(() => ({
@@ -2021,10 +1955,6 @@ describe('validateField', () => {
   });
 
   it('should return all validation error messages', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     (getRadioValue as jest.Mock).mockImplementation(() => ({
       value: '',
     }));
@@ -2170,10 +2100,6 @@ describe('validateField', () => {
   });
 
   describe('with Browser native validation', () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     it('should invoke setCustomValidity for invalid input', () => {
       const setCustomValidity = jest.fn();
       const reportValidity = jest.fn();
@@ -2289,10 +2215,6 @@ describe('validateField', () => {
   });
 
   it('should validate field array with required attribute', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return false;
-    });
-
     expect(
       await validateField(
         {
@@ -2407,35 +2329,6 @@ describe('validateField', () => {
         false,
         false,
         true,
-      ),
-    ).toEqual({});
-  });
-
-  /**
-   * In a custom built multislect, the value is an array of objects. But the referenced element does not necessarily have a value attribute.
-   */
-  it('should not detect isEmpty when handling a custom built multi select', async () => {
-    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
-      return true;
-    });
-
-    expect(
-      await validateField(
-        {
-          _f: {
-            mount: true,
-            name: 'test',
-            ref: { value: '', name: 'test' },
-            required: true,
-          },
-        },
-        {
-          test: [
-            { label: 'Blackberry', value: 'blackberry' },
-            { label: 'Banana', value: 'banana' },
-          ],
-        },
-        false,
       ),
     ).toEqual({});
   });

--- a/src/__tests__/logic/validateFieldMultiSelect.test.tsx
+++ b/src/__tests__/logic/validateFieldMultiSelect.test.tsx
@@ -1,0 +1,38 @@
+import validateField from '../../logic/validateField';
+import * as isHTMLElement from '../../utils/isHTMLElement';
+
+jest.mock('../../utils/isHTMLElement', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('validateField', () => {
+  /**
+   * In a custom built multislect, the value is an array of objects. But the referenced element does not necessarily have a value attribute.
+   */
+  it('should not detect isEmpty when handling a custom built multi select', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return true;
+    });
+
+    expect(
+      await validateField(
+        {
+          _f: {
+            mount: true,
+            name: 'test',
+            ref: { value: '', name: 'test' },
+            required: true,
+          },
+        },
+        {
+          test: [
+            { label: 'Blackberry', value: 'blackberry' },
+            { label: 'Banana', value: 'banana' },
+          ],
+        },
+        false,
+      ),
+    ).toEqual({});
+  });
+});

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -73,9 +73,9 @@ export default async <T extends FieldValues>(
     ((valueAsNumber || isFileInput(ref)) &&
       isUndefined(ref.value) &&
       isUndefined(inputValue)) ||
-    (isHTMLElement(ref) && !isMultiSelect && ref.value === '') ||
+    (!isMultiSelect && isHTMLElement(ref) && ref.value === '') ||
     inputValue === '' ||
-    (Array.isArray(inputValue) && !inputValue.length);
+    (isMultiSelect && !inputValue.length);
 
   const appendErrorsCurry = appendErrors.bind(
     null,

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -67,18 +67,15 @@ export default async <T extends FieldValues>(
   const isRadio = isRadioInput(ref);
   const isCheckBox = isCheckBoxInput(ref);
   const isRadioOrCheckbox = isRadio || isCheckBox;
+  const isMultiSelect = Array.isArray(inputValue);
 
-  const isSelectWithValue = Array.isArray(inputValue) && inputValue.length;
-  const isTextFieldWithValue =
-    (isHTMLElement(ref) && ref.value !== '') || inputValue !== '';
-  const isNumberOrFileFieldWithValue =
-    (valueAsNumber || isFileInput(ref)) &&
-    !isUndefined(ref.value) &&
-    !isUndefined(inputValue);
   const isEmpty =
-    !isSelectWithValue &&
-    !isTextFieldWithValue &&
-    !isNumberOrFileFieldWithValue;
+    ((valueAsNumber || isFileInput(ref)) &&
+      isUndefined(ref.value) &&
+      isUndefined(inputValue)) ||
+    (isHTMLElement(ref) && !isMultiSelect && ref.value === '') ||
+    inputValue === '' ||
+    (Array.isArray(inputValue) && !inputValue.length);
 
   const appendErrorsCurry = appendErrors.bind(
     null,

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -67,11 +67,18 @@ export default async <T extends FieldValues>(
   const isRadio = isRadioInput(ref);
   const isCheckBox = isCheckBoxInput(ref);
   const isRadioOrCheckbox = isRadio || isCheckBox;
-  
-  const isSelectWithValue = (Array.isArray(inputValue) && inputValue.length);
-  const isTextFieldWithValue = (isHTMLElement(ref) && ref.value !== '') || inputValue !== '';
-  const isNumberOrFileFieldWithValue = ((valueAsNumber || isFileInput(ref)) && !isUndefined(ref.value) && !isUndefined(inputValue));
-  const isEmpty = !isSelectWithValue && !isTextFieldWithValue && !isNumberOrFileFieldWithValue;
+
+  const isSelectWithValue = Array.isArray(inputValue) && inputValue.length;
+  const isTextFieldWithValue =
+    (isHTMLElement(ref) && ref.value !== '') || inputValue !== '';
+  const isNumberOrFileFieldWithValue =
+    (valueAsNumber || isFileInput(ref)) &&
+    !isUndefined(ref.value) &&
+    !isUndefined(inputValue);
+  const isEmpty =
+    !isSelectWithValue &&
+    !isTextFieldWithValue &&
+    !isNumberOrFileFieldWithValue;
 
   const appendErrorsCurry = appendErrors.bind(
     null,

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -67,13 +67,12 @@ export default async <T extends FieldValues>(
   const isRadio = isRadioInput(ref);
   const isCheckBox = isCheckBoxInput(ref);
   const isRadioOrCheckbox = isRadio || isCheckBox;
-  const isEmpty =
-    ((valueAsNumber || isFileInput(ref)) &&
-      isUndefined(ref.value) &&
-      isUndefined(inputValue)) ||
-    (isHTMLElement(ref) && ref.value === '') ||
-    inputValue === '' ||
-    (Array.isArray(inputValue) && !inputValue.length);
+  
+  const isSelectWithValue = (Array.isArray(inputValue) && inputValue.length);
+  const isTextFieldWithValue = (isHTMLElement(ref) && ref.value !== '') || inputValue !== '';
+  const isNumberOrFileFieldWithValue = ((valueAsNumber || isFileInput(ref)) && !isUndefined(ref.value) && !isUndefined(inputValue));
+  const isEmpty = !isSelectWithValue && !isTextFieldWithValue && !isNumberOrFileFieldWithValue;
+
   const appendErrorsCurry = appendErrors.bind(
     null,
     name,

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -67,15 +67,14 @@ export default async <T extends FieldValues>(
   const isRadio = isRadioInput(ref);
   const isCheckBox = isCheckBoxInput(ref);
   const isRadioOrCheckbox = isRadio || isCheckBox;
-  const isMultiSelect = Array.isArray(inputValue);
-
+  const isArrayType = Array.isArray(inputValue);
   const isEmpty =
     ((valueAsNumber || isFileInput(ref)) &&
       isUndefined(ref.value) &&
       isUndefined(inputValue)) ||
-    (!isMultiSelect && isHTMLElement(ref) && ref.value === '') ||
+    (!isArrayType && isHTMLElement(ref) && ref.value === '') ||
     inputValue === '' ||
-    (isMultiSelect && !inputValue.length);
+    (isArrayType && !inputValue.length);
 
   const appendErrorsCurry = appendErrors.bind(
     null,


### PR DESCRIPTION
First of all, this project is _absolutely_ amazing! It's simply the best form library i ever worked with! 

I've debugged the `validateField` method a lot now and I think the line "isEmpty" could be improved. The or-construct used here is too big i think.

We have the problem that if only one of the parts is "true", react-hook-form thinks the field is empty: This was never a problem in all previous cases (TextField, RadioButton, Checkbox). But it becomes a problem as soon as you work with dropdowns, especially with a multiselect combobox.

<img width="487" alt="Screenshot 2023-11-09 at 20 09 17" src="https://github.com/react-hook-form/react-hook-form/assets/1505976/5e0942c4-b4e0-435c-b3fc-a63bfb66bb62">

In that case, we have a value that is an array, and - as you can see, the field would have a valid value indeed - but still, react-hook-form thinks its empty.

<img width="616" alt="Screenshot 2023-11-09 at 20 09 44" src="https://github.com/react-hook-form/react-hook-form/assets/1505976/25af53fb-f3d4-4bc8-9ef6-857f1b0320d4">

This is because the "ref" is not having a value in plain HTML:

<img width="323" alt="Screenshot 2023-11-09 at 20 09 59" src="https://github.com/react-hook-form/react-hook-form/assets/1505976/b540df31-72c6-4104-92de-0808915d4ffe">

But, the last part where it checks that the value also could be an Array, is not failing:

<img width="371" alt="Screenshot 2023-11-09 at 20 10 12" src="https://github.com/react-hook-form/react-hook-form/assets/1505976/b7aafeeb-8421-4136-81d2-861c36e86dce">

This forces us to do a very ugly workaround in our implementation:

<img width="398" alt="Screenshot 2023-11-09 at 20 14 50" src="https://github.com/react-hook-form/react-hook-form/assets/1505976/8e96a9b6-cd9a-4168-8ba0-1194c1073718">

This "hack" is fixing the ternary, but nobody in our company is going to understand why our MultiSelectDropdown must have this value on the "ToggleButton".

It is just to suppress the ref-check.

With my change here in this pull request, this would be solved. We would need to check that the inputValue is an Array, before we go into the "isEmpty" line and then we can add that to the ref.value check.

I hope this makes sense so far - i've checked it with all our implementations and it seems to work fine, and i can get rid of our strange hack, providing a value in the plain DOM.



