### PR TITLE
docs(v7): add simple useFieldArray example using append()

### DIFF
--- a/examples/V7/useFieldArraySimpleExample.tsx
+++ b/examples/V7/useFieldArraySimpleExample.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { useForm, useFieldArray } from "react-hook-form";
+
+export default function UseFieldArraySimpleExample() {
+  const { register, control, handleSubmit } = useForm({
+    defaultValues: {
+      users: [{ name: "" }]
+    }
+  });
+
+  const { fields, append } = useFieldArray({
+    control,
+    name: "users"
+  });
+
+  const onSubmit = (data) => console.log(data);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      {fields.map((field, index) => (
+        <input
+          key={field.id}
+          {...register(`users.${index}.name`)}
+          placeholder={`User ${index + 1}`}
+        />
+      ))}
+      <button type="button" onClick={() => append({ name: "" })}>
+        Add User
+      </button>
+      <input type="submit" />
+    </form>
+  );
+}


### PR DESCRIPTION
This PR adds a basic usage example of `useFieldArray` for React Hook Form v7. 

The example demonstrates how to dynamically append form fields using `append()` and `register()`, making it easier for developers to understand how to manage arrays of fields in forms.

Related to: #10344
