### PR TITLE
Fix SetError to Preserve Existing Errors elsewhere in the object

### DIFF
--- a/src/__tests__/useForm/setError.test.tsx
+++ b/src/__tests__/useForm/setError.test.tsx
@@ -164,4 +164,91 @@ describe('setError', () => {
       screen.findByText('not found');
     });
   });
+
+  it('should allow sequential calls to set with child after ancestor', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ input: { first: string; last: string } }>(),
+    );
+    result.current.formState.errors;
+
+    act(() => {
+      result.current.setError('input', {
+        type: 'test',
+        message: 'Some error that depends on both fields',
+      });
+    });
+
+    expect(result.current.formState.errors).toEqual({
+      input: {
+        type: 'test',
+        message: 'Some error that depends on both fields',
+        ref: undefined,
+      },
+    });
+
+    act(() => {
+      result.current.setError('input.first', {
+        type: 'test',
+        message: 'Name must be capitalized',
+      });
+    });
+
+    expect(result.current.formState.errors).toEqual({
+      input: {
+        type: 'test',
+        message: 'Some error that depends on both fields',
+        ref: undefined,
+        first: {
+          type: 'test',
+          message: 'Name must be capitalized',
+          ref: undefined,
+        },
+      },
+    });
+  });
+
+  it('should allow sequential calls to set with ancestor after child', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ input: { first: string; last: string } }>(),
+    );
+
+    result.current.formState.errors;
+
+    act(() => {
+      result.current.setError('input.first', {
+        type: 'test',
+        message: 'Name must be capitalized',
+      });
+    });
+
+    expect(result.current.formState.errors).toEqual({
+      input: {
+        first: {
+          type: 'test',
+          message: 'Name must be capitalized',
+          ref: undefined,
+        },
+      },
+    });
+
+    act(() => {
+      result.current.setError('input', {
+        type: 'test',
+        message: 'Some error that depends on both fields',
+      });
+    });
+
+    expect(result.current.formState.errors).toEqual({
+      input: {
+        type: 'test',
+        message: 'Some error that depends on both fields',
+        ref: undefined,
+        first: {
+          type: 'test',
+          message: 'Name must be capitalized',
+          ref: undefined,
+        },
+      },
+    });
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -904,8 +904,13 @@ export function createFormControl<
 
   const setError: UseFormSetError<TFieldValues> = (name, error, options) => {
     const ref = (get(_fields, name, { _f: {} })._f || {}).ref;
+    const currentError = get(_formState.errors, name) || {};
+
+    // Don't override existing error messages elsewhere in the object tree.
+    const { ref: currentRef, message, type, ...restOfErrorTree } = currentError;
 
     set(_formState.errors, name, {
+      ...restOfErrorTree,
       ...error,
       ref,
     });


### PR DESCRIPTION
When calling setError, if a call was made to set an error on a descendant within a form (`foo.bar.baz`), then a later call was made to set an error on the ancestor (`foo.bar`), the previous error would be lost. 

This was the run of `pnpm test` after the first commit, which only contained the test:
![image](https://github.com/react-hook-form/react-hook-form/assets/22628418/f8e1de4f-89bc-4d77-9af2-95407703ccad)

Following the update to `setError`, we make sure you don't lose the errors that are further down the tree by including them in the call to set. To be fair, one /could/ consider just spreading in the entire `currentError`, but by destructuring and omitting `message` and `type` we make sure that they get overwritten by the current error.
