### PR TITLE
test(utils): add unit tests for live function with Ref type

### DIFF
--- a/src/__tests__/utils/live.test.ts
+++ b/src/__tests__/utils/live.test.ts
@@ -1,0 +1,33 @@
+import type { Ref } from '../../types';
+import isHTMLElement from '../../utils/isHTMLElement';
+import live from '../../utils/live';
+
+jest.mock('../../utils/isHTMLElement');
+
+const mockIsHTMLElement = isHTMLElement as jest.MockedFunction<
+  typeof isHTMLElement
+>;
+
+describe('live', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return true when ref is HTMLElement and connected', () => {
+    mockIsHTMLElement.mockReturnValue(true);
+    const ref: Ref = { isConnected: true, name: 'mock' };
+    expect(live(ref)).toBe(true);
+  });
+
+  it('should return false when ref is not connected', () => {
+    mockIsHTMLElement.mockReturnValue(true);
+    const ref: Ref = { isConnected: false, name: 'mock' };
+    expect(live(ref)).toBe(false);
+  });
+
+  it('should return false when ref is not an HTMLElement', () => {
+    mockIsHTMLElement.mockReturnValue(false);
+    const ref: Ref = { isConnected: false, name: 'mock' };
+    expect(live(ref)).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for the live utility function to verify its behavior under different scenarios:

Returns true when the ref is an HTMLElement and is connected to the DOM.

Returns false when the ref is not connected.

Returns false when the ref is not an HTMLElement.

These tests use a mocked version of isHTMLElement to isolate the function logic.
The goal is to ensure the correctness and reliability of the live function used internally in the library.