### PR TITLE
fix(useForm): leave formState flags in a consistent state when throwing in handleSubmit onValid

### DIFF
--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -253,11 +253,15 @@ describe('handleSubmit', () => {
     expect(callback).toBeCalled();
   });
 
-  it('should bubble the error up when an error occurs in the provided handleSubmit function', async () => {
+  it('should bubble the error up when an error occurs in the provided handleSubmit function by leaving formState flags in a consistent state', async () => {
     const errorMsg = 'this is an error';
     const App = () => {
       const [error, setError] = React.useState('');
-      const { register, handleSubmit } = useForm();
+      const {
+        register,
+        handleSubmit,
+        formState: { isSubmitting, isSubmitted, isSubmitSuccessful },
+      } = useForm();
 
       const rejectPromiseFn = jest.fn().mockRejectedValue(new Error(errorMsg));
 
@@ -265,6 +269,9 @@ describe('handleSubmit', () => {
         <form>
           <input {...register('test')} />
           <p>{error}</p>
+          <p>isSubmitting : {isSubmitting ? 'true' : 'false'}</p>
+          <p>isSubmitted : {isSubmitted ? 'true' : 'false'}</p>
+          <p>isSubmitSuccessful : {isSubmitSuccessful ? 'true' : 'false'}</p>
           <button
             type={'button'}
             onClick={() =>
@@ -280,10 +287,16 @@ describe('handleSubmit', () => {
     };
 
     render(<App />);
+    expect(await screen.findByText('isSubmitting : false')).toBeVisible();
+    expect(await screen.findByText('isSubmitted : false')).toBeVisible();
+    expect(await screen.findByText('isSubmitSuccessful : false')).toBeVisible();
 
     fireEvent.click(screen.getByRole('button'));
 
     expect(await screen.findByText(errorMsg)).toBeVisible();
+    expect(await screen.findByText('isSubmitting : false')).toBeVisible();
+    expect(await screen.findByText('isSubmitted : true')).toBeVisible();
+    expect(await screen.findByText('isSubmitSuccessful : false')).toBeVisible();
   });
 
   describe('with validationSchema', () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1092,6 +1092,7 @@ export function createFormControl<
 
   const handleSubmit: UseFormHandleSubmit<TFieldValues> =
     (onValid, onInvalid) => async (e) => {
+      let onValidError = undefined;
       if (e) {
         e.preventDefault && e.preventDefault();
         e.persist && e.persist();
@@ -1116,7 +1117,11 @@ export function createFormControl<
         _subjects.state.next({
           errors: {},
         });
-        await onValid(fieldValues as TFieldValues, e);
+        try {
+          await onValid(fieldValues as TFieldValues, e);
+        } catch (error) {
+          onValidError = error;
+        }
       } else {
         if (onInvalid) {
           await onInvalid({ ..._formState.errors }, e);
@@ -1128,10 +1133,13 @@ export function createFormControl<
       _subjects.state.next({
         isSubmitted: true,
         isSubmitting: false,
-        isSubmitSuccessful: isEmptyObject(_formState.errors),
+        isSubmitSuccessful: isEmptyObject(_formState.errors) && !onValidError,
         submitCount: _formState.submitCount + 1,
         errors: _formState.errors,
       });
+      if (onValidError) {
+        throw onValidError;
+      }
     };
 
   const resetField: UseFormResetField<TFieldValues> = (name, options = {}) => {


### PR DESCRIPTION
## Proposed Changes

onValid function given to handleSubmit from useForm is often the way to send request to server but when this function throw it leave isSubmitting flag true and isSubmitted flag on false what is inconsistent.

This change keep the current behavior of bubbling up the error but fix the inconsistent formState 

Fixes [#11084](https://github.com/react-hook-form/react-hook-form/issues/11084)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
