### PR TITLE
Fix isEmpty check in validateField for custom field components

### DIFF
--- a/src/__tests__/logic/validateFieldArrayState.test.tsx
+++ b/src/__tests__/logic/validateFieldArrayState.test.tsx
@@ -1,0 +1,40 @@
+import validateField from '../../logic/validateField';
+import * as isHTMLElement from '../../utils/isHTMLElement';
+
+jest.mock('../../utils/isHTMLElement', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('validateField', () => {
+  it('should not detect isEmpty when handling a custom built select', async () => {
+    jest.spyOn(isHTMLElement, 'default').mockImplementation(() => {
+      return true;
+    });
+
+    /**
+     * With a custom built select component it can happen that the
+     * referenced element does not have a value attribute.
+     * But the state is correctly set at the moment of validation.
+     */
+    expect(
+      await validateField(
+        {
+          _f: {
+            mount: true,
+            name: 'test',
+            ref: { value: '', name: 'test' },
+            required: true,
+          },
+        },
+        {
+          test: [
+            { label: 'Blackberry', value: 'blackberry' },
+            { label: 'Banana', value: 'banana' },
+          ],
+        },
+        false,
+      ),
+    ).toEqual({});
+  });
+});

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -67,14 +67,16 @@ export default async <T extends FieldValues>(
   const isRadio = isRadioInput(ref);
   const isCheckBox = isCheckBoxInput(ref);
   const isRadioOrCheckbox = isRadio || isCheckBox;
-  const isArrayType = Array.isArray(inputValue);
+  const isInputValueEmpty =
+    inputValue === '' || (Array.isArray(inputValue) && !inputValue.length);
+
   const isEmpty =
     ((valueAsNumber || isFileInput(ref)) &&
       isUndefined(ref.value) &&
       isUndefined(inputValue)) ||
-    (!isArrayType && isHTMLElement(ref) && ref.value === '') ||
-    inputValue === '' ||
-    (isArrayType && !inputValue.length);
+    isInputValueEmpty ||
+    (isInputValueEmpty && isHTMLElement(ref) && ref.value === '');
+
   const appendErrorsCurry = appendErrors.bind(
     null,
     name,

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -67,13 +67,14 @@ export default async <T extends FieldValues>(
   const isRadio = isRadioInput(ref);
   const isCheckBox = isCheckBoxInput(ref);
   const isRadioOrCheckbox = isRadio || isCheckBox;
+  const isArrayType = Array.isArray(inputValue);
   const isEmpty =
     ((valueAsNumber || isFileInput(ref)) &&
       isUndefined(ref.value) &&
       isUndefined(inputValue)) ||
-    (isHTMLElement(ref) && ref.value === '') ||
+    (!isArrayType && isHTMLElement(ref) && ref.value === '') ||
     inputValue === '' ||
-    (Array.isArray(inputValue) && !inputValue.length);
+    (isArrayType && !inputValue.length);
   const appendErrorsCurry = appendErrors.bind(
     null,
     name,

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -15,7 +15,6 @@ import isCheckBoxInput from '../utils/isCheckBoxInput';
 import isEmptyObject from '../utils/isEmptyObject';
 import isFileInput from '../utils/isFileInput';
 import isFunction from '../utils/isFunction';
-import isHTMLElement from '../utils/isHTMLElement';
 import isMessage from '../utils/isMessage';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
 import isObject from '../utils/isObject';

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -68,14 +68,16 @@ export default async <T extends FieldValues>(
   const isCheckBox = isCheckBoxInput(ref);
   const isRadioOrCheckbox = isRadio || isCheckBox;
   const isInputValueEmpty =
-    inputValue === '' || (Array.isArray(inputValue) && !inputValue.length);
+    isUndefined(inputValue) ||
+    inputValue === null ||
+    inputValue === '' ||
+    (Array.isArray(inputValue) && !inputValue.length);
 
   const isEmpty =
     ((valueAsNumber || isFileInput(ref)) &&
       isUndefined(ref.value) &&
       isUndefined(inputValue)) ||
-    isInputValueEmpty ||
-    (isInputValueEmpty && isHTMLElement(ref) && ref.value === '');
+    isInputValueEmpty;
 
   const appendErrorsCurry = appendErrors.bind(
     null,


### PR DESCRIPTION
With a custom built field component it can happen that the referenced element does not have a value attribute.
But the state is correctly set at the moment of validation.

In that case, the `validateField` function thinks the field is empty, because of this line:
```
isHTMLElement(ref) && ref.value === ''
```

I've added a test to show that behavior and it fails with the current implementation as it does in our case of a multi select field with downshift.js

I think we could improve the "is-empty-check" by increasing the priority of the `inputValue` - we don't need to check if the ref-element's value attribute is empty when we have a valid `inputValue`, right?
