### PR TITLE
🧧 default to crypto.randomUUID in generateId

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,7 +56,7 @@ export default tseslint.config(
       '@typescript-eslint/ban-types': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
-      "@typescript-eslint/consistent-type-imports": "error",
+      '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-unused-vars': [
         'warn',
         { ignoreRestSiblings: true },

--- a/src/__tests__/logic/generateId.test.ts
+++ b/src/__tests__/logic/generateId.test.ts
@@ -5,6 +5,14 @@ describe('generateId', () => {
     expect(/\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}/i.test(generateId())).toBeTruthy();
   });
 
+  it('should fallback to performance if crypto is undefined', () => {
+    Object.defineProperty(window, 'crypto', {
+      value: undefined,
+    });
+
+    expect(/\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}/i.test(generateId())).toBeTruthy();
+  });
+
   it('should fallback to current date if performance is undefined', () => {
     Object.defineProperty(window, 'performance', {
       value: undefined,

--- a/src/logic/generateId.ts
+++ b/src/logic/generateId.ts
@@ -1,4 +1,8 @@
 export default () => {
+  if (crypto?.randomUUID) {
+    return crypto.randomUUID();
+  }
+
   const d =
     typeof performance === 'undefined' ? Date.now() : performance.now() * 1000;
 

--- a/src/logic/generateId.ts
+++ b/src/logic/generateId.ts
@@ -1,4 +1,4 @@
-import isUndefined from "../utils/isUndefined";
+import isUndefined from '../utils/isUndefined';
 
 export default () => {
   if (!isUndefined(crypto) && crypto.randomUUID) {

--- a/src/logic/generateId.ts
+++ b/src/logic/generateId.ts
@@ -1,5 +1,7 @@
+import isUndefined from "../utils/isUndefined";
+
 export default () => {
-  if (crypto?.randomUUID) {
+  if (!isUndefined(crypto) && crypto.randomUUID) {
     return crypto.randomUUID();
   }
 


### PR DESCRIPTION
## Proposed Changes

Use the native crypto module to generate UUIDv4s, when the browser supports it. 

I feel silly opening this PR, but I had a pen-test audit call out that our application was using an insecure UUID generator.

## Type of change
Enhancement?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes