### PR TITLE
test: add unit tests for convertToArrayPayload utility

### DIFF
--- a/src/__tests__/utils/convertToArrayPayload.test.ts
+++ b/src/__tests__/utils/convertToArrayPayload.test.ts
@@ -1,0 +1,17 @@
+import convertToArrayPayload from '../../utils/convertToArrayPayload';
+
+describe('convertToArrayPayload', () => {
+  it('should return the same array when input is already an array', () => {
+    const arr = [1, 2, 3];
+    expect(convertToArrayPayload(arr)).toStrictEqual(arr);
+  });
+
+  it('should wrap non-array values into an array', () => {
+    expect(convertToArrayPayload(1)).toStrictEqual([1]);
+    expect(convertToArrayPayload('test')).toStrictEqual(['test']);
+    const object = {
+      a: 'test',
+    };
+    expect(convertToArrayPayload(object)).toStrictEqual([object]);
+  });
+});


### PR DESCRIPTION
Add unit tests for convertToArrayPayload to cover array and non-array inputs

This PR adds unit tests for the convertToArrayPayload utility function.

Covers behavior for both array and non-array inputs

Ensures that:
- If the input is already an array, it is returned as-is
- If the input is not an array (e.g., number, string, object), it is wrapped into an array

Uses toStrictEqual assertions to ensure both structure and reference correctness

This improves confidence in the behavior of this small but widely used utility and guards against regressions during refactoring. The tests are type-agnostic and work across primitive and object types.