### PR TITLE
Add comparison of new Set objects to the deepEqual function.

### DIFF
--- a/src/__tests__/logic/getDirtyFields.test.ts
+++ b/src/__tests__/logic/getDirtyFields.test.ts
@@ -341,4 +341,66 @@ describe('getDirtyFields', () => {
       ],
     });
   });
+
+  it('should work with set object', () => {
+    expect(
+      getDirtyFields(
+        {
+          test: {
+            test1: new Set(['test']),
+            test2: new Set(['test', 'test1']),
+          },
+          test2: {
+            test1: new Set([
+              {
+                test: new Set([
+                  'test',
+                  {
+                    test1: 'test1',
+                  },
+                ]),
+              },
+            ]),
+            test2: new Set([
+              {
+                test: 'test1',
+              },
+            ]),
+          },
+        },
+        {
+          test: {
+            test1: new Set(['test']),
+            test2: new Set(['test1', 'test']),
+          },
+          test2: {
+            test1: new Set([
+              {
+                test: new Set([
+                  'test',
+                  {
+                    test1: 'test1',
+                  },
+                ]),
+              },
+            ]),
+            test2: new Set([
+              {
+                test: 'test',
+              },
+            ]),
+          },
+        },
+      ),
+    ).toEqual({
+      test: {
+        test1: false,
+        test2: false,
+      },
+      test2: {
+        test1: false,
+        test2: true,
+      },
+    });
+  });
 });

--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -95,4 +95,45 @@ describe('deepEqual', () => {
       deepEqual({ test: new Date('1990') }, { test: new Date('1990') }),
     ).toBeTruthy();
   });
+
+  it('should compare set object', () => {
+    expect(deepEqual(new Set([1, 2]), new Set([2, 1]))).toBeTruthy();
+
+    expect(deepEqual(new Set([1, 2]), new Set([1, 1, 2]))).toBeTruthy();
+
+    expect(deepEqual(new Set([[1, 2]]), new Set([[1, 3, 2]]))).toBeFalsy();
+
+    expect(
+      deepEqual(
+        new Set([
+          { test: '123' },
+          {
+            test: [
+              1,
+              2,
+              {
+                test: '345',
+              },
+            ],
+          },
+          1,
+          2,
+        ]),
+        new Set([
+          {
+            test: [
+              1,
+              2,
+              {
+                test: '345',
+              },
+            ],
+          },
+          1,
+          2,
+          { test: '123' },
+        ]),
+      ),
+    ).toBeTruthy();
+  });
 });

--- a/src/__tests__/utils/isSetObject.test.ts
+++ b/src/__tests__/utils/isSetObject.test.ts
@@ -1,0 +1,14 @@
+import isSetObject from '../../utils/isSetObject';
+
+describe('isSetObject', () => {
+  it('should return true when it is a set object', () => {
+    expect(isSetObject(new Set())).toBeTruthy();
+    expect(isSetObject(new Set([1, 2, 3]))).toBeTruthy();
+  });
+
+  it('should return false when it is not a set object', () => {
+    expect(isSetObject({})).toBeFalsy();
+    expect(isSetObject([])).toBeFalsy();
+    expect(isSetObject(new Date())).toBeFalsy();
+  });
+});

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -18,10 +18,8 @@ export default function deepEqual(object1: any, object2: any) {
       return false;
     }
 
-    const setArr2 = Array.from(object2);
-
     return Array.from(object1).every((elem1): boolean =>
-      setArr2.some((elem2): boolean => deepEqual(elem1, elem2)),
+      Array.from(object2).some((elem2): boolean => deepEqual(elem1, elem2)),
     );
   }
 

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -18,10 +18,9 @@ export default function deepEqual(object1: any, object2: any) {
       return false;
     }
 
-    const setArr1 = Array.from(object1);
     const setArr2 = Array.from(object2);
 
-    return setArr1.every((elem1): boolean =>
+    return Array.from(object1).every((elem1): boolean =>
       setArr2.some((elem2): boolean => deepEqual(elem1, elem2)),
     );
   }
@@ -45,8 +44,8 @@ export default function deepEqual(object1: any, object2: any) {
 
       if (
         (isDateObject(val1) && isDateObject(val2)) ||
-        (isObject(val1) && isObject(val2)) ||
         (isSetObject(val1) && isSetObject(val2)) ||
+        (isObject(val1) && isObject(val2)) ||
         (Array.isArray(val1) && Array.isArray(val2))
           ? !deepEqual(val1, val2)
           : val1 !== val2

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -2,6 +2,7 @@ import isObject from '../utils/isObject';
 
 import isDateObject from './isDateObject';
 import isPrimitive from './isPrimitive';
+import isSetObject from './isSetObject';
 
 export default function deepEqual(object1: any, object2: any) {
   if (isPrimitive(object1) || isPrimitive(object2)) {
@@ -10,6 +11,19 @@ export default function deepEqual(object1: any, object2: any) {
 
   if (isDateObject(object1) && isDateObject(object2)) {
     return object1.getTime() === object2.getTime();
+  }
+
+  if (isSetObject(object1) && isSetObject(object2)) {
+    if (object1.size !== object2.size) {
+      return false;
+    }
+
+    const setArr1 = Array.from(object1);
+    const setArr2 = Array.from(object2);
+
+    return setArr1.every((elem1): boolean =>
+      setArr2.some((elem2): boolean => deepEqual(elem1, elem2)),
+    );
   }
 
   const keys1 = Object.keys(object1);
@@ -32,6 +46,7 @@ export default function deepEqual(object1: any, object2: any) {
       if (
         (isDateObject(val1) && isDateObject(val2)) ||
         (isObject(val1) && isObject(val2)) ||
+        (isSetObject(val1) && isSetObject(val2)) ||
         (Array.isArray(val1) && Array.isArray(val2))
           ? !deepEqual(val1, val2)
           : val1 !== val2

--- a/src/utils/isObject.ts
+++ b/src/utils/isObject.ts
@@ -1,5 +1,6 @@
 import isDateObject from './isDateObject';
 import isNullOrUndefined from './isNullOrUndefined';
+import isSetObject from './isSetObject';
 
 export const isObjectType = (value: unknown): value is object =>
   typeof value === 'object';
@@ -8,4 +9,5 @@ export default <T extends object>(value: unknown): value is T =>
   !isNullOrUndefined(value) &&
   !Array.isArray(value) &&
   isObjectType(value) &&
-  !isDateObject(value);
+  !isDateObject(value) &&
+  !isSetObject(value);

--- a/src/utils/isSetObject.ts
+++ b/src/utils/isSetObject.ts
@@ -1,0 +1,1 @@
+export default (value: unknown): value is Set<unknown> => value instanceof Set;


### PR DESCRIPTION
### Description

Due to Object.keys returning an empty array for a new Set, the comparison erroneously returns true. Consequently leading to the isDirty value always returning false for values that are sets.

Therefore, I added logic to the deepEqual function to accommodate comparison of sets.

### Codesandbox

[Link](https://codesandbox.io/p/sandbox/react-hook-form-js-forked-wjtmy9?file=%2Fsrc%2FApp.js&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clup49y4600063b6koai6b6mg%2522%252C%2522sizes%2522%253A%255B100%252C0%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clup49y4500023b6kfgu0vvq3%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clup49y4500033b6kxj7p3qyh%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clup49y4500053b6k4ov89ncr%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B63.68240283180878%252C36.31759716819122%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clup49y4500023b6kfgu0vvq3%2522%253A%257B%2522id%2522%253A%2522clup49y4500023b6kfgu0vvq3%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clup4g69w00023b6qm8prjixv%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A81%252C%2522startColumn%2522%253A16%252C%2522endLineNumber%2522%253A81%252C%2522endColumn%2522%253A16%257D%255D%252C%2522filepath%2522%253A%2522%252Fsrc%252FApp.js%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clup4g69w00023b6qm8prjixv%2522%257D%252C%2522clup49y4500053b6k4ov89ncr%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clup49y4500043b6ktpvjdidj%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clup49y4500053b6k4ov89ncr%2522%252C%2522activeTabId%2522%253A%2522clup49y4500043b6ktpvjdidj%2522%257D%252C%2522clup49y4500033b6kxj7p3qyh%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clup49y4500033b6kxj7p3qyh%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Afalse%252C%2522sidebarPanelSize%2522%253A15%257D)

