### PR TITLE
feat: Provide Validation Event Type to `resolver` Function

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -502,7 +502,15 @@ export type RegisterOptions<TFieldValues extends FieldValues = FieldValues, TFie
 });
 
 // @public (undocumented)
-export type Resolver<TFieldValues extends FieldValues = FieldValues, TContext = any> = (values: TFieldValues, context: TContext | undefined, options: ResolverOptions<TFieldValues>) => Promise<ResolverResult<TFieldValues>> | ResolverResult<TFieldValues>;
+export type Resolver<TFieldValues extends FieldValues = FieldValues, TContext = any> = (values: TFieldValues, context: (ResolverContext & TContext) | TContext | undefined, options: ResolverOptions<TFieldValues>) => Promise<ResolverResult<TFieldValues>> | ResolverResult<TFieldValues>;
+
+// @public (undocumented)
+export interface ResolverContext {
+    // Warning: (ae-forgotten-export) The symbol "EVENTS" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    validationEvent?: typeof EVENTS.BLUR | typeof EVENTS.CHANGE | typeof EVENTS.SUBMIT;
+}
 
 // @public (undocumented)
 export type ResolverError<TFieldValues extends FieldValues = FieldValues> = {

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1139,7 +1139,7 @@ describe('useForm', () => {
           {
             test: 'test',
           },
-          undefined,
+          expect.objectContaining({ validationEvent: 'change' }),
           {
             criteriaMode: undefined,
             fields: {
@@ -1164,7 +1164,7 @@ describe('useForm', () => {
           {
             test: 'test',
           },
-          undefined,
+          expect.objectContaining({ validationEvent: 'submit' }),
           {
             criteriaMode: undefined,
             fields: {

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@testing-library/react';
 import { act, renderHook } from '@testing-library/react-hooks';
 
-import { VALIDATION_MODE } from '../constants';
+import { EVENTS, VALIDATION_MODE } from '../constants';
 import {
   Control,
   FieldErrors,
@@ -1139,7 +1139,7 @@ describe('useForm', () => {
           {
             test: 'test',
           },
-          expect.objectContaining({ validationEvent: 'change' }),
+          expect.objectContaining({ validationEvent: EVENTS.CHANGE }),
           {
             criteriaMode: undefined,
             fields: {
@@ -1164,7 +1164,7 @@ describe('useForm', () => {
           {
             test: 'test',
           },
-          expect.objectContaining({ validationEvent: 'submit' }),
+          expect.objectContaining({ validationEvent: EVENTS.SUBMIT }),
           {
             criteriaMode: undefined,
             fields: {

--- a/src/__tests__/useForm/resolver.test.tsx
+++ b/src/__tests__/useForm/resolver.test.tsx
@@ -11,32 +11,21 @@ describe('resolver', () => {
       test: string;
     };
 
+    const resolverSpy = jest.fn(() => ({ errors: {}, values: {} }));
+    const testContext = { test: 'test' };
+
     const App = () => {
-      const [test, setTest] = React.useState('');
-      const [data, setData] = React.useState({});
-      const { handleSubmit } = useForm<FormValues>({
-        resolver: (_, context) => {
-          return {
-            errors: {},
-            values: context as FormValues,
-          };
-        },
-        context: {
-          test,
-        },
+      const { handleSubmit, register } = useForm<FormValues>({
+        mode: 'onSubmit',
+        resolver: resolverSpy,
+        context: testContext,
       });
 
       return (
-        <>
-          <input
-            value={test}
-            onChange={(e) => {
-              setTest(e.target.value);
-            }}
-          />
-          <button onClick={handleSubmit((data) => setData(data))}>Test</button>
-          <p>{JSON.stringify(data)}</p>
-        </>
+        <form onSubmit={handleSubmit(() => null)}>
+          <input {...register('test')} />
+          <input type="submit" />
+        </form>
       );
     };
 
@@ -47,9 +36,11 @@ describe('resolver', () => {
     });
     fireEvent.click(screen.getByRole('button'));
 
-    expect(
-      await screen.findByText('{"test":"test"}', undefined, { timeout: 3000 }),
-    ).toBeVisible();
+    expect(resolverSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining(testContext),
+      expect.anything(),
+    );
   });
 
   it('should support resolver schema switching', async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ export const EVENTS = {
   BLUR: 'blur',
   FOCUS_OUT: 'focusout',
   CHANGE: 'change',
+  SUBMIT: 'submit',
 } as const;
 
 export const VALIDATION_MODE = {

--- a/src/types/resolvers.ts
+++ b/src/types/resolvers.ts
@@ -1,3 +1,5 @@
+import { EVENTS } from '../constants';
+
 import { FieldErrors } from './errors';
 import { Field, FieldName, FieldValues, InternalFieldName } from './fields';
 import { CriteriaMode } from './form';
@@ -16,6 +18,13 @@ export type ResolverResult<TFieldValues extends FieldValues = FieldValues> =
   | ResolverSuccess<TFieldValues>
   | ResolverError<TFieldValues>;
 
+export interface ResolverContext {
+  validationEvent?:
+    | typeof EVENTS.BLUR
+    | typeof EVENTS.CHANGE
+    | typeof EVENTS.SUBMIT;
+}
+
 export interface ResolverOptions<TFieldValues extends FieldValues> {
   criteriaMode?: CriteriaMode;
   fields: Record<InternalFieldName, Field['_f']>;
@@ -28,6 +37,6 @@ export type Resolver<
   TContext = any,
 > = (
   values: TFieldValues,
-  context: TContext | undefined,
+  context: (ResolverContext & TContext) | TContext | undefined,
   options: ResolverOptions<TFieldValues>,
 ) => Promise<ResolverResult<TFieldValues>> | ResolverResult<TFieldValues>;


### PR DESCRIPTION
**Please see #11960 for a description of the problem these changes attempt to solve.**

This pull request changes the `_executeSchema` function in the `src/logic/createFormControl.ts` file to accept an additional `context` argument. The `context` argument will then be passed to the `resolver` prop provided in a `useForm` call.

This allows context values to be passed to a validation library from `react-hook-form`. This pull request makes it so that when a schema is validated based on a user event, that event type is provided to the `resolver` function. This allows developers to have access to the event that initiated the validation call within the schema declaration itself.

#### Example Use Case with `Yup`
```jsx
import { useForm } from 'react-hook-form';
import { yupResolver } from '@hookform/resolvers/yup';
import * as yup from 'yup';

const schema = yup.object({
  username: yup
    .string()
    .required()
    .min(3)
    .when('$validationEvent', {
      is: 'submit',
      then: (schema) => schema.test(
        'is-username-available',
        'Username is not available.',
        async (value) => (
          await fetch(`/usernames?username=${value}`)
        )?.usernameAvailable === true,
      ),
    }),
});

function UsernameForm() {
  const { handleSubmit, register } = useForm(
    mode: 'onChange',
    resolver: yupResolver(schema),
  );

  const onSubmit = (formData) => console.log(formData);

  return (
    <form onSubmit={handleSubmit(onSubmit)}>
      <input {...register('username')} />
      <input type="submit" />
    </form>
  );
}
```