### PR TITLE
Optimize deepEqual for TypedArrays

### DIFF
--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -56,7 +56,7 @@ describe('deepEqual', () => {
     ).toBeFalsy();
   });
 
-  it('should return false when two TypedArrays match', () => {
+  it('should return true when two TypedArrays match', () => {
     expect(
       deepEqual(
         new TextEncoder().encode('123'),

--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -41,6 +41,33 @@ describe('deepEqual', () => {
     expect(deepEqual(undefined, {})).toBeFalsy();
   });
 
+  it('should return false when two TypedArrays not match', () => {
+    expect(
+      deepEqual(
+        new TextEncoder().encode('12'),
+        new TextEncoder().encode('123'),
+      ),
+    ).toBeFalsy();
+    expect(
+      deepEqual(
+        new TextEncoder().encode('123'),
+        new TextEncoder().encode('455'),
+      ),
+    ).toBeFalsy();
+  });
+
+  it('should return false when two TypedArrays match', () => {
+    expect(
+      deepEqual(
+        new TextEncoder().encode('123'),
+        new TextEncoder().encode('123'),
+      ),
+    ).toBeTruthy();
+    expect(
+      deepEqual(new TextEncoder().encode(''), new TextEncoder().encode('')),
+    ).toBeTruthy();
+  });
+
   it('should return true when two sets matches', () => {
     expect(
       deepEqual([{ name: 'useFieldArray' }], [{ name: 'useFieldArray' }]),

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -2,6 +2,7 @@ import isObject from '../utils/isObject';
 
 import isDateObject from './isDateObject';
 import isPrimitive from './isPrimitive';
+import isTypedArray from './isTypedArray';
 
 export default function deepEqual(object1: any, object2: any) {
   if (isPrimitive(object1) || isPrimitive(object2)) {
@@ -10,6 +11,21 @@ export default function deepEqual(object1: any, object2: any) {
 
   if (isDateObject(object1) && isDateObject(object2)) {
     return object1.getTime() === object2.getTime();
+  }
+
+  if (isTypedArray(object1) || isTypedArray(object2)) {
+    if (!(isTypedArray(object1) && isTypedArray(object2))) {
+      return false;
+    }
+    if (object1.length !== object2.length) {
+      return false;
+    }
+    for (let i = 0; i < object1.length; i++) {
+      if (object1[i] !== object2[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   const keys1 = Object.keys(object1);

--- a/src/utils/isTypedArray.ts
+++ b/src/utils/isTypedArray.ts
@@ -1,0 +1,12 @@
+export default (value: unknown) =>
+  value instanceof Int8Array ||
+  value instanceof Uint8Array ||
+  value instanceof Uint8ClampedArray ||
+  value instanceof Int16Array ||
+  value instanceof Uint16Array ||
+  value instanceof Int32Array ||
+  value instanceof Uint32Array ||
+  value instanceof Float32Array ||
+  value instanceof Float64Array ||
+  value instanceof BigInt64Array ||
+  value instanceof BigUint64Array;


### PR DESCRIPTION
I've noticed that when setting the value of a field to a large `Uint8Array` (e.g., more than 1MB), the browser chokes while running the `deepEqual` function, which performs poorly when dealing with that type of value. This PR fixes that problem. :) 