### PR TITLE
update form state outside of shouldRenderFormState

### DIFF
--- a/src/logic/shouldRenderFormState.ts
+++ b/src/logic/shouldRenderFormState.ts
@@ -1,6 +1,5 @@
 import { VALIDATION_MODE } from '../constants';
 import {
-  Control,
   FieldValues,
   FormState,
   InternalFieldName,
@@ -11,10 +10,8 @@ import isEmptyObject from '../utils/isEmptyObject';
 export default <T extends FieldValues, K extends ReadFormState>(
   formStateData: Partial<FormState<T>> & { name?: InternalFieldName },
   _proxyFormState: K,
-  updateFormState: Control<T>['_updateFormState'],
   isRoot?: boolean,
 ) => {
-  updateFormState(formStateData);
   const { name, ...formState } = formStateData;
 
   return (

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -88,14 +88,8 @@ export function useForm<
     next: (
       value: Partial<FormState<TFieldValues>> & { name?: InternalFieldName },
     ) => {
-      if (
-        shouldRenderFormState(
-          value,
-          control._proxyFormState,
-          control._updateFormState,
-          true,
-        )
-      ) {
+      control._updateFormState(value);
+      if (shouldRenderFormState(value, control._proxyFormState, true)) {
         updateFormState({ ...control._formState });
       }
     },

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -68,22 +68,26 @@ function useFormState<TFieldValues extends FieldValues = FieldValues>(
     disabled,
     next: (
       value: Partial<FormState<TFieldValues>> & { name?: InternalFieldName },
-    ) =>
-      _mounted.current &&
-      shouldSubscribeByName(
-        _name.current as InternalFieldName,
-        value.name,
-        exact,
-      ) &&
-      shouldRenderFormState(
-        value,
-        _localProxyFormState.current,
-        control._updateFormState,
-      ) &&
-      updateFormState({
-        ...control._formState,
-        ...value,
-      }),
+    ) => {
+      if (!_mounted.current) {
+        return;
+      }
+      if (
+        shouldSubscribeByName(
+          _name.current as InternalFieldName,
+          value.name,
+          exact,
+        )
+      ) {
+        control._updateFormState(value);
+        if (shouldRenderFormState(value, _localProxyFormState.current)) {
+          updateFormState({
+            ...control._formState,
+            ...value,
+          });
+        }
+      }
+    },
     subject: control._subjects.state,
   });
 


### PR DESCRIPTION
This is small refactor of shouldRenderFormState

### My motivation:
Updating form state inside shouldRenderFormState feels wrong to me.
It feels wrong to me 
1. to pass a function inside another function just to call it at the first line.
2. to make a side effect inside a function whose name starts with 'should'

Why updateFormState wasn't called outside of shouldRenderFormState? Was it made on purpose?
I'm really curios.