### PR TITLE
feat: add errors prop

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -668,7 +668,7 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
 };
 
 // @public
-export type UseFormHandleSubmit<TFieldValues extends FieldValues, TTransformedValues extends FieldValues | undefined = undefined> = (onValid?: TTransformedValues extends FieldValues ? SubmitHandler<TTransformedValues> : SubmitHandler<TFieldValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
+export type UseFormHandleSubmit<TFieldValues extends FieldValues, TTransformedValues extends FieldValues | undefined = undefined> = (onValid: TTransformedValues extends FieldValues ? SubmitHandler<TTransformedValues> : SubmitHandler<TFieldValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
 
 // @public (undocumented)
 export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContext = any> = Partial<{
@@ -677,7 +677,6 @@ export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContex
     reValidateMode: Exclude<Mode, 'onTouched' | 'all'>;
     defaultValues: DefaultValues<TFieldValues> | AsyncDefaultValues<TFieldValues>;
     values: TFieldValues;
-    defaultErrors: FieldErrors<TFieldValues>;
     errors: FieldErrors<TFieldValues>;
     resetOptions: Parameters<UseFormReset<TFieldValues>>[1];
     resolver: Resolver<TFieldValues, TContext>;
@@ -864,7 +863,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:441:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:440:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -60,6 +60,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
     _getWatch: WatchInternal<TFieldValues>;
     _updateFieldArray: BatchFieldArrayUpdate;
     _getFieldArray: <TFieldArrayValues>(name: InternalFieldName) => Partial<TFieldArrayValues>[];
+    _setErrors: (errors: FieldErrors<TFieldValues>) => void;
     _updateDisabledField: (props: {
         disabled?: boolean;
         name: FieldName<any>;
@@ -667,7 +668,7 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
 };
 
 // @public
-export type UseFormHandleSubmit<TFieldValues extends FieldValues, TTransformedValues extends FieldValues | undefined = undefined> = (onValid: TTransformedValues extends FieldValues ? SubmitHandler<TTransformedValues> : SubmitHandler<TFieldValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
+export type UseFormHandleSubmit<TFieldValues extends FieldValues, TTransformedValues extends FieldValues | undefined = undefined> = (onValid?: TTransformedValues extends FieldValues ? SubmitHandler<TTransformedValues> : SubmitHandler<TFieldValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
 
 // @public (undocumented)
 export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContext = any> = Partial<{
@@ -676,6 +677,8 @@ export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContex
     reValidateMode: Exclude<Mode, 'onTouched' | 'all'>;
     defaultValues: DefaultValues<TFieldValues> | AsyncDefaultValues<TFieldValues>;
     values: TFieldValues;
+    defaultErrors: FieldErrors<TFieldValues>;
+    errors: FieldErrors<TFieldValues>;
     resetOptions: Parameters<UseFormReset<TFieldValues>>[1];
     resolver: Resolver<TFieldValues, TContext>;
     context: TContext;
@@ -861,7 +864,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:439:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:441:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useForm.server.test.tsx
+++ b/src/__tests__/useForm.server.test.tsx
@@ -25,6 +25,32 @@ describe('useForm with SSR', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('should display error with errors prop', () => {
+    const App = () => {
+      const {
+        register,
+        formState: { errors },
+      } = useForm<{
+        test: string;
+      }>({
+        errors: {
+          test: { type: 'test', message: 'test error' },
+        },
+      });
+
+      return (
+        <div>
+          <input {...register('test')} />
+          <span role="alert">{errors.test && errors.test.message}</span>
+        </div>
+      );
+    };
+
+    expect(renderToString(<App />)).toEqual(
+      '<div><input name="test"/><span role="alert">test error</span></div>',
+    );
+  });
+
   it('should not pass down constrained API for server side rendering', () => {
     const App = () => {
       const { register } = useForm<{

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -12,6 +12,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { VALIDATION_MODE } from '../constants';
 import {
   Control,
+  FieldErrors,
   RegisterOptions,
   UseFormRegister,
   UseFormReturn,
@@ -550,6 +551,55 @@ describe('useForm', () => {
       });
 
       await waitFor(() => expect(span.textContent).toBe('data'));
+    });
+
+    it('should display the latest error message with errors prop', () => {
+      const Form = () => {
+        type FormValues = {
+          test1: string;
+          test2: string;
+        };
+        const [errorsState, setErrorsState] = React.useState<
+          FieldErrors<FormValues>
+        >({
+          test1: { type: 'test1', message: 'test1 error' },
+        });
+        const {
+          register,
+          formState: { errors },
+        } = useForm<FormValues>({
+          errors: errorsState,
+        });
+
+        return (
+          <div>
+            <input {...register('test1')} type="text" />
+            <span role="alert">{errors.test1 && errors.test1.message}</span>
+            <input {...register('test2')} type="text" />
+            <span role="alert">{errors.test2 && errors.test2.message}</span>
+            <button
+              onClick={() =>
+                setErrorsState((errors) => ({
+                  ...errors,
+                  test2: { type: 'test2', message: 'test2 error' },
+                }))
+              }
+            >
+              Set Errors
+            </button>
+          </div>
+        );
+      };
+
+      render(<Form />);
+
+      const alert1 = screen.getAllByRole('alert')[0];
+      expect(alert1.textContent).toBe('test1 error');
+
+      fireEvent.click(screen.getByRole('button'));
+
+      const alert2 = screen.getAllByRole('alert')[1];
+      expect(alert2.textContent).toBe('test2 error');
     });
   });
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -46,7 +46,6 @@ import compact from '../utils/compact';
 import convertToArrayPayload from '../utils/convertToArrayPayload';
 import createSubject from '../utils/createSubject';
 import deepEqual from '../utils/deepEqual';
-import { deepMerge } from '../utils/deepMerge';
 import get from '../utils/get';
 import isBoolean from '../utils/isBoolean';
 import isCheckBoxInput from '../utils/isCheckBoxInput';
@@ -249,7 +248,7 @@ export function createFormControl<
   };
 
   const _setErrors = (errors: FieldErrors<TFieldValues>) => {
-    deepMerge(_formState.errors, errors);
+    _formState.errors = errors;
     _subjects.state.next({
       errors: _formState.errors,
       isValid: false,

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -112,7 +112,7 @@ export function createFormControl<
     isValid: false,
     touchedFields: {},
     dirtyFields: {},
-    errors: isObject(_options.errors) ? _options.errors || {} : {},
+    errors: _options.errors || {},
     disabled: false,
   };
   let _fields: FieldRefs = {};

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -8,6 +8,7 @@ import {
   EventType,
   Field,
   FieldError,
+  FieldErrors,
   FieldNamesMarkedBoolean,
   FieldPath,
   FieldRefs,
@@ -45,6 +46,7 @@ import compact from '../utils/compact';
 import convertToArrayPayload from '../utils/convertToArrayPayload';
 import createSubject from '../utils/createSubject';
 import deepEqual from '../utils/deepEqual';
+import { deepMerge } from '../utils/deepMerge';
 import get from '../utils/get';
 import isBoolean from '../utils/isBoolean';
 import isCheckBoxInput from '../utils/isCheckBoxInput';
@@ -111,7 +113,7 @@ export function createFormControl<
     isValid: false,
     touchedFields: {},
     dirtyFields: {},
-    errors: {},
+    errors: isObject(_options.errors) ? _options.errors || {} : {},
     disabled: false,
   };
   let _fields: FieldRefs = {};
@@ -243,6 +245,14 @@ export function createFormControl<
     set(_formState.errors, name, error);
     _subjects.state.next({
       errors: _formState.errors,
+    });
+  };
+
+  const _setErrors = (errors: FieldErrors<TFieldValues>) => {
+    deepMerge(_formState.errors, errors);
+    _subjects.state.next({
+      errors: _formState.errors,
+      isValid: false,
     });
   };
 
@@ -1330,6 +1340,7 @@ export function createFormControl<
       _disableForm,
       _subjects,
       _proxyFormState,
+      _setErrors,
       get _fields() {
         return _fields;
       },

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -113,6 +113,7 @@ export type UseFormProps<
   reValidateMode: Exclude<Mode, 'onTouched' | 'all'>;
   defaultValues: DefaultValues<TFieldValues> | AsyncDefaultValues<TFieldValues>;
   values: TFieldValues;
+  errors: FieldErrors<TFieldValues>;
   resetOptions: Parameters<UseFormReset<TFieldValues>>[1];
   resolver: Resolver<TFieldValues, TContext>;
   context: TContext;
@@ -785,6 +786,7 @@ export type Control<
   _getFieldArray: <TFieldArrayValues>(
     name: InternalFieldName,
   ) => Partial<TFieldArrayValues>[];
+  _setErrors: (errors: FieldErrors<TFieldValues>) => void;
   _updateDisabledField: (
     props: {
       disabled?: boolean;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -66,7 +66,7 @@ export function useForm<
     submitCount: 0,
     dirtyFields: {},
     touchedFields: {},
-    errors: isObject(props.errors) ? props.errors || {} : {},
+    errors: props.errors || {},
     disabled: false,
     defaultValues: isFunction(props.defaultValues)
       ? undefined

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -5,6 +5,7 @@ import getProxyFormState from './logic/getProxyFormState';
 import shouldRenderFormState from './logic/shouldRenderFormState';
 import deepEqual from './utils/deepEqual';
 import isFunction from './utils/isFunction';
+import isObject from './utils/isObject';
 import {
   FieldValues,
   FormState,
@@ -65,7 +66,7 @@ export function useForm<
     submitCount: 0,
     dirtyFields: {},
     touchedFields: {},
-    errors: {},
+    errors: isObject(props.errors) ? props.errors || {} : {},
     disabled: false,
     defaultValues: isFunction(props.defaultValues)
       ? undefined
@@ -126,6 +127,12 @@ export function useForm<
       control._resetDefaultValues();
     }
   }, [props.values, control]);
+
+  React.useEffect(() => {
+    if (props.errors) {
+      control._setErrors(props.errors);
+    }
+  }, [props.errors, control]);
 
   React.useEffect(() => {
     if (!control._state.mount) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -5,7 +5,6 @@ import getProxyFormState from './logic/getProxyFormState';
 import shouldRenderFormState from './logic/shouldRenderFormState';
 import deepEqual from './utils/deepEqual';
 import isFunction from './utils/isFunction';
-import isObject from './utils/isObject';
 import {
   FieldValues,
   FormState,


### PR DESCRIPTION
## Related Issue

- [https://github.com/react-hook-form/react-hook-form/pull/11061](https://github.com/react-hook-form/react-hook-form/pull/11061)

## CSB

- https://codesandbox.io/s/react-hook-form-v7-ts-template-forked-vcgwf4
- https://codesandbox.io/p/sandbox/github/react-hook-form/react-hook-form/tree/experiment/trigger-submit-on-pass/examples/server-actions

## Overview

This pull request introduces the addition of the `errors` prop, designed to dynamically respond to changes and update error states. This becomes particularly useful when your form needs to be synchronized with external states or server data. By incorporating this prop, you can seamlessly render error messages irrespective of JavaScript being enabled or disabled.

## Benefits

Furthermore, this prop serves as a convenient syntax sugar, replacing the `useEffect + setError` combination with the more concise `errors` prop. Also it plays a crucial role in supporting Server Actions, allowing you to retrieve the errors returned by actions using `react-dom`'s `useFormState` . By passing these errors as the `errors` prop, you seamlessly integrate Server Actions' errors with React Hook Form's error handling.

```diff
  import { useFormState } from 'react-dom';
  import { useForm } from 'react-hook-form';
  
  const [formState, action] = useFormState(myAction, null);
  const {
    register,
    handleSubmit,
    formState: { errors },
  } = useForm({
    defaultValues: formState.values,
+   errors: formState.errors,
    progressive: true,
  });
```

This enhancement not only simplifies the codebase but also enhances the compatibility and cohesion between server-side and client-side error handling in React Hook Form.