### PR TITLE
🐞 fix #12988 sync two defaultValues after reset with new defaultValues

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -26,7 +26,13 @@ import type {
 import isFunction from '../utils/isFunction';
 import noop from '../utils/noop';
 import sleep from '../utils/sleep';
-import { Controller, createFormControl, useFieldArray, useForm } from '../';
+import {
+  Controller,
+  createFormControl,
+  useFieldArray,
+  useForm,
+  useFormState,
+} from '../';
 
 jest.useFakeTimers();
 
@@ -2722,6 +2728,51 @@ describe('useForm', () => {
 
       fireEvent.input(input, { target: { value: 'abc' } });
       expect(input.value).toBe('abc');
+    });
+  });
+
+  describe('When using defaultValues', () => {
+    function App() {
+      type FormValues = {
+        firstName: string;
+      };
+
+      const [defaults, setDefaults] = React.useState<FormValues>({
+        firstName: '1',
+      });
+
+      const { control, formState, reset, register } = useForm<FormValues>({
+        defaultValues: defaults,
+      });
+
+      const { defaultValues: stateDefaults } = useFormState({ control });
+
+      const handleClick = () => {
+        const next = { firstName: String(Number(defaults.firstName) + 1) };
+        setDefaults(next);
+        reset(next);
+      };
+
+      return (
+        <div>
+          <input {...register('firstName')} />
+          <button onClick={handleClick}>reset</button>
+          <span data-testid="react">{defaults.firstName}</span>
+          <span data-testid="form">{formState.defaultValues?.firstName}</span>
+          <span data-testid="state">{stateDefaults?.firstName}</span>
+        </div>
+      );
+    }
+    it('formState.defaultValues and useFormState().defaultValues should be equal after reset', () => {
+      render(<App />);
+
+      fireEvent.click(screen.getByText('reset'));
+      fireEvent.click(screen.getByText('reset'));
+      fireEvent.click(screen.getByText('reset'));
+
+      const reactValue = screen.getByTestId('react').textContent;
+      expect(screen.getByTestId('form').textContent).toBe(reactValue);
+      expect(screen.getByTestId('state').textContent).toBe(reactValue);
     });
   });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1438,6 +1438,9 @@ export function createFormControl<
         ? _formState.isSubmitSuccessful
         : false,
       isSubmitting: false,
+      defaultValues: !isEmptyObject(_defaultValues)
+        ? (_defaultValues as FormState<TFieldValues>['defaultValues'])
+        : undefined,
     });
   };
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1438,9 +1438,7 @@ export function createFormControl<
         ? _formState.isSubmitSuccessful
         : false,
       isSubmitting: false,
-      defaultValues: !isEmptyObject(_defaultValues)
-        ? (_defaultValues as FormState<TFieldValues>['defaultValues'])
-        : undefined,
+      defaultValues: _defaultValues as FormState<TFieldValues>['defaultValues'],
     });
   };
 


### PR DESCRIPTION
To resolve #12988

Hello, Bill 😁

### Issue
`useFormState().defaultValues` does not update after `reset()` with new defaultValues.

### Cause
- This issue occurs in [v.7.61.0](https://github.com/react-hook-form/react-hook-form/releases/tag/v7.61.0)
- The changes introduced in PR #12961 are the cause of this issue.

### Solution
- Modified the code to update defaultValues when the `reset()` method is called.
- Added a test to verify that `useFormState().defaultValues` and `formState.defaultValues` change identically.