### PR TITLE
Remove single quotations for lint in package.json, so it can run properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build:modern": "rollup --bundleConfigAsCjs -c ./scripts/rollup/rollup.config.js",
     "build:esm": "rollup --bundleConfigAsCjs -c ./scripts/rollup/rollup.esm.config.js",
     "prettier:fix": "prettier --config .prettierrc --write \"**/*.{js,ts,tsx,css}\"",
-    "lint": "eslint '**/*.{js,ts,tsx}'",
+    "lint": "eslint **/*.{js,ts,tsx}",
     "lint:fix": "pnpm lint --fix",
     "type": "tsc --noEmit",
     "jest-preview": "jest-preview",


### PR DESCRIPTION
In package.json, there is a small problem with Lint, because there are both double and single quotation marks. So, single ones are removed and now it works properly.