### PR TITLE
improve useWatch type when compute prop is specified

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -809,21 +809,23 @@ export type UseFromSubscribe<TFieldValues extends FieldValues> = (payload: {
 
 // @public
 export function useWatch<TFieldValues extends FieldValues = FieldValues, TTransformedValues = TFieldValues>(props: {
+    name?: undefined;
     defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
     control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
     exact?: boolean;
-    compute?: <T>(formValues: T) => T;
+    compute?: undefined;
 }): DeepPartialSkipArrayKey<TFieldValues>;
 
 // @public
-export function useWatch<TFieldValues extends FieldValues = FieldValues, TComputeValues extends unknown = unknown>(props: {
-    defaultValue?: TFieldValues;
-    control?: Control<TFieldValues>;
+export function useWatch<TFieldValues extends FieldValues = FieldValues, TTransformedValues = TFieldValues, TComputeValue = unknown>(props: {
+    name?: undefined;
+    defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
+    control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
     exact?: boolean;
-    compute?: (formValues: TFieldValues) => TComputeValues;
-}): TComputeValues;
+    compute: (formValues: TFieldValues) => TComputeValue;
+}): TComputeValue;
 
 // @public
 export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>, TTransformedValues = TFieldValues>(props: {
@@ -832,7 +834,18 @@ export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldN
     control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
     exact?: boolean;
+    compute?: undefined;
 }): FieldPathValue<TFieldValues, TFieldName>;
+
+// @public
+export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>, TTransformedValues = TFieldValues, TComputeValue = unknown>(props: {
+    name: TFieldName;
+    defaultValue?: FieldPathValue<TFieldValues, TFieldName>;
+    control?: Control<TFieldValues, any, TTransformedValues>;
+    disabled?: boolean;
+    exact?: boolean;
+    compute: (fieldValue: FieldPathValue<TFieldValues, TFieldName>) => TComputeValue;
+}): TComputeValue;
 
 // @public
 export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldNames extends readonly FieldPath<TFieldValues>[] = readonly FieldPath<TFieldValues>[], TTransformedValues = TFieldValues>(props: {
@@ -841,7 +854,18 @@ export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldN
     control?: Control<TFieldValues, any, TTransformedValues>;
     disabled?: boolean;
     exact?: boolean;
+    compute?: undefined;
 }): FieldPathValues<TFieldValues, TFieldNames>;
+
+// @public
+export function useWatch<TFieldValues extends FieldValues = FieldValues, TFieldNames extends readonly FieldPath<TFieldValues>[] = readonly FieldPath<TFieldValues>[], TTransformedValues = TFieldValues, TComputeValue = unknown>(props: {
+    name: readonly [...TFieldNames];
+    defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
+    control?: Control<TFieldValues, any, TTransformedValues>;
+    disabled?: boolean;
+    exact?: boolean;
+    compute: (fieldValue: FieldPathValues<TFieldValues, TFieldNames>) => TComputeValue;
+}): TComputeValue;
 
 // @public
 export function useWatch<TFieldValues extends FieldValues = FieldValues>(): DeepPartialSkipArrayKey<TFieldValues>;
@@ -853,7 +877,7 @@ export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
     name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[];
     control?: Control<TFieldValues>;
     exact?: boolean;
-    compute?: <T>(formValues: T) => T;
+    compute?: (formValues: any) => any;
 };
 
 // @public (undocumented)

--- a/src/__tests__/type.test.tsx
+++ b/src/__tests__/type.test.tsx
@@ -504,7 +504,7 @@ test('should provide correct type for validate function with useFieldArray', () 
   App;
 });
 
-test('should support compute function with useWatch', () => {
+test('should support compute function via useWatch without name prop', () => {
   const Form = () => {
     type FormValue = {
       test: string;
@@ -530,6 +530,60 @@ test('should support compute function with useWatch', () => {
         {test.data}
       </div>
     );
+  };
+
+  render(<Form />);
+});
+
+test('should support compute function via useWatch with string name prop', () => {
+  const Form = () => {
+    type FormValue = {
+      test: string;
+    };
+
+    const methods = useForm<FormValue>({
+      defaultValues: { test: 'test' },
+    });
+
+    const test: boolean = useWatch({
+      control: methods.control,
+      name: 'test' as const,
+      compute: (data: string) => {
+        return data === 'test';
+      },
+    });
+
+    return <div>{test}</div>;
+  };
+
+  render(<Form />);
+});
+
+test('should support compute function via useWatch with array name prop', () => {
+  const Form = () => {
+    type FormValue = {
+      test1: string;
+      test2: number;
+      test3: boolean;
+    };
+
+    const methods = useForm<FormValue>({
+      defaultValues: {
+        test1: 'test',
+        test2: 1,
+        test3: true,
+      },
+    });
+
+    const test: string = useWatch({
+      control: methods.control,
+      name: ['test1', 'test2'] as const,
+      compute: ([test1Value, test2Value]: [string, number]) => {
+        return `${test1Value}${test2Value}`;
+      },
+    });
+
+    return <div>{test}</div>;
   };
 
   render(<Form />);

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -895,7 +895,7 @@ export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
     | readonly FieldPath<TFieldValues>[];
   control?: Control<TFieldValues>;
   exact?: boolean;
-  compute?: <T>(formValues: T) => T;
+  compute?: (formValues: any) => any;
 };
 
 export type FormProviderProps<

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -40,11 +40,12 @@ export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
   TTransformedValues = TFieldValues,
 >(props: {
+  name?: undefined;
   defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
   control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
   exact?: boolean;
-  compute?: <T>(formValues: T) => T;
+  compute?: undefined;
 }): DeepPartialSkipArrayKey<TFieldValues>;
 /**
  * Custom hook to subscribe to field change and compute function to produce state update
@@ -66,14 +67,16 @@ export function useWatch<
  */
 export function useWatch<
   TFieldValues extends FieldValues = FieldValues,
-  TComputeValues extends unknown = unknown,
+  TTransformedValues = TFieldValues,
+  TComputeValue = unknown,
 >(props: {
-  defaultValue?: TFieldValues;
-  control?: Control<TFieldValues>;
+  name?: undefined;
+  defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
+  control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
   exact?: boolean;
-  compute?: (formValues: TFieldValues) => TComputeValues;
-}): TComputeValues;
+  compute: (formValues: TFieldValues) => TComputeValue;
+}): TComputeValue;
 /**
  * Custom hook to subscribe to field change and isolate re-rendering at the component level.
  *
@@ -104,7 +107,44 @@ export function useWatch<
   control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
   exact?: boolean;
+  compute?: undefined;
 }): FieldPathValue<TFieldValues, TFieldName>;
+/**
+ * Custom hook to subscribe to field change and compute function to produce state update
+ *
+ * @remarks
+ *
+ * [API](https://react-hook-form.com/docs/usewatch)
+ *
+ * @param props - defaultValue, disable subscription and match exact name.
+ *
+ * @example
+ * ```tsx
+ * const { control } = useForm();
+ * const values = useWatch({
+ *   control,
+ *   name: "fieldA",
+ *   defaultValue: "default value",
+ *   exact: false,
+ *   compute: (fieldValue) => fieldValue === "data" ? fieldValue : null,
+ * })
+ * ```
+ */
+export function useWatch<
+  TFieldValues extends FieldValues = FieldValues,
+  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TTransformedValues = TFieldValues,
+  TComputeValue = unknown,
+>(props: {
+  name: TFieldName;
+  defaultValue?: FieldPathValue<TFieldValues, TFieldName>;
+  control?: Control<TFieldValues, any, TTransformedValues>;
+  disabled?: boolean;
+  exact?: boolean;
+  compute: (
+    fieldValue: FieldPathValue<TFieldValues, TFieldName>,
+  ) => TComputeValue;
+}): TComputeValue;
 /**
  * Custom hook to subscribe to field change and isolate re-rendering at the component level.
  *
@@ -139,7 +179,48 @@ export function useWatch<
   control?: Control<TFieldValues, any, TTransformedValues>;
   disabled?: boolean;
   exact?: boolean;
+  compute?: undefined;
 }): FieldPathValues<TFieldValues, TFieldNames>;
+/**
+ * Custom hook to subscribe to field change and compute function to produce state update
+ *
+ * @remarks
+ *
+ * [API](https://react-hook-form.com/docs/usewatch)
+ *
+ * @param props - defaultValue, disable subscription and match exact name.
+ *
+ * @example
+ * ```tsx
+ * const { control } = useForm();
+ * const values = useWatch({
+ *   control,
+ *   name: ["fieldA", "fieldB"],
+ *   defaultValue: {
+ *     fieldA: "data",
+ *     fieldB: 0
+ *   },
+ *   compute: ([fieldAValue, fieldBValue]) => fieldB === 2 ? fieldA : null,
+ *   exact: false,
+ * })
+ * ```
+ */
+export function useWatch<
+  TFieldValues extends FieldValues = FieldValues,
+  TFieldNames extends
+    readonly FieldPath<TFieldValues>[] = readonly FieldPath<TFieldValues>[],
+  TTransformedValues = TFieldValues,
+  TComputeValue = unknown,
+>(props: {
+  name: readonly [...TFieldNames];
+  defaultValue?: DeepPartialSkipArrayKey<TFieldValues>;
+  control?: Control<TFieldValues, any, TTransformedValues>;
+  disabled?: boolean;
+  exact?: boolean;
+  compute: (
+    fieldValue: FieldPathValues<TFieldValues, TFieldNames>,
+  ) => TComputeValue;
+}): TComputeValue;
 /**
  * Custom hook to subscribe to field change and isolate re-rendering at the component level.
  *


### PR DESCRIPTION
Overview:

- Introduced function overloads to useWatch to provide more precise typings based on the presence and type of the name prop.
- Enabled conditional typing of the compute function and useWatch's return type depending on how name is specified.
- Enabled better inference of return types based on name prop variations via function overloads.