### PR TITLE
feat: support deep equality checking with circular references

### DIFF
--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -95,4 +95,29 @@ describe('deepEqual', () => {
       deepEqual({ test: new Date('1990') }, { test: new Date('1990') }),
     ).toBeTruthy();
   });
+
+  it('should be capable of comparing objects with circular references', () => {
+    let a: any = { test: '123' };
+    let b: any = { test: '123' };
+    a.self = a;
+    b.self = b;
+
+    expect(deepEqual(a, b)).toBeTruthy();
+
+    a.other = { test: '123' };
+    b.other = { test: '456' };
+
+    expect(deepEqual(a, b)).toBeFalsy();
+
+    b.other.test = '123';
+
+    a.other.parent = b;
+    b.other.parent = a;
+
+    expect(deepEqual(a, b)).toBeTruthy();
+
+    b.other.parent = a.other;
+
+    expect(deepEqual(a, b)).toBeFalsy();
+  });
 });

--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -97,8 +97,8 @@ describe('deepEqual', () => {
   });
 
   it('should be capable of comparing objects with circular references', () => {
-    let a: any = { test: '123' };
-    let b: any = { test: '123' };
+    const a: any = { test: '123' };
+    const b: any = { test: '123' };
     a.self = a;
     b.self = b;
 

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -3,7 +3,11 @@ import isObject from '../utils/isObject';
 import isDateObject from './isDateObject';
 import isPrimitive from './isPrimitive';
 
-export default function deepEqual(object1: any, object2: any) {
+export default function deepEqual(
+  object1: any,
+  object2: any,
+  _internal_visited = new WeakSet(),
+) {
   if (isPrimitive(object1) || isPrimitive(object2)) {
     return object1 === object2;
   }
@@ -19,6 +23,12 @@ export default function deepEqual(object1: any, object2: any) {
     return false;
   }
 
+  if (_internal_visited.has(object1) || _internal_visited.has(object2)) {
+    return true;
+  }
+  _internal_visited.add(object1);
+  _internal_visited.add(object2);
+
   for (const key of keys1) {
     const val1 = object1[key];
 
@@ -33,7 +43,7 @@ export default function deepEqual(object1: any, object2: any) {
         (isDateObject(val1) && isDateObject(val2)) ||
         (isObject(val1) && isObject(val2)) ||
         (Array.isArray(val1) && Array.isArray(val2))
-          ? !deepEqual(val1, val2)
+          ? !deepEqual(val1, val2, _internal_visited)
           : val1 !== val2
       ) {
         return false;


### PR DESCRIPTION
Let deepEqual handle objects with circular references without infinitely recursing. 