### PR TITLE
fix: skip call `executeBuiltInValidation` if no sub-fields left

### DIFF
--- a/src/__tests__/logic/createFormControl.test.ts
+++ b/src/__tests__/logic/createFormControl.test.ts
@@ -1,0 +1,65 @@
+import { createFormControl } from '../../logic/createFormControl';
+import isEmptyObject from '../../utils/isEmptyObject';
+
+jest.mock('../../utils/isEmptyObject', () => {
+  const original = jest.requireActual('../../utils/isEmptyObject');
+  return {
+    __esModule: true,
+    default: jest.fn(original.default),
+  };
+});
+
+describe('createFormControl', () => {
+  it('should call `executeBuiltInValidation` once for a single field', async () => {
+    const { register, control } = createFormControl({
+      defaultValues: {
+        foo: 'foo',
+      },
+    });
+
+    register('foo', {});
+
+    await control._updateValid(true);
+
+    expect(isEmptyObject).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call `executeBuiltInValidation` twice for a field as an object with a single sub-field', async () => {
+    const { register, control } = createFormControl({
+      defaultValues: {
+        foo: {
+          bar: 'bar',
+        },
+      },
+    });
+
+    register('foo.bar', {});
+
+    await control._updateValid(true);
+
+    expect(isEmptyObject).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call executeBuiltInValidation the correct number of times in case the field is an array', async () => {
+    const { register, control } = createFormControl({
+      defaultValues: {
+        foo: [
+          {
+            bar: 'bar',
+            baz: 'baz',
+          },
+          {
+            bar: 'bar',
+            baz: 'baz',
+          },
+        ],
+      },
+    });
+
+    register('foo.1.bar', {});
+
+    await control._updateValid(true);
+
+    expect(isEmptyObject).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -481,7 +481,7 @@ export function createFormControl<
               : unset(_formState.errors, _f.name));
         }
 
-        Object.keys(fieldValue).length &&
+        !isEmptyObject(fieldValue) &&
           (await executeBuiltInValidation(
             fieldValue,
             shouldOnlyCheckValid,

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -481,7 +481,7 @@ export function createFormControl<
               : unset(_formState.errors, _f.name));
         }
 
-        fieldValue &&
+        Object.keys(fieldValue).length &&
           (await executeBuiltInValidation(
             fieldValue,
             shouldOnlyCheckValid,


### PR DESCRIPTION
We've had a performance issue with `useFieldArray` and too many rows with validated fields. I've noticed that with function do some extra recursion with empty an `fieldValue` which mostly the reason of our issues