### PR TITLE
Add correct type for onChange function

### DIFF
--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -19,11 +19,18 @@ export type ControllerFieldState = {
   error?: FieldError;
 };
 
+export type ControllerChangeEvent<T> =
+  | T
+  | { target: { value: T } }
+  | { type: 'checkbox'; target: { checked: T } };
+
 export type ControllerRenderProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
-  onChange: (...event: any[]) => void;
+  onChange: (
+    event: ControllerChangeEvent<FieldPathValue<TFieldValues, TName>>,
+  ) => void;
   onBlur: Noop;
   value: FieldPathValue<TFieldValues, TName>;
   disabled?: boolean;

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -19,7 +19,7 @@ export type ControllerFieldState = {
   error?: FieldError;
 };
 
-export type ControllerChangeEvent<T> =
+export type ControllerChangeEvent<T = any> =
   | T
   | { target: { value: T } }
   | { type: 'checkbox'; target: { checked: T } };


### PR DESCRIPTION
Hi!

After playing around with React Hook Form, I noticed that the onChange function accepts way more than React's built-in events. It also supports:

- Any value that doesn't have a `target` property.
- Any object that has a `target.value` property.
- Any object that has a `type: "checkbox"` and `target.checked` property.

**Reference:** https://github.com/react-hook-form/react-hook-form/blob/master/src/logic/getEventValue.ts

Not knowing that those types are valid makes it seem like the user _needs_ to use the `setValue` function when working with custom components that cannot pass React's built-in `ChangeEvent` to RHF. 

In reality, custom components can call RHF's `onChange` with almost anything.

This PR adds the correct type information to the `onChange` function. This will only allow values that do not change the type of the current field. By default, the type is set to `any` which allows untyped fields to send anything as an `event`.