### PR TITLE
exposed `scrollIntoView()` to ref created via `useController()`

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -159,6 +159,15 @@ export function useController<
           if (field && elm) {
             field._f.ref = {
               focus: () => elm.focus(),
+              scrollIntoView: (
+                arg?:
+                  | boolean
+                  | {
+                      inline?: 'center' | 'end' | 'nearest' | 'start';
+                      block?: 'center' | 'end' | 'nearest' | 'start';
+                      behavior?: 'auto' | 'instant' | 'smooth';
+                    },
+              ) => elm.scrollIntoView(arg),
               select: () => elm.select(),
               setCustomValidity: (message: string) =>
                 elm.setCustomValidity(message),


### PR DESCRIPTION
Currently there is no way to access `scrollIntoView()` method of an element that is controlled via `useController()`. This is much needed when it comes to errors handling and will allow to scroll to the element with the error