### PR TITLE
Fix: add type guard to fieldRef.select

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1376,7 +1376,9 @@ export function createFormControl<
 
       if (fieldRef.focus) {
         fieldRef.focus();
-        options.shouldSelect && fieldRef.select();
+        options.shouldSelect &&
+          isFunction(fieldRef.select) &&
+          fieldRef.select();
       }
     }
   };


### PR DESCRIPTION
An error occurs if we run setFoucs with `{shouldSelect:true}` enabled for an element (select) other than input or textArea.
(Because the select element does not have a select method)

Therefore, I added a simple type guard.

```typescript
const Basic: React.FC = () => {
  const { mode } = useParams();
  const [data, setData] = React.useState({});
  const {
    register,
    handleSubmit,
    setFocus
  } = useForm<{
    selectNumber: string;
  }>({
    mode: mode as keyof ValidationMode,
  });
  
  renderCounter++;


  React.useEffect(() => {
    setFocus("selectNumber",{shouldSelect:true});
  }, [setFocus]);

  return (
    <form
      onSubmit={handleSubmit((data) => {
        setData(data);
      })}
    >
      <select {...register('selectNumber', { required: true })}>
        <option value="">Select</option>
        <option value={'1'}>1</option>
        <option value={'2'}>2</option>
      </select>
      <button id="submit">Submit</button>
    </form>
  );
};
```