### PR TITLE
Add noop Utils Function

### DIFF
--- a/src/__tests__/controller.test.tsx
+++ b/src/__tests__/controller.test.tsx
@@ -13,6 +13,7 @@ import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 import { FormProvider } from '../useFormContext';
 import { useWatch } from '../useWatch';
+import noop from '../utils/noop';
 
 function Input<TFieldValues extends FieldValues>({
   onChange,
@@ -271,7 +272,7 @@ describe('Controller', () => {
       });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <Controller
             defaultValue=""
             name="test"
@@ -839,7 +840,7 @@ describe('Controller', () => {
   });
 
   it('should retain default value or defaultValues at Controller', () => {
-    let getValuesMethod = () => {};
+    let getValuesMethod = noop;
     const Component = () => {
       const { control, getValues } = useForm<{
         test: number;
@@ -1119,7 +1120,7 @@ describe('Controller', () => {
       });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((field, index) => {
             return (
               <div key={field.id}>
@@ -1455,7 +1456,7 @@ describe('Controller', () => {
       const { control, handleSubmit } = useForm<{ numbers: number[] }>();
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <Controller
             control={control}
             name="numbers"

--- a/src/__tests__/isPlainObject.test.ts
+++ b/src/__tests__/isPlainObject.test.ts
@@ -1,10 +1,11 @@
 import isPlainObject from '../utils/isPlainObject';
+import noop from '../utils/noop';
 
 describe('isPlainObject', function () {
   it('should identify plan object or not', function () {
     function test() {
       return {
-        test: () => {},
+        test: noop,
       };
     }
 

--- a/src/__tests__/logic/getValidateError.test.ts
+++ b/src/__tests__/logic/getValidateError.test.ts
@@ -1,4 +1,5 @@
 import getValidateError from '../../logic/getValidateError';
+import noop from '../../utils/noop';
 
 describe('getValidateError', () => {
   it('should return field error in correct format', () => {
@@ -40,6 +41,6 @@ describe('getValidateError', () => {
   });
 
   it('should return undefined when called with non string result', () => {
-    expect(getValidateError(undefined, () => {})).toBeUndefined();
+    expect(getValidateError(undefined, noop)).toBeUndefined();
   });
 });

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -7,6 +7,7 @@ import { useController } from '../useController';
 import { useForm } from '../useForm';
 import { FormProvider, useFormContext } from '../useFormContext';
 import isBoolean from '../utils/isBoolean';
+import noop from '../utils/noop';
 
 describe('useController', () => {
   it('should render input correctly', () => {
@@ -416,7 +417,7 @@ describe('useController', () => {
       });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <Input control={control} />
           <input type="submit" />
         </form>

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -21,6 +21,7 @@ import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 import { FormProvider } from '../useFormContext';
 import { useFormState } from '../useFormState';
+import noop from '../utils/noop';
 
 let i = 0;
 
@@ -2859,7 +2860,7 @@ describe('useFieldArray', () => {
 
       return (
         <React.StrictMode>
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             {fields.map((field, index) => {
               return (
                 <div key={field.id}>
@@ -3173,7 +3174,7 @@ describe('useFieldArray', () => {
   });
 
   it('should avoid omit keyName when defaultValues contains keyName attribute', () => {
-    let getValuesMethod: Function = () => {};
+    let getValuesMethod: Function = noop;
 
     const App = () => {
       const { control, getValues } = useForm({
@@ -3224,7 +3225,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             <p>{errors.test?.root?.message}</p>
             <button>submit</button>
             <button
@@ -3284,7 +3285,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             <p>{errors.test?.root?.message}</p>
             <button>submit</button>
             <button
@@ -3341,7 +3342,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             <p>{errors.test?.root?.message}</p>
             <button>submit</button>
             <button
@@ -3396,7 +3397,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             <p>{errors.test?.root?.message}</p>
             <button>submit</button>
             <button
@@ -3465,7 +3466,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             {fields.map((field, index) => {
               return (
                 <div key={field.id}>
@@ -3564,7 +3565,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             {fields.map((field, index) => {
               return (
                 <div key={field.id}>
@@ -3614,7 +3615,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             {fields.map((field, index) => {
               return (
                 <div key={field.id}>
@@ -3715,7 +3716,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             {fields.map((field, index) => {
               return (
                 <div key={field.id}>
@@ -3776,7 +3777,7 @@ describe('useFieldArray', () => {
         });
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             {fields.map((field, index) => {
               return (
                 <div key={field.id}>

--- a/src/__tests__/useFieldArray/focus.test.tsx
+++ b/src/__tests__/useFieldArray/focus.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import noop from '../../utils/noop';
 
 describe('useFieldArray focus', () => {
   it('should not focus any element when shouldFocus is set to false', () => {
@@ -80,7 +81,7 @@ describe('useFieldArray focus', () => {
       const { fields, insert } = useFieldArray({ control, name: 'test' });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((field, index) => (
             <div key={field.id}>
               <input

--- a/src/__tests__/useFieldArray/insert.test.tsx
+++ b/src/__tests__/useFieldArray/insert.test.tsx
@@ -13,6 +13,7 @@ import { Control, FieldPath } from '../../types';
 import { useController } from '../../useController';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import noop from '../../utils/noop';
 
 jest.useFakeTimers();
 
@@ -255,7 +256,7 @@ describe('insert', () => {
       errors = rest.formState.errors;
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((field, i) => (
             <input
               key={field.id}
@@ -300,7 +301,7 @@ describe('insert', () => {
       errors = rest.formState.errors;
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((field, i) => (
             <input
               key={field.id}

--- a/src/__tests__/useFieldArray/move.test.tsx
+++ b/src/__tests__/useFieldArray/move.test.tsx
@@ -5,6 +5,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { VALIDATION_MODE } from '../../constants';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import noop from '../../utils/noop';
 
 let i = 0;
 
@@ -67,7 +68,7 @@ describe('move', () => {
       errors = rest.formState.errors;
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((field, i) => (
             <input
               key={field.id}

--- a/src/__tests__/useFieldArray/prepend.test.tsx
+++ b/src/__tests__/useFieldArray/prepend.test.tsx
@@ -7,6 +7,7 @@ import { Control, FieldPath } from '../../types';
 import { useController } from '../../useController';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import noop from '../../utils/noop';
 
 let i = 0;
 
@@ -169,7 +170,7 @@ describe('prepend', () => {
       errors = tempErrors;
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((field, i) => (
             <input
               key={field.id}

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -13,6 +13,7 @@ import { Controller } from '../../controller';
 import { Control, DeepMap, FieldError } from '../../types';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import noop from '../../utils/noop';
 
 jest.useFakeTimers();
 
@@ -455,7 +456,7 @@ describe('remove', () => {
       errors = tempErrors;
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((field, i) => (
             <input
               key={field.id}
@@ -772,7 +773,7 @@ describe('remove', () => {
       });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <ul>
             {fields.map((item, index) => {
               return (
@@ -831,7 +832,7 @@ describe('remove', () => {
       });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <ul>
             {fields.map((item, index) => {
               return (

--- a/src/__tests__/useFieldArray/swap.test.tsx
+++ b/src/__tests__/useFieldArray/swap.test.tsx
@@ -5,6 +5,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { VALIDATION_MODE } from '../../constants';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import noop from '../../utils/noop';
 
 let i = 0;
 
@@ -121,7 +122,7 @@ describe('swap', () => {
       errors = rest.formState.errors;
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((field, i) => (
             <input
               key={field.id}

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -18,6 +18,7 @@ import {
   UseFormReturn,
 } from '../types';
 import isFunction from '../utils/isFunction';
+import noop from '../utils/noop';
 import sleep from '../utils/sleep';
 import { Controller, useFieldArray, useForm } from '../';
 
@@ -61,9 +62,9 @@ describe('useForm', () => {
       result.current.register('test', { required: true });
 
       await act(async () => {
-        await result.current.handleSubmit(() => {})({
-          preventDefault: () => {},
-          persist: () => {},
+        await result.current.handleSubmit(noop)({
+          preventDefault: noop,
+          persist: noop,
         } as React.SyntheticEvent);
       });
 
@@ -85,9 +86,9 @@ describe('useForm', () => {
       result.current.register('test', { required: true });
 
       await act(async () => {
-        await result.current.handleSubmit(() => {})({
-          preventDefault: () => {},
-          persist: () => {},
+        await result.current.handleSubmit(noop)({
+          preventDefault: noop,
+          persist: noop,
         } as React.SyntheticEvent);
       });
 
@@ -176,7 +177,7 @@ describe('useForm', () => {
         }>();
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             {show && <input {...register('firstName', { required: true })} />}
             {errors.firstName && <p>First name is required.</p>}
 
@@ -608,7 +609,7 @@ describe('useForm', () => {
       resolver,
       mode,
       rules = { required: 'required' },
-      onSubmit = () => {},
+      onSubmit = noop,
     }: {
       resolver?: any;
       mode?: 'onBlur' | 'onSubmit' | 'onChange';
@@ -916,7 +917,7 @@ describe('useForm', () => {
           }>();
           watchedField = watch();
           return (
-            <form onSubmit={handleSubmit(() => {})}>
+            <form onSubmit={handleSubmit(noop)}>
               <input {...register('test')} />
               <button>button</button>
             </form>
@@ -939,7 +940,7 @@ describe('useForm', () => {
           }>();
           watchedField = watch('test');
           return (
-            <form onSubmit={handleSubmit(() => {})}>
+            <form onSubmit={handleSubmit(noop)}>
               <input {...register('test')} />
               <button>button</button>
             </form>
@@ -962,7 +963,7 @@ describe('useForm', () => {
           }>();
           watchedField = watch('test');
           return (
-            <form onSubmit={handleSubmit(() => {})}>
+            <form onSubmit={handleSubmit(noop)}>
               <input {...register('test.0')} />
               <input {...register('test.1')} />
               <input {...register('test.2')} />
@@ -1470,7 +1471,7 @@ describe('useForm', () => {
         errorsObject = errors;
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             {[1, 2, 3].map((value, index) => (
               <div key={`test.${index}`}>
                 <label
@@ -1559,7 +1560,7 @@ describe('useForm', () => {
         errorsObject = errors;
 
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             <input type={'checkbox'} {...register(`checkbox.0.test`)} />
 
             <input {...register(`checkbox.1.test1`)} />

--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -12,6 +12,7 @@ import { VALIDATION_MODE } from '../../constants';
 import { Controller } from '../../controller';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import noop from '../../utils/noop';
 
 describe('formState', () => {
   describe('isValid', () => {
@@ -346,7 +347,7 @@ describe('formState', () => {
           </p>
           <button
             type={'button'}
-            onClick={() => handleSubmit(rejectPromiseFn)().catch(() => {})}
+            onClick={() => handleSubmit(rejectPromiseFn)().catch(noop)}
           >
             Submit
           </button>
@@ -374,7 +375,7 @@ describe('formState', () => {
       });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <input {...register('test', { required: true })} />
           {errors.test && <p>error</p>}
 
@@ -564,7 +565,7 @@ describe('formState', () => {
       submittingState.push(isSubmitting);
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <input
             {...register('value', { required: true })}
             defaultValue="Any default value!"
@@ -651,7 +652,7 @@ describe('formState', () => {
       dirtyFieldsState = dirtyFields;
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <input
             {...register('test', { setValueAs: (value) => value + '1' })}
           />

--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -6,6 +6,7 @@ import { VALIDATION_MODE } from '../../constants';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
 import isFunction from '../../utils/isFunction';
+import noop from '../../utils/noop';
 
 describe('handleSubmit', () => {
   it('should invoke the callback when validation pass', async () => {
@@ -14,8 +15,8 @@ describe('handleSubmit', () => {
 
     await act(async () => {
       await result.current.handleSubmit(callback)({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
     expect(callback).toBeCalled();
@@ -48,8 +49,8 @@ describe('handleSubmit', () => {
           },
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });
@@ -76,8 +77,8 @@ describe('handleSubmit', () => {
           },
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });
@@ -99,8 +100,8 @@ describe('handleSubmit', () => {
       await result.current.handleSubmit((data: any) => {
         data.deep.values = '12';
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
 
@@ -108,8 +109,8 @@ describe('handleSubmit', () => {
       await result.current.handleSubmit((data: any) => {
         expect(data.deep).toEqual({ values: '5' });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });
@@ -123,8 +124,8 @@ describe('handleSubmit', () => {
 
     await act(async () => {
       await result.current.handleSubmit(callback)({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
     expect(callback).not.toBeCalled();
@@ -145,8 +146,8 @@ describe('handleSubmit', () => {
     const callback = jest.fn();
     await act(async () => {
       await result.current.handleSubmit(callback)({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
 
@@ -170,8 +171,8 @@ describe('handleSubmit', () => {
     const callback = jest.fn();
     await act(async () => {
       await result.current.handleSubmit(callback)({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
 
@@ -200,8 +201,8 @@ describe('handleSubmit', () => {
           test: 'test',
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent),
     );
   });
@@ -234,8 +235,8 @@ describe('handleSubmit', () => {
 
     await act(async () => {
       await result.current.handleSubmit(callback)({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
 
@@ -245,8 +246,8 @@ describe('handleSubmit', () => {
 
     await act(async () => {
       await result.current.handleSubmit(callback)({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
 
@@ -321,8 +322,8 @@ describe('handleSubmit', () => {
 
       await act(async () => {
         await result.current.handleSubmit(callback)({
-          preventDefault: () => {},
-          persist: () => {},
+          preventDefault: noop,
+          persist: noop,
         } as React.SyntheticEvent);
       });
       expect(callback).toBeCalled();
@@ -349,8 +350,8 @@ describe('handleSubmit', () => {
 
       await act(async () => {
         await result.current.handleSubmit(callback)({
-          preventDefault: () => {},
-          persist: () => {},
+          preventDefault: noop,
+          persist: noop,
         } as React.SyntheticEvent);
       });
       expect(callback.mock.calls[0][0]).toEqual({ test: 'test' });
@@ -368,8 +369,8 @@ describe('handleSubmit', () => {
           onValidCallback,
           onInvalidCallback,
         )({
-          preventDefault: () => {},
-          persist: () => {},
+          preventDefault: noop,
+          persist: noop,
         } as React.SyntheticEvent);
       });
       expect(onValidCallback).toBeCalledTimes(1);
@@ -391,8 +392,8 @@ describe('handleSubmit', () => {
           onValidCallback,
           onInvalidCallback,
         )({
-          preventDefault: () => {},
-          persist: () => {},
+          preventDefault: noop,
+          persist: noop,
         } as React.SyntheticEvent);
       });
 
@@ -410,14 +411,11 @@ describe('handleSubmit', () => {
     result.current.register('test', { required: true });
 
     await act(async () => {
-      await result.current.handleSubmit(
-        () => {},
-        (errors) => {
-          Object.freeze(errors);
-        },
-      )({
-        preventDefault: () => {},
-        persist: () => {},
+      await result.current.handleSubmit(noop, (errors) => {
+        Object.freeze(errors);
+      })({
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
 

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -15,6 +15,7 @@ import { useForm } from '../../useForm';
 import { FormProvider, useFormContext } from '../../useFormContext';
 import isFunction from '../../utils/isFunction';
 import isString from '../../utils/isString';
+import noop from '../../utils/noop';
 
 describe('register', () => {
   it('should support register passed to ref', async () => {
@@ -41,8 +42,8 @@ describe('register', () => {
           test: 'testData',
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });
@@ -798,7 +799,7 @@ describe('register', () => {
         return (
           <>
             <FormProvider {...formMethods}>
-              <form onSubmit={handleSubmit(() => {})}>
+              <form onSubmit={handleSubmit(noop)}>
                 <Checkbox />
                 <button>Submit</button>
                 <p>{formState.errors.test?.message}</p>

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -19,6 +19,7 @@ import { useController } from '../../useController';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
 import { useWatch } from '../../useWatch';
+import noop from '../../utils/noop';
 
 jest.useFakeTimers();
 
@@ -36,8 +37,8 @@ describe('reset', () => {
           test: 'data',
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
 
@@ -1133,7 +1134,7 @@ describe('reset', () => {
       const [show, setShow] = React.useState(true);
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <input {...register('firstName')} placeholder="First Name" />
           {show && <input {...register('lastName')} placeholder="Last Name" />}
           <button
@@ -1305,7 +1306,7 @@ describe('reset', () => {
       });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <input {...register('firstName')} />
           <Child reset={reset} />
         </form>
@@ -1500,8 +1501,8 @@ describe('reset', () => {
           test: 'data',
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
 

--- a/src/__tests__/useForm/resolver.test.tsx
+++ b/src/__tests__/useForm/resolver.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { useForm } from '../../useForm';
+import noop from '../../utils/noop';
 import sleep from '../../utils/sleep';
 
 describe('resolver', () => {
@@ -130,7 +131,7 @@ describe('resolver', () => {
       });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <input {...register('test')} />
           <button>Submit</button>
         </form>

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -9,6 +9,7 @@ import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
 import get from '../../utils/get';
 import isFunction from '../../utils/isFunction';
+import noop from '../../utils/noop';
 import sleep from '../../utils/sleep';
 
 jest.useFakeTimers();
@@ -60,8 +61,8 @@ describe('setValue', () => {
           test: '1',
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });
@@ -88,8 +89,8 @@ describe('setValue', () => {
           test: fileList,
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });
@@ -126,8 +127,8 @@ describe('setValue', () => {
           test: ['1'],
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });
@@ -145,8 +146,8 @@ describe('setValue', () => {
           test: '1',
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });
@@ -169,8 +170,8 @@ describe('setValue', () => {
           test: ['1'],
         });
       })({
-        preventDefault: () => {},
-        persist: () => {},
+        preventDefault: noop,
+        persist: noop,
       } as React.SyntheticEvent);
     });
   });

--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -8,6 +8,7 @@ import { useController } from '../../useController';
 import { useForm } from '../../useForm';
 import { FormProvider } from '../../useFormContext';
 import { useFormState } from '../../useFormState';
+import noop from '../../utils/noop';
 
 describe('trigger', () => {
   it('should remove all errors before set new errors when trigger entire form', async () => {
@@ -870,7 +871,7 @@ describe('trigger', () => {
 
     function App() {
       const { handleSubmit, control, trigger } = useForm<FormValue>();
-      const onSubmit = () => {};
+      const onSubmit = noop;
 
       return (
         <div>

--- a/src/__tests__/useForm/watch.test.tsx
+++ b/src/__tests__/useForm/watch.test.tsx
@@ -8,6 +8,7 @@ import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
 import { useWatch } from '../../useWatch';
 import isFunction from '../../utils/isFunction';
+import noop from '../../utils/noop';
 
 describe('watch', () => {
   it('should return undefined when input gets unregister', async () => {
@@ -287,7 +288,7 @@ describe('watch', () => {
       output.push(watch());
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           {fields.map((item, index) => {
             return (
               <div key={item.id}>

--- a/src/__tests__/useFormContext.test.tsx
+++ b/src/__tests__/useFormContext.test.tsx
@@ -7,6 +7,7 @@ import { FormProvider, useFormContext } from '../useFormContext';
 import { useFormState } from '../useFormState';
 import { useWatch } from '../useWatch';
 import deepEqual from '../utils/deepEqual';
+import noop from '../utils/noop';
 
 describe('FormProvider', () => {
   it('should have access to all methods with useFormContext', () => {
@@ -101,7 +102,7 @@ describe('FormProvider', () => {
       return (
         <div>
           <FormProvider {...methods}>
-            <form onSubmit={handleSubmit(() => {})}>
+            <form onSubmit={handleSubmit(noop)}>
               <input {...register('firstName')} placeholder="First Name" />
               <input type="submit" />
             </form>
@@ -205,7 +206,7 @@ describe('FormProvider', () => {
       }>();
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <input {...register('test', { required: 'This is required' })} />
           <p>{errors.test?.message}</p>
           <button>submit</button>

--- a/src/__tests__/useFormState.test.tsx
+++ b/src/__tests__/useFormState.test.tsx
@@ -8,6 +8,7 @@ import { useForm } from '../useForm';
 import { FormProvider } from '../useFormContext';
 import { useFormState } from '../useFormState';
 import deepEqual from '../utils/deepEqual';
+import noop from '../utils/noop';
 
 describe('useFormState', () => {
   it('should render correct form state with isDirty, dirty, touched', () => {
@@ -275,7 +276,7 @@ describe('useFormState', () => {
       count++;
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <Test control={control} />
           <button>Submit</button>
         </form>
@@ -755,7 +756,7 @@ describe('useFormState', () => {
       const { errors } = useFormState({ control });
 
       return (
-        <form onSubmit={handleSubmit(() => {})}>
+        <form onSubmit={handleSubmit(noop)}>
           <input {...register('firstName', { required: 'Required' })} />
           <p>{errors.firstName?.message}</p>
           <button>Submit</button>

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -19,6 +19,7 @@ import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 import { FormProvider, useFormContext } from '../useFormContext';
 import { useWatch } from '../useWatch';
+import noop from '../utils/noop';
 
 let i = 0;
 
@@ -513,7 +514,7 @@ describe('useWatch', () => {
         } = useForm<FormInputs>();
         parentCount++;
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             <>
               <input {...register('parent')} />
               <Child register={register} control={control} />
@@ -589,7 +590,7 @@ describe('useWatch', () => {
         } = useForm<FormInputs>();
         parentCount++;
         return (
-          <form onSubmit={handleSubmit(() => {})}>
+          <form onSubmit={handleSubmit(noop)}>
             <>
               <input {...register('parent')} />
               <Child register={register} control={control} />

--- a/src/__tests__/utils/cloneObject.test.ts
+++ b/src/__tests__/utils/cloneObject.test.ts
@@ -1,4 +1,5 @@
 import cloneObject from '../../utils/cloneObject';
+import noop from '../../utils/noop';
 
 describe('clone', () => {
   it('should clone object and not mutate the original object', () => {
@@ -83,18 +84,16 @@ describe('clone', () => {
   });
 
   it('should skip clone if a node is instance of function', () => {
-    function testFunction() {}
-
     const data = {
       test: {
-        testFunction,
+        testFunction: noop,
         test: 'inner-string',
         deep: {
-          testFunction,
+          testFunction: noop,
           test: 'deep-string',
         },
       },
-      testFunction,
+      testFunction: noop,
       other: 'string',
     };
 
@@ -105,12 +104,12 @@ describe('clone', () => {
       test: {
         test: 'inner-string',
         deep: {
-          testFunction,
+          testFunction: noop,
           test: 'deep-string',
         },
-        testFunction,
+        testFunction: noop,
       },
-      testFunction,
+      testFunction: noop,
       other: 'string',
     });
   });

--- a/src/__tests__/utils/noop.test.ts
+++ b/src/__tests__/utils/noop.test.ts
@@ -1,0 +1,13 @@
+import noop from '../../utils/noop';
+
+describe('noop', () => {
+  it('should be a function', () => {
+    expect(noop instanceof Function).toBeTruthy();
+  });
+
+  it('should return undefined', () => {
+    const result = noop();
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/__tests__/utils/objectHasFunction.test.ts
+++ b/src/__tests__/utils/objectHasFunction.test.ts
@@ -1,3 +1,4 @@
+import noop from '../../utils/noop';
 import objectHasFunction from '../../utils/objectHasFunction';
 
 describe('objectHasFunction', () => {
@@ -11,7 +12,7 @@ describe('objectHasFunction', () => {
 
     expect(
       objectHasFunction({
-        test: () => {},
+        test: noop,
       }),
     ).toBeTruthy();
   });

--- a/src/utils/noop.ts
+++ b/src/utils/noop.ts
@@ -1,0 +1,1 @@
+export default function noop() {}


### PR DESCRIPTION
@bluebill1049 👋
I looked at the already defined `Noop` type and added a `noop` utility function that does nothing. (+test code)

```ts
type Noop = () => void;
```
```ts
export default function noop() {}
```

I thought it would be appropriate to use it as a meaningful function like `noop` rather than simply writing "() => {}".
I'd appreciate it if you could review it. 🙏