### PR TITLE
💚 ci: cleanup actions versions

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -4,12 +4,17 @@ description: This is a composite GitHub Action that sets up pnpm, node and insta
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v2
+    - name: Install pnpm
+      uses: pnpm/action-setup@v3
       with:
         version: 8
-    - uses: actions/setup-node@v3
+
+    - name: Setup Node version to 20
+      uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: pnpm
-    - run: pnpm install --frozen-lockfile
+
+    - name: Install Dependencies
+      run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/workflows/lock-issue.yml
+++ b/.github/workflows/lock-issue.yml
@@ -15,7 +15,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: 60


### PR DESCRIPTION
Closes: #11627

- Most of the CI warnings are due to [the recent Node 20 push](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 
), which is resolved by upgrading to the latest Node action version.
- For the cron job locking action specific warnings, I believe upgrading to the latest action version introduces the necessary changes to the API to address them.
- The CodeQL action may be redundant as this is now natively built into GitHub and can be operated and set up following [this guide](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning) via repository settings, which I don't have permissions to do.
- I don't think we can do anything with the Package Size action, which doesn't specify the Node version in its configuration, so it will probably just be forced to run on Node 16 once GitHub makes the switch. It doesn't seem to be very well maintained at the moment, but there aren't many other alternatives to choose from at the moment, as almost all of them seem to be unmaintained. The upstream PR that would solve this is preactjs/compressed-size-action#103