### PR TITLE
🐞 fix #12316 setValue should work for arrays of primitives to handle checkboxes (#12316)

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -158,6 +158,81 @@ describe('setValue', () => {
     });
   });
 
+  it('should set value of multiple checkbox input correctly as a child', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ parent: { test: string[] } }>(),
+    );
+
+    const { ref } = result.current.register('parent.test');
+
+    const elm = document.createElement('input');
+    elm.type = 'checkbox';
+    elm.name = 'test';
+    elm.value = '2';
+
+    document.body.append(elm);
+    isFunction(ref) && ref(elm);
+
+    const { ref: ref1 } = result.current.register('parent.test');
+
+    const elm1 = document.createElement('input');
+    elm1.type = 'checkbox';
+    elm1.name = 'test';
+    elm1.value = '1';
+
+    document.body.append(elm1);
+
+    isFunction(ref1) && ref1(elm1);
+
+    result.current.setValue('parent', { test: ['1'] });
+    expect(elm1).toBeChecked();
+
+    await act(async () => {
+      await result.current.handleSubmit((data) => {
+        expect(data).toEqual({
+          parent: {
+            test: ['1'],
+          },
+        });
+      })({
+        preventDefault: noop,
+        persist: noop,
+      } as React.SyntheticEvent);
+    });
+  });
+
+  it('should set value of single checkbox input correctly as a child', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ parent: { test: string } }>(),
+    );
+
+    const { ref } = result.current.register('parent.test');
+
+    const elm = document.createElement('input');
+    elm.type = 'checkbox';
+    elm.name = 'test';
+    elm.value = '1';
+
+    document.body.append(elm);
+    isFunction(ref) && ref(elm);
+
+    result.current.setValue('parent', { test: '1' });
+    expect(elm).toBeChecked();
+
+    await act(async () => {
+      await result.current.handleSubmit((data) => {
+        expect(data).toEqual({
+          parent: {
+            test: '1',
+          },
+        });
+      })({
+        preventDefault: noop,
+        persist: noop,
+      } as React.SyntheticEvent);
+    });
+  });
+
   it('should set value of multiple select correctly', async () => {
     const { result } = renderHook(() => useForm<{ test: string[] }>());
     const { ref } = result.current.register('test');

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -58,7 +58,6 @@ import isHTMLElement from '../utils/isHTMLElement';
 import isMultipleSelect from '../utils/isMultipleSelect';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
 import isObject from '../utils/isObject';
-import isPrimitive from '../utils/isPrimitive';
 import isRadioOrCheckbox from '../utils/isRadioOrCheckbox';
 import isString from '../utils/isString';
 import isUndefined from '../utils/isUndefined';
@@ -649,7 +648,7 @@ export function createFormControl<
       const field = get(_fields, fieldName);
 
       (_names.array.has(name) ||
-        !isPrimitive(fieldValue) ||
+        isObject(fieldValue) ||
         (field && !field._f)) &&
       !isDateObject(fieldValue)
         ? setValues(fieldName, fieldValue, options)


### PR DESCRIPTION
Fix #12316 by making the type check stricter for whether we should recurse into nested values or set values at that level. The original `!isPrimitive` check matched all object types (including arrays)