### PR TITLE
chore: improve `exclude` patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "dist",
-    "dist/__tests__"
+    "dist"
   ],
   "exports": {
     "./package.json": "./package.json",
@@ -30,7 +29,7 @@
     "prebuild": "pnpm clean",
     "build": "pnpm build:modern",
     "build:watch": "pnpm build:modern -w",
-    "postbuild": "rimraf dist/__tests__ && node ./scripts/rollup/assert-esm-exports.mjs && node ./scripts/rollup/assert-cjs-exports.cjs",
+    "postbuild": "node ./scripts/rollup/assert-esm-exports.mjs && node ./scripts/rollup/assert-cjs-exports.cjs",
     "build:modern": "rollup --bundleConfigAsCjs -c ./scripts/rollup/rollup.config.js",
     "build:esm": "rollup --bundleConfigAsCjs -c ./scripts/rollup/rollup.esm.config.js",
     "prettier:fix": "prettier --config .prettierrc --write .",

--- a/scripts/rollup/createRollupConfig.js
+++ b/scripts/rollup/createRollupConfig.js
@@ -28,9 +28,7 @@ export function createRollupConfig(options, callback) {
     external: Object.keys(pkg.peerDependencies),
     plugins: [
       typescript({
-        tsconfig: options.tsconfig,
         clean: true,
-        exclude: ['**/__tests__', '**/*.test.ts', '**/__typetest__'],
       }),
       options.format === 'umd' &&
         commonjs({
@@ -39,9 +37,7 @@ export function createRollupConfig(options, callback) {
       options.format !== 'esm' &&
         terser({
           output: { comments: false },
-          compress: {
-            drop_console: true,
-          },
+          compress: { drop_console: true },
         }),
     ].filter(Boolean),
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,16 +18,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
-  "exclude": [
-    "node_modules",
-    "app",
-    "examples",
-    "cypress",
-    "src/*.test.ts",
-    "src/*.test.tsx",
-    "src/*.test-d.ts",
-    "src/*.test-d.tsx",
-    "src/__mocks__"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**/*", "**/__typetest__/**/*"]
 }


### PR DESCRIPTION
This improves `exclude` patterns of 'tsconfig.json'. See inline comments of the details.

Currently `dist/__tests__` and `dist/__typetest__` are emitted. The `postbuild` deletes `dist/__tests__`, but `dist/__typetest__` are shipped to npm registry. This change makes sure no test files are emitted to the `dist` directory. That build time shortens and the shipped packed becomes smaller too.