### PR TITLE
Get new dirtyFields when reset keeping defaults and dirty values

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1278,7 +1278,9 @@ export function createFormControl<
         ? _formState.isSubmitted
         : false,
       dirtyFields: keepStateOptions.keepDirtyValues
-        ? _formState.dirtyFields
+        ? keepStateOptions.keepDefaultValues && _formValues
+          ? getDirtyFields(_defaultValues, _formValues)
+          : _formState.dirtyFields
         : keepStateOptions.keepDefaultValues && formValues
         ? getDirtyFields(_defaultValues, formValues)
         : {},


### PR DESCRIPTION
Fixes #11386 

I'm not positive this is the best way to do this, but it seems to work, tests pass, and it works in my app without breaking anything else.