### PR TITLE
🐞 fix: use useIsomorphicLayoutEffect to address warning in SSR

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -84,7 +84,10 @@ export function useForm<
   const control = _formControl.current.control;
   control._options = props;
 
-  React.useLayoutEffect(
+  const useIsomorphicLayoutEffect =
+    typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
+  useIsomorphicLayoutEffect(
     () =>
       control._subscribe({
         formState: control._proxyFormState,


### PR DESCRIPTION
Hello, Bill 

In [Comment in #12580](https://github.com/react-hook-form/react-hook-form/pull/12642#issuecomment-2789799768), it was mentioned that **using useLayoutEffect in an SSR environment can cause warnings**. To address this issue, I referred to the [uselayout effect-ssr.md](https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85) document and implemented `useIsomorphicLayoutEffect`.

`useIsomorphicLayoutEffect` is a custom hook that conditionally uses either `useEffect` or `useLayoutEffect` depending on whether it’s running on the client or server side.

I didn’t create a separate directory for `useIsomorphicLayoutEffect`—instead, I defined and used it directly within `useForm.ts`. Creating a new folder like hooks might cause confusion given the current structure, and aside from this case, it seems unlikely that we’ll need additional custom hooks.

Thank you 😁