### PR TITLE
🐞 fix #12772 reset form useWatch to utilize ref for defaultValue and …

### DIFF
--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -8,6 +8,7 @@ import {
   within,
 } from '@testing-library/react';
 
+import { Controller } from '../controller';
 import {
   Control,
   UseFieldArrayReturn,
@@ -1484,6 +1485,68 @@ describe('useWatch', () => {
 
         expect(await screen.findByText('test')).toBeDefined();
       });
+    });
+    it('Should update the value immediately after reset when used with Controller', async () => {
+      const getDefaultValue = () => ({
+        test: undefined,
+      });
+
+      const Component = () => {
+        const { reset, control } = useForm({
+          defaultValues: getDefaultValue(),
+        });
+
+        return (
+          <form>
+            <Controller
+              control={control}
+              name="test"
+              render={({ field: { onChange, value } }) => (
+                <select
+                  data-testid="test-select"
+                  value={value ?? ''}
+                  onChange={(e) => {
+                    onChange(e.target.value);
+                  }}
+                >
+                  <option value=""></option>
+                  <option value="test1">test1</option>
+                  <option value="test2">test2</option>
+                </select>
+              )}
+            />
+            <button
+              type="button"
+              data-testid="reset-button"
+              onClick={() => reset(getDefaultValue())}
+            >
+              Reset
+            </button>
+          </form>
+        );
+      };
+
+      render(<Component />);
+
+      fireEvent.change(screen.getByTestId('test-select'), {
+        target: { value: 'test1' },
+      });
+
+      expect(screen.getByTestId('test-select')).toHaveValue('test1');
+
+      fireEvent.click(screen.getByTestId('reset-button'));
+
+      expect(screen.getByTestId('test-select')).toHaveValue('');
+
+      fireEvent.change(screen.getByTestId('test-select'), {
+        target: { value: 'test2' },
+      });
+
+      expect(screen.getByTestId('test-select')).toHaveValue('test2');
+
+      fireEvent.click(screen.getByTestId('reset-button'));
+
+      expect(screen.getByTestId('test-select')).toHaveValue('');
     });
   });
 

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -1486,6 +1486,7 @@ describe('useWatch', () => {
         expect(await screen.findByText('test')).toBeDefined();
       });
     });
+
     it('Should update the value immediately after reset when used with Controller', async () => {
       const getDefaultValue = () => ({
         test: undefined,

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -152,13 +152,13 @@ export function useWatch<TFieldValues extends FieldValues>(
     disabled,
     exact,
   } = props || {};
+  const _defaultValue = React.useRef(defaultValue);
   const [value, updateValue] = React.useState(
     control._getWatch(
       name as InternalFieldName,
       _defaultValue.current as DeepPartialSkipArrayKey<TFieldValues>,
     ),
   );
-  const _defaultValue = React.useRef(defaultValue);
 
   React.useEffect(
     () =>

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -11,7 +11,6 @@ import {
   InternalFieldName,
   UseWatchProps,
 } from './types';
-import { useDeepEqualEffect } from './useDeepEqualEffect';
 import { useFormContext } from './useFormContext';
 
 /**
@@ -153,15 +152,9 @@ export function useWatch<TFieldValues extends FieldValues>(
     disabled,
     exact,
   } = props || {};
+  const _defaultValue = React.useRef(defaultValue);
 
-  const [value, updateValue] = React.useState(
-    control._getWatch(
-      name as InternalFieldName,
-      defaultValue as DeepPartialSkipArrayKey<TFieldValues>,
-    ),
-  );
-
-  useDeepEqualEffect(
+  React.useEffect(
     () =>
       control._subscribe({
         name: name as InternalFieldName,
@@ -177,11 +170,18 @@ export function useWatch<TFieldValues extends FieldValues>(
               control._names,
               formState.values || control._formValues,
               false,
-              defaultValue,
+              _defaultValue.current,
             ),
           ),
       }),
-    [name, defaultValue, disabled, exact],
+    [name, control, disabled, exact],
+  );
+
+  const [value, updateValue] = React.useState(
+    control._getWatch(
+      name as InternalFieldName,
+      _defaultValue.current as DeepPartialSkipArrayKey<TFieldValues>,
+    ),
   );
 
   React.useEffect(() => control._removeUnmounted());

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -152,6 +152,12 @@ export function useWatch<TFieldValues extends FieldValues>(
     disabled,
     exact,
   } = props || {};
+  const [value, updateValue] = React.useState(
+    control._getWatch(
+      name as InternalFieldName,
+      _defaultValue.current as DeepPartialSkipArrayKey<TFieldValues>,
+    ),
+  );
   const _defaultValue = React.useRef(defaultValue);
 
   React.useEffect(
@@ -175,13 +181,6 @@ export function useWatch<TFieldValues extends FieldValues>(
           ),
       }),
     [name, control, disabled, exact],
-  );
-
-  const [value, updateValue] = React.useState(
-    control._getWatch(
-      name as InternalFieldName,
-      _defaultValue.current as DeepPartialSkipArrayKey<TFieldValues>,
-    ),
   );
 
   React.useEffect(() => control._removeUnmounted());


### PR DESCRIPTION
🐞 fix #12772 reset form

**Problem:**

Previously, the `useWatch` hook could sometimes fail to immediately reflect the form values after a `reset` operation, particularly when `defaultValue` was provided and used in conjunction with `Controller`. This could lead to a scenario where a user had to trigger the reset action twice for the `useWatch` value to update correctly to the default value

The likely cause was related to how `defaultValue` was managed and included in the dependency array of `useDeepEqualEffect`. When the form was reset, the internal handling of default values could potentially cause `useWatch`'s internal subscription to briefly become out of sync with the form's actual state, as the `useDeepEqualEffect` might trigger a re-subscription based on a perceived change in the `defaultValue` object reference or content during the reset process. This timing mismatch meant the hook might not pick up the newly reset value immediately.

**Solution:**

This change modifies how `defaultValue` is handled within the `useWatch` hook. Instead of including `defaultValue` in the `useEffect` dependency array (previously via `useDeepEqualEffect`), `defaultValue` is now stored in a `useRef`.

By storing `defaultValue` in a `useRef`, its value can be accessed within the effect callback without being part of the dependency array.

**Impact:**

This ensures that the subscription established by `useWatch` is not unnecessarily torn down and re-established solely due to potential changes or re-creations of the `defaultValue` object during the form reset process. The subscription remains stable, allowing `useWatch` to reliably pick up and reflect the form's state, including the correctly applied default values, immediately after `reset` is called. This resolves the issue where a second reset was sometimes required.