### PR TITLE
docs: remove blue underline from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,92 +62,38 @@ function App() {
 
 We’re incredibly grateful to these kind and generous sponsors for their support!
 
-<a target="_blank" href="https://www.follower24.de/">
-    <img width="120" src="https://images.opencollective.com/follower24/00297f8/avatar/256.png?height=256" />
-</a>
-<a target="_blank" href='https://workleap.com/'>
-    <img width="120" src="https://images.opencollective.com/workleap/db82f38/logo/256.png?height=256" />
-</a>
-<a target="_blank" href='https://www.sent.dm'>
-    <img width="120" src="https://avatars.githubusercontent.com/u/153308555?s=200&v=4" />
-</a>
-<a target="_blank" href='https://www.sgkb.ch/'>
-    <img width="120" src="https://images.opencollective.com/st-galler-kantonalbank-ag/bfdd17f/logo/256.png?height=256" />
-</a>
-<a target="_blank" href='https://route4me.com/'>
-    <img width="120" src="https://images.opencollective.com/route4me/71fb6fa/avatar/256.png?height=256" />
-</a>
-<a target="_blank" href='https://niche.com'>
-    <img width="120" src="https://avatars.githubusercontent.com/u/8988784?s=200&v=4" />
-</a>
-<a target="_blank" href='https://toss.im'>
-    <img width="120" src="https://images.opencollective.com/toss/3ed69b3/logo/256.png" />
-</a>
-<a target="_blank" href='https://principal.com/about-us'>
-    <img width="120" src="https://images.opencollective.com/principal/431e690/logo/256.png?height=256" />
-</a>
-<a target="_blank" href="https://hygraph.com">
-    <img width="120" src="https://avatars.githubusercontent.com/u/31031438" />
-</a>
-<a target="_blank" href="https://www.beekai.com/">
-    <img width="120" src="https://www.beekai.com/marketing/logo/logo.svg" />
-</a>
-<a target="_blank" href="https://kanamekey.com">
-    <img width="120" src="https://images.opencollective.com/kaname/d15fd98/logo/256.png" />
-</a>
+<a target="_blank" href="https://www.follower24.de/"><img width="120" src="https://images.opencollective.com/follower24/00297f8/avatar/256.png?height=256" /></a>
+<a target="_blank" href='https://workleap.com/'><img width="120" src="https://images.opencollective.com/workleap/db82f38/logo/256.png?height=256" /></a>
+<a target="_blank" href='https://www.sent.dm'><img width="120" src="https://avatars.githubusercontent.com/u/153308555?s=200&v=4" /></a>
+<a target="_blank" href='https://www.sgkb.ch/'><img width="120" src="https://images.opencollective.com/st-galler-kantonalbank-ag/bfdd17f/logo/256.png?height=256" /></a>
+<a target="_blank" href='https://route4me.com/'><img width="120" src="https://images.opencollective.com/route4me/71fb6fa/avatar/256.png?height=256" /></a>
+<a target="_blank" href='https://niche.com'><img width="120" src="https://avatars.githubusercontent.com/u/8988784?s=200&v=4" /></a>
+<a target="_blank" href='https://toss.im'><img width="120" src="https://images.opencollective.com/toss/3ed69b3/logo/256.png" /></a>
+<a target="_blank" href='https://principal.com/about-us'><img width="120" src="https://images.opencollective.com/principal/431e690/logo/256.png?height=256" /></a>
+<a target="_blank" href="https://hygraph.com"><img width="120" src="https://avatars.githubusercontent.com/u/31031438" /></a>
+<a target="_blank" href="https://www.beekai.com/"><img width="120" src="https://www.beekai.com/marketing/logo/logo.svg" /></a>
+<a target="_blank" href="https://kanamekey.com"><img width="120" src="https://images.opencollective.com/kaname/d15fd98/logo/256.png" /></a>
 
 ### Past Sponsors
 
 Thank you to our previous sponsors for your generous support!
 
-<a target="_blank" href='https://www.sanity.io/'>
-    <img width="24" height="24" src="https://images.opencollective.com/sanity_io/558f87f/logo/256.png?height=256" />
-</a>
-<a target="_blank" href='https://twicsy.com/'>
-    <img width="24" height="24" src="https://images.opencollective.com/buy-instagram-followers-twicsy/b4c5d7f/logo/256.png?height=256" />
-</a>
-<a href="https://www.leniolabs.com/" target="_blank">
-  <img src="https://www.leniolabs.com/images/leniolabs-isologo-example.jpg" width="24" height="24" />
-</a>
-<a target="_blank" href="https://underbelly.is">
-    <img width="24" src="https://images.opencollective.com/underbelly/989a4a6/logo/256.png" />
-</a>
-<a target="_blank" href="https://feathery.io">
-    <img width="24" src="https://images.opencollective.com/feathery1/c29b0a1/logo/256.png" />
-</a>
-<a target="_blank" href="https://getform.io">
-    <img width="24" src="https://images.opencollective.com/getformio2/3c978c8/avatar/256.png" />
-</a>
-<a href="https://marmelab.com/" target="_blank">
-  <img src="https://images.opencollective.com/marmelab/d7fd82f/logo/256.png" width="24" height="24" />
-</a>
-<a target="_blank" href="https://formcarry.com/">
-    <img width="24" src="https://images.opencollective.com/formcarry/a40a4ea/logo/256.png" />
-</a>
-<a target="_blank" href="https://fabform.io">
-    <img width="24" src="https://images.opencollective.com/fabform/2834037/logo/256.png" />
-</a>
-<a target="_blank" href="https://www.thinkmill.com.au/">
-    <img width="24" src="https://images.opencollective.com/thinkmill/28910ec/logo/256.png" />
-</a>
-<a target="_blank" href="https://kwork.studio/">
-    <img width="24" src="https://images.opencollective.com/knowledge-work/f91b72d/logo/256.png" />
-</a>
-<a target="_blank" href="https://fiberplane.com/">
-    <img width="24" src="https://avatars.githubusercontent.com/u/61152955?s=200&v=4" />
-</a>
-<a target="_blank" href="https://www.jetbrains.com/">
-    <img width="24" src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.png" />
-</a>
-<a target="_blank" href="https://www.mirakl.com/">
-    <img width="24" src="https://images.opencollective.com/mirakl/0b191f0/logo/256.png" />
-</a>
-<a target="_blank" href='https://wantedlyinc.com'>
-    <img width="24" src="https://images.opencollective.com/wantedly/d94e44e/logo/256.png" />
-</a>
-<a target="_blank" href="https://www.casinoreviews.net/">
-    <img width="24" src="https://images.opencollective.com/casinoreviews/f0877d1/logo/256.png" />
-</a>
+<a target="_blank" href='https://www.sanity.io/'><img width="24" height="24" src="https://images.opencollective.com/sanity_io/558f87f/logo/256.png?height=256" /></a>
+<a target="_blank" href='https://twicsy.com/'><img width="24" height="24" src="https://images.opencollective.com/buy-instagram-followers-twicsy/b4c5d7f/logo/256.png?height=256" /></a>
+<a href="https://www.leniolabs.com/" target="_blank"><img src="https://www.leniolabs.com/images/leniolabs-isologo-example.jpg" width="24" height="24" /></a>
+<a target="_blank" href="https://underbelly.is"><img width="24" src="https://images.opencollective.com/underbelly/989a4a6/logo/256.png" /></a>
+<a target="_blank" href="https://feathery.io"><img width="24" src="https://images.opencollective.com/feathery1/c29b0a1/logo/256.png" /></a>
+<a target="_blank" href="https://getform.io"><img width="24" src="https://images.opencollective.com/getformio2/3c978c8/avatar/256.png" /></a>
+<a href="https://marmelab.com/" target="_blank"><img src="https://images.opencollective.com/marmelab/d7fd82f/logo/256.png" width="24" height="24" /></a>
+<a target="_blank" href="https://formcarry.com/"><img width="24" src="https://images.opencollective.com/formcarry/a40a4ea/logo/256.png" /></a>
+<a target="_blank" href="https://fabform.io"><img width="24" src="https://images.opencollective.com/fabform/2834037/logo/256.png" /></a>
+<a target="_blank" href="https://www.thinkmill.com.au/"><img width="24" src="https://images.opencollective.com/thinkmill/28910ec/logo/256.png" /></a>
+<a target="_blank" href="https://kwork.studio/"><img width="24" src="https://images.opencollective.com/knowledge-work/f91b72d/logo/256.png" /></a>
+<a target="_blank" href="https://fiberplane.com/"><img width="24" src="https://avatars.githubusercontent.com/u/61152955?s=200&v=4" /></a>
+<a target="_blank" href="https://www.jetbrains.com/"><img width="24" src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.png" /></a>
+<a target="_blank" href="https://www.mirakl.com/"><img width="24" src="https://images.opencollective.com/mirakl/0b191f0/logo/256.png" /></a>
+<a target="_blank" href='https://wantedlyinc.com'><img width="24" src="https://images.opencollective.com/wantedly/d94e44e/logo/256.png" /></a>
+<a target="_blank" href="https://www.casinoreviews.net/"><img width="24" src="https://images.opencollective.com/casinoreviews/f0877d1/logo/256.png" /></a>
 
 ### Backers
 


### PR DESCRIPTION
## Summary

Documentation:
- Condense sponsor link markup in [README.md](https://github.com/react-hook-form/react-hook-form/blob/master/README.md) by collapsing `<a>` and `<img>` tags onto single lines to remove blue underlines from sponsor logos.

## Appearance

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/ee4bb9ea-8eee-499e-8b02-8e5589921272) | ![after](https://github.com/user-attachments/assets/a21169c6-b898-472d-8761-2c0216e5426f) |

## Why?

Previously, the images were displayed with line breaks between them, causing blue link lines to appear, which disrupted the clean look of the images. By removing these line breaks, the images now appear without the blue link lines, providing a more cohesive and visually appealing README. 