### PR TITLE
Matching `ChangeHandler` type to an actual implementation

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -93,10 +93,7 @@ export type TriggerConfig = Partial<{
   shouldFocus: boolean;
 }>;
 
-export type ChangeHandler = (event: {
-  target: any;
-  type?: any;
-}) => Promise<void | boolean>;
+export type ChangeHandler = (event: unknown) => Promise<void | boolean>;
 
 export type DelayCallback = (wait: number) => void;
 


### PR DESCRIPTION
The actual implementation checks event.type and if it's not a browser event it simply consumes the whole event as a value. Right now I cannot `register` over a custom component with `onChange: (value: string)` as the typing requires my `event` to have a `target: any` property, so primitive values in `onChange` cause a typescript error.