### PR TITLE
fix issue:#11985 logic createFormControl check field before usage

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -310,7 +310,9 @@ export function createFormControl<
       name,
     };
     const disabledField = !!(
-      get(_fields, name) && get(_fields, name)._f && get(_fields, name)._f.disabled
+      get(_fields, name) &&
+      get(_fields, name)._f &&
+      get(_fields, name)._f.disabled
     );
 
     if (!isBlurEvent || shouldDirty) {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -310,7 +310,7 @@ export function createFormControl<
       name,
     };
     const disabledField = !!(
-      get(_fields, name) && get(_fields, name)._f.disabled
+      get(_fields, name) && get(_fields, name)._f && get(_fields, name)._f.disabled
     );
 
     if (!isBlurEvent || shouldDirty) {


### PR DESCRIPTION
In the function `updateTouchAndDirty` the disabled field is accessed before checking the existence of the _f field.

This change adds the check for the _f field in fields before usage.