### PR TITLE
fix: add info.value type to WatchObserver

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -867,6 +867,7 @@ export type WatchInternal<TFieldValues> = (fieldNames?: InternalFieldName | Inte
 export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartial<TFieldValues>, info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;
+    value?: unknown;
 }) => void;
 
 // Warnings were encountered during analysis:

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -825,6 +825,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (
   info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;
+    value?: unknown;
   },
 ) => void;
 


### PR DESCRIPTION
Adjust `info` parameter of `WatchObserver` type to its actual value.