### PR TITLE
Allow resolver output type to truly differ (#11951)

### DIFF
--- a/reports/api-extractor.md
+++ b/reports/api-extractor.md
@@ -35,7 +35,7 @@ export type ChangeHandler = (event: {
 }) => Promise<void | boolean>;
 
 // @public (undocumented)
-export type Control<TFieldValues extends FieldValues = FieldValues, TContext = any> = {
+export type Control<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues> = {
     _subjects: Subjects<TFieldValues>;
     _removeUnmounted: Noop;
     _names: Names;
@@ -45,7 +45,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
         watch: boolean;
     };
     _reset: UseFormReset<TFieldValues>;
-    _options: UseFormProps<TFieldValues, TContext>;
+    _options: UseFormProps<TFieldValues, TContext, TTransformedValues>;
     _getDirty: GetIsDirty;
     _resetDefaultValues: Noop;
     _formState: FormState<TFieldValues>;
@@ -75,7 +75,8 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
     _disableForm: (disabled?: boolean) => void;
     _subscribe: FromSubscribe<TFieldValues>;
     register: UseFormRegister<TFieldValues>;
-    handleSubmit: UseFormHandleSubmit<TFieldValues>;
+    handleSubmit: UseFormHandleSubmit<TFieldValues, TTransformedValues>;
+    _disableForm: (disabled?: boolean) => void;
     unregister: UseFormUnregister<TFieldValues>;
     getFieldState: UseFormGetFieldState<TFieldValues>;
     setError: UseFormSetError<TFieldValues>;
@@ -261,11 +262,11 @@ export type FieldValue<TFieldValues extends FieldValues> = TFieldValues[Internal
 export type FieldValues = Record<string, any>;
 
 // @public
-export function Form<T extends FieldValues, U extends FieldValues | undefined = undefined>(props: FormProps<T, U>): React_2.JSX.Element;
+export function Form<TFieldValues extends FieldValues, TTransformedValues = TFieldValues>(props: FormProps<TFieldValues, TTransformedValues>): React_2.JSX.Element;
 
 // @public (undocumented)
-export type FormProps<TFieldValues extends FieldValues, TTransformedValues extends FieldValues | undefined = undefined> = Omit<React_2.FormHTMLAttributes<HTMLFormElement>, 'onError' | 'onSubmit'> & Partial<{
-    control: Control<TFieldValues>;
+export type FormProps<TFieldValues extends FieldValues, TTransformedValues = TFieldValues> = Omit<React_2.FormHTMLAttributes<HTMLFormElement>, 'onError' | 'onSubmit'> & Partial<{
+    control: Control<TFieldValues, any, TTransformedValues>;
     headers: Record<string, string>;
     validateStatus: (status: number) => boolean;
     onError: ({ response, error, }: {
@@ -278,7 +279,7 @@ export type FormProps<TFieldValues extends FieldValues, TTransformedValues exten
     onSuccess: ({ response }: {
         response: Response;
     }) => void;
-    onSubmit: TTransformedValues extends FieldValues ? FormSubmitHandler<TTransformedValues> : FormSubmitHandler<TFieldValues>;
+    onSubmit: FormSubmitHandler<TTransformedValues>;
     method: 'post' | 'put' | 'delete';
     children: React_2.ReactNode | React_2.ReactNode[];
     render: (props: {
@@ -288,10 +289,10 @@ export type FormProps<TFieldValues extends FieldValues, TTransformedValues exten
 }>;
 
 // @public
-export const FormProvider: <TFieldValues extends FieldValues, TContext = any, TTransformedValues extends FieldValues | undefined = undefined>(props: FormProviderProps<TFieldValues, TContext, TTransformedValues>) => React_2.JSX.Element;
+export const FormProvider: <TFieldValues extends FieldValues, TContext = any, TTransformedValues = TFieldValues>(props: FormProviderProps<TFieldValues, TContext, TTransformedValues>) => React_2.JSX.Element;
 
 // @public (undocumented)
-export type FormProviderProps<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues extends FieldValues | undefined = undefined> = {
+export type FormProviderProps<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues> = {
     children: React_2.ReactNode | React_2.ReactNode[];
 } & UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
@@ -334,8 +335,8 @@ export type FormStateSubjectRef<TFieldValues extends FieldValues> = Subject<Part
 }>;
 
 // @public (undocumented)
-export type FormSubmitHandler<TFieldValues extends FieldValues> = (payload: {
-    data: TFieldValues;
+export type FormSubmitHandler<TTransformedValues> = (payload: {
+    data: TTransformedValues;
     event?: React_2.BaseSyntheticEvent;
     formData: FormData;
     formDataJson: string;
@@ -513,7 +514,7 @@ export type RegisterOptions<TFieldValues extends FieldValues = FieldValues, TFie
 });
 
 // @public (undocumented)
-export type Resolver<TFieldValues extends FieldValues = FieldValues, TContext = any> = (values: TFieldValues, context: TContext | undefined, options: ResolverOptions<TFieldValues>) => Promise<ResolverResult<TFieldValues>> | ResolverResult<TFieldValues>;
+export type Resolver<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues> = (values: TFieldValues, context: TContext | undefined, options: ResolverOptions<TFieldValues>) => Promise<ResolverResult<TFieldValues, TTransformedValues>> | ResolverResult<TFieldValues, TTransformedValues>;
 
 // @public (undocumented)
 export type ResolverError<TFieldValues extends FieldValues = FieldValues> = {
@@ -534,11 +535,11 @@ export interface ResolverOptions<TFieldValues extends FieldValues> {
 }
 
 // @public (undocumented)
-export type ResolverResult<TFieldValues extends FieldValues = FieldValues> = ResolverSuccess<TFieldValues> | ResolverError<TFieldValues>;
+export type ResolverResult<TFieldValues extends FieldValues = FieldValues, TTransformedValues = TFieldValues> = ResolverSuccess<TTransformedValues> | ResolverError<TFieldValues>;
 
 // @public (undocumented)
-export type ResolverSuccess<TFieldValues extends FieldValues = FieldValues> = {
-    values: TFieldValues;
+export type ResolverSuccess<TTransformedValues> = {
+    values: TTransformedValues;
     errors: {};
 };
 
@@ -573,7 +574,7 @@ export type Subjects<TFieldValues extends FieldValues = FieldValues> = {
 export type SubmitErrorHandler<TFieldValues extends FieldValues> = (errors: FieldErrors<TFieldValues>, event?: React_2.BaseSyntheticEvent) => unknown | Promise<unknown>;
 
 // @public (undocumented)
-export type SubmitHandler<TFieldValues extends FieldValues> = (data: TFieldValues, event?: React_2.BaseSyntheticEvent) => unknown | Promise<unknown>;
+export type SubmitHandler<T> = (data: T, event?: React_2.BaseSyntheticEvent) => unknown | Promise<unknown>;
 
 // @public (undocumented)
 export type TriggerConfig = Partial<{
@@ -581,15 +582,15 @@ export type TriggerConfig = Partial<{
 }>;
 
 // @public
-export function useController<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(props: UseControllerProps<TFieldValues, TName>): UseControllerReturn<TFieldValues, TName>;
+export function useController<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>, TTransformedValues = TFieldValues>(props: UseControllerProps<TFieldValues, TName, TTransformedValues>): UseControllerReturn<TFieldValues, TName>;
 
 // @public (undocumented)
-export type UseControllerProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> = {
+export type UseControllerProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>, TTransformedValues = TFieldValues> = {
     name: TName;
     rules?: Omit<RegisterOptions<TFieldValues, TName>, 'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'>;
     shouldUnregister?: boolean;
     defaultValue?: FieldPathValue<TFieldValues, TName>;
-    control?: Control<TFieldValues>;
+    control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
 };
 
@@ -652,13 +653,13 @@ export type UseFieldArraySwap = (indexA: number, indexB: number) => void;
 export type UseFieldArrayUpdate<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (index: number, value: FieldArray<TFieldValues, TFieldArrayName>) => void;
 
 // @public
-export function useForm<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues extends FieldValues | undefined = undefined>(props?: UseFormProps<TFieldValues, TContext>): UseFormReturn<TFieldValues, TContext, TTransformedValues>;
+export function useForm<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues>(props?: UseFormProps<TFieldValues, TContext, TTransformedValues>): UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
 // @public
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | `root.${string}` | 'root') => void;
 
 // @public
-export const useFormContext: <TFieldValues extends FieldValues, TContext = any, TransformedValues extends FieldValues | undefined = undefined>() => UseFormReturn<TFieldValues, TContext, TransformedValues>;
+export const useFormContext: <TFieldValues extends FieldValues, TContext = any, TTransformedValues = undefined>() => UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
 // @public
 export type UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName, formState?: FormState<TFieldValues>) => {
@@ -677,10 +678,10 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
 };
 
 // @public
-export type UseFormHandleSubmit<TFieldValues extends FieldValues, TTransformedValues extends FieldValues | undefined = undefined> = (onValid: TTransformedValues extends undefined ? SubmitHandler<TFieldValues> : TTransformedValues extends FieldValues ? SubmitHandler<TTransformedValues> : never, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
+export type UseFormHandleSubmit<TFieldValues extends FieldValues, TTransformedValues = TFieldValues> = (onValid: SubmitHandler<TTransformedValues>, onInvalid?: SubmitErrorHandler<TFieldValues>) => (e?: React_2.BaseSyntheticEvent) => Promise<void>;
 
 // @public (undocumented)
-export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContext = any> = Partial<{
+export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues> = Partial<{
     mode: Mode;
     disabled: boolean;
     reValidateMode: Exclude<Mode, 'onTouched' | 'all'>;
@@ -688,7 +689,7 @@ export type UseFormProps<TFieldValues extends FieldValues = FieldValues, TContex
     values: TFieldValues;
     errors: FieldErrors<TFieldValues>;
     resetOptions: Parameters<UseFormReset<TFieldValues>>[1];
-    resolver: Resolver<TFieldValues, TContext>;
+    resolver: Resolver<TFieldValues, TContext, TTransformedValues>;
     context: TContext;
     shouldFocusError: boolean;
     shouldUnregister: boolean;
@@ -731,7 +732,7 @@ export type UseFormResetField<TFieldValues extends FieldValues> = <TFieldName ex
 }>) => void;
 
 // @public (undocumented)
-export type UseFormReturn<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues extends FieldValues | undefined = undefined> = {
+export type UseFormReturn<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues> = {
     watch: UseFormWatch<TFieldValues>;
     getValues: UseFormGetValues<TFieldValues>;
     getFieldState: UseFormGetFieldState<TFieldValues>;
@@ -744,7 +745,7 @@ export type UseFormReturn<TFieldValues extends FieldValues = FieldValues, TConte
     reset: UseFormReset<TFieldValues>;
     handleSubmit: UseFormHandleSubmit<TFieldValues, TTransformedValues>;
     unregister: UseFormUnregister<TFieldValues>;
-    control: Control<TFieldValues, TContext>;
+    control: Control<TFieldValues, TContext, TTransformedValues>;
     register: UseFormRegister<TFieldValues>;
     setFocus: UseFormSetFocus<TFieldValues>;
     subscribe: UseFromSubscribe<TFieldValues>;
@@ -762,11 +763,11 @@ export type UseFormSetFocus<TFieldValues extends FieldValues> = <TFieldName exte
 export type UseFormSetValue<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(name: TFieldName, value: FieldPathValue<TFieldValues, TFieldName>, options?: SetValueConfig) => void;
 
 // @public
-export function useFormState<TFieldValues extends FieldValues = FieldValues>(props?: UseFormStateProps<TFieldValues>): UseFormStateReturn<TFieldValues>;
+export function useFormState<TFieldValues extends FieldValues = FieldValues, TTransformedValues = TFieldValues>(props?: UseFormStateProps<TFieldValues, TTransformedValues>): UseFormStateReturn<TFieldValues>;
 
 // @public (undocumented)
-export type UseFormStateProps<TFieldValues extends FieldValues> = Partial<{
-    control?: Control<TFieldValues>;
+export type UseFormStateProps<TFieldValues extends FieldValues, TTransformedValues = TFieldValues> = Partial<{
+    control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
     name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[];
     exact?: boolean;
@@ -804,27 +805,27 @@ export type UseFromSubscribe<TFieldValues extends FieldValues> = (payload: {
 }) => () => void;
 
 // @public
-export function useWatch<TFieldValues extends FieldValues = FieldValues>(props: {
+export function useWatch<TFieldValues extends FieldValues = FieldValues, TTransformedValues = TFieldValues>(props: {
     defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
-    control?: Control<TFieldValues>;
+    control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
     exact?: boolean;
 }): DeepPartialSkipArrayKey<TFieldValues>;
 
 // @public
-export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(props: {
+export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>, TTransformedValues = TFieldValues>(props: {
     name: TFieldName;
     defaultValue?: FieldPathValue<TFieldValues, TFieldName>;
-    control?: Control<TFieldValues>;
+    control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
     exact?: boolean;
 }): FieldPathValue<TFieldValues, TFieldName>;
 
 // @public
-export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldNames extends readonly FieldPath<TFieldValues>[] = readonly FieldPath<TFieldValues>[]>(props: {
+export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldNames extends readonly FieldPath<TFieldValues>[] = readonly FieldPath<TFieldValues>[], TTransformedValues = TFieldValues>(props: {
     name: readonly [...TFieldNames];
     defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
-    control?: Control<TFieldValues>;
+    control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
     exact?: boolean;
 }): FieldPathValues<TFieldValues, TFieldNames>;

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -1639,6 +1639,70 @@ describe('useWatch', () => {
         '333',
       );
     });
+
+    it('should return field value, not resolver transformed value', async () => {
+      const Form = () => {
+        const { control, setValue } = useForm<
+          { test: string },
+          any,
+          { test: number }
+        >({
+          defaultValues: { test: '3' },
+          resolver: ({ test }) => ({
+            values: { test: parseInt(test, 10) },
+            errors: {},
+          }),
+        });
+        const { field } = useController({
+          control,
+          name: 'test',
+        });
+
+        React.useEffect(() => {
+          setValue('test', '9');
+        }, [setValue]);
+
+        return <>{field.value === '9' ? 'yes' : 'no'}</>;
+      };
+
+      render(<Form />);
+
+      await waitFor(() => {
+        screen.getByText('yes');
+      });
+    });
+
+    it('should return field value when resolver transformed value is a different shape', async () => {
+      const Form = () => {
+        const { control, setValue } = useForm<
+          { alpha: string; beta: string },
+          any,
+          { add: number }
+        >({
+          defaultValues: { alpha: '3', beta: '4' },
+          resolver: ({ alpha, beta }) => ({
+            values: { add: parseInt(alpha, 10) + parseInt(beta, 10) },
+            errors: {},
+          }),
+        });
+        const { field } = useController({
+          control,
+          name: 'alpha',
+        });
+
+        React.useEffect(() => {
+          setValue('alpha', '9');
+        }, [setValue]);
+
+        return <>{field.value === '9' ? 'yes' : 'no'}</>;
+      };
+
+      render(<Form />);
+
+      await waitFor(() => {
+        screen.getByText('yes');
+      });
+    });
   });
 
   describe('formContext', () => {

--- a/src/__typetest__/form.test-d.ts
+++ b/src/__typetest__/form.test-d.ts
@@ -27,6 +27,23 @@ import { useForm } from '../useForm';
   }
 }
 
+/** it should infer the correct TTransformedValues from useForm generic */ {
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const { handleSubmit } = useForm<
+    { test: string },
+    unknown,
+    { test: string } | { test1: number }
+  >();
+
+  handleSubmit((data) => {
+    // @ts-expect-error `data` should be union and thus should not be assignable to `{ test: string }`
+    expectType<{ test: string }>(data);
+    // @ts-expect-error `data` should be union and thus should not be assignable to `{ test1: number }`
+    expectType<{ test1: number }>(data);
+    expectType<{ test: string } | { test1: number }>(data);
+  });
+}
+
 /** {@link UseFormGetFieldState} */ {
   /** it should return associated field state */ {
     /* eslint-disable react-hooks/rules-of-hooks */

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -29,10 +29,10 @@ const POST_REQUEST = 'post';
  * ```
  */
 function Form<
-  T extends FieldValues,
-  U extends FieldValues | undefined = undefined,
->(props: FormProps<T, U>) {
-  const methods = useFormContext<T>();
+  TFieldValues extends FieldValues,
+  TTransformedValues = TFieldValues,
+>(props: FormProps<TFieldValues, TTransformedValues>) {
+  const methods = useFormContext<TFieldValues, any, TTransformedValues>();
   const [mounted, setMounted] = React.useState(false);
   const {
     control = methods.control,

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -97,6 +97,7 @@ const defaultOptions = {
 export function createFormControl<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
+  TTransformedValues = TFieldValues,
 >(
   props: UseFormProps<TFieldValues, TContext> = {},
 ): Omit<UseFormReturn<TFieldValues, TContext>, 'formState'> & {
@@ -1201,15 +1202,15 @@ export function createFormControl<
     }
   };
 
-  const handleSubmit: UseFormHandleSubmit<TFieldValues> =
+  const handleSubmit: UseFormHandleSubmit<TFieldValues, TTransformedValues> =
     (onValid, onInvalid) => async (e) => {
       let onValidError = undefined;
       if (e) {
         e.preventDefault && e.preventDefault();
         e.persist && e.persist();
       }
-
-      let fieldValues = cloneObject(_formValues);
+      let fieldValues: TFieldValues | TTransformedValues | {} =
+        cloneObject(_formValues);
 
       _subjects.state.next({
         isSubmitting: true,
@@ -1236,7 +1237,7 @@ export function createFormControl<
           errors: {},
         });
         try {
-          await onValid(fieldValues as TFieldValues, e);
+          await onValid(fieldValues as TTransformedValues, e);
         } catch (error) {
           onValidError = error;
         }

--- a/src/logic/getProxyFormState.ts
+++ b/src/logic/getProxyFormState.ts
@@ -1,9 +1,13 @@
 import { VALIDATION_MODE } from '../constants';
 import { Control, FieldValues, FormState, ReadFormState } from '../types';
 
-export default <TFieldValues extends FieldValues, TContext = any>(
+export default <
+  TFieldValues extends FieldValues,
+  TContext = any,
+  TTransformedValues = TFieldValues,
+>(
   formState: FormState<TFieldValues>,
-  control: Control<TFieldValues, TContext>,
+  control: Control<TFieldValues, TContext, TTransformedValues>,
   localProxyFormState?: ReadFormState,
   isRoot = true,
 ) => {

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -35,6 +35,7 @@ export type ControllerRenderProps<
 export type UseControllerProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TTransformedValues = TFieldValues,
 > = {
   name: TName;
   rules?: Omit<
@@ -43,7 +44,7 @@ export type UseControllerProps<
   >;
   shouldUnregister?: boolean;
   defaultValue?: FieldPathValue<TFieldValues, TName>;
-  control?: Control<TFieldValues>;
+  control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
 };
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -53,13 +53,13 @@ export type ValidationModeFlags = {
 
 export type CriteriaMode = 'firstError' | 'all';
 
-export type SubmitHandler<TFieldValues extends FieldValues> = (
-  data: TFieldValues,
+export type SubmitHandler<T> = (
+  data: T,
   event?: React.BaseSyntheticEvent,
 ) => unknown | Promise<unknown>;
 
-export type FormSubmitHandler<TFieldValues extends FieldValues> = (payload: {
-  data: TFieldValues;
+export type FormSubmitHandler<TTransformedValues> = (payload: {
+  data: TTransformedValues;
   event?: React.BaseSyntheticEvent;
   formData: FormData;
   formDataJson: string;
@@ -95,6 +95,7 @@ type AsyncDefaultValues<TFieldValues> = (
 export type UseFormProps<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
+  TTransformedValues = TFieldValues,
 > = Partial<{
   mode: Mode;
   disabled: boolean;
@@ -103,7 +104,7 @@ export type UseFormProps<
   values: TFieldValues;
   errors: FieldErrors<TFieldValues>;
   resetOptions: Parameters<UseFormReset<TFieldValues>>[1];
-  resolver: Resolver<TFieldValues, TContext>;
+  resolver: Resolver<TFieldValues, TContext, TTransformedValues>;
   context: TContext;
   shouldFocusError: boolean;
   shouldUnregister: boolean;
@@ -644,7 +645,7 @@ export type UseFormUnregister<TFieldValues extends FieldValues> = (
  */
 export type UseFormHandleSubmit<
   TFieldValues extends FieldValues,
-  TTransformedValues extends FieldValues | undefined = undefined,
+  TTransformedValues = TFieldValues,
 > = (
   onValid: TTransformedValues extends undefined
     ? SubmitHandler<TFieldValues>
@@ -797,6 +798,7 @@ export type FromSubscribe<TFieldValues extends FieldValues> = (payload: {
 export type Control<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
+  TTransformedValues = TFieldValues,
 > = {
   _subjects: Subjects<TFieldValues>;
   _removeUnmounted: Noop;
@@ -807,7 +809,7 @@ export type Control<
     watch: boolean;
   };
   _reset: UseFormReset<TFieldValues>;
-  _options: UseFormProps<TFieldValues, TContext>;
+  _options: UseFormProps<TFieldValues, TContext, TTransformedValues>;
   _getDirty: GetIsDirty;
   _resetDefaultValues: Noop;
   _formState: FormState<TFieldValues>;
@@ -830,7 +832,7 @@ export type Control<
   _disableForm: (disabled?: boolean) => void;
   _subscribe: FromSubscribe<TFieldValues>;
   register: UseFormRegister<TFieldValues>;
-  handleSubmit: UseFormHandleSubmit<TFieldValues>;
+  handleSubmit: UseFormHandleSubmit<TFieldValues, TTransformedValues>;
   unregister: UseFormUnregister<TFieldValues>;
   getFieldState: UseFormGetFieldState<TFieldValues>;
   setError: UseFormSetError<TFieldValues>;
@@ -848,7 +850,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (
 export type UseFormReturn<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
-  TTransformedValues extends FieldValues | undefined = undefined,
+  TTransformedValues = TFieldValues,
 > = {
   watch: UseFormWatch<TFieldValues>;
   getValues: UseFormGetValues<TFieldValues>;
@@ -862,14 +864,17 @@ export type UseFormReturn<
   reset: UseFormReset<TFieldValues>;
   handleSubmit: UseFormHandleSubmit<TFieldValues, TTransformedValues>;
   unregister: UseFormUnregister<TFieldValues>;
-  control: Control<TFieldValues, TContext>;
+  control: Control<TFieldValues, TContext, TTransformedValues>;
   register: UseFormRegister<TFieldValues>;
   setFocus: UseFormSetFocus<TFieldValues>;
   subscribe: UseFromSubscribe<TFieldValues>;
 };
 
-export type UseFormStateProps<TFieldValues extends FieldValues> = Partial<{
-  control?: Control<TFieldValues>;
+export type UseFormStateProps<
+  TFieldValues extends FieldValues,
+  TTransformedValues = TFieldValues,
+> = Partial<{
+  control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
   name?:
     | FieldPath<TFieldValues>
@@ -895,17 +900,17 @@ export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
 export type FormProviderProps<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
-  TTransformedValues extends FieldValues | undefined = undefined,
+  TTransformedValues = TFieldValues,
 > = {
   children: React.ReactNode | React.ReactNode[];
 } & UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
 export type FormProps<
   TFieldValues extends FieldValues,
-  TTransformedValues extends FieldValues | undefined = undefined,
+  TTransformedValues = TFieldValues,
 > = Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onError' | 'onSubmit'> &
   Partial<{
-    control: Control<TFieldValues>;
+    control: Control<TFieldValues, any, TTransformedValues>;
     headers: Record<string, string>;
     validateStatus: (status: number) => boolean;
     onError: ({
@@ -921,9 +926,7 @@ export type FormProps<
           error: unknown;
         }) => void;
     onSuccess: ({ response }: { response: Response }) => void;
-    onSubmit: TTransformedValues extends FieldValues
-      ? FormSubmitHandler<TTransformedValues>
-      : FormSubmitHandler<TFieldValues>;
+    onSubmit: FormSubmitHandler<TTransformedValues>;
     method: 'post' | 'put' | 'delete';
     children: React.ReactNode | React.ReactNode[];
     render: (props: {

--- a/src/types/resolvers.ts
+++ b/src/types/resolvers.ts
@@ -2,8 +2,8 @@ import { FieldErrors } from './errors';
 import { Field, FieldName, FieldValues, InternalFieldName } from './fields';
 import { CriteriaMode } from './form';
 
-export type ResolverSuccess<TFieldValues extends FieldValues = FieldValues> = {
-  values: TFieldValues;
+export type ResolverSuccess<TTransformedValues> = {
+  values: TTransformedValues;
   errors: {};
 };
 
@@ -12,9 +12,10 @@ export type ResolverError<TFieldValues extends FieldValues = FieldValues> = {
   errors: FieldErrors<TFieldValues>;
 };
 
-export type ResolverResult<TFieldValues extends FieldValues = FieldValues> =
-  | ResolverSuccess<TFieldValues>
-  | ResolverError<TFieldValues>;
+export type ResolverResult<
+  TFieldValues extends FieldValues = FieldValues,
+  TTransformedValues = TFieldValues,
+> = ResolverSuccess<TTransformedValues> | ResolverError<TFieldValues>;
 
 export interface ResolverOptions<TFieldValues extends FieldValues> {
   criteriaMode?: CriteriaMode;
@@ -26,8 +27,11 @@ export interface ResolverOptions<TFieldValues extends FieldValues> {
 export type Resolver<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
+  TTransformedValues = TFieldValues,
 > = (
   values: TFieldValues,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,
-) => Promise<ResolverResult<TFieldValues>> | ResolverResult<TFieldValues>;
+) =>
+  | Promise<ResolverResult<TFieldValues, TTransformedValues>>
+  | ResolverResult<TFieldValues, TTransformedValues>;

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -49,10 +49,11 @@ import { useWatch } from './useWatch';
 export function useController<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TTransformedValues = TFieldValues,
 >(
-  props: UseControllerProps<TFieldValues, TName>,
+  props: UseControllerProps<TFieldValues, TName, TTransformedValues>,
 ): UseControllerReturn<TFieldValues, TName> {
-  const methods = useFormContext<TFieldValues>();
+  const methods = useFormContext<TFieldValues, any, TTransformedValues>();
   const { name, disabled, control = methods.control, shouldUnregister } = props;
   const isArrayField = isNameInFieldArray(control._names.array, name);
   const value = useWatch({

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -39,9 +39,9 @@ import { FieldValues, FormState, UseFormProps, UseFormReturn } from './types';
 export function useForm<
   TFieldValues extends FieldValues = FieldValues,
   TContext = any,
-  TTransformedValues extends FieldValues | undefined = undefined,
+  TTransformedValues = TFieldValues,
 >(
-  props: UseFormProps<TFieldValues, TContext> = {},
+  props: UseFormProps<TFieldValues, TContext, TTransformedValues> = {},
 ): UseFormReturn<TFieldValues, TContext, TTransformedValues> {
   const _formControl = React.useRef<
     UseFormReturn<TFieldValues, TContext, TTransformedValues> | undefined

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -37,12 +37,12 @@ const HookFormContext = React.createContext<UseFormReturn | null>(null);
 export const useFormContext = <
   TFieldValues extends FieldValues,
   TContext = any,
-  TransformedValues extends FieldValues | undefined = undefined,
->(): UseFormReturn<TFieldValues, TContext, TransformedValues> =>
+  TTransformedValues = undefined,
+>(): UseFormReturn<TFieldValues, TContext, TTransformedValues> =>
   React.useContext(HookFormContext) as UseFormReturn<
     TFieldValues,
     TContext,
-    TransformedValues
+    TTransformedValues
   >;
 
 /**
@@ -78,7 +78,7 @@ export const useFormContext = <
 export const FormProvider = <
   TFieldValues extends FieldValues,
   TContext = any,
-  TTransformedValues extends FieldValues | undefined = undefined,
+  TTransformedValues = TFieldValues,
 >(
   props: FormProviderProps<TFieldValues, TContext, TTransformedValues>,
 ) => {

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -39,10 +39,13 @@ import { useFormContext } from './useFormContext';
  * }
  * ```
  */
-function useFormState<TFieldValues extends FieldValues = FieldValues>(
-  props?: UseFormStateProps<TFieldValues>,
+function useFormState<
+  TFieldValues extends FieldValues = FieldValues,
+  TTransformedValues = TFieldValues,
+>(
+  props?: UseFormStateProps<TFieldValues, TTransformedValues>,
 ): UseFormStateReturn<TFieldValues> {
-  const methods = useFormContext<TFieldValues>();
+  const methods = useFormContext<TFieldValues, any, TTransformedValues>();
   const { control = methods.control, disabled, name, exact } = props || {};
   const [formState, updateFormState] = React.useState(control._formState);
   const _localProxyFormState = React.useRef({

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -36,9 +36,10 @@ import { useFormContext } from './useFormContext';
  */
 export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
+  TTransformedValues = TFieldValues,
 >(props: {
   defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
-  control?: Control<TFieldValues>;
+  control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
   exact?: boolean;
 }): DeepPartialSkipArrayKey<TFieldValues>;
@@ -65,10 +66,11 @@ export function useWatch<
 export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TTransformedValues = TFieldValues,
 >(props: {
   name: TFieldName;
   defaultValue?: FieldPathValue<TFieldValues, TFieldName>;
-  control?: Control<TFieldValues>;
+  control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
   exact?: boolean;
 }): FieldPathValue<TFieldValues, TFieldName>;
@@ -97,12 +99,12 @@ export function useWatch<
  */
 export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
-  TFieldNames extends
-    readonly FieldPath<TFieldValues>[] = readonly FieldPath<TFieldValues>[],
+  TFieldNames extends readonly FieldPath<TFieldValues>[] = readonly FieldPath<TFieldValues>[],
+  TTransformedValues = TFieldValues,
 >(props: {
   name: readonly [...TFieldNames];
   defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
-  control?: Control<TFieldValues>;
+  control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
   exact?: boolean;
 }): FieldPathValues<TFieldValues, TFieldNames>;


### PR DESCRIPTION
* Default TTransformedValues to TFieldValues without constraint

This allows for resolvers to parse to a different type that doesn't have to have the same shape as TFieldValues.

This commit contains type-only changes. No runtime changes are introduced.

* Tests for TTransformedValues change

Test that `useWatch` returns `TFieldValues` values, not `TTransformedValues` ones.

Test that `TTransformedValues` are submitted on success and `TFieldValues` on failure.

* Add type test for useForm inference

From: https://github.com/react-hook-form/react-hook-form/pull/11913/files

---------