### PR TITLE
Fix integer default value not working for radio inputs

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -1392,4 +1392,45 @@ describe('setValue', () => {
     expect(screen.getByText('dirty')).toBeVisible();
     expect(screen.getByText('touched')).toBeVisible();
   });
+
+  it('should handle integer value as defaultValue', () => {
+    function App() {
+      const { register } = useForm({
+        defaultValues: { myField: 12 },
+      });
+
+      return (
+        <form>
+          <input
+            data-testid="0"
+            type="radio"
+            {...register('myField')}
+            value={4}
+          />
+          <input
+            data-testid="1"
+            type="radio"
+            {...register('myField')}
+            value={12}
+          />
+          <input
+            data-testid="2"
+            type="radio"
+            {...register('myField')}
+            value={32}
+          />
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    expect((screen.getByTestId('0') as HTMLInputElement).checked).toEqual(
+      false,
+    );
+    expect((screen.getByTestId('1') as HTMLInputElement).checked).toEqual(true);
+    expect((screen.getByTestId('2') as HTMLInputElement).checked).toEqual(
+      false,
+    );
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -586,9 +586,30 @@ export function createFormControl<
               : fieldReference.refs[0] &&
                 (fieldReference.refs[0].checked = !!fieldValue);
           } else {
+            let stringFieldValue: string;
+            switch (typeof fieldValue) {
+              case 'string':
+                stringFieldValue = fieldValue;
+                break;
+              case 'bigint':
+              case 'boolean':
+              case 'number':
+              case 'symbol':
+                stringFieldValue = fieldValue.toString();
+                break;
+              case 'object':
+                stringFieldValue = JSON.stringify(fieldValue);
+                break;
+              case 'undefined':
+                stringFieldValue = '';
+                break;
+              case 'function':
+                throw new Error('Cannot set field value to a Function');
+            }
+
             fieldReference.refs.forEach(
               (radioRef: HTMLInputElement) =>
-                (radioRef.checked = radioRef.value === fieldValue),
+                (radioRef.checked = radioRef.value === stringFieldValue),
             );
           }
         } else if (isFileInput(fieldReference.ref)) {


### PR DESCRIPTION
Currently, setting default values with integers does not work for radio inputs:

```tsx
import React from "react";
import ReactDOM from "react-dom";
import { useForm } from "react-hook-form";

function App() {
  const choices = [12, 17, 192, 10];
  const defaultValues = { myNumber: 192 };

  const { register } = useForm({ defaultValues });

  return (
    <form>
      {choices.map((choice) => {
        return (
          <label key={choice} style={{display: "block"}}>
            <input
              type="radio"
              value={choice}
              {...register("myNumber")}
            />
            {choice}
          </label>
        );
      })}
    </form>
  );
}

const rootElement = document.getElementById("root");
ReactDOM.render(<App />, rootElement);
```

Converting the defaultValue to a string does work:
```tsx
const defaultValues = { myNumber: "192" };
```

This PR makes this conversion within react hook forms, in a way that (I believe) is consistent with what a user would expect.

Note: Please keep in mind that this is my fist PR here and I'm quite new to react as well as react-hook-form, so you can safely assume I have no idea what I'm doing here.

Checklist:
[✓] create tests
[✓] pass tests
[✓] lint
[✓] automation suite
[✓] build
[✓] api-extractor
