### PR TITLE
fix: remove stale keys when updating rules

### DIFF
--- a/app/src/controller.tsx
+++ b/app/src/controller.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useForm, Controller, ValidationMode } from 'react-hook-form';
 import ReactSelect from 'react-select';
 import {
@@ -23,7 +23,7 @@ const options = [
 
 const defaultValues = {
   Native: '',
-  TextField: '',
+  TextField: 'asd',
   Select: '',
   ReactSelect: '',
   Checkbox: false,
@@ -61,15 +61,18 @@ export default function Field() {
 
   const rerender = () => setRerender(Math.random());
 
+  const [isRulesEnabled, setIsRulesEnabled] = useState(false);
+
   return (
     <form onSubmit={handleSubmit(() => {})}>
       <div className="container">
-        <section id="input-checkbox">
+        {/* <section id="input-checkbox">
           <label>MUI Checkbox</label>
           <Controller
             name="Checkbox"
             control={control}
-            rules={{ required: true }}
+            rules={isRulesEnabled ? { required: true } : undefined}
+            //rules={{required: isRulesEnabled}}
             render={({ field: props }) => (
               <Checkbox
                 {...props}
@@ -79,101 +82,28 @@ export default function Field() {
           />
         </section>
 
-        {errors.Checkbox && <p id="Checkbox">Checkbox Error</p>}
-
-        <section id="input-radio-group">
-          <label>Radio Group</label>
-          <Controller
-            render={({ field }) => (
-              <RadioGroup aria-label="gender" {...field} name="gender1">
-                <FormControlLabel
-                  value="female"
-                  control={<Radio />}
-                  label="Female"
-                />
-                <FormControlLabel
-                  value="male"
-                  control={<Radio />}
-                  label="Male"
-                />
-                <FormControlLabel
-                  value="other"
-                  control={<Radio />}
-                  label="Other"
-                />
-              </RadioGroup>
-            )}
-            rules={{ required: true }}
-            name="RadioGroup"
-            control={control}
-          />
-        </section>
-
-        {errors.RadioGroup && <p id="RadioGroup">RadioGroup Error</p>}
+        {errors.Checkbox && <p id="Checkbox">Checkbox Error</p>} */}
 
         <section id="input-textField">
+          <p>isRulesEnabled: {String(isRulesEnabled)}</p>
           <label>MUI TextField</label>
           <Controller
             render={({ field }) => <TextField {...field} />}
             name="TextField"
             control={control}
-            rules={{ required: true }}
+            rules={isRulesEnabled ? {minLength: 5}: undefined}
           />
         </section>
+        {errors.TextField && <p id='TextField'>TextField error</p>}
 
-        {errors.TextField && <p id="TextField">TextField Error</p>}
-
-        <section id="input-select">
-          <label>MUI Select</label>
-          <Controller
-            render={({ field }) => (
-              <Select {...field}>
-                <MenuItem value={10}>Ten</MenuItem>
-                <MenuItem value={20}>Twenty</MenuItem>
-                <MenuItem value={30}>Thirty</MenuItem>
-              </Select>
-            )}
-            rules={{ required: true }}
-            name="Select"
-            control={control}
-          />
-        </section>
-
-        {errors.Select && <p id="Select">Select Error</p>}
-
-        <section id="input-switch">
-          <label>MUI Switch</label>
-          <Controller
-            name="switch"
-            rules={{ required: true }}
-            render={({ field: props }) => (
-              <Switch
-                {...props}
-                onChange={(e) => props.onChange(e.target.checked)}
-              />
-            )}
-            control={control}
-          />
-        </section>
-
-        {errors.switch && <p id="switch">switch Error</p>}
-
-        <section id="input-ReactSelect">
-          <label>React Select</label>
-          <Controller
-            render={({ field }) => (
-              <PureReactSelect isClearable options={options} {...field} />
-            )}
-            name="ReactSelect"
-            control={control}
-            rules={{ required: true }}
-          />
-        </section>
-
-        {errors.ReactSelect && <p id="ReactSelect">ReactSelect Error</p>}
       </div>
+     
 
       <span id="renderCount">{renderCount}</span>
+
+      <button type="button" onClick={() => setIsRulesEnabled(!isRulesEnabled)}>
+        Toggle error
+      </button>
 
       <button type="button" onClick={rerender}>
         Rerender

--- a/src/__tests__/utils/mergeMissingKeysAsUndefined.ts
+++ b/src/__tests__/utils/mergeMissingKeysAsUndefined.ts
@@ -1,0 +1,40 @@
+import mergeMissingKeysAsUndefined from '../../utils/mergeMissingKeysAsUndefined';
+
+describe('mergeMissingKeysAsUndefined', () => {
+  it('should preserve existing keys in newRules', () => {
+    const oldRules = { min: 1, max: 10 };
+    const newRules = { min: 5 };
+    const result = mergeMissingKeysAsUndefined(oldRules, newRules);
+    expect(result).toEqual({ min: 5, max: undefined });
+  });
+
+  it('should return all keys as undefined when newRules is undefined', () => {
+    const oldRules = { required: true, minLength: 2 };
+    const result = mergeMissingKeysAsUndefined(oldRules, undefined);
+    expect(result).toEqual({ required: undefined, minLength: undefined });
+  });
+
+  it('should return newRules unchanged if all keys match oldRules', () => {
+    const oldRules = { required: true };
+    const newRules = { required: false };
+    const result = mergeMissingKeysAsUndefined(oldRules, newRules);
+    expect(result).toEqual({ required: false });
+  });
+
+  it('should ignore extra keys in newRules not in oldRules', () => {
+    const oldRules = { required: true };
+    const newRules = { required: false, maxLength: 10 };
+    const result = mergeMissingKeysAsUndefined(oldRules, newRules);
+    expect(result).toEqual({ required: false, maxLength: 10 });
+  });
+
+  it('should return an empty object if oldRules is undefined', () => {
+    const result = mergeMissingKeysAsUndefined(undefined, { a: 1 });
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('should return an empty object if both inputs are undefined', () => {
+    const result = mergeMissingKeysAsUndefined(undefined, undefined);
+    expect(result).toEqual({});
+  });
+});

--- a/src/utils/mergeMissingKeysAsUndefined.ts
+++ b/src/utils/mergeMissingKeysAsUndefined.ts
@@ -1,0 +1,10 @@
+export default (oldObject?: any, newObject?: any) => {
+  const result = { ...(newObject || {}) };
+
+  for (const key in oldObject) {
+    if (newObject === undefined || !Object.hasOwn(newObject, key)) {
+      (result as any)[key] = undefined;
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
This PR fixes #12729.

This PR is definitely not perfect — for example, some tests are still missing. I wasn’t able to get everything set up quickly or easily, so I wanted to open this initial draft PR before investing more time, especially since I’m not even sure if you agree with the issue or the changes yet. 🙂

After digging a bit deeper into the code, I noticed that when updating the rules object passed to the Controller, we don’t remove old keys — we just spread the new object. This leads to a situation where, for example, if you initially provide minLength and then later try to remove it by providing `undefined`, the key is still present and not properly unset.

Also please see the example `controller.tsx` I adjusted, in which you can easily see the fix in action, since I did not really provide any meaningful tests, yet ;)