### PR TITLE
Fix #12680: Update Fieldarray Unmount Status

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -414,8 +414,16 @@ export function useFieldArray<
     !get(control._formValues, name) && control._setFieldArray(name);
 
     return () => {
-      (control._options.shouldUnregister || shouldUnregister) &&
-        control.unregister(name as FieldPath<TFieldValues>);
+      const updateMounted = (name: InternalFieldName, value: boolean) => {
+        const field: Field = get(control._fields, name);
+        if (field && field._f) {
+          field._f.mount = value;
+        }
+      };
+
+      control._options.shouldUnregister || shouldUnregister
+        ? control.unregister(name as FieldPath<TFieldValues>)
+        : updateMounted(name, false);
     };
   }, [name, control, keyName, shouldUnregister]);
 


### PR DESCRIPTION
Fix for: https://github.com/react-hook-form/react-hook-form/issues/12680

Issue
Error for a FieldArray root still persist after unmounting

Cause
When unmounting a FieldArray, currently there's no handler to change `field._f.mount` to false

Solution
Add a handler to change field mount attribute to false when unmounting in `useFieldArray`, similar to one in `useController`

Thank you and please CMIIW