### PR TITLE
Update watch observer value type to use DeepPartialSkipArrayKey

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -864,7 +864,7 @@ export type ValidationValueMessage<TValidationValue extends ValidationValue = Va
 export type WatchInternal<TFieldValues> = (fieldNames?: InternalFieldName | InternalFieldName[], defaultValue?: DeepPartial<TFieldValues>, isMounted?: boolean, isGlobal?: boolean) => FieldPathValue<FieldValues, InternalFieldName> | FieldPathValues<FieldValues, InternalFieldName[]>;
 
 // @public (undocumented)
-export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartial<TFieldValues>, info: {
+export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartialSkipArrayKey<TFieldValues>, info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;
 }) => void;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -21,7 +21,7 @@ import {
   FieldPathValues,
 } from './path';
 import { Resolver } from './resolvers';
-import { DeepMap, DeepPartial, Noop } from './utils';
+import { DeepMap, DeepPartial, DeepPartialSkipArrayKey, Noop } from './utils';
 import { RegisterOptions } from './validator';
 
 declare const $NestedValue: unique symbol;
@@ -821,7 +821,7 @@ export type Control<
 };
 
 export type WatchObserver<TFieldValues extends FieldValues> = (
-  value: TFieldValues,
+  value: DeepPartialSkipArrayKey<TFieldValues>,
   info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -821,7 +821,7 @@ export type Control<
 };
 
 export type WatchObserver<TFieldValues extends FieldValues> = (
-  value: DeepPartial<TFieldValues>,
+  value: TFieldValues,
   info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;


### PR DESCRIPTION
I believe this is more accurate since `undefined` items in arrays should not be valid, please correct me if this is not correct