### PR TITLE
fix: do not override prototype of `data` in `cloneObject`

### DIFF
--- a/src/__tests__/utils/cloneObject.test.ts
+++ b/src/__tests__/utils/cloneObject.test.ts
@@ -166,4 +166,13 @@ describe('clone', () => {
       delete Array.prototype.somePolyfill;
     });
   });
+
+  it('should not override prototype of nested object', () => {
+    const UtcProto = {
+      _tag: 'Utc',
+    };
+    const dateTime = Object.create(UtcProto);
+    const copy = cloneObject(dateTime);
+    expect(copy._tag).toBe('Utc');
+  });
 });

--- a/src/__tests__/utils/cloneObject.test.ts
+++ b/src/__tests__/utils/cloneObject.test.ts
@@ -171,6 +171,18 @@ describe('clone', () => {
     const UtcProto = {
       _tag: 'Utc',
     };
+    const formValues = {
+      dateTime: Object.create(UtcProto),
+    };
+    const copy = cloneObject(formValues);
+    expect(Object.getPrototypeOf(copy.dateTime)).toEqual(UtcProto);
+    expect(copy.dateTime._tag).toBe('Utc');
+  });
+
+  it('should not override prototype of nested object', () => {
+    const UtcProto = {
+      _tag: 'Utc',
+    };
     const dateTime = Object.create(UtcProto);
     const copy = cloneObject(dateTime);
     expect(copy._tag).toBe('Utc');

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -14,7 +14,7 @@ export default function cloneObject<T>(data: T): T {
     !(isWeb && (data instanceof Blob || isFileListInstance)) &&
     (isArray || isObject(data))
   ) {
-    copy = isArray ? [] : {};
+    copy = isArray ? [] : Object.create(Object.getPrototypeOf(data));
 
     if (!isArray && !isPlainObject(data)) {
       copy = data;


### PR DESCRIPTION
I've encountered an issue while using `effectTsResolver` and `DateTime` structure in particular: in `handleSubmit` callback inside `formValues` my `dateTime` field always fails validation against `effect/Schema`.

After some digging I realized that the issue is in `cloneObject` util: the base object for `copy` is just a plain `{}` but in `effect` many data types heavily relies on prototypes.

For example the same `DateTime`: https://github.com/Effect-TS/effect/blob/main/packages/effect/src/internal/dateTime.ts#L203-L212