### PR TITLE
Optimizing form reset, Remove unnecessary consts

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1254,12 +1254,11 @@ export function createFormControl<
     keepStateOptions = {},
   ) => {
     const isEmptyResetValues = isEmptyObject(formValues);
-    const values = isEmptyResetValues 
-      ? _defaultValues 
-      : formValues 
-        ? cloneObject(formValues) 
+    const values = isEmptyResetValues
+      ? _defaultValues
+      : formValues
+        ? cloneObject(formValues)
         : _defaultValues;
-    
     if (!keepStateOptions.keepDefaultValues) {
       _defaultValues = values;
     }

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1253,13 +1253,15 @@ export function createFormControl<
     formValues,
     keepStateOptions = {},
   ) => {
-    const updatedValues = formValues ? cloneObject(formValues) : _defaultValues;
-    const cloneUpdatedValues = cloneObject(updatedValues);
     const isEmptyResetValues = isEmptyObject(formValues);
-    const values = isEmptyResetValues ? _defaultValues : cloneUpdatedValues;
-
+    const values = isEmptyResetValues 
+      ? _defaultValues 
+      : formValues 
+        ? cloneObject(formValues) 
+        : _defaultValues;
+    
     if (!keepStateOptions.keepDefaultValues) {
-      _defaultValues = updatedValues;
+      _defaultValues = values;
     }
 
     if (!keepStateOptions.keepValues) {


### PR DESCRIPTION
related to #12454
I removed unnecessary consts in form reset, `updatedValues` and  `cloneUpdatedValues` and replace it with one line 
Simplified value assignment logic:
```
typescriptCopyconst values = isEmptyResetValues
  ? _defaultValues
  : formValues
    ? cloneObject(formValues)
    : _defaultValues;
```
This replaces the previous multi-step value determination
Reduces intermediate variable allocations
