### PR TITLE
chore: replace ts-ignore with ts-expect-error

### DIFF
--- a/src/__tests__/utils/unset.test.ts
+++ b/src/__tests__/utils/unset.test.ts
@@ -300,14 +300,14 @@ describe('unset', () => {
         test: [{ firstName: 'test' }],
       };
 
-      // @ts-ignore
+      //@ts-expect-error
       test.test.root = {
         test: 'message',
       };
 
       unset(test, 'test.0.firstName');
 
-      // @ts-ignore
+      //@ts-expect-error
       expect(test.test.root).toBeDefined();
     });
   });

--- a/src/__tests__/utils/unset.test.ts
+++ b/src/__tests__/utils/unset.test.ts
@@ -300,14 +300,14 @@ describe('unset', () => {
         test: [{ firstName: 'test' }],
       };
 
-      //@ts-expect-error
+      // @ts-expect-error
       test.test.root = {
         test: 'message',
       };
 
       unset(test, 'test.0.firstName');
 
-      //@ts-expect-error
+      // @ts-expect-error
       expect(test.test.root).toBeDefined();
     });
   });


### PR DESCRIPTION
Removes a bunch of unnecessary @ts-ignore statements

See here: https://www.totaltypescript.com/concepts/how-to-use-ts-expect-error