### PR TITLE
fix: edit input field placeholder

### DIFF
--- a/app/src/basic.tsx
+++ b/app/src/basic.tsx
@@ -47,7 +47,7 @@ const Basic: React.FC = () => {
       }, onInvalid)}
     >
       <input
-        placeholder="nest.nest1"
+        placeholder="nestItem.nest1"
         {...register('nestItem.nest1', { required: true })}
       />
       {errors.nestItem?.nest1 && <p>nest 1 error</p>}


### PR DESCRIPTION
This is a simple task of modifying the field name and field placeholder used in the basic page of the example app, which results in inconsistency due to differences.