### PR TITLE
test: add unit tests for unsetEmptyArray, isWeb, and getValidationModes

### DIFF
--- a/src/__tests__/logic/getValidationModes.test.ts
+++ b/src/__tests__/logic/getValidationModes.test.ts
@@ -1,0 +1,54 @@
+import { VALIDATION_MODE } from '../../constants';
+import getValidationModes from '../../logic/getValidationModes';
+
+describe('getValidationModes', () => {
+  it('shold return correct flags for each mode', () => {
+    expect(getValidationModes(VALIDATION_MODE.onBlur)).toEqual({
+      isOnSubmit: false,
+      isOnBlur: true,
+      isOnChange: false,
+      isOnAll: false,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(VALIDATION_MODE.onChange)).toEqual({
+      isOnSubmit: false,
+      isOnBlur: false,
+      isOnChange: true,
+      isOnAll: false,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(VALIDATION_MODE.onSubmit)).toEqual({
+      isOnSubmit: true,
+      isOnBlur: false,
+      isOnChange: false,
+      isOnAll: false,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(undefined)).toEqual({
+      isOnSubmit: true,
+      isOnBlur: false,
+      isOnChange: false,
+      isOnAll: false,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(VALIDATION_MODE.all)).toEqual({
+      isOnSubmit: false,
+      isOnBlur: false,
+      isOnChange: false,
+      isOnAll: true,
+      isOnTouch: false,
+    });
+
+    expect(getValidationModes(VALIDATION_MODE.onTouched)).toEqual({
+      isOnSubmit: false,
+      isOnBlur: false,
+      isOnChange: false,
+      isOnAll: false,
+      isOnTouch: true,
+    });
+  });
+});

--- a/src/__tests__/logic/shouldRenderFormState.test.ts
+++ b/src/__tests__/logic/shouldRenderFormState.test.ts
@@ -1,0 +1,89 @@
+import shouldRenderFormState from '../../logic/shouldRenderFormState';
+import type { ReadFormState } from '../../types';
+
+describe('shouldRenderFormState', () => {
+  const updateFormState = jest.fn();
+
+  beforeEach(() => {
+    updateFormState.mockClear();
+  });
+
+  it('should return true when formState is Empty', () => {
+    const proxy = {
+      isValid: true,
+    } as ReadFormState;
+    const result = shouldRenderFormState({}, proxy, updateFormState);
+    expect(result).toBe(true);
+  });
+
+  it('should return true when changed keys are more', () => {
+    const proxy = { isValid: true } as ReadFormState;
+    const result = shouldRenderFormState(
+      { isValid: false, isDirty: true },
+      proxy,
+      updateFormState,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return true when changed state key is subscribed', () => {
+    const proxy: ReadFormState = {
+      isDirty: true,
+      isValid: false,
+    } as ReadFormState;
+    const result = shouldRenderFormState(
+      { isDirty: true },
+      proxy,
+      updateFormState,
+    );
+
+    expect(result).toBe('isDirty');
+    expect(updateFormState).toHaveBeenCalledWith({ isDirty: true });
+  });
+
+  it('should return false when changed state key is not subscribed', () => {
+    const proxy: ReadFormState = {
+      isDirty: false,
+      isValid: true,
+    } as ReadFormState;
+    const result = shouldRenderFormState(
+      { isDirty: true },
+      proxy,
+      updateFormState,
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  describe('when root subscribe', () => {
+    it('should return subscribed key name if expecting all', () => {
+      const proxy: ReadFormState = {
+        isDirty: 'all',
+        isValid: false,
+      } as ReadFormState;
+      const result = shouldRenderFormState(
+        { isDirty: true },
+        proxy,
+        updateFormState,
+        true,
+      );
+
+      expect(result).toBe('isDirty');
+    });
+
+    it('should return undefined if not expecting all', () => {
+      const proxy: ReadFormState = {
+        isDirty: true,
+        isValid: false,
+      } as ReadFormState;
+      const result = shouldRenderFormState(
+        { isDirty: true },
+        proxy,
+        updateFormState,
+        true,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/__tests__/logic/unsetEmptyArray.test.ts
+++ b/src/__tests__/logic/unsetEmptyArray.test.ts
@@ -1,0 +1,31 @@
+import unsetEmptyArray from '../../logic/unsetEmptyArray';
+import unset from '../../utils/unset';
+
+jest.mock('../../utils/unset', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('unsetEmptyArray', () => {
+  const mockedUnset = unset as jest.MockedFunction<typeof unset>;
+
+  beforeAll(() => {
+    mockedUnset.mockClear();
+  });
+
+  it('should call unset when the array is empty', () => {
+    const ref = { foo: [] as unknown[] };
+
+    unsetEmptyArray(ref, 'foo');
+
+    expect(mockedUnset).toHaveBeenCalledWith(ref, 'foo');
+  });
+
+  it('should not call unset when the array is not empty', () => {
+    const ref = { foo: ['data'] };
+
+    unsetEmptyArray(ref, 'foo');
+
+    expect(mockedUnset).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds unit tests for the following utility functions:

- `unsetEmptyArray`: verifies it unsets keys with empty or falsy arrays
- `isWeb`: ensures correct environment detection (browser vs. SSR)
- `getValidationModes`: checks validation mode flag generation

This PR consolidates test coverage for key utility logic.(#12939, #12938, #12937)
