### PR TITLE
fix: Change `DeepPartial` type definition to be compatible with `unknown`

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -135,7 +135,7 @@ export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends Browser
 
 // @public (undocumented)
 export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue ? T : {
-    [K in keyof T]?: DeepPartial<T[K]>;
+    [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };
 
 // @public (undocumented)

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -43,7 +43,7 @@ export type LiteralUnion<T extends U, U extends Primitive> =
 
 export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue
   ? T
-  : { [K in keyof T]?: DeepPartial<T[K]> };
+  : { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] };
 
 export type DeepPartialSkipArrayKey<T> = T extends
   | BrowserNativeObject


### PR DESCRIPTION
With the previous type definition, some codes like the example below containing the `unknown` type caused a type error:
```typescript
interface InterfaceWithUnknown {
  a: unknown;
}

interface IFormInput {
  test: InterfaceWithUnknown;
}

export default function App() {
  const x: IFormInput = {
    test: {
      a: 'hi',
    },
  };

  const { register, handleSubmit } = useForm<IFormInput>({
    // Type 'IFormInput' is not assignable to type '{ test?: { a?: {} | undefined; } | undefined; }'.
    defaultValues: x,
  });
  ...   
}

```
I found out that this could be very similar to a case that happened on the [redux](https://github.com/reduxjs/redux/issues/3368) repository.
This PR fixes the type definition to take account of such cases and remove the error.
