### PR TITLE
Fix TTransformedValues inference for #12638

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -654,10 +654,8 @@ export type UseFieldArraySwap = (indexA: number, indexB: number) => void;
 // @public
 export type UseFieldArrayUpdate<TFieldValues extends FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = (index: number, value: FieldArray<TFieldValues, TFieldArrayName>) => void;
 
-// Warning: (ae-forgotten-export) The symbol "ExtractTransformedValues" needs to be exported by the entry point index.d.ts
-//
 // @public
-export function useForm<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues>(props?: UseFormProps<TFieldValues, TContext, TTransformedValues>): UseFormReturn<TFieldValues, TContext, ExtractTransformedValues<(typeof props)['resolver'], TTransformedValues>>;
+export function useForm<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues>(props?: UseFormProps<TFieldValues, TContext, TTransformedValues>): UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
 // @public
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | `root.${string}` | 'root') => void;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -5,18 +5,7 @@ import getProxyFormState from './logic/getProxyFormState';
 import deepEqual from './utils/deepEqual';
 import isEmptyObject from './utils/isEmptyObject';
 import isFunction from './utils/isFunction';
-import {
-  FieldValues,
-  FormState,
-  Resolver,
-  UseFormProps,
-  UseFormReturn,
-} from './types';
-
-type ExtractTransformedValues<R, Default> =
-  R extends Resolver<any, any, infer TResolvedValues>
-    ? TResolvedValues
-    : Default;
+import { FieldValues, FormState, UseFormProps, UseFormReturn } from './types';
 
 /**
  * Custom hook to manage the entire form.
@@ -53,18 +42,9 @@ export function useForm<
   TTransformedValues = TFieldValues,
 >(
   props: UseFormProps<TFieldValues, TContext, TTransformedValues> = {},
-): UseFormReturn<
-  TFieldValues,
-  TContext,
-  ExtractTransformedValues<(typeof props)['resolver'], TTransformedValues>
-> {
+): UseFormReturn<TFieldValues, TContext, TTransformedValues> {
   const _formControl = React.useRef<
-    | UseFormReturn<
-        TFieldValues,
-        TContext,
-        ExtractTransformedValues<(typeof props)['resolver'], TTransformedValues>
-      >
-    | undefined
+    UseFormReturn<TFieldValues, TContext, TTransformedValues> | undefined
   >(undefined);
   const _values = React.useRef<typeof props.values>(undefined);
   const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({


### PR DESCRIPTION
cc @jorisre 

fixes types as part of #12638 

## Why

- Using ExtractTransformedValues<> from `(typeof props)['resolver']` does not work because within the implementation signature, the value in `typeof props` does not capture any specific type information that is not a part of the `useForm` function’s generic type parameters. 
- Since `useForm` is only generic over TFieldValues/TContext/TTransformedValues, there is no type information to be gained from `(typeof props)['resolver']` because the compiler will *never* see the type `(typeof props)['resolver']` as anything more specific than `Resolver<TFieldValues, TContext, TTransformedValues>`.
- Therefore, we should just use TTransformedValues
    - The compiler already checks that the type of `resolver` matches TTransformedValues
    - moreover, the compiler can already *infer* the type of TTransformedValues based on the type of `props.resolver`, without using the broken ExtractTransformedValues type helper


## Effect

This PR fixes the broken types in the `handleSubmit` tests in https://github.com/react-hook-form/resolvers/pull/753

Before, `form` is erroneously inferred with a TTransformedValues parameter of `any`, and the test fails
<img width="921" alt="Screenshot 2025-03-06 at 1 21 19 PM" src="https://github.com/user-attachments/assets/b0a5e968-6ffd-4e95-968a-f7e107a49e03" />

After, `form` infers the correct type for TTransformedValues and there is no type error; the test passes
<img width="1009" alt="Screenshot 2025-03-06 at 1 23 15 PM" src="https://github.com/user-attachments/assets/e85932ab-dbd5-4333-860f-463ca4fa92d9" />