### PR TITLE
Fix `getFieldState` return error for nested fields, including dot syntax

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -225,7 +225,7 @@ export type FieldErrors<T extends FieldValues = FieldValues> = Partial<FieldValu
 
 // @public (undocumented)
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-    [K in keyof T]?: T[K] extends BrowserNativeObject | Blob ? FieldError : K extends 'root' | `root.${string}` ? GlobalError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
+    [K in keyof T]?: K extends 'root' | `root.${string}` ? GlobalError : NestedFieldError<T[K]>;
 };
 
 // @public (undocumented)
@@ -433,6 +433,9 @@ export type Names = {
 
 // @public (undocumented)
 export type NativeFieldValue = string | number | boolean | null | undefined | unknown[];
+
+// @public (undocumented)
+export type NestedFieldError<T> = T extends BrowserNativeObject | Blob ? FieldError : T extends object ? Merge<FieldError, FieldErrorsImpl<T>> : FieldError;
 
 // @public @deprecated (undocumented)
 export type NestedValue<TValue extends object = object> = {
@@ -665,7 +668,7 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName
     isDirty: boolean;
     isTouched: boolean;
     isValidating: boolean;
-    error?: PathValue<TFieldValues, TFieldName> extends object ? Merge<FieldError, FieldErrorsImpl<PathValue<TFieldValues, TFieldName>>> : FieldError;
+    error?: NestedFieldError<PathValue<TFieldValues, TFieldName>>;
 };
 
 // @public (undocumented)
@@ -871,7 +874,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:452:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:445:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -665,7 +665,7 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName
     isDirty: boolean;
     isTouched: boolean;
     isValidating: boolean;
-    error?: FieldError;
+    error?: PathValue<TFieldValues, TFieldName> extends object ? Merge<FieldError, FieldErrorsImpl<PathValue<TFieldValues, TFieldName>>> : FieldError;
 };
 
 // @public (undocumented)
@@ -871,7 +871,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:444:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:452:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -31,14 +31,16 @@ export type DeepRequired<T> = T extends BrowserNativeObject | Blob
     };
 
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-  [K in keyof T]?: T[K] extends BrowserNativeObject | Blob
-    ? FieldError
-    : K extends 'root' | `root.${string}`
+  [K in keyof T]?: K extends 'root' | `root.${string}`
     ? GlobalError
-    : T[K] extends object
-    ? Merge<FieldError, FieldErrorsImpl<T[K]>>
-    : FieldError;
+    : NestedFieldError<T[K]>;
 };
+
+export type NestedFieldError<T> = T extends BrowserNativeObject | Blob
+  ? FieldError
+  : T extends object
+  ? Merge<FieldError, FieldErrorsImpl<T>>
+  : FieldError;
 
 export type GlobalError = Partial<{
   type: string | number;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { VALIDATION_MODE } from '../constants';
 import { Subject, Subscription } from '../utils/createSubject';
 
-import { ErrorOption, FieldError, FieldErrors } from './errors';
+import { ErrorOption, FieldErrors, NestedFieldError } from './errors';
 import { EventType } from './events';
 import { FieldArray } from './fieldArray';
 import {
@@ -19,6 +19,7 @@ import {
   FieldPath,
   FieldPathValue,
   FieldPathValues,
+  PathValue,
 } from './path';
 import { Resolver } from './resolvers';
 import { DeepMap, DeepPartial, Noop } from './utils';
@@ -362,7 +363,7 @@ export type UseFormGetFieldState<TFieldValues extends FieldValues> = <
   isDirty: boolean;
   isTouched: boolean;
   isValidating: boolean;
-  error?: FieldError;
+  error?: NestedFieldError<PathValue<TFieldValues, TFieldName>>;
 };
 
 export type UseFormWatch<TFieldValues extends FieldValues> = {


### PR DESCRIPTION
Fixes the type errors  #11831 tried to fix, but shouldn't mess up typing when using dot separated field names (e.g. `foo.0.bar`) mentioned in #11927.  

I also extracted part of the `FieldErrorsImpl` type into a new `NestedFieldError` type to avoid duplication. I'm not sure the name really fits, but something like `FieldErrorImpl` felt too similar to the former.