### PR TITLE
fix(useForm): make `values` and `defaultValues` work correctly with `createFormControl` and `useMemo`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "disableOptimisticBPs": true,
       "cwd": "${workspaceFolder}",
       "runtimeExecutable": "pnpm",
-      "args": ["test", "--", "--runInBand", "--watchAll=false"]
+      "args": ["test", "--runInBand", "--watchAll=false"]
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "source.fixAll.eslint": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "jest.jestCommandLine": "pnpm test --",
+  "jest.jestCommandLine": "pnpm test",
   "jest.autoRun": {
     "watch": false,
     "onSave": "test-file",

--- a/src/__tests__/useForm/watch.test.tsx
+++ b/src/__tests__/useForm/watch.test.tsx
@@ -510,7 +510,17 @@ describe('watch', () => {
 
     expect(await screen.findByText('1234')).toBeVisible();
 
-    expect(watchedData).toEqual([{}, {}, { test: '1234' }]);
+    expect(watchedData).toEqual([
+      {},
+      {
+        test: '1234',
+        data: '1234',
+      },
+      {
+        test: '1234',
+        data: '1234',
+      },
+    ]);
   });
 
   it('should not be able to overwrite global watch state', () => {

--- a/src/__tests__/useFormState.test.tsx
+++ b/src/__tests__/useFormState.test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { Controller } from '../controller';
@@ -810,13 +810,7 @@ describe('useFormState', () => {
     }
 
     function App() {
-      const [values, setValues] = React.useState({ firstName: '' });
-
-      useEffect(() => {
-        setValues({ firstName: 'test' });
-      }, [setValues]);
-
-      return <Form values={values} />;
+      return <Form values={{ firstName: 'test' }} />;
     }
 
     render(<App />);

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -121,7 +121,7 @@ export function createFormControl<
     errors: _options.errors || {},
     disabled: _options.disabled || false,
   };
-  let _fields: FieldRefs = {};
+  const _fields: FieldRefs = {};
   let _defaultValues =
     isObject(_options.defaultValues) || isObject(_options.values)
       ? cloneObject(_options.values || _options.defaultValues) || {}
@@ -1340,14 +1340,15 @@ export function createFormControl<
           }
         }
 
-        _fields = {};
+        for (const fieldName of _names.mount) {
+          setValue(
+            fieldName as FieldPath<TFieldValues>,
+            get(values, fieldName),
+          );
+        }
       }
 
-      _formValues = _options.shouldUnregister
-        ? keepStateOptions.keepDefaultValues
-          ? (cloneObject(_defaultValues) as TFieldValues)
-          : ({} as TFieldValues)
-        : (cloneObject(values) as TFieldValues);
+      _formValues = cloneObject(values) as TFieldValues;
 
       _subjects.array.next({
         values: { ...values },

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -124,7 +124,7 @@ export function createFormControl<
   let _fields: FieldRefs = {};
   let _defaultValues =
     isObject(_options.defaultValues) || isObject(_options.values)
-      ? cloneObject(_options.defaultValues || _options.values) || {}
+      ? cloneObject(_options.values || _options.defaultValues) || {}
       : {};
   let _formValues = _options.shouldUnregister
     ? ({} as TFieldValues)

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -46,7 +46,7 @@ export function useForm<
   const _formControl = React.useRef<
     UseFormReturn<TFieldValues, TContext, TTransformedValues> | undefined
   >(undefined);
-  const _values = React.useRef<typeof props.values>(props.values);
+  const _values = React.useRef<typeof props.values>(undefined);
   const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
     isDirty: false,
     isValidating: false,
@@ -71,6 +71,14 @@ export function useForm<
       ...(props.formControl ? props.formControl : createFormControl(props)),
       formState,
     };
+
+    if (
+      props.formControl &&
+      props.defaultValues &&
+      !isFunction(props.defaultValues)
+    ) {
+      props.formControl.reset(props.defaultValues, props.resetOptions);
+    }
   }
 
   const control = _formControl.current.control;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -46,7 +46,7 @@ export function useForm<
   const _formControl = React.useRef<
     UseFormReturn<TFieldValues, TContext, TTransformedValues> | undefined
   >(undefined);
-  const _values = React.useRef<typeof props.values>(undefined);
+  const _values = React.useRef<typeof props.values>(props.values);
   const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
     isDirty: false,
     isValidating: false,


### PR DESCRIPTION
1. Brings back test scenarios added in https://github.com/react-hook-form/react-hook-form/issues/12634 but removed in https://github.com/react-hook-form/react-hook-form/commit/ef80ff677c548aa67d1b9d6186a556057f8c0477 and https://github.com/react-hook-form/react-hook-form/commit/d9e7e4d8efcf1715fee580b198cdc8bc701c3f8a
2. Adds test scenario added in https://github.com/react-hook-form/react-hook-form/pull/12652
3. Adds test scenario for an issue found in #12665
4. Adds fixes to `useForm` and `createFormControl` so that all above test scenarios pass
5. Fixes test debugging with VS Code 