### PR TITLE
Issue with Resolvers tranform 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "jest.jestCommandLine": "pnpm test --",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": true
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "jest.jestCommandLine": "pnpm test --",

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -429,9 +429,9 @@ export function createFormControl<
       _formState.errors = errors;
     }
 
-    if(isEmptyObject(errors)) {
-      for(const [key, value] of Object.entries(values)) {
-        setValue(key as Path<TFieldValues>, value)
+    if (isEmptyObject(errors)) {
+      for (const [key, value] of Object.entries(values)) {
+        setValue(key as Path<TFieldValues>, value);
       }
     }
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -416,7 +416,7 @@ export function createFormControl<
     );
 
   const executeSchemaAndUpdateState = async (names?: InternalFieldName[]) => {
-    const { errors } = await _executeSchema(names);
+    const { errors, values } = await _executeSchema(names);
 
     if (names) {
       for (const name of names) {
@@ -427,6 +427,12 @@ export function createFormControl<
       }
     } else {
       _formState.errors = errors;
+    }
+
+    if(isEmptyObject(errors)) {
+      for(const [key, value] of Object.entries(values)) {
+        setValue(key as Path<TFieldValues>, value)
+      }
     }
 
     return errors;

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -21,6 +21,7 @@ import {
   PathValue,
   ReadFormState,
   Ref,
+  ResolverResult,
   SetFieldValue,
   SetValueConfig,
   Subjects,
@@ -415,8 +416,21 @@ export function createFormControl<
       ),
     );
 
+  const onAfterSchemaValid = (resolverResult: ResolverResult<TFieldValues>) => {
+    const { errors, values } = resolverResult;
+    if (isEmptyObject(errors)) {
+      for (const [key, value] of Object.entries(values)) {
+        setFieldValue(key, value, {
+          shouldDirty: true,
+          shouldValidate: false,
+        });
+      }
+    }
+  };
+
   const executeSchemaAndUpdateState = async (names?: InternalFieldName[]) => {
-    const { errors, values } = await _executeSchema(names);
+    const validationResult = await _executeSchema(names);
+    const { errors } = validationResult;
 
     if (names) {
       for (const name of names) {
@@ -429,11 +443,7 @@ export function createFormControl<
       _formState.errors = errors;
     }
 
-    if (isEmptyObject(errors)) {
-      for (const [key, value] of Object.entries(values)) {
-        setValue(key as Path<TFieldValues>, value);
-      }
-    }
+    onAfterSchemaValid(validationResult);
 
     return errors;
   };
@@ -820,7 +830,6 @@ export function createFormControl<
     let isValid;
     let validationResult;
     const fieldNames = convertToArrayPayload(name) as InternalFieldName[];
-
     _updateIsValidating(true, fieldNames);
 
     if (_options.resolver) {
@@ -1132,9 +1141,11 @@ export function createFormControl<
       });
 
       if (_options.resolver) {
-        const { errors, values } = await _executeSchema();
+        const validationResult = await _executeSchema();
+        const { errors, values } = validationResult;
         _formState.errors = errors;
         fieldValues = values;
+        onAfterSchemaValid(validationResult);
       } else {
         await executeBuiltInValidation(_fields);
       }
@@ -1165,6 +1176,7 @@ export function createFormControl<
         submitCount: _formState.submitCount + 1,
         errors: _formState.errors,
       });
+
       if (onValidError) {
         throw onValidError;
       }


### PR DESCRIPTION
Hi, I found one annoying, some time ago the next feature was broken.

**PROBLEM:**
1. describing schema validation w/ transform function > most common usage it's trim string input
2. Trigger validation 
3. Expected to get string without spaces at the end & start of string
4. The Result > value still with spaces 

**CODE SANDBOX EXAMPLE** > https://codesandbox.io/p/sandbox/react-hook-forms-resolvers-issue-mpyd39

Perhaps there is a more graceful solution to this problem. Thanks!
