### PR TITLE
fix: unregister previous field when switching conditional Controllers

### DIFF
--- a/src/useController.ts
+++ b/src/useController.ts
@@ -183,9 +183,16 @@ export function useController<
     [name, disabled, formState.disabled, onChange, onBlur, ref, value],
   );
 
+  const previousNameRef = React.useRef<string | undefined>(undefined);
+
   React.useEffect(() => {
     const _shouldUnregisterField =
       control._options.shouldUnregister || shouldUnregister;
+    const previousName = previousNameRef.current;
+
+    if (previousName && previousName !== name && !isArrayField) {
+      control.unregister(previousName as FieldPath<TFieldValues>);
+    }
 
     control.register(name, {
       ..._props.current.rules,
@@ -213,6 +220,8 @@ export function useController<
     }
 
     !isArrayField && control.register(name);
+
+    previousNameRef.current = name;
 
     return () => {
       (

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -88,6 +88,8 @@ export function useController<
 
   const _props = React.useRef(props);
 
+  const _previousNameRef = React.useRef<string | undefined>(undefined);
+
   const _registerProps = React.useRef(
     control.register(name, {
       ...props.rules,
@@ -183,12 +185,10 @@ export function useController<
     [name, disabled, formState.disabled, onChange, onBlur, ref, value],
   );
 
-  const previousNameRef = React.useRef<string | undefined>(undefined);
-
   React.useEffect(() => {
     const _shouldUnregisterField =
       control._options.shouldUnregister || shouldUnregister;
-    const previousName = previousNameRef.current;
+    const previousName = _previousNameRef.current;
 
     if (previousName && previousName !== name && !isArrayField) {
       control.unregister(previousName as FieldPath<TFieldValues>);
@@ -221,7 +221,7 @@ export function useController<
 
     !isArrayField && control.register(name);
 
-    previousNameRef.current = name;
+    _previousNameRef.current = name;
 
     return () => {
       (


### PR DESCRIPTION
fix #13039

This PR addresses the issue where field values could leak between Controllers rendered conditionally at the same position.

`useController` now tracks the previous field name and automatically unregisters it when the name changes, preventing removed fields from lingering in the form state. Field Array functionality is preserved.

If users prefer handling this with explicit `key` props, this PR can be closed! 🙂