### PR TITLE
🏷️ improve CustomElement type

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -117,7 +117,7 @@ export type ControllerRenderProps<TFieldValues extends FieldValues = FieldValues
 export type CriteriaMode = 'firstError' | 'all';
 
 // @public (undocumented)
-export type CustomElement<TFieldValues extends FieldValues> = {
+export type CustomElement<TFieldValues extends FieldValues> = Partial<HTMLElement> & {
     name: FieldName<TFieldValues>;
     type?: string;
     value?: any;

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -8,16 +8,17 @@ export type FieldName<TFieldValues extends FieldValues> =
     ? Extract<keyof TFieldValues, string>
     : string;
 
-export type CustomElement<TFieldValues extends FieldValues> = HTMLElement & {
-  name: FieldName<TFieldValues>;
-  type?: string;
-  value?: any;
-  disabled?: boolean;
-  checked?: boolean;
-  options?: HTMLOptionsCollection;
-  files?: FileList | null;
-  focus?: Noop;
-};
+export type CustomElement<TFieldValues extends FieldValues> =
+  Partial<HTMLElement> & {
+    name: FieldName<TFieldValues>;
+    type?: string;
+    value?: any;
+    disabled?: boolean;
+    checked?: boolean;
+    options?: HTMLOptionsCollection;
+    files?: FileList | null;
+    focus?: Noop;
+  };
 
 export type FieldValue<TFieldValues extends FieldValues> =
   TFieldValues[InternalFieldName];

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -8,7 +8,7 @@ export type FieldName<TFieldValues extends FieldValues> =
     ? Extract<keyof TFieldValues, string>
     : string;
 
-export type CustomElement<TFieldValues extends FieldValues> = {
+export type CustomElement<TFieldValues extends FieldValues> = HTMLElement & {
   name: FieldName<TFieldValues>;
   type?: string;
   value?: any;


### PR DESCRIPTION
Thanks for providing a good library. It helps me a lot.

I've noticed that the type of `Ref` is different from the actual one. You can use the major properties and Web API in a type-safe manner.

For example, scrolling to the form with validation errors:

```tsx
useEffect(() => {
  if (formState.errors.email?.ref) {
    formState.errors.email.ref.scrollIntoView({
      block: 'center',
      behavior: 'smooth',
    })
  }
}, [formState.errors.email?.ref])
```

This can also be effectively utilized when referring to attributes such as `id` or `aria` properties.