### PR TITLE
docs: fix typo in code example

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -220,7 +220,7 @@ export type UseFormRegisterReturn<
  * // Register custom field at useEffect
  * useEffect(() => {
  *   register("name4");
- *   register("name5", { value: '"hiddenValue" });
+ *   register("name5", { value: "hiddenValue" });
  * }, [register])
  *
  * // Register without ref


### PR DESCRIPTION
# Pull Request Template

## Proposed Changes

Fixed a typo in the code example of `UseFormRegister` that had an unnecessary `'`. Spotted this accidentally while browsing the documentation in my editor and the code highlighting of the example code was off.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
