### PR TITLE
🐞 fix #12580 setError in useEffect does not work when used inside the FormProvider context

### DIFF
--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -2609,9 +2609,9 @@ describe('useFieldArray', () => {
           names: [{ name: 'will' }, { name: 'Mike' }],
         },
       });
-      const { setValue } = methods;
+      const { setValue, watch } = methods;
 
-      result.push(methods.watch());
+      result.push(watch());
 
       return (
         <form>
@@ -2657,6 +2657,16 @@ describe('useFieldArray', () => {
 
     // Let's check all values of renders with implicitly the number of render (for each value)
     expect(result).toEqual([
+      {
+        names: [
+          {
+            name: 'will',
+          },
+          {
+            name: 'Mike',
+          },
+        ],
+      },
       {
         names: [
           {
@@ -2753,6 +2763,16 @@ describe('useFieldArray', () => {
 
     // Let's check all values of renders with implicitly the number of render (for each value)
     expect(watchedValues).toEqual([
+      {
+        test: [
+          {
+            value: 'test',
+          },
+          {
+            value: 'test1',
+          },
+        ],
+      },
       {
         test: [
           {

--- a/src/__tests__/useForm/setError.test.tsx
+++ b/src/__tests__/useForm/setError.test.tsx
@@ -10,6 +10,7 @@ import {
 
 import { DeepMap, ErrorOption, FieldError, GlobalError } from '../../types';
 import { useForm } from '../../useForm';
+import { FormProvider, useFormContext } from '../../useFormContext';
 
 describe('setError', () => {
   const tests: [string, ErrorOption, DeepMap<any, FieldError>][] = [
@@ -256,5 +257,51 @@ describe('setError', () => {
         },
       },
     });
+  });
+});
+
+it('should update error state in FormProvider when setError is called in useEffect', async () => {
+  type FormValues = {
+    firstname: string;
+    lastname: string;
+  };
+
+  const MyForm = () => {
+    const {
+      register,
+      setError,
+      formState: { errors },
+    } = useFormContext<FormValues>();
+
+    React.useEffect(() => {
+      setError('firstname', { type: 'manual', message: 'This is an error' });
+    }, [setError]);
+
+    return (
+      <form>
+        <div>
+          <input {...register('firstname')} placeholder="firstname" />
+          {errors.firstname && <p>{errors.firstname.message}</p>}
+        </div>
+        <div>
+          <input {...register('lastname')} placeholder="lastname" />
+        </div>
+      </form>
+    );
+  };
+
+  const App = () => {
+    const methods = useForm<FormValues>();
+    return (
+      <FormProvider {...methods}>
+        <MyForm />
+      </FormProvider>
+    );
+  };
+
+  render(<App />);
+
+  await waitFor(() => {
+    expect(screen.getByText('This is an error')).toBeInTheDocument();
   });
 });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -75,7 +75,7 @@ export function useForm<
   const control = _formControl.current.control;
   control._options = props;
 
-  React.useEffect(
+  React.useLayoutEffect(
     () =>
       control._subscribe({
         formState: control._proxyFormState,


### PR DESCRIPTION
to resolve #12632 

Hello. I have created this PR to fix the issue related to setError. I learned a lot by following the subscribe flow to identify the cause. 😁 Detailed information is provided below.

### Issue
setError in useEffect does not work when used inside the FormProvider context

### Cause
**The `observer` is registered too late, so when `setError` attempts to call the observers in the list, the list is empty.** As a result, if you delay the timing using `requestAnimationFrame` or `setTimeout`, it works correctly. however, if we do not use such special techniques, the error is not registered.

### Solution
I considered two solutions:

1. Register the `observer` faster than the current implementation.
2. Delay the execution timing of `setError`.

From a user experience perspective, I believe that `option 1` is more advantageous, so I applied the approach of using `useLayoutEffect` instead of `useEffect` to register faster than before.

### Changes
- Changed the execution timing of `control._subscribe` by using `useLayoutEffect` instead of useEffect.
- Modified the test cases in `useFieldArray.test.ts` accordingly.
- Added a new test case that reproduces this issue.

Thank you.