### PR TITLE
fix: handle explicit "multipart/form-data" encType in Form Component

### DIFF
--- a/src/__tests__/form.test.tsx
+++ b/src/__tests__/form.test.tsx
@@ -31,6 +31,21 @@ const server = setupServer(
 
     return new HttpResponse(null, { status: 500 });
   }),
+  http.post('/formData', async ({ request }) => {
+    if (
+      request.headers.get('content-type')?.startsWith('multipart/form-data') &&
+      request.headers.get('content-type')?.includes('boundary=')
+    ) {
+      try {
+        await request.formData();
+        return new HttpResponse(null, { status: 200 });
+      } catch {
+        return new HttpResponse(null, { status: 500 });
+      }
+    }
+
+    return new HttpResponse(null, { status: 500 });
+  }),
 );
 
 describe('Form', () => {
@@ -293,6 +308,36 @@ describe('Form', () => {
         <Form
           encType={'application/json'}
           action={'/json'}
+          control={control}
+          onSuccess={onSuccess}
+        >
+          <button>Submit</button>
+          <p>{isSubmitSuccessful ? 'submitSuccessful' : 'submitFailed'}</p>
+        </Form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(onSuccess).toBeCalled();
+    });
+  });
+
+  it('should support explicit "multipart/form-data" encType', async () => {
+    const onSuccess = jest.fn();
+    const App = () => {
+      const {
+        control,
+        formState: { isSubmitSuccessful },
+      } = useForm();
+
+      return (
+        <Form
+          encType={'multipart/form-data'}
+          action={'/formData'}
           control={control}
           onSuccess={onSuccess}
         >

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -88,7 +88,7 @@ function Form<
             method,
             headers: {
               ...headers,
-              ...(encType != 'multipart/form-data'
+              ...(encType && encType !== 'multipart/form-data'
                 ? { 'Content-Type': encType }
                 : {}),
             },

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -88,7 +88,9 @@ function Form<
             method,
             headers: {
               ...headers,
-              ...(encType ? { 'Content-Type': encType } : {}),
+              ...(encType != 'multipart/form-data'
+                ? { 'Content-Type': encType }
+                : {}),
             },
             body: shouldStringifySubmissionData ? formDataJson : formData,
           });


### PR DESCRIPTION
## Proposed Changes

**Summary:**  
Fixes an issue where setting `encType` to `"multipart/form-data"` caused an incorrect `Content-Type` header to be sent, resulting in invalid FormData submissions. Now, the `Content-Type` header is only set explicitly when `encType` is not `"multipart/form-data"`.

**Motivation and Context:**  
Previously, when `encType` was set to `"multipart/form-data"`, the code explicitly set the `Content-Type` header. This prevented the browser from automatically adding the correct boundary parameter, causing the server to receive malformed FormData. This change ensures that the browser handles the `Content-Type` header for multipart submissions, fixing compatibility with servers expecting properly formatted FormData.

**Issue Fixed:**  
Fixes the issue where FormData submissions with explicit `"multipart/form-data"` `encType` were broken due to missing boundary information.

**Dependencies:**  
No additional dependencies are required for this change.

Fixes #12770

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
