### PR TITLE
Allow components with `useController` hook be memoized

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -124,7 +124,7 @@ export function createFormControl<
   let _fields: FieldRefs = {};
   let _defaultValues =
     isObject(_options.defaultValues) || isObject(_options.values)
-      ? cloneObject(_options.defaultValues || _options.values) || {}
+      ? cloneObject(_options.values || _options.defaultValues) || {}
       : {};
   let _formValues = _options.shouldUnregister
     ? ({} as TFieldValues)

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -46,7 +46,7 @@ export function useForm<
   const _formControl = React.useRef<
     UseFormReturn<TFieldValues, TContext, TTransformedValues> | undefined
   >(undefined);
-  const _values = React.useRef<typeof props.values>(undefined);
+  const _values = React.useRef<typeof props.values>(props.values);
   const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
     isDirty: false,
     isValidating: false,


### PR DESCRIPTION
Resolves https://github.com/react-hook-form/react-hook-form/issues/12634 .

It appeared that the actual problem was that the component had set its' `values` right after the first render, causing all fields to be unregistered. 

Without memo, the fields would get registered on the consecutive render - but it doesn't happen here, as the individual controls don't get rerendered, if they are memoized.