### PR TITLE
Trigger watch callbacks in response to value changes only

### DIFF
--- a/src/__tests__/useForm/watch.test.tsx
+++ b/src/__tests__/useForm/watch.test.tsx
@@ -613,10 +613,10 @@ describe('watch', () => {
     render(<App />);
 
     fireEvent.click(screen.getByRole('button'));
-    expect(mockedFn).toHaveBeenCalledTimes(2);
+    expect(mockedFn).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole('button'));
-    expect(mockedFn).toHaveBeenCalledTimes(4);
+    expect(mockedFn).toHaveBeenCalledTimes(2);
   });
 
   it('should remain isReady form state for subscription', () => {

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -342,6 +342,48 @@ describe('useWatch', () => {
     expect(screen.getByText('345')).toBeVisible();
   });
 
+  it('should avoid triggering extra callbacks', () => {
+    const onChange = jest.fn();
+    type FormInputs = {
+      firstName: string;
+    };
+
+    const App = () => {
+      const {
+        register,
+        formState: { errors },
+        clearErrors,
+        watch,
+      } = useForm<FormInputs>();
+
+      React.useEffect(() => {
+        const unsubscribe = watch(onChange)?.unsubscribe;
+        return () => unsubscribe?.();
+      }, [watch]);
+
+      return (
+        <form>
+          <label>First Name</label>
+          <input type="text" {...register('firstName', { required: true })} />
+          {errors.firstName && <p>This Field is Required</p>}
+
+          <button type="button" onClick={() => clearErrors('firstName')}>
+            Clear First Name Errors
+          </button>
+          <button type="button" onClick={() => clearErrors()}>
+            Clear All Errors
+          </button>
+          <input type="submit" />
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByText('Clear All Errors'));
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
   describe('when disabled prop is used', () => {
     it('should be able to disabled subscription and started with true', async () => {
       type FormValues = {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -993,6 +993,7 @@ export function createFormControl<
     isFunction(name)
       ? _subjects.state.subscribe({
           next: (payload) =>
+            'values' in payload &&
             name(
               _getWatch(undefined, defaultValue),
               payload as {


### PR DESCRIPTION
Prior to 7.55.0, `watch` with a callback would trigger that callback only in response to value changes.  (This is the behavior that I expected from [the documentation](https://react-hook-form.com/docs/useform/watch): "Subscribe to field update/change," and the other forms of the `watch` API are specifically for field values.) Some code in our application depended on this behavior; for example:

```ts
useEffect(() => {
  const subscription = watch(async (formData) => {
    if (await trigger()) {
      doSomethingWithValidForm(formData);
    }
  });
  return () => subscription.unsubscribe();
}, [trigger, watch]);
```

React Hook Form 7.55 changed this behavior to trigger the watch callback on every state change, not just value changes.  Specifically, in 7f95b265d16aee8b6b34d2746f4248aebb9d4678, every occurrence of `_subjects.values.next({ values: ... })` was changed to `_subjects.state.next({ values: ... })`, and `watch` now subscribes to `_subjects.state` instead of `_subjects.value`. As a result, the watch callback to be called on every state change.  Note that, in that commit, tests in `watch.test.tsx` had to be updated to reflect the extra calls.

We can get back the pre-7.55 behavior by only triggering the `watch` callback if the `values` property is present in the payload of the state change, since it was present for every call to `_subject.values.next` in pre-7.55.

Note that this change potentially breaks compatibility with 7.55 through 7.60 (since `watch` is no longer called on every state change), but it fixes a break in backward compatibility with pre-7.55.

I'd really appreciate it if this could be merged: the break in backward compatibility relative to 7.54 and below has affected multiple users, and any issues with changing behavior relative to 7.55 and above should be less severe (especially since `watch` is deprecated starting in 7.55 and the easier-to-use `subscribe` API is now available). Thank you.

Fixes #12721 and #12821. See also #12918.