### PR TITLE
allow field names that single numeric strings to process as strings, not array indexes

### DIFF
--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -21,7 +21,7 @@ export default (
     if (index !== lastIndex) {
       const objValue = object[key];
       newValue =
-        isObject(objValue) || Array.isArray(objValue)
+        isObject(objValue) || Array.isArray(objValue) || (tempPath.length == 1 && typeof key === "string")
           ? objValue
           : !isNaN(+tempPath[index + 1])
             ? []


### PR DESCRIPTION
when using field names like "0", "1", etc. the output is converted to an array, even when mixed names (e.g. "A" and "1") are used.