### PR TITLE
feat: add support for opaque fields

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -131,19 +131,19 @@ export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends Browser
 } : TValue;
 
 // @public (undocumented)
-export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue ? T : {
+export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue | Opaque<unknown> ? T : {
     [K in keyof T]?: ExtractObjects<T[K]> extends never ? T[K] : DeepPartial<T[K]>;
 };
 
 // @public (undocumented)
-export type DeepPartialSkipArrayKey<T> = T extends BrowserNativeObject | NestedValue ? T : T extends ReadonlyArray<any> ? {
+export type DeepPartialSkipArrayKey<T> = T extends BrowserNativeObject | NestedValue | Opaque<unknown> ? T : T extends ReadonlyArray<any> ? {
     [K in keyof T]: DeepPartialSkipArrayKey<T[K]>;
 } : {
     [K in keyof T]?: DeepPartialSkipArrayKey<T[K]>;
 };
 
 // @public (undocumented)
-export type DeepRequired<T> = T extends BrowserNativeObject | Blob ? T : {
+export type DeepRequired<T> = T extends BrowserNativeObject | Blob | Opaque<unknown> ? T : {
     [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
 };
 
@@ -221,7 +221,7 @@ export type FieldErrors<T extends FieldValues = FieldValues> = Partial<FieldValu
 
 // @public (undocumented)
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-    [K in keyof T]?: T[K] extends BrowserNativeObject | Blob ? FieldError : K extends 'root' | `root.${string}` ? GlobalError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
+    [K in keyof T]?: T[K] extends BrowserNativeObject | Blob | Opaque<unknown> ? FieldError : K extends 'root' | `root.${string}` ? GlobalError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
 };
 
 // @public (undocumented)
@@ -456,6 +456,11 @@ export type NonUndefined<T> = T extends undefined ? never : T;
 
 // @public (undocumented)
 export type Noop = () => void;
+
+// @public (undocumented)
+export type Opaque<T> = T & {
+    readonly __opaque: unique symbol;
+};
 
 // Warning: (ae-forgotten-export) The symbol "PathInternal" needs to be exported by the entry point index.d.ts
 //

--- a/src/__typetest__/errors.test-d.ts
+++ b/src/__typetest__/errors.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 
-import { FieldError, FieldErrors, GlobalError, Merge } from '../types';
+import { FieldError, FieldErrors, GlobalError, Merge, Opaque } from '../types';
 
 import { _ } from './__fixtures__';
 
@@ -59,8 +59,12 @@ import { _ } from './__fixtures__';
     >(actual);
   }
 
-  /** it should not treat Date, File, FileList or Blob as record fields */
+  /** it should not treat Date, File, FileList, Blob or Opaque as record fields */
   {
+    type Foo = Opaque<{
+      foo: 'bar';
+    }>;
+
     const actual = _ as FieldErrors<{
       date: Date;
       file: File;
@@ -70,6 +74,7 @@ import { _ } from './__fixtures__';
         file: File;
         fileList: FileList;
       };
+      opaque: Foo;
     }>;
     expectType<FieldError | undefined>(actual.date);
     expectType<FieldError | undefined>(actual.file);
@@ -77,5 +82,6 @@ import { _ } from './__fixtures__';
     expectType<FieldError | undefined>(actual.record?.date);
     expectType<FieldError | undefined>(actual.record?.file);
     expectType<FieldError | undefined>(actual.record?.fileList);
+    expectType<FieldError | undefined>(actual.opaque);
   }
 }

--- a/src/__typetest__/path/eager.test-d.ts
+++ b/src/__typetest__/path/eager.test-d.ts
@@ -1,6 +1,12 @@
 import { expectType } from 'tsd';
 
-import { ArrayPath, FieldPathValues, Path, PathValue } from '../../types';
+import {
+  ArrayPath,
+  FieldPathValues,
+  Opaque,
+  Path,
+  PathValue,
+} from '../../types';
 import { _, Depth3Type } from '../__fixtures__';
 
 /** {@link Path} */ {
@@ -41,6 +47,15 @@ import { _, Depth3Type } from '../__fixtures__';
       | {};
     const actual = _ as Path<Foo>;
     expectType<'foo' | 'bar' | 'bar.baz'>(actual);
+  }
+
+  /** it should not traverse into opaque types */ {
+    type Foo = Opaque<{
+      foo: 'bar';
+    }>;
+
+    const actual = _ as Path<{ foo: Foo; bar: Foo }>;
+    expectType<'foo' | 'bar'>(actual);
   }
 }
 

--- a/src/__typetest__/util.test-d.ts
+++ b/src/__typetest__/util.test-d.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectType } from 'tsd';
 
-import { DeepPartial, ExtractObjects, IsAny, IsNever } from '../types';
+import { DeepPartial, ExtractObjects, IsAny, IsNever, Opaque } from '../types';
 
 import { _ } from './__fixtures__';
 
@@ -87,6 +87,16 @@ import { _ } from './__fixtures__';
       x?: string;
       y?: { a?: string; b?: number };
     }>(actual);
+  }
+
+  /** it should not make opaque internals optional */ {
+    type Foo = Opaque<{
+      foo: 'bar';
+    }>;
+    const actual = _ as DeepPartial<{
+      foo: Foo;
+    }>;
+    expectType<{ foo?: Foo }>(actual);
   }
 
   /** it should be assignable for types containing unknown */ {

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,5 +1,11 @@
 import { FieldValues, InternalFieldName, Ref } from './fields';
-import { BrowserNativeObject, IsAny, LiteralUnion, Merge } from './utils';
+import {
+  BrowserNativeObject,
+  IsAny,
+  LiteralUnion,
+  Merge,
+  Opaque,
+} from './utils';
 import { RegisterOptions, ValidateResult } from './validator';
 
 export type Message = string;
@@ -24,14 +30,17 @@ export type ErrorOption = {
   types?: MultipleFieldErrors;
 };
 
-export type DeepRequired<T> = T extends BrowserNativeObject | Blob
+export type DeepRequired<T> = T extends
+  | BrowserNativeObject
+  | Blob
+  | Opaque<unknown>
   ? T
   : {
       [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
     };
 
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-  [K in keyof T]?: T[K] extends BrowserNativeObject | Blob
+  [K in keyof T]?: T[K] extends BrowserNativeObject | Blob | Opaque<unknown>
     ? FieldError
     : K extends 'root' | `root.${string}`
       ? GlobalError

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -1,5 +1,11 @@
 import { FieldValues } from '../fields';
-import { BrowserNativeObject, IsAny, IsEqual, Primitive } from '../utils';
+import {
+  BrowserNativeObject,
+  IsAny,
+  IsEqual,
+  Opaque,
+  Primitive,
+} from '../utils';
 
 import { ArrayKey, IsTuple, TupleKeys } from './common';
 
@@ -24,6 +30,7 @@ type AnyIsEqual<T1, T2> = T1 extends T2
 type PathImpl<K extends string | number, V, TraversedTypes> = V extends
   | Primitive
   | BrowserNativeObject
+  | Opaque<unknown>
   ? `${K}`
   : // Check so that we don't recurse into the same type
     // by ensuring that the types are mutually assignable

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -31,6 +31,8 @@ export type Primitive =
   | symbol
   | bigint;
 
+export type Opaque<T> = T & { readonly __opaque: unique symbol };
+
 export type BrowserNativeObject = Date | FileList | File;
 
 export type EmptyObject = { [K in string | number]: never };
@@ -47,7 +49,10 @@ export type ExtractObjects<T> = T extends infer U
     : never
   : never;
 
-export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue
+export type DeepPartial<T> = T extends
+  | BrowserNativeObject
+  | NestedValue
+  | Opaque<unknown>
   ? T
   : {
       [K in keyof T]?: ExtractObjects<T[K]> extends never
@@ -58,6 +63,7 @@ export type DeepPartial<T> = T extends BrowserNativeObject | NestedValue
 export type DeepPartialSkipArrayKey<T> = T extends
   | BrowserNativeObject
   | NestedValue
+  | Opaque<unknown>
   ? T
   : T extends ReadonlyArray<any>
     ? { [K in keyof T]: DeepPartialSkipArrayKey<T[K]> }


### PR DESCRIPTION
Adds a new Opaque<T> type which can be used to mark certain property values as opaque. This prevents unwanted expansion of properties which RHF should consider opaque.

As an example, if you have a form field for a date picker, and the picker value is a `Dayjs` value, right now RHF will recommend e.g. `date.clone` as a valid field path. By wrapping it with the new `Opaque<Dayjs>`, RHF will then treat it like any other special type like `Date` or `File`.