### PR TITLE
fix(createFormControl): don't unregister fields on reset

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "disableOptimisticBPs": true,
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "pnpm",
-      "args": ["test", "--", "--runInBand", "--watchAll=false"]
+      "args": ["test", "--runInBand", "--watchAll=false"]
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "source.fixAll.eslint": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "jest.jestCommandLine": "pnpm test --",
+  "jest.jestCommandLine": "pnpm test",
   "jest.autoRun": {
     "watch": false,
     "onSave": "test-file",

--- a/src/__tests__/useForm/watch.test.tsx
+++ b/src/__tests__/useForm/watch.test.tsx
@@ -510,7 +510,17 @@ describe('watch', () => {
 
     expect(await screen.findByText('1234')).toBeVisible();
 
-    expect(watchedData).toEqual([{}, {}, { test: '1234' }]);
+    expect(watchedData).toEqual([
+      {},
+      {
+        test: '1234',
+        data: '1234',
+      },
+      {
+        test: '1234',
+        data: '1234',
+      },
+    ]);
   });
 
   it('should not be able to overwrite global watch state', () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -121,7 +121,7 @@ export function createFormControl<
     errors: _options.errors || {},
     disabled: _options.disabled || false,
   };
-  let _fields: FieldRefs = {};
+  const _fields: FieldRefs = {};
   let _defaultValues =
     isObject(_options.defaultValues) || isObject(_options.values)
       ? cloneObject(_options.values || _options.defaultValues) || {}
@@ -1340,14 +1340,15 @@ export function createFormControl<
           }
         }
 
-        _fields = {};
+        for (const fieldName of _names.mount) {
+          setValue(
+            fieldName as FieldPath<TFieldValues>,
+            get(values, fieldName),
+          );
+        }
       }
 
-      _formValues = _options.shouldUnregister
-        ? keepStateOptions.keepDefaultValues
-          ? (cloneObject(_defaultValues) as TFieldValues)
-          : ({} as TFieldValues)
-        : (cloneObject(values) as TFieldValues);
+      _formValues = cloneObject(values) as TFieldValues;
 
       _subjects.array.next({
         values: { ...values },


### PR DESCRIPTION
After https://github.com/react-hook-form/react-hook-form/pull/12635 , unfortunately in my app an issue similar to https://github.com/react-hook-form/react-hook-form/issues/12634 is still existing.

After further debugging, it appeared that [this line](https://github.com/react-hook-form/react-hook-form/blob/master/src/logic/createFormControl.ts#L1343) is the cause. In some scenarios, when form values are reset, fields seem to behave as if they were unregistered, even if they component haven't been dismounted.

And assuming that the child components (which call the `useController` hook) don't get rerendered after this (which can happen, if they are memoized using react's `memo` or `useMemo` functions), then the controls won't get reregistered.

Causing the existing controls to still appear in the DOM, but e.g. their `onChange` will do nothing when being called.

This PR fixes this - instead of completely clearing the internal `_fields` object, it just resets the values of currently registered (mounted) fields.