### PR TITLE
refac: improved isObjectType and swap

### DIFF
--- a/src/utils/isObject.ts
+++ b/src/utils/isObject.ts
@@ -1,7 +1,8 @@
 import isDateObject from './isDateObject';
 import isNullOrUndefined from './isNullOrUndefined';
 
-export const isObjectType = (value: unknown) => typeof value === 'object';
+export const isObjectType = (value: unknown): value is object =>
+  typeof value === 'object';
 
 export default <T extends object>(value: unknown): value is T =>
   !isNullOrUndefined(value) &&

--- a/src/utils/swap.ts
+++ b/src/utils/swap.ts
@@ -1,3 +1,3 @@
 export default <T>(data: T[], indexA: number, indexB: number): void => {
-  data[indexA] = [data[indexB], (data[indexB] = data[indexA])][0];
+  [data[indexA], data[indexB]] = [data[indexB], data[indexA]];
 };


### PR DESCRIPTION
@bluebill1049 👋
I clearly specified the type of `isObjectType` for the `type guard` to work.

Task on `swap` Just a quick suggestion. I think we could use the ECMAScript 6 syntax `destructuring assignment` to make it more concise and readable. What do you think?
