### PR TITLE
Extend union type of form methods for new Form component

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -906,7 +906,7 @@ export type FormProps<
     onSubmit: TTransformedValues extends FieldValues
       ? FormSubmitHandler<TTransformedValues>
       : FormSubmitHandler<TFieldValues>;
-    method: 'post' | 'put' | 'delete';
+    method: 'post' | 'put' | 'delete' | 'POST' | 'PUT' | 'DELETE';
     children: React.ReactNode | React.ReactNode[];
     render: (props: {
       submit: (e?: React.FormEvent) => void;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -75,7 +75,7 @@ export type FormSubmitHandler<TFieldValues extends FieldValues> = (payload: {
   event?: React.BaseSyntheticEvent;
   formData: FormData;
   formDataJson: string;
-  method?: 'post' | 'put' | 'delete';
+  method?: 'post' | 'put' | 'delete' | 'POST' | 'PUT' | 'DELETE';
 }) => unknown | Promise<unknown>;
 
 export type SubmitErrorHandler<TFieldValues extends FieldValues> = (


### PR DESCRIPTION
Hello, when using the experimental `Form` component with Nextjs server actions, the following warning is outputted in the browser console:

```
Warning: Prop `method` did not match. Server: "POST" Client: "post"
```

Example

```
const methods = useForm<SearchFormValues>({
  defaultValues: {
    // default values
  },
  progressive: true,
});

const [formState, action] = useFormState(namOfServerAction, null);

<Form
  action={action}
  control={methods.control}
  method="post"
>
  // fields
</Form>
```

Changing `"post"` to `"POST"` removes the warning in the browser console, but triggers a TypeScript warning as the method type only contains `'post' | 'put' | 'delete'` This change adds uppercase variants of the existing methods to the union type.

Cheers