### PR TITLE
feat: render multiple errors on change

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -693,6 +693,7 @@ export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContex
     progressive: boolean;
     criteriaMode: CriteriaMode;
     delayError: number;
+    experimentalMultiError?: boolean;
 }>;
 
 // @public
@@ -870,7 +871,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:444:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:445:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -765,7 +765,6 @@ export function createFormControl<
               _subjects.state.next({
                 errors: {},
               });
-
             } else {
               _focusError();
               setTimeout(_focusError);

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -697,7 +697,7 @@ export function createFormControl<
 
     if (field) {
       let error;
-      let isValid;
+      let isValid: boolean | undefined;
       const fieldValue = getCurrentFieldValue();
       const isBlurEvent =
         event.type === EVENTS.BLUR || event.type === EVENTS.FOCUS_OUT;
@@ -757,6 +757,24 @@ export function createFormControl<
         _updateIsFieldValueUpdated(fieldValue);
 
         if (isFieldValueUpdated) {
+          if (props.experimentalMultiError) {
+            _formState.errors = errors;
+            unset(_formState.errors, 'root');
+
+            if (isEmptyObject(_formState.errors)) {
+              _subjects.state.next({
+                errors: {},
+              });
+
+            } else {
+              _focusError();
+              setTimeout(_focusError);
+            }
+
+            _subjects.state.next({
+              errors: _formState.errors,
+            });
+          }
           const previousErrorLookupResult = schemaErrorLookup(
             _formState.errors,
             _fields,
@@ -803,7 +821,9 @@ export function createFormControl<
               | FieldPath<TFieldValues>
               | FieldPath<TFieldValues>[],
           );
-        shouldRenderByError(name, isValid, error, fieldState);
+        if (!props.experimentalMultiError) {
+          shouldRenderByError(name, isValid, error, fieldState);
+        }
       }
     }
   };

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -123,6 +123,7 @@ export type UseFormProps<
   progressive: boolean;
   criteriaMode: CriteriaMode;
   delayError: number;
+  experimentalMultiError?: boolean;
 }>;
 
 export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<


### PR DESCRIPTION
Experimental demonstration which allows errors to render for other fields aside from the one that was touched.

pass `experimentalMultiError: true` to useForm

currently doesn't support delayed errors and hasn't been tested against any other resolver aside from yup
