### PR TITLE
test: add unit tests for shouldRenderFormState and group root subscriber cases

### DIFF
--- a/src/__tests__/logic/shouldRenderFormState.test.ts
+++ b/src/__tests__/logic/shouldRenderFormState.test.ts
@@ -1,0 +1,89 @@
+import shouldRenderFormState from '../../logic/shouldRenderFormState';
+import type { ReadFormState } from '../../types';
+
+describe('shouldRenderFormState', () => {
+  const updateFormState = jest.fn();
+
+  beforeEach(() => {
+    updateFormState.mockClear();
+  });
+
+  it('should return true when formState is Empty', () => {
+    const proxy = {
+      isValid: true,
+    } as ReadFormState;
+    const result = shouldRenderFormState({}, proxy, updateFormState);
+    expect(result).toBe(true);
+  });
+
+  it('should return true when changed keys are more', () => {
+    const proxy = { isValid: true } as ReadFormState;
+    const result = shouldRenderFormState(
+      { isValid: false, isDirty: true },
+      proxy,
+      updateFormState,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return true when changed state key is subscribed', () => {
+    const proxy: ReadFormState = {
+      isDirty: true,
+      isValid: false,
+    } as ReadFormState;
+    const result = shouldRenderFormState(
+      { isDirty: true },
+      proxy,
+      updateFormState,
+    );
+
+    expect(result).toBe('isDirty');
+    expect(updateFormState).toHaveBeenCalledWith({ isDirty: true });
+  });
+
+  it('should return false when changed state key is not subscribed', () => {
+    const proxy: ReadFormState = {
+      isDirty: false,
+      isValid: true,
+    } as ReadFormState;
+    const result = shouldRenderFormState(
+      { isDirty: true },
+      proxy,
+      updateFormState,
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  describe('when root subscribe', () => {
+    it('should return subscribed key name if expecting all', () => {
+      const proxy: ReadFormState = {
+        isDirty: 'all',
+        isValid: false,
+      } as ReadFormState;
+      const result = shouldRenderFormState(
+        { isDirty: true },
+        proxy,
+        updateFormState,
+        true,
+      );
+
+      expect(result).toBe('isDirty');
+    });
+
+    it('should return undefined if not expecting all', () => {
+      const proxy: ReadFormState = {
+        isDirty: true,
+        isValid: false,
+      } as ReadFormState;
+      const result = shouldRenderFormState(
+        { isDirty: true },
+        proxy,
+        updateFormState,
+        true,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Adds comprehensive unit tests for the internal utility function `shouldRenderFormState`.  
This ensures correctness of form state reactivity based on subscription flags and root-level validation mode.

- Adds test cases for:
  - Empty `formState` returns `true`
  - Changed keys exceed subscription length
  - Matching subscribed keys (including `isRoot` logic)
- Covers all logical branches (including default return, `VALIDATION_MODE.all`)
- Groups root subscriber–specific scenarios under a dedicated `describe` block for clarity

This logic determines whether a form should re-render based on field-level or global state subscription.  
Having full test coverage prevents subtle bugs and provides confidence in future refactors.