### PR TITLE
fix: acknowledge root errors in onChange

### DIFF
--- a/src/__tests__/logic/schemaErrorLookup.test.ts
+++ b/src/__tests__/logic/schemaErrorLookup.test.ts
@@ -232,4 +232,51 @@ describe('errorsLookup', () => {
       name: 'test.testXYZ',
     });
   });
+
+  it('should find the nearest root error', () => {
+    const errors = {
+      test: {
+        0: {
+          root: {
+            type: 'root',
+            message: 'higher-root',
+          },
+          nested: {
+            root: {
+              type: 'root',
+              message: 'correct-root',
+            },
+            0: {
+              deepNested: {
+                type: 'deepNested',
+                message: 'error',
+              },
+            }
+          },
+        },
+      },
+    };
+
+    expect(
+      schemaErrorLookup<{test: {nested: {deepNested: string}[]}[]}>(
+        errors,
+        {},
+        'test.0.nested.1',
+      ),
+    ).toEqual({
+      error: { message: 'correct-root', type: 'root' },
+      name: 'test.0.nested.root',
+    });
+
+    expect(
+      schemaErrorLookup<{test: {nested: {deepNested: string}[]}[]}>(
+        errors,
+        {},
+        'test.0.nested.0',
+      ),
+    ).toEqual({
+      error: { message: 'error', type: 'deepNested' },
+      name: 'test.0.nested.0',
+    });
+  });
 });

--- a/src/__tests__/logic/schemaErrorLookup.test.ts
+++ b/src/__tests__/logic/schemaErrorLookup.test.ts
@@ -251,14 +251,14 @@ describe('errorsLookup', () => {
                 type: 'deepNested',
                 message: 'error',
               },
-            }
+            },
           },
         },
       },
     };
 
     expect(
-      schemaErrorLookup<{test: {nested: {deepNested: string}[]}[]}>(
+      schemaErrorLookup<{ test: { nested: { deepNested: string }[] }[] }>(
         errors,
         {},
         'test.0.nested.1',
@@ -269,14 +269,14 @@ describe('errorsLookup', () => {
     });
 
     expect(
-      schemaErrorLookup<{test: {nested: {deepNested: string}[]}[]}>(
+      schemaErrorLookup<{ test: { nested: { deepNested: string }[] }[] }>(
         errors,
         {},
-        'test.0.nested.0',
+        'test.0.nested.0.deepNested',
       ),
     ).toEqual({
       error: { message: 'error', type: 'deepNested' },
-      name: 'test.0.nested.0',
+      name: 'test.0.nested.0.deepNested',
     });
   });
 });

--- a/src/logic/schemaErrorLookup.ts
+++ b/src/logic/schemaErrorLookup.ts
@@ -37,6 +37,13 @@ export default function schemaErrorLookup<T extends FieldValues = FieldValues>(
       };
     }
 
+    if (foundError && foundError.root && foundError.root.type) {
+      return {
+          name: `${fieldName}.root`,
+          error: foundError.root,
+      }
+  }
+
     names.pop();
   }
 

--- a/src/logic/schemaErrorLookup.ts
+++ b/src/logic/schemaErrorLookup.ts
@@ -39,10 +39,10 @@ export default function schemaErrorLookup<T extends FieldValues = FieldValues>(
 
     if (foundError && foundError.root && foundError.root.type) {
       return {
-          name: `${fieldName}.root`,
-          error: foundError.root,
-      }
-  }
+        name: `${fieldName}.root`,
+        error: foundError.root,
+      };
+    }
 
     names.pop();
   }


### PR DESCRIPTION
When changing a field, particularly arrays, new errors can be created at root or nested root level. These should count as a net new error and should cause an update to the errors object. Currently, if you `compact` an array using something like a yup schema, root errors aren't added to the errors object, even though their children are dirty/changed.

[Here is a CodeSandbox](https://codesandbox.io/p/sandbox/recursing-edison-hmnksj) that demonstrates the behavior I'm trying to fix. If you add whitespace to any of the fields (they're trimmed so whitespace doesn't count), you'll note that the errors are empty. This change would include the root error in the errors object.

This is somewhat of a regression, this used to work before the resolvers made a change to put this errors under the `root` instead of straight on the error object for arrays.