### PR TITLE
Change Path type check in PathValue type to single check at start

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -454,10 +454,10 @@ export type Path<T> = T extends any ? PathInternal<T> : never;
 // @public
 export type PathString = string;
 
-// Warning: (ae-forgotten-export) The symbol "ArrayKey" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "PathValueImpl" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type PathValue<T, P extends Path<T> | ArrayPath<T>> = T extends any ? P extends `${infer K}.${infer R}` ? K extends keyof T ? R extends Path<T[K]> ? PathValue<T[K], R> : never : K extends `${ArrayKey}` ? T extends ReadonlyArray<infer V> ? PathValue<V, R & Path<V>> : never : never : P extends keyof T ? T[P] : P extends `${ArrayKey}` ? T extends ReadonlyArray<infer V> ? V : never : never : never;
+export type PathValue<T, P extends Path<T> | ArrayPath<T>> = PathValueImpl<T, P>;
 
 // @public (undocumented)
 export type Primitive = null | undefined | string | number | boolean | symbol | bigint;

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -18,7 +18,6 @@ import {
   InternalFieldName,
   Names,
   Path,
-  PathValue,
   ReadFormState,
   Ref,
   SetFieldValue,
@@ -1223,10 +1222,7 @@ export function createFormControl<
       } else {
         setValue(
           name,
-          options.defaultValue as PathValue<
-            TFieldValues,
-            FieldPath<TFieldValues>
-          >,
+          options.defaultValue as Parameters<typeof setValue<typeof name>>[1],
         );
         set(_defaultValues, name, cloneObject(options.defaultValue));
       }

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -144,15 +144,18 @@ export type FieldArrayPath<TFieldValues extends FieldValues> =
  * PathValue<[number, string], '1'> = string
  * ```
  */
-export type PathValue<T, P extends Path<T> | ArrayPath<T>> = T extends any
+export type PathValue<T, P extends Path<T> | ArrayPath<T>> = PathValueImpl<
+  T,
+  P
+>;
+
+type PathValueImpl<T, P extends string> = T extends any
   ? P extends `${infer K}.${infer R}`
     ? K extends keyof T
-      ? R extends Path<T[K]>
-        ? PathValue<T[K], R>
-        : never
+      ? PathValueImpl<T[K], R>
       : K extends `${ArrayKey}`
         ? T extends ReadonlyArray<infer V>
-          ? PathValue<V, R & Path<V>>
+          ? PathValueImpl<V, R>
           : never
         : never
     : P extends keyof T


### PR DESCRIPTION
I've noticed that in a project I'm working on, the intellij typescript service was struggling with react-hook-form typing, when using large types.

I started investigating and found that the `Path<>` calls in the `PathValue` are very intense for large input types, and they seemed redundant. As such, in this PR, I propose that the type only does a single `extends Path<> | ArrayPath<>` at the start, and remove the checks in the recursive part of the type.

I believe this is safe since the type would end up at `never` eventually even if the path was somehow invalid. However, since there is now still a check at the start, nothing should change outwardly.

The only internal issue I encountered was in `resetField`, where the type cast of the `defaultValue` was no longer correct. I believe this has to do with how typescript inferences certain types and I initially made a solution using the new `NoInfer` type, but this would raise the minimum typescript to use hook form to 5.4. Instead I chose the solution you see below.

This change has made a enormous difference for the responsiveness of Intellij and has also cut the type-checking of my project by about 10 seconds (from 50s to 40s, even while hook form is only used in specific parts of the application)