### PR TITLE
fix: checkbox duplication handling in useFieldArray

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -612,18 +612,20 @@ export function createFormControl<
           );
         } else if (fieldReference.refs) {
           if (isCheckBoxInput(fieldReference.ref)) {
-            fieldReference.refs.length > 1
+            Array.isArray(fieldValue)
               ? fieldReference.refs.forEach(
                   (checkboxRef) =>
                     (!checkboxRef.defaultChecked || !checkboxRef.disabled) &&
-                    (checkboxRef.checked = Array.isArray(fieldValue)
-                      ? !!(fieldValue as []).find(
-                          (data: string) => data === checkboxRef.value,
-                        )
-                      : fieldValue === checkboxRef.value),
+                    (checkboxRef.checked = !!(fieldValue as []).find(
+                      (data: string) => data === checkboxRef.value,
+                    )),
                 )
-              : fieldReference.refs[0] &&
-                (fieldReference.refs[0].checked = !!fieldValue);
+              : fieldReference.refs.forEach(
+                  (checkboxRef) =>
+                    (!checkboxRef.defaultChecked || !checkboxRef.disabled) &&
+                    (checkboxRef.checked =
+                      fieldValue === checkboxRef.value || !!fieldValue),
+                );
           } else {
             fieldReference.refs.forEach(
               (radioRef: HTMLInputElement) =>

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -612,20 +612,18 @@ export function createFormControl<
           );
         } else if (fieldReference.refs) {
           if (isCheckBoxInput(fieldReference.ref)) {
-            Array.isArray(fieldValue)
-              ? fieldReference.refs.forEach(
-                  (checkboxRef) =>
-                    (!checkboxRef.defaultChecked || !checkboxRef.disabled) &&
-                    (checkboxRef.checked = !!(fieldValue as []).find(
-                      (data: string) => data === checkboxRef.value,
-                    )),
-                )
-              : fieldReference.refs.forEach(
-                  (checkboxRef) =>
-                    (!checkboxRef.defaultChecked || !checkboxRef.disabled) &&
-                    (checkboxRef.checked =
-                      fieldValue === checkboxRef.value || !!fieldValue),
-                );
+            fieldReference.refs.forEach((checkboxRef) => {
+              if (!checkboxRef.defaultChecked || !checkboxRef.disabled) {
+                if (Array.isArray(fieldValue)) {
+                  checkboxRef.checked = !!fieldValue.find(
+                    (data: string) => data === checkboxRef.value,
+                  );
+                } else {
+                  checkboxRef.checked =
+                    fieldValue === checkboxRef.value || !!fieldValue;
+                }
+              }
+            });
           } else {
             fieldReference.refs.forEach(
               (radioRef: HTMLInputElement) =>


### PR DESCRIPTION
## Proposed Changes

Fixed an issue with checkbox duplication handling in `useFieldArray`. Resolved logic in `createFormControl` to correctly manage `checked` values for single and array-based inputs. Added tests to ensure the proper handling of checkbox states during duplication.

fix #12742

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes