### PR TITLE
chore: upgrade codeql github workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,10 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ master, v6 ]
+    branches: [master, v6]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: '40 0 * * 3'
 
@@ -21,19 +21,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ['javascript']
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL Github action v1 is deprecated, v2 is also actually deprecated, we should be moving to v3 now.

There may be some steps required by maintainers of this repo to fully upgrade to CodeQL v3 but this PR is the first step towards that.