### PR TITLE
Fix #12655: Unmounted Clean Nested Field Incorrectly Update On Reset with keepDirtyValues

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -72,6 +72,7 @@ import getDirtyFields from './getDirtyFields';
 import getEventValue from './getEventValue';
 import getFieldValue from './getFieldValue';
 import getFieldValueAs from './getFieldValueAs';
+import getNestedLeafKeys from './getNestedLeafKeys';
 import getResolverOptions from './getResolverOptions';
 import getRuleValue from './getRuleValue';
 import getValidationModes from './getValidationModes';
@@ -1310,7 +1311,7 @@ export function createFormControl<
       if (keepStateOptions.keepDirtyValues) {
         const fieldsToCheck = new Set([
           ..._names.mount,
-          ...Object.keys(getDirtyFields(_defaultValues, _formValues)),
+          ...getNestedLeafKeys(getDirtyFields(_defaultValues, _formValues)),
         ]);
         for (const fieldName of Array.from(fieldsToCheck)) {
           get(_formState.dirtyFields, fieldName)

--- a/src/logic/getNestedLeafKeys.ts
+++ b/src/logic/getNestedLeafKeys.ts
@@ -1,0 +1,27 @@
+export default function getNestedLeafKeys(obj: any, prefix = ''): string[] {
+  // If the input is not an object or is null, return an empty array.
+  if (typeof obj !== 'object' || obj === null) {
+    return [];
+  }
+  let keys: string[] = [];
+  for (const key in obj) {
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+      continue;
+    }
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    const value = obj[key];
+    // If the value is a non-null object, not an array, and has keys, then recurse.
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      Object.keys(value).length > 0
+    ) {
+      keys = keys.concat(getNestedLeafKeys(value, fullKey));
+    } else {
+      // For arrays and primitives (or empty objects), treat the current key as a leaf.
+      keys.push(fullKey);
+    }
+  }
+  return keys;
+}


### PR DESCRIPTION
Fix for: #12655 

**Issue**
For a  form that have nested field, if one of the nested fields attribute is dirty when resetting, other attribute in that fields are not resetting into the intended values.

**Cause**
In `_reset` function, there are a logic to list all of the fields to be checked whether they are dirty or not, and if true it will trigger value change. However the logic using `Object.keys` only target  outermost attribute/field and not nested fields.

**Solution**
Change the `Object.keys` implementation in that line into an utils function to collect all the leaf attribute/field

Thank you and please CMIIW