### PR TITLE
fix: use field name to update isValidating fields

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -484,7 +484,7 @@ export function createFormControl<
             field._f && hasPromiseValidation((field as Field)._f);
 
           if (isPromiseFunction && _proxyFormState.validatingFields) {
-            _updateIsValidating([name], true);
+            _updateIsValidating([_f.name], true);
           }
 
           const fieldError = await validateField(
@@ -497,7 +497,7 @@ export function createFormControl<
           );
 
           if (isPromiseFunction && _proxyFormState.validatingFields) {
-            _updateIsValidating([name]);
+            _updateIsValidating([_f.name]);
           }
 
           if (fieldError[_f.name]) {


### PR DESCRIPTION
To resolve #12999

Hi Bill,

### Issue 
Updating validatingFields state is not properly handling nested field names when called via `trigger()`.

### Solution
Using `_f.name` to update `isValidating` state
