### PR TITLE
fix: make `mode` and `reValidateMode` reactive

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -167,8 +167,7 @@ export function createFormControl<
     array: createSubject(),
     state: createSubject(),
   };
-  const validationModeBeforeSubmit = getValidationModes(_options.mode);
-  const validationModeAfterSubmit = getValidationModes(_options.reValidateMode);
+
   const shouldDisplayAllAssociatedErrors =
     _options.criteriaMode === VALIDATION_MODE.all;
 
@@ -735,6 +734,10 @@ export function createFormControl<
         (isDateObject(fieldValue) && isNaN(fieldValue.getTime())) ||
         deepEqual(fieldValue, get(_formValues, name, fieldValue));
     };
+    const validationModeBeforeSubmit = getValidationModes(_options.mode);
+    const validationModeAfterSubmit = getValidationModes(
+      _options.reValidateMode,
+    );
 
     if (field) {
       let error;


### PR DESCRIPTION
Moved `validationModeBeforeSubmit` and `validationModeAfterSubmit` into the `onChange` handler so that we re-compute both modes on every event trigger. This ensures the handler always respects the latest mode and reValidateMode settings instead of relying on stale, one-time values.

Related issue: #12797 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)