### PR TITLE
fix: correct type of `error` field in `getFieldState` return object

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -665,7 +665,7 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName
     isDirty: boolean;
     isTouched: boolean;
     isValidating: boolean;
-    error?: FieldError;
+    error?: FieldErrors<TFieldValues>[TFieldName];
 };
 
 // @public (undocumented)

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { VALIDATION_MODE } from '../constants';
 import { Subject, Subscription } from '../utils/createSubject';
 
-import { ErrorOption, FieldError, FieldErrors } from './errors';
+import { ErrorOption, FieldErrors } from './errors';
 import { EventType } from './events';
 import { FieldArray } from './fieldArray';
 import {
@@ -362,7 +362,7 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <
   isDirty: boolean;
   isTouched: boolean;
   isValidating: boolean;
-  error?: FieldError;
+  error?: FieldErrors<TFieldValues>[TFieldName];
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {


### PR DESCRIPTION
To fix #11814.

I changed the type of the `error` field inside the return object of a form's `getFieldState` to be more general. The current implementation doesn't account for nested errors inside objects since it uses the basic `FieldError` type. I changed it to an indexed access type that uses the type of the actual errors object present in the form state, which itself accounts for nested objects.