### PR TITLE
🧪 test(useWatch): destructure setValue from useForm

### DIFF
--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -1533,9 +1533,11 @@ describe('useWatch', () => {
           defaultValues: { test: 'test' },
         });
 
+        const { setValue } = methods;
+
         React.useEffect(() => {
-          methods.setValue('test', 'bill');
-        }, [methods]);
+          setValue('test', 'bill');
+        }, [setValue]);
 
         return (
           <>


### PR DESCRIPTION
Related to #12463.

I searched for all `useEffect` in the codebase and I was able to find only one that was receiving the whole `useForm` result in dependencies array.