### PR TITLE
fix: prevent onBlur for readOnly fields

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -766,12 +766,16 @@ export function createFormControl<
 
       set(_formValues, name, fieldValue);
 
-      if (isBlurEvent) {
-        field._f.onBlur && field._f.onBlur(event);
-        delayErrorCallback && delayErrorCallback(0);
-      } else if (field._f.onChange) {
-        field._f.onChange(event);
-      }
+     if (isBlurEvent) {
+  const target = event.target as HTMLInputElement;
+  if (!target.readOnly) {
+    field._f.onBlur && field._f.onBlur(event);
+    delayErrorCallback && delayErrorCallback(0);
+  }
+} else if (field._f.onChange) {
+  field._f.onChange(event);
+}
+
 
       const fieldState = updateTouchAndDirty(name, fieldValue, isBlurEvent);
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -766,16 +766,15 @@ export function createFormControl<
 
       set(_formValues, name, fieldValue);
 
-     if (isBlurEvent) {
-  const target = event.target as HTMLInputElement;
-  if (!target.readOnly) {
-    field._f.onBlur && field._f.onBlur(event);
-    delayErrorCallback && delayErrorCallback(0);
-  }
-} else if (field._f.onChange) {
-  field._f.onChange(event);
-}
-
+      if (isBlurEvent) {
+        const target = event.target as HTMLInputElement;
+        if (!target.readOnly) {
+          field._f.onBlur && field._f.onBlur(event);
+          delayErrorCallback && delayErrorCallback(0);
+        }
+      } else if (field._f.onChange) {
+        field._f.onChange(event);
+      }
 
       const fieldState = updateTouchAndDirty(name, fieldValue, isBlurEvent);
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -767,8 +767,7 @@ export function createFormControl<
       set(_formValues, name, fieldValue);
 
       if (isBlurEvent) {
-        const target = event.target as HTMLInputElement;
-        if (!target.readOnly) {
+        if (!target || !target.readOnly) {
           field._f.onBlur && field._f.onBlur(event);
           delayErrorCallback && delayErrorCallback(0);
         }


### PR DESCRIPTION
Prevents onBlur event from firing for readonly input fields to fix unintended validation triggers.