### PR TITLE
feat: set caret potision on focus

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1449,6 +1449,9 @@ export function createFormControl<
         options.shouldSelect &&
           isFunction(fieldRef.select) &&
           fieldRef.select();
+        options.caret &&
+          isFunction(fieldRef.setSelectionRange) &&
+          fieldRef.setSelectionRange(options.caret, options.caret);
       }
     }
   };

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -242,6 +242,7 @@ export type UseFormRegister<TFieldValues extends FieldValues> = <
 
 export type SetFocusOptions = Partial<{
   shouldSelect: boolean;
+  caret: number;
 }>;
 
 /**

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -146,6 +146,8 @@ export function useController<
           setCustomValidity: (message: string) =>
             elm.setCustomValidity(message),
           reportValidity: () => elm.reportValidity(),
+          setSelectionRange: (start: number, end: number) =>
+            elm.setSelectionRange && elm.setSelectionRange(start, end),
         };
       }
     },


### PR DESCRIPTION
Add an option to set the caret position when focusing a element

Usage:
```ts
setFocus('field', {
  caret: 10,
})
```

Can combine with `getValues` to set the caret position to the end
```ts
setFocus('field', {
  caret: getValues('field').length,
})
```
