### PR TITLE
Fix example of  ObjectKeys type

### DIFF
--- a/src/types/path/common.ts
+++ b/src/types/path/common.ts
@@ -282,8 +282,8 @@ export type NumericKeys<T extends Traversable> = UnionToIntersection<
  * @typeParam T - object type
  * @example
  * ```
- * ObjectKeys<{foo: string, bar: string}, string> = 'foo' | 'bar'
- * ObjectKeys<{foo: string, bar: number}, string> = 'foo'
+ * ObjectKeys<{foo: string, bar: string}> = 'foo' | 'bar'
+ * ObjectKeys<{foo: string, bar: number} | { foo: string }> = 'foo'
  * ```
  */
 export type ObjectKeys<T extends Traversable> = Exclude<


### PR DESCRIPTION
The example of ObjectKeys type was likely copied from the Keys type, so I've revised it with the correct example: