### PR TITLE
Fix: hasPromiseValidation return true or false appropriately.

### DIFF
--- a/src/__tests__/logic/hasPromiseValidation.test.ts
+++ b/src/__tests__/logic/hasPromiseValidation.test.ts
@@ -1,0 +1,69 @@
+import hasPromiseValidation from '../../logic/hasPromiseValidation';
+
+const commonParam = {
+  mount: true,
+  name: 'test1',
+  ref: {
+    name: 'test1',
+    value: '',
+  },
+};
+
+describe('hasPromiseValidation', () => {
+  it('validate option does not exist', () => {
+    expect(hasPromiseValidation(commonParam)).toEqual(false);
+  });
+  it('should return true when validate option has a function type value and is an async function', () => {
+    const param = {
+      ...commonParam,
+      validate: async () => {
+        return true;
+      },
+    };
+
+    expect(hasPromiseValidation(param)).toEqual(true);
+  });
+  it('should return false when validate option has a function type value and is not an async function', () => {
+    const param = {
+      ...commonParam,
+      validate: () => {
+        return true;
+      },
+    };
+
+    expect(hasPromiseValidation(param)).toEqual(false);
+  });
+  it('should return true when validate option has an object type value, and the values of all properties are async function.', () => {
+    const param = {
+      ...commonParam,
+      validate: {
+        positive: async (v: string) => parseInt(v) > 0,
+        lessThanTen: async (v: string) => parseInt(v) < 10,
+      },
+    };
+
+    expect(hasPromiseValidation(param)).toEqual(true);
+  });
+  it('should return true when validate option has an object type value, and the value of one property is an async function.', () => {
+    const param = {
+      ...commonParam,
+      validate: {
+        positive: (v: string) => parseInt(v) > 0,
+        lessThanTen: async (v: string) => parseInt(v) < 10,
+      },
+    };
+
+    expect(hasPromiseValidation(param)).toEqual(true);
+  });
+  it('should return false when validate option has an object type value, and the values of all properties are not async function.', () => {
+    const param = {
+      ...commonParam,
+      validate: {
+        positive: (v: string) => parseInt(v) > 0,
+        lessThanTen: (v: string) => parseInt(v) < 10,
+      },
+    };
+
+    expect(hasPromiseValidation(param)).toEqual(false);
+  });
+});

--- a/src/logic/hasPromiseValidation.ts
+++ b/src/logic/hasPromiseValidation.ts
@@ -5,7 +5,8 @@ import isObject from '../utils/isObject';
 const ASYNC_FUNCTION = 'AsyncFunction';
 
 export default (fieldReference: Field['_f']) =>
-  (!fieldReference || !fieldReference.validate) &&
+  !!fieldReference &&
+  !!fieldReference.validate &&
   !!(
     (isFunction(fieldReference.validate) &&
       fieldReference.validate.constructor.name === ASYNC_FUNCTION) ||


### PR DESCRIPTION
In the `hasPromiseValidation` function, `fieldReference` or `fieldReference.validate` is false and `fieldReference.validate` cannot be a function or an object, so the function always returns false. 

Therefore, i modified the first condition to return true or false appropriately.

Also, I wrote an additional unit test for that function because it doesn't seem to exist.

+ Due to the impact of this bug, the `isValidating` value appears to not be updated properly even if a promise function is used in validation option. 

```typescript
const isPromiseFunction = field._f && hasPromiseValidation((field as Field)._f);

if (isPromiseFunction && _proxyFormState.validatingFields) {
     _updateIsValidating([name], true);
}
```