### PR TITLE
fix: change info.values type in WatchObserver

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -532,7 +532,7 @@ export type ResolverSuccess<TFieldValues extends FieldValues = FieldValues> = {
 };
 
 // @public (undocumented)
-export const set: (object: FieldValues, path: string, value?: unknown) => FieldValues | undefined;
+export const set: (object: FieldValues, path: string, value?: unknown) => FieldValues;
 
 // @public (undocumented)
 export type SetFieldValue<TFieldValues extends FieldValues> = FieldValue<TFieldValues>;

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -532,7 +532,7 @@ export type ResolverSuccess<TFieldValues extends FieldValues = FieldValues> = {
 };
 
 // @public (undocumented)
-export const set: (object: FieldValues, path: string, value?: unknown) => FieldValues;
+export const set: (object: FieldValues, path: string, value?: unknown) => FieldValues | undefined;
 
 // @public (undocumented)
 export type SetFieldValue<TFieldValues extends FieldValues> = FieldValue<TFieldValues>;
@@ -867,7 +867,7 @@ export type WatchInternal<TFieldValues> = (fieldNames?: InternalFieldName | Inte
 export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartial<TFieldValues>, info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;
-    value?: unknown;
+    values?: unknown;
 }) => void;
 
 // Warnings were encountered during analysis:

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -825,7 +825,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (
   info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;
-    value?: unknown;
+    values?: unknown;
   },
 ) => void;
 


### PR DESCRIPTION
I am so sorry. 
I made a typo.
The real property name is `values`. 
Here:
https://github.com/react-hook-form/react-hook-form/blob/master/src/logic/createFormControl.ts#L738 