### PR TITLE
test: add unit tests for getValidationModes

### DIFF
--- a/src/__tests__/logic/getValidationModes.test.ts
+++ b/src/__tests__/logic/getValidationModes.test.ts
@@ -1,0 +1,54 @@
+import { VALIDATION_MODE } from '../../constants';
+import getValidationModes from '../../logic/getValidationModes';
+
+describe('getValidationModes', () => {
+  it('shold return correct flags for each mode', () => {
+    expect(getValidationModes(VALIDATION_MODE.onBlur)).toEqual({
+      isOnSubmit: false,
+      isOnBlur: true,
+      isOnChange: false,
+      isOnAll: false,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(VALIDATION_MODE.onChange)).toEqual({
+      isOnSubmit: false,
+      isOnBlur: false,
+      isOnChange: true,
+      isOnAll: false,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(VALIDATION_MODE.onSubmit)).toEqual({
+      isOnSubmit: true,
+      isOnBlur: false,
+      isOnChange: false,
+      isOnAll: false,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(undefined)).toEqual({
+      isOnSubmit: true,
+      isOnBlur: false,
+      isOnChange: false,
+      isOnAll: false,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(VALIDATION_MODE.all)).toEqual({
+      isOnSubmit: false,
+      isOnBlur: false,
+      isOnChange: false,
+      isOnAll: true,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(VALIDATION_MODE.onTouched)).toEqual({
+      isOnSubmit: false,
+      isOnBlur: false,
+      isOnChange: false,
+      isOnAll: false,
+      isOnTouch: true,
+    });
+  });
+});


### PR DESCRIPTION
Adds unit tests for the `getValidationModes` utility function.

- Verifies correct boolean flags returned for each `VALIDATION_MODE`
  - `onSubmit`
  - `onBlur`
  - `onChange`
  - `onAll`
  - `onTouched`
- Also verifies default behavior when mode is `undefined`
- Covers all logical branches of the function

This ensures that mode-based validation behavior in React Hook Form is correctly derived from `VALIDATION_MODE`, and that future regressions in this logic are prevented.