### PR TITLE
Add children render prop support to Controller component

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -86,14 +86,12 @@ export type ControllerFieldState = {
     error?: FieldError;
 };
 
-// @public
-export type ControllerProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>, TTransformedValues = TFieldValues> = {
-    render: ({ field, fieldState, formState, }: {
-        field: ControllerRenderProps<TFieldValues, TName>;
-        fieldState: ControllerFieldState;
-        formState: UseFormStateReturn<TFieldValues>;
-    }) => React_2.ReactElement;
-} & UseControllerProps<TFieldValues, TName, TTransformedValues>;
+// @public (undocumented)
+export type ControllerProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>, TTransformedValues = TFieldValues> = ({
+    render: ControllerRender<TFieldValues, TName>;
+} | {
+    children: ControllerRender<TFieldValues, TName>;
+}) & UseControllerProps<TFieldValues, TName, TTransformedValues>;
 
 // @public (undocumented)
 export type ControllerRenderProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> = {
@@ -888,6 +886,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
+// src/types/controller.ts:101:7 - (ae-forgotten-export) The symbol "ControllerRender" needs to be exported by the entry point index.d.ts
 // src/types/form.ts:468:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/src/__tests__/controller.server.test.tsx
+++ b/src/__tests__/controller.server.test.tsx
@@ -24,4 +24,20 @@ describe('Controller with SSR', () => {
 
     renderToString(<Component />);
   });
+
+  it('should render correctly with children', () => {
+    const Component = () => {
+      const { control } = useForm<{
+        test: string;
+      }>();
+
+      return (
+        <Controller defaultValue="default" name="test" control={control}>
+          {({ field }) => <input {...field} />}
+        </Controller>
+      );
+    };
+
+    renderToString(<Component />);
+  });
 });

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -49,7 +49,15 @@ const Controller = <
   TTransformedValues = TFieldValues,
 >(
   props: ControllerProps<TFieldValues, TName, TTransformedValues>,
-) =>
-  props.render(useController<TFieldValues, TName, TTransformedValues>(props));
+) => {
+  const renderedController = useController<
+    TFieldValues,
+    TName,
+    TTransformedValues
+  >(props);
+  return ('children' in props ? props.children : props.render)(
+    renderedController,
+  );
+};
 
 export { Controller };

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -25,19 +25,20 @@ import { useController } from './useController';
  *       <Controller
  *         control={control}
  *         name="test"
- *         render={({ field: { onChange, onBlur, value, ref }, formState, fieldState }) => (
- *           <>
- *             <input
- *               onChange={onChange} // send value to hook form
- *               onBlur={onBlur} // notify when input is touched
- *               value={value} // return updated value
- *               ref={ref} // set ref for focus management
- *             />
- *             <p>{formState.isSubmitted ? "submitted" : ""}</p>
- *             <p>{fieldState.isTouched ? "touched" : ""}</p>
- *           </>
- *         )}
- *       />
+ *       >
+ *       ({ field: { onChange, onBlur, value, ref }, formState, fieldState }) => (
+ *         <>
+ *           <input
+ *             onChange={onChange} // send value to hook form
+ *             onBlur={onBlur} // notify when input is touched
+ *             value={value} // return updated value
+ *             ref={ref} // set ref for focus management
+ *           />
+ *           <p>{formState.isSubmitted ? "submitted" : ""}</p>
+ *           <p>{fieldState.isTouched ? "touched" : ""}</p>
+ *         </>
+ *       )
+ *       </Controller>
  *     </form>
  *   );
  * }

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -78,18 +78,30 @@ export type UseControllerReturn<
  * />
  * ```
  */
+
+type ControllerRender<
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>,
+> = ({
+  field,
+  fieldState,
+  formState,
+}: {
+  field: ControllerRenderProps<TFieldValues, TName>;
+  fieldState: ControllerFieldState;
+  formState: UseFormStateReturn<TFieldValues>;
+}) => React.ReactElement;
+
 export type ControllerProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
   TTransformedValues = TFieldValues,
-> = {
-  render: ({
-    field,
-    fieldState,
-    formState,
-  }: {
-    field: ControllerRenderProps<TFieldValues, TName>;
-    fieldState: ControllerFieldState;
-    formState: UseFormStateReturn<TFieldValues>;
-  }) => React.ReactElement;
-} & UseControllerProps<TFieldValues, TName, TTransformedValues>;
+> = (
+  | {
+      render: ControllerRender<TFieldValues, TName>;
+    }
+  | {
+      children: ControllerRender<TFieldValues, TName>;
+    }
+) &
+  UseControllerProps<TFieldValues, TName, TTransformedValues>;


### PR DESCRIPTION
## Changes

- Added support for using children prop in the Controller component.
- Controller can now be rendered using either the render prop or a children function.
- Modified ControllerProps type to require either render or children prop.
- Extracted ControllerRender type to eliminate code duplication and improve readability.

## Motivation

- Provides more intuitive usage that aligns with common React component patterns by supporting children prop.
- Allows users to use the Controller component in their preferred way (render prop or children function).
- Maintains consistency with other React libraries and provides a better developer experience.

## Compatibility

- Existing render prop is still supported, ensuring compatibility with existing code.
- This change is additive only and doesn't affect existing users.


## Usage
```
<Controller
   control={control}
   name="test"
 >
   ({ field: { onChange, onBlur, value, ref }, formState, fieldState }) => (
      <>
         <input
            onChange={onChange} // send value to hook form
            onBlur={onBlur} // notify when input is touched
            value={value} // return updated value
            ref={ref} // set ref for focus management
         />
         <p>{formState.isSubmitted ? "submitted" : ""}</p>
         <p>{fieldState.isTouched ? "touched" : ""}</p>
      </>
   )
 </Controller>
```