### PR TITLE
🐞 fix: add type info for callback args in subscribe

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -347,6 +347,7 @@ export type FromSubscribe<TFieldValues extends FieldValues> = <TFieldNames exten
     formState?: Partial<ReadFormState>;
     callback: (data: Partial<FormState<TFieldValues>> & {
         values: TFieldValues;
+        name?: InternalFieldName;
     }) => void;
     exact?: boolean;
     reRenderRoot?: boolean;
@@ -807,6 +808,7 @@ export type UseFromSubscribe<TFieldValues extends FieldValues> = <TFieldNames ex
     formState?: Partial<ReadFormState>;
     callback: (data: Partial<FormState<TFieldValues>> & {
         values: TFieldValues;
+        name?: InternalFieldName;
     }) => void;
     exact?: boolean;
 }) => () => void;
@@ -893,7 +895,7 @@ export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartia
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:481:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:484:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -397,7 +397,10 @@ export type UseFromSubscribe<TFieldValues extends FieldValues> = <
   name?: readonly [...TFieldNames] | TFieldNames[number];
   formState?: Partial<ReadFormState>;
   callback: (
-    data: Partial<FormState<TFieldValues>> & { values: TFieldValues },
+    data: Partial<FormState<TFieldValues>> & {
+      values: TFieldValues;
+      name?: InternalFieldName;
+    },
   ) => void;
   exact?: boolean;
 }) => () => void;
@@ -798,7 +801,10 @@ export type FromSubscribe<TFieldValues extends FieldValues> = <
   name?: readonly [...TFieldNames] | TFieldNames[number];
   formState?: Partial<ReadFormState>;
   callback: (
-    data: Partial<FormState<TFieldValues>> & { values: TFieldValues },
+    data: Partial<FormState<TFieldValues>> & {
+      values: TFieldValues;
+      name?: InternalFieldName;
+    },
   ) => void;
   exact?: boolean;
   reRenderRoot?: boolean;


### PR DESCRIPTION
to resolve #12856

Hello, Bill 😁

### Issue
When trying to access the `name` field in the callback arguments of `subscribe`, a type error occurs.

### Cause
No type information is provided for the`name` field in the callback arguments of `subscribe`.

### Solution
Add type information for the `name` field in the callback arguments of `subscribe`.