### PR TITLE
🐛 fix(formState, disabled): infer controlled disabled form state

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -113,7 +113,7 @@ export function createFormControl<
     touchedFields: {},
     dirtyFields: {},
     errors: _options.errors || {},
-    disabled: false,
+    disabled: _options.disabled || false,
   };
   let _fields: FieldRefs = {};
   let _defaultValues =

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -66,7 +66,7 @@ export function useForm<
     dirtyFields: {},
     touchedFields: {},
     errors: props.errors || {},
-    disabled: false,
+    disabled: props.disabled || false,
     defaultValues: isFunction(props.defaultValues)
       ? undefined
       : props.defaultValues,


### PR DESCRIPTION
Since the `disabled` state of the form can be controlled, we should inherit the `disabled` state passed from the `useForm` hook. This will prevent the form from flashing the wrong state when it is disabled.