### PR TITLE
fix: field name type conflict in nested FieldErrors

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -422,7 +422,7 @@ export type MaxType = InputValidationRules['max'] | InputValidationRules['maxLen
 
 // @public (undocumented)
 export type Merge<A, B> = {
-    [K in keyof A | keyof B]?: K extends keyof A & keyof B ? [A[K], B[K]] extends [object, object] ? Merge<A[K], B[K]> : A[K] | B[K] : K extends keyof A ? A[K] : K extends keyof B ? B[K] : never;
+    [K in keyof A | keyof B]?: K extends keyof A & keyof B ? [A[K], B[K]] extends [object, object] ? Merge<A[K], B[K]> : B[K] : K extends keyof A ? A[K] : K extends keyof B ? B[K] : never;
 };
 
 // @public (undocumented)

--- a/src/__typetest__/errors.test-d.ts
+++ b/src/__typetest__/errors.test-d.ts
@@ -78,4 +78,16 @@ import { _ } from './__fixtures__';
     expectType<FieldError | undefined>(actual.record?.file);
     expectType<FieldError | undefined>(actual.record?.fileList);
   }
+
+  /** it should handle field name conflicts with FieldError properties correctly */
+  {
+    const actual = _ as FieldErrors<{
+      frequencyInput: {
+        type: 'monthly' | 'yearly';
+      };
+    }>;
+
+    expectType<FieldError | undefined>(actual.frequencyInput?.type);
+    expectType<string | undefined>(actual.frequencyInput?.type?.message);
+  }
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -125,7 +125,7 @@ export type Merge<A, B> = {
   [K in keyof A | keyof B]?: K extends keyof A & keyof B
     ? [A[K], B[K]] extends [object, object]
       ? Merge<A[K], B[K]>
-      : A[K] | B[K]
+      : B[K]
     : K extends keyof A
       ? A[K]
       : K extends keyof B


### PR DESCRIPTION

  ## Summary

  - Fixes TypeScript inference issue where field names like `type` conflict
  with FieldError properties
  - Updates `Merge` utility type to prioritize second type parameter over
  first when merging conflicting properties
  - Adds comprehensive type tests to prevent regression

  ## Problem

  When defining nested fields with names that match FieldError properties
  (like `type`), TypeScript incorrectly infers the field as a string instead
  of a FieldError object:

  ```typescript
  interface MyFormInput {
    frequencyInput: {
      type: 'monthly' | 'yearly';
    };
  }

  // ❌ Before: TS error on .message access
  errors.frequencyInput?.type?.message
```

  ## Solution

  Modified the Merge utility type in `src/types/utils.ts` to prioritize the
  second type parameter (B[K]) over union types (A[K] | B[K]) when properties
  conflict, ensuring proper FieldError typing.
 
## Related Issues
- https://github.com/react-hook-form/react-hook-form/issues/12924