### PR TITLE
refactor: shorthand baseGet logic in unset fn

### DIFF
--- a/src/utils/unset.ts
+++ b/src/utils/unset.ts
@@ -31,7 +31,7 @@ export default function unset(object: any, path: string | (string | number)[]) {
       ? [path]
       : stringToPath(path);
 
-  const childObject = paths.length === 1 ? object : baseGet(object, paths);
+  const childObject = baseGet(object, paths);
 
   const index = paths.length - 1;
   const key = paths[index];


### PR DESCRIPTION
below logic not need conditional statements and simply use `baseGet(object,path)`. because the result will be the same.

```
const childObject = paths.length === 1 ? object : baseGet(object, paths);
```

The reason is that when `path.length === 1`, the `baseGet` function returns an object as is without executing the while statement.

The logic has been modified for clarity, so please check it out.
