### PR TITLE
feat: Focus form field for errors supplied by errors prop

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -65,6 +65,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
     _runSchema: (names: InternalFieldName[]) => Promise<{
         errors: FieldErrors;
     }>;
+    _focusError: () => boolean | undefined;
     _disableForm: (disabled?: boolean) => void;
     _subscribe: FromSubscribe<TFieldValues>;
     register: UseFormRegister<TFieldValues>;

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -601,11 +601,44 @@ describe('useForm', () => {
 
       const alert1 = screen.getAllByRole('alert')[0];
       expect(alert1.textContent).toBe('test1 error');
+      const test1Input = screen.getAllByRole('textbox')[0];
+      expect(test1Input).toHaveFocus();
 
       fireEvent.click(screen.getByRole('button'));
 
       const alert2 = screen.getAllByRole('alert')[1];
       expect(alert2.textContent).toBe('test2 error');
+      expect(test1Input).toHaveFocus();
+    });
+
+    it("shouldn't focus the input of the error defined in the errors prop if shouldFocusError is false", () => {
+      const formErrors = {
+        test1: { type: 'test1', message: 'test1 error' },
+      };
+      const Form = () => {
+        type FormValues = {
+          test1: string;
+        };
+        const {
+          register,
+          formState: { errors },
+        } = useForm<FormValues>({
+          errors: formErrors,
+          shouldFocusError: false,
+        });
+
+        return (
+          <div>
+            <input {...register('test1')} type="text" />
+            <span role="alert">{errors.test1 && errors.test1.message}</span>
+          </div>
+        );
+      };
+
+      const renderRes = render(<Form />);
+      const alert1 = screen.getAllByRole('alert')[0];
+      expect(alert1.textContent).toBe('test1 error');
+      expect(renderRes.baseElement).toHaveFocus();
     });
   });
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1474,6 +1474,7 @@ export function createFormControl<
       setError,
       _subscribe,
       _runSchema,
+      _focusError,
       _getWatch,
       _getDirty,
       _setValid,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -829,6 +829,7 @@ export type Control<
     name: FieldName<any>;
   }) => void;
   _runSchema: (names: InternalFieldName[]) => Promise<{ errors: FieldErrors }>;
+  _focusError: () => boolean | undefined;
   _disableForm: (disabled?: boolean) => void;
   _subscribe: FromSubscribe<TFieldValues>;
   register: UseFormRegister<TFieldValues>;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -115,10 +115,14 @@ export function useForm<
     if (props.reValidateMode) {
       control._options.reValidateMode = props.reValidateMode;
     }
+  }, [control, props.mode, props.reValidateMode]);
+
+  React.useEffect(() => {
     if (props.errors && !isEmptyObject(props.errors)) {
       control._setErrors(props.errors);
+      control._focusError();
     }
-  }, [control, props.errors, props.mode, props.reValidateMode]);
+  }, [control, props.errors]);
 
   React.useEffect(() => {
     props.shouldUnregister &&


### PR DESCRIPTION
I originally filed #12794 as an issue, but now I understand that this was never supported functionality. This PR adds the functionality, although the bigger question is whether or not this is something that we want in the first place.

Note: this does change the "default" behavior for errors supplied via the `errors` prop, since before they wouldn't cause the field to be focused, but after this PR they will. If this change in default behavior isn't acceptable, I could add a new optional prop `shouldFocusErrorFromProps` to `useForm` and have it default to `false` so that the default behavior is unchanged. Personally I think that having both validation _and_ server error focus controlled by the same prop makes sense, since the form state doesn't distinguish errors based on their source.