### PR TITLE
fix(build): Remove React wildcard import to resolve ESM build issues

### DIFF
--- a/src/useIsomorphicLayoutEffect.ts
+++ b/src/useIsomorphicLayoutEffect.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 export const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;


### PR DESCRIPTION
Closes #12892
Closes #12763


This PR removes the `import * as React from 'react'` wildcard import in favor of a default import. This is the only wildcard import in the codebase and is known to cause issues with some build tools (see issues above).

I've been investigating this issue and it seems related to build tooling not supporting `.mjs` files properly. Given that there's only one instance of the wildcard import it seemed like a legit fix.

Here's [the resulting diff](https://www.jstoolset.com/diff/b9d6cabf0a26fdd8) of `index.esm.js`. Note that the only meaningful change is that `import * as React from 'react'` is gone, other changes are just a rename from `React__default` to `React`.

While this is a targeted fix, a more robust solution could be to update the build process or add a lint rule to prevent future wildcard imports. I'm happy to explore this further.

Since it's my first PR in react-hook-form, let me know if I'm missing any important step :) happy to iterate.

thanks!