### PR TITLE
fix: Prop `method` did not match. Server: "POST" Client: "post"

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -278,7 +278,7 @@ export type FormProps<TFieldValues extends FieldValues, TTransformedValues exten
         response: Response;
     }) => void;
     onSubmit: TTransformedValues extends FieldValues ? FormSubmitHandler<TTransformedValues> : FormSubmitHandler<TFieldValues>;
-    method: 'post' | 'put' | 'delete';
+    method: 'POST' | 'PUT' | 'DELETE';
     children: React_2.ReactNode | React_2.ReactNode[];
     render: (props: {
         submit: (e?: React_2.FormEvent) => void;
@@ -336,7 +336,7 @@ export type FormSubmitHandler<TFieldValues extends FieldValues> = (payload: {
     event?: React_2.BaseSyntheticEvent;
     formData: FormData;
     formDataJson: string;
-    method?: 'post' | 'put' | 'delete';
+    method?: 'POST' | 'PUT' | 'DELETE';
 }) => unknown | Promise<unknown>;
 
 // @public (undocumented)

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -4,7 +4,7 @@ import get from './utils/get';
 import { FieldValues, FormProps } from './types';
 import { useFormContext } from './useFormContext';
 
-const POST_REQUEST = 'post';
+const POST_REQUEST = 'POST';
 
 /**
  * Form component to manage submission.

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -75,7 +75,7 @@ export type FormSubmitHandler<TFieldValues extends FieldValues> = (payload: {
   event?: React.BaseSyntheticEvent;
   formData: FormData;
   formDataJson: string;
-  method?: 'post' | 'put' | 'delete';
+  method?: 'POST' | 'PUT' | 'DELETE';
 }) => unknown | Promise<unknown>;
 
 export type SubmitErrorHandler<TFieldValues extends FieldValues> = (
@@ -906,7 +906,7 @@ export type FormProps<
     onSubmit: TTransformedValues extends FieldValues
       ? FormSubmitHandler<TTransformedValues>
       : FormSubmitHandler<TFieldValues>;
-    method: 'post' | 'put' | 'delete';
+    method: 'POST' | 'PUT' | 'DELETE';
     children: React.ReactNode | React.ReactNode[];
     render: (props: {
       submit: (e?: React.FormEvent) => void;


### PR DESCRIPTION
This fixes the warning when used in SSR.