### PR TITLE
test: add unit tests for unsetEmptyArray behavior

### DIFF
--- a/src/__tests__/logic/unsetEmptyArray.test.ts
+++ b/src/__tests__/logic/unsetEmptyArray.test.ts
@@ -1,0 +1,31 @@
+import unsetEmptyArray from '../../logic/unsetEmptyArray';
+import unset from '../../utils/unset';
+
+jest.mock('../../utils/unset', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('unsetEmptyArray', () => {
+  const mockedUnset = unset as jest.MockedFunction<typeof unset>;
+
+  beforeAll(() => {
+    mockedUnset.mockClear();
+  });
+
+  it('should call unset when the array is empty', () => {
+    const ref = { foo: [] as unknown[] };
+
+    unsetEmptyArray(ref, 'foo');
+
+    expect(mockedUnset).toHaveBeenCalledWith(ref, 'foo');
+  });
+
+  it('should not call unset when the array is not empty', () => {
+    const ref = { foo: ['data'] };
+
+    unsetEmptyArray(ref, 'foo');
+
+    expect(mockedUnset).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds unit tests for the `unsetEmptyArray` utility function, which unsets a given path in an object if the value is an empty array (or falsy after compaction).

- Tests that `unset()` is called when the target value is an empty array
- Tests that `unset()` is **not** called when the array has truthy elements
- Mocks `unset()` using Jest and verifies call behavior

This function is used internally to clean up empty values in form-related objects like `errors` or `dirtyFields`.  
Having test coverage ensures correct conditional cleanup and improves confidence in future refactors.