### PR TITLE
🐛 fix(reset): remove global reset option flag

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -149,8 +149,6 @@ export function createFormControl<
     array: createSubject(),
     state: createSubject(),
   };
-  const shouldCaptureDirtyFields =
-    props.resetOptions && props.resetOptions.keepDirtyValues;
   const validationModeBeforeSubmit = getValidationModes(_options.mode);
   const validationModeAfterSubmit = getValidationModes(_options.reValidateMode);
   const shouldDisplayAllAssociatedErrors =
@@ -1193,7 +1191,7 @@ export function createFormControl<
     }
 
     if (!keepStateOptions.keepValues) {
-      if (keepStateOptions.keepDirtyValues || shouldCaptureDirtyFields) {
+      if (keepStateOptions.keepDirtyValues) {
         for (const fieldName of _names.mount) {
           get(_formState.dirtyFields, fieldName)
             ? set(values, fieldName, get(_formValues, fieldName))


### PR DESCRIPTION
It appears that the flag [`shouldCaptureDirtyFields`](https://github.com/react-hook-form/react-hook-form/blob/4f4eae58797af983660513f2eac0497a8beca8bb/src/logic/createFormControl.ts#L152C1-L153C62) defined globally has caused "the connection" between the `values` API and the `reset` form method. It seems safe to remove this flag since [`resetOptions` are still passed](https://github.com/react-hook-form/react-hook-form/blob/4f4eae58797af983660513f2eac0497a8beca8bb/src/useForm.ts#L123C36-L123C65) when the `values` change between renders.