### PR TITLE
fix: type inference for `useFormContext`

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -661,7 +661,7 @@ export function useForm<TFieldValues extends FieldValues = FieldValues, TContext
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | `root.${string}` | 'root') => void;
 
 // @public
-export const useFormContext: <TFieldValues extends FieldValues, TContext = any, TTransformedValues = undefined>() => UseFormReturn<TFieldValues, TContext, TTransformedValues>;
+export const useFormContext: <TFieldValues extends FieldValues, TContext = any, TTransformedValues = TFieldValues>() => UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
 // @public
 export type UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName, formState?: FormState<TFieldValues>) => {

--- a/src/__typetest__/use-form-context.test-d.ts
+++ b/src/__typetest__/use-form-context.test-d.ts
@@ -1,0 +1,33 @@
+import { expectType } from 'tsd';
+
+import { useFormContext } from '../useFormContext';
+
+/** it should correctly infer the output type from useFormContext */ {
+  type Input = {
+    test: string;
+  };
+
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const { handleSubmit } = useFormContext<Input>();
+
+  handleSubmit((data) => {
+    expectType<Input>(data);
+  });
+}
+
+/** it should correctly infer the output type from useFormContext with different output type */ {
+  type Input = {
+    test: string;
+  };
+
+  type Output = {
+    test: number;
+  };
+
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const { handleSubmit } = useFormContext<Input, any, Output>();
+
+  handleSubmit((data) => {
+    expectType<Output>(data);
+  });
+}

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -37,7 +37,7 @@ const HookFormContext = React.createContext<UseFormReturn | null>(null);
 export const useFormContext = <
   TFieldValues extends FieldValues,
   TContext = any,
-  TTransformedValues = undefined,
+  TTransformedValues = TFieldValues,
 >(): UseFormReturn<TFieldValues, TContext, TTransformedValues> =>
   React.useContext(HookFormContext) as UseFormReturn<
     TFieldValues,


### PR DESCRIPTION
closes #12686