### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
### Summary
This PR adds a `.editorconfig` file to enforce consistent code style across the project.

### Details
- Defines UTF-8 charset
- Uses LF for line endings
- Ensures final newline at end of file
- Enforces 2-space indentation
- Trims trailing whitespace (except in Markdown files)

### Why?
This helps contributors maintain consistent formatting automatically, reducing style-related diffs and keeping the codebase cleaner.

### Checklist
- [x] Added `.editorconfig` file
- [x] Verified formatting rules
- [x] Ready for review
