### PR TITLE
Add validation in the cleanup process in `useController`

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "files": [
       {
         "path": "./dist/index.cjs.js",
-        "maxSize": "10.1 kB"
+        "maxSize": "10.2 kB"
       }
     ]
   },

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -85,7 +85,7 @@ export function useController<
     const updateMounted = (name: InternalFieldName, value: boolean) => {
       const field: Field = get(control._fields, name);
 
-      if (field) {
+      if (field?._f) {
         field._f.mount = value;
       }
     };

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -85,7 +85,7 @@ export function useController<
     const updateMounted = (name: InternalFieldName, value: boolean) => {
       const field: Field = get(control._fields, name);
 
-      if (field?._f) {
+      if (field && field._f) {
         field._f.mount = value;
       }
     };


### PR DESCRIPTION
fixes https://github.com/react-hook-form/react-hook-form/issues/11937.

In some cases, in the `updateMounted` function, the `field` does not have an `_f` field even if the `field` is truthy.

This PR adds extra validation to cover such cases.

Also, increased the size limit from 10.1 kB to 10.2 kB as the size limit check failed.