### PR TITLE
fix: change `DeepPartial` to account for object union types & `unknown`

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -174,6 +174,9 @@ export type ErrorOption = {
 export type EventType = 'focus' | 'blur' | 'change' | 'changeText' | 'valueChange' | 'contentSizeChange' | 'endEditing' | 'keyPress' | 'submitEditing' | 'layout' | 'selectionChange' | 'longPress' | 'press' | 'pressIn' | 'pressOut' | 'momentumScrollBegin' | 'momentumScrollEnd' | 'scroll' | 'scrollBeginDrag' | 'scrollEndDrag' | 'load' | 'error' | 'progress' | 'custom';
 
 // @public (undocumented)
+export type ExtractObjects<T> = T extends infer U ? U extends object ? U : never : never;
+
+// @public (undocumented)
 export type Field = {
     _f: {
         ref: Ref;

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -135,7 +135,7 @@ export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends Browser
 
 // @public (undocumented)
 export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue ? T : {
-    [K in keyof T]?: T[K] extends never ? T[K] : DeepPartial<T[K]>;
+    [K in keyof T]?: ExtractObjects<T[K]> extends never ? T[K] : DeepPartial<T[K]>;
 };
 
 // @public (undocumented)

--- a/src/__typetest__/util.test-d.ts
+++ b/src/__typetest__/util.test-d.ts
@@ -1,6 +1,6 @@
-import { expectType } from 'tsd';
+import { expectAssignable, expectType } from 'tsd';
 
-import { IsAny, IsNever } from '../types';
+import { DeepPartial, ExtractObjects, IsAny, IsNever } from '../types';
 
 import { _ } from './__fixtures__';
 
@@ -45,5 +45,52 @@ import { _ } from './__fixtures__';
   /** it should evaluate to false for string */ {
     const actual = _ as IsNever<string>;
     expectType<false>(actual);
+  }
+}
+
+/** {@link ExtractObjects} */ {
+  /** it should extract all objects from a union */ {
+    const actual = _ as ExtractObjects<
+      { x: string } | { y: number; z: { w: number } } | number | string | null
+    >;
+    expectType<{ x: string } | { y: number; z: { w: number } }>(actual);
+  }
+}
+
+/** {@link DeepPartial} */ {
+  /** it should make all nested properties optional */ {
+    const actual = _ as DeepPartial<{
+      x: string;
+      y: number;
+      z: { w: boolean };
+    }>;
+    expectType<{ x?: string; y?: number; z?: { w?: boolean } }>(actual);
+  }
+
+  /** it should make all nested properties optional for union types */ {
+    const actual = _ as DeepPartial<{
+      x: string | number;
+      y: { a: string | null } | null;
+    }>;
+    expectType<{
+      x?: string | number;
+      y?: { a?: string | null } | null;
+    }>(actual);
+  }
+
+  /** it should make all nested properties optional for intersection types */ {
+    const actual = _ as DeepPartial<{
+      x: string;
+      y: { a: string } & { b: number };
+    }>;
+    expectType<{
+      x?: string;
+      y?: { a?: string; b?: number };
+    }>(actual);
+  }
+
+  /** it should be assignable for types containing unknown */ {
+    const actual = _ as { x: unknown };
+    expectAssignable<DeepPartial<{ x: unknown }>>(actual);
   }
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -41,10 +41,18 @@ export type LiteralUnion<T extends U, U extends Primitive> =
   | T
   | (U & { _?: never });
 
+export type ExtractObjects<T> = T extends infer U
+  ? U extends object
+    ? U
+    : never
+  : never;
+
 export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue
   ? T
   : {
-      [K in keyof T]?: T[K] extends never ? T[K] : DeepPartial<T[K]>;
+      [K in keyof T]?: ExtractObjects<T[K]> extends never
+        ? T[K]
+        : DeepPartial<T[K]>;
     };
 
 export type DeepPartialSkipArrayKey<T> = T extends


### PR DESCRIPTION
From the previous enhancement to allow `unknown` to be compatible with `DeepPartial`(#11333), it introduced an unintended bug, being incompatible with union types containing both object & non-object types. Although this was resolved in #11373, it again made the definition of `DeepPartial` incompatible with any types containing `unknown` again.

With a new proposed definition that should be able to handle such cases, I have added some test cases discovered throughout #11333 and #11373 as type tests along with the new definition. By using `ExtractObjects` to extract any type that extends `object` from a potential union type, it successfully applies `DeepPartial` for such object types while supporting `unknown` as well.