### PR TITLE
docs: fix contributors image url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Thanks go to all our backers! [[Become a backer](https://opencollective.com/reac
 Thanks go to these wonderful people! [[Become a contributor](CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
-  <img src="https://opencollective.com/react-hook-form/contributors.svg?width=890&button=false" />
+  <img src="https://opencollective.com/react-hook-form/contributors.svg?width=890" />
 </a>
 
 <br />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/210d2caa-96f8-4a20-90a1-c003176de932)
