### PR TITLE
fix: Enable getDirtyField to support Sets as a field type

### DIFF
--- a/src/__tests__/logic/getDirtyFields.test.ts
+++ b/src/__tests__/logic/getDirtyFields.test.ts
@@ -341,4 +341,28 @@ describe('getDirtyFields', () => {
       ],
     });
   });
+  it('should show dirty when comparing sets', () => {
+    const result = getDirtyFields(
+      { test: new Set(['val1']) },
+      { test: new Set(['val2']) },
+    );
+
+    expect(result).toEqual({ test: true });
+  });
+  it('should show dirty when comparing sets in incorrect order', () => {
+    const result = getDirtyFields(
+      { test: new Set(['val1', 'val2']) },
+      { test: new Set(['val2', 'val1']) },
+    );
+
+    expect(result).toEqual({ test: true });
+  });
+  it('should not show dirty when comparing like sets', () => {
+    const result = getDirtyFields(
+      { test: new Set(['val1', 'val2']) },
+      { test: new Set(['val1', 'val2']) },
+    );
+
+    expect(result).toEqual({ test: false });
+  });
 });

--- a/src/__tests__/logic/getDirtyFields.test.ts
+++ b/src/__tests__/logic/getDirtyFields.test.ts
@@ -357,6 +357,14 @@ describe('getDirtyFields', () => {
 
     expect(result).toEqual({ test: true });
   });
+  it('should show dirty when comparing different length sets', () => {
+    const result = getDirtyFields(
+      { test: new Set(['val1']) },
+      { test: new Set(['val1', 'val2']) },
+    );
+
+    expect(result).toEqual({ test: true });
+  });
   it('should not show dirty when comparing like sets', () => {
     const result = getDirtyFields(
       { test: new Set(['val1', 'val2']) },

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -12,6 +12,11 @@ export default function deepEqual(object1: any, object2: any) {
     return object1.getTime() === object2.getTime();
   }
 
+  if (object1 instanceof Set && object2 instanceof Set) {
+    object1 = Array.from(object1);
+    object2 = Array.from(object2);
+  }
+
   const keys1 = Object.keys(object1);
   const keys2 = Object.keys(object2);
 

--- a/src/utils/isObject.ts
+++ b/src/utils/isObject.ts
@@ -8,4 +8,5 @@ export default <T extends object>(value: unknown): value is T =>
   !isNullOrUndefined(value) &&
   !Array.isArray(value) &&
   isObjectType(value) &&
-  !isDateObject(value);
+  !isDateObject(value) &&
+  !(value instanceof Set);


### PR DESCRIPTION
When using `Set` as a field type, the `getDirtyField` does not recognize changes to the field. This is because it attempts to iterate the field with `for ... in` which doesn't work on a `Set` type.

This PR excludes `Set` objects from being considered objects and are treated more or less like primitives when doing the `getDirtyField` traversal. The deep equals then treats the `Set` as an array, comparing order as well as values.

This PR does not support a `Set` being the top level object of a form.