### PR TITLE
fix: only excute trigger fuction when deps has a valid array

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -858,6 +858,7 @@ export function createFormControl<
 
       if (isFieldValueUpdated) {
         field._f.deps &&
+          (!Array.isArray(field._f.deps) || field._f.deps.length > 0) &&
           trigger(
             field._f.deps as
               | FieldPath<TFieldValues>


### PR DESCRIPTION
To resolve #13040

Hello, Bill 😁
This PR includes a small fix.

### Issue

When `deps` is an empty array, errors keep updating on every key input.


### Cause

An empty array is still evaluated as truthy, which caused trigger to run on every `onChange` event.


### Solution

Updated the logic so that `trigger` function inside `onChange` only executes when the dependency array contains elements.