### PR TITLE
feat: add `type` option in `useWatch`

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -796,6 +796,7 @@ export function useWatch<TFieldValues extends FieldValues = FieldValues>(props: 
     control?: Control<TFieldValues>;
     disabled?: boolean;
     exact?: boolean;
+    type?: EventType;
 }): DeepPartialSkipArrayKey<TFieldValues>;
 
 // @public
@@ -805,6 +806,7 @@ export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldN
     control?: Control<TFieldValues>;
     disabled?: boolean;
     exact?: boolean;
+    type?: EventType;
 }): FieldPathValue<TFieldValues, TFieldName>;
 
 // @public
@@ -814,6 +816,7 @@ export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldN
     control?: Control<TFieldValues>;
     disabled?: boolean;
     exact?: boolean;
+    type?: EventType;
 }): FieldPathValues<TFieldValues, TFieldNames>;
 
 // @public
@@ -826,6 +829,7 @@ export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
     name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[];
     control?: Control<TFieldValues>;
     exact?: boolean;
+    type?: EventType;
 };
 
 // @public (undocumented)

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -340,6 +340,46 @@ describe('useWatch', () => {
     expect(screen.getByText('345')).toBeVisible();
   });
 
+  it('should subscribe to specific event type', () => {
+    const App = () => {
+      const { control, register, setValue } = useForm();
+      const value = useWatch({
+        name: 'test',
+        control,
+        defaultValue: 'test',
+        type: 'change',
+      });
+
+      return (
+        <div>
+          <input {...register('test')} />
+          <p>{value}</p>
+          <button
+            onClick={() => {
+              setValue('test', '12345');
+            }}
+          >
+            set programmatically
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: {
+        value: '1234',
+      },
+    });
+
+    expect(screen.getByText('1234')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('1234')).toBeVisible();
+  });
+
   describe('when disabled prop is used', () => {
     it('should be able to disabled subscription and started with true', async () => {
       type FormValues = {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -874,6 +874,7 @@ export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
     | readonly FieldPath<TFieldValues>[];
   control?: Control<TFieldValues>;
   exact?: boolean;
+  type?: EventType;
 };
 
 export type FormProviderProps<

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -6,6 +6,7 @@ import cloneObject from './utils/cloneObject';
 import {
   Control,
   DeepPartialSkipArrayKey,
+  EventType,
   FieldPath,
   FieldPathValue,
   FieldPathValues,
@@ -44,6 +45,7 @@ export function useWatch<
   control?: Control<TFieldValues>;
   disabled?: boolean;
   exact?: boolean;
+  type?: EventType;
 }): DeepPartialSkipArrayKey<TFieldValues>;
 /**
  * Custom hook to subscribe to field change and isolate re-rendering at the component level.
@@ -74,6 +76,7 @@ export function useWatch<
   control?: Control<TFieldValues>;
   disabled?: boolean;
   exact?: boolean;
+  type?: EventType;
 }): FieldPathValue<TFieldValues, TFieldName>;
 /**
  * Custom hook to subscribe to field change and isolate re-rendering at the component level.
@@ -108,6 +111,7 @@ export function useWatch<
   control?: Control<TFieldValues>;
   disabled?: boolean;
   exact?: boolean;
+  type?: EventType;
 }): FieldPathValues<TFieldValues, TFieldNames>;
 /**
  * Custom hook to subscribe to field change and isolate re-rendering at the component level.
@@ -151,6 +155,7 @@ export function useWatch<TFieldValues extends FieldValues>(
     defaultValue,
     disabled,
     exact,
+    type,
   } = props || {};
   const _name = React.useRef(name);
 
@@ -159,8 +164,13 @@ export function useWatch<TFieldValues extends FieldValues>(
   useSubscribe({
     disabled,
     subject: control._subjects.values,
-    next: (formState: { name?: InternalFieldName; values?: FieldValues }) => {
+    next: (formState: {
+      name?: InternalFieldName;
+      type?: EventType;
+      values?: FieldValues;
+    }) => {
       if (
+        (type ? formState.type === type : true) &&
         shouldSubscribeByName(
           _name.current as InternalFieldName,
           formState.name,


### PR DESCRIPTION
Unlike in `watch` it's impossible to get an event type in `useWatch`. This small addition allows to subscribe to changes of a specific type.

Potentially can help with #8542 or #8048.