### PR TITLE
chore: update prettier configuration and apply formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,13 @@
+# Exclude paths
 /reports
+dist
+pnpm-lock.yaml
+# Exclude README related files and trigger files
+README.md
+README.*
+*.README.*
+.github/workflows/README.yml
+scripts/README/**
+docs/Helpers.yaml
+docs/Sponsors.yaml
+docs/Template.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ appearance, race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Our Responsibilities
 

--- a/app/index.html
+++ b/app/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,13 +4,23 @@ import tseslint from 'typescript-eslint';
 import reactPlugin from 'eslint-plugin-react';
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import pluginCypress from 'eslint-plugin-cypress/flat';
-import reactHookPlugin from "eslint-plugin-react-hooks";
-import simpleImportSort from "eslint-plugin-simple-import-sort";
+import reactHookPlugin from 'eslint-plugin-react-hooks';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import { fixupPluginRules } from '@eslint/compat';
 
 export default tseslint.config(
   {
-    ignores: ["app", "examples", "node_modules", "dist", "coverage", "src/types/global.d.ts","!.*.js", "reports", "scripts/README"],
+    ignores: [
+      'app',
+      'examples',
+      'node_modules',
+      'dist',
+      'coverage',
+      'src/types/global.d.ts',
+      '!.*.js',
+      'reports',
+      'scripts/README',
+    ],
   },
   reactPlugin.configs.flat.recommended,
   ...tseslint.configs.recommended,
@@ -19,7 +29,7 @@ export default tseslint.config(
   {
     plugins: {
       'react-hooks': fixupPluginRules(reactHookPlugin),
-      "simple-import-sort": simpleImportSort
+      'simple-import-sort': simpleImportSort,
     },
     languageOptions: {
       ecmaVersion: 2020,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "postbuild": "rimraf dist/__tests__ && node ./scripts/rollup/assert-esm-exports.mjs && node ./scripts/rollup/assert-cjs-exports.cjs",
     "build:modern": "rollup --bundleConfigAsCjs -c ./scripts/rollup/rollup.config.js",
     "build:esm": "rollup --bundleConfigAsCjs -c ./scripts/rollup/rollup.esm.config.js",
-    "prettier:fix": "prettier --config .prettierrc --write \"**/*.{js,ts,tsx,css}\"",
+    "prettier:fix": "prettier --config .prettierrc --write .",
     "lint": "eslint '**/*.{js,ts,tsx}'",
     "lint:fix": "pnpm lint --fix",
     "type": "tsc --noEmit",

--- a/scripts/rollup/assert-esm-exports.mjs
+++ b/scripts/rollup/assert-esm-exports.mjs
@@ -10,17 +10,14 @@ import fs from 'fs';
 import path from 'path';
 import url from 'url';
 
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 /**
  * A shell one-liner to update this array when neccessary (run from root of repo):
  *  node -e "import('react-hook-form').then((mod) => console.log(JSON.stringify(Object.keys(mod), null, 2)))" > scripts/rollup/all-exports.json
  */
 const expected = JSON.parse(
-  fs.readFileSync(
-    path.resolve(__dirname, './all-exports.json'),
-    'utf-8',
-  ),
+  fs.readFileSync(path.resolve(__dirname, './all-exports.json'), 'utf-8'),
 );
 
 assert.deepStrictEqual(Object.keys(exported), expected);


### PR DESCRIPTION
Improved the scope of code formatting in the project. Previously, Prettier was only applied to JS and TS files, but now it has been modified to apply consistent styling to various file formats including Markdown, YAML, HTML, and more. To achieve this, I updated the Prettier configuration and applied it, resulting in formatting changes to the following files:

CODE_OF_CONDUCT.md
eslint.config.mjs
index.html
assert-esm-exports.mjs

This change enhances the overall consistency of the project.

Additionally, I've excluded README-related files and their associated configuration files from Prettier formatting by adding them to .prettierignore. This was necessary to prevent build errors that were occurring with the automated README generation workflow.
If there are any files in the .prettierignore that you believe could be safely removed from the ignore list, please let me know, and I can provide those filenames.

I couldn't determine the exact intention behind the feedback "could you revert the readme change?" - whether it meant to revert changes to Sponsors.yaml specifically or to avoid modifying README files altogether. For now, I've excluded all README-related files from Prettier formatting to prevent any potential conflicts with the automated README generation workflow. If you have a better approach in mind, please let me know, and I'd be happy to make the necessary adjustments.