### PR TITLE
fix: enforce type safety for `deps` property in `RegisterOptions`

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -486,7 +486,7 @@ export type RegisterOptions<TFieldValues extends FieldValues = FieldValues, TFie
     onChange?: (event: any) => void;
     onBlur?: (event: any) => void;
     disabled: boolean;
-    deps: InternalFieldName | InternalFieldName[];
+    deps: FieldPath<TFieldValues> | FieldPath<TFieldValues>[];
 }> & ({
     pattern?: ValidationRule<RegExp>;
     valueAsNumber?: false;

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -45,7 +45,7 @@ export type RegisterOptions<
   onChange?: (event: any) => void;
   onBlur?: (event: any) => void;
   disabled: boolean;
-  deps: InternalFieldName | InternalFieldName[];
+  deps: FieldPath<TFieldValues> | FieldPath<TFieldValues>[];
 }> &
   (
     | {

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -1,7 +1,7 @@
 import { INPUT_VALIDATION_RULES } from '../constants';
 
 import { Message } from './errors';
-import { FieldValues, InternalFieldName } from './fields';
+import { FieldValues } from './fields';
 import { FieldPath, FieldPathValue } from './path';
 
 export type ValidationValue = boolean | number | string | RegExp;


### PR DESCRIPTION
## Overview
This PR restricts the `deps` property within `RegisterOptions` to accept only field names or an array of field names **instead of `string | string[]`.**
This change improves type safety and prevents potential issues. Fixes #11968 