### PR TITLE
🚏 feat: support optional array fields in PathValueImpl type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Pay attention that we use pnpm v9 along with Node.js 20.
 4. If you've added a code that should be tested, ensure the test suite still passes.
 
    ```shellscript
-   pnpm test && pnpm tsd
+   pnpm test && pnpm test:type
    ```
 
 5. Try to write some unit tests to cover as much of your code as possible.

--- a/src/__typetest__/path/eager.test-d.ts
+++ b/src/__typetest__/path/eager.test-d.ts
@@ -98,6 +98,35 @@ import { _ } from '../__fixtures__';
     const actual = _ as PathValue<Depth3Type<boolean>, 'baz.42.value'>;
     expectType<boolean>(actual);
   }
+
+  /** it should apply optional type for optional arrays */ {
+    const actual = _ as PathValue<Depth3Type<string[] | undefined>, 'value.1'>;
+    expectType<string | undefined>(actual);
+  }
+
+  /** it should traverse an object and apply optional type for optional arrays */ {
+    const actual = _ as PathValue<
+      Depth3Type<string[] | undefined>,
+      'foo.foo.value.3'
+    >;
+    expectType<string | undefined>(actual);
+  }
+
+  /** it should traverse a tuple and apply optional type for optional arrays */ {
+    const actual = _ as PathValue<
+      Depth3Type<string[] | undefined>,
+      'bar.0.value.3'
+    >;
+    expectType<string | undefined>(actual);
+  }
+
+  /** it should traverse an array and apply optional type for optional arrays */ {
+    const actual = _ as PathValue<
+      Depth3Type<string[] | undefined>,
+      'baz.0.value.3'
+    >;
+    expectType<string | undefined>(actual);
+  }
 }
 
 /** {@link FieldPathValues} */ {

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -152,7 +152,9 @@ export type PathValue<T, P extends Path<T> | ArrayPath<T>> = PathValueImpl<
 type PathValueImpl<T, P extends string> = T extends any
   ? P extends `${infer K}.${infer R}`
     ? K extends keyof T
-      ? PathValueImpl<T[K], R>
+      ? undefined extends T[K]
+        ? PathValueImpl<T[K], R> | undefined
+        : PathValueImpl<T[K], R>
       : K extends `${ArrayKey}`
         ? T extends ReadonlyArray<infer V>
           ? PathValueImpl<V, R>
@@ -163,7 +165,9 @@ type PathValueImpl<T, P extends string> = T extends any
       : P extends `${ArrayKey}`
         ? T extends ReadonlyArray<infer V>
           ? V
-          : never
+          : undefined extends T
+            ? undefined
+            : never
         : never
   : never;
 


### PR DESCRIPTION
When targeting an item of an optional array field, the `PathValueImpl` type omits the fact that the array is optional.

Given a type `MyType`, with an optional string array as a field:

```typescript
type MyType = {
    optionalArray?: string[]
}
```

- The returned type of ``PathValueImpl<MyType, `optionalArray.${number}`>`` should be `string | undefined` since `optionalArray` is possibly `undefined`. Using the current version, the returned type would be `string`.
- Similarly, the returned type of ``PathValueImpl<string[] | undefined,`${number}`>`` should be `string | undefined`. Using the current version, the returned type would be `string`.

Given this, the following code should not get any Typescript errors:

```typescript
const optionalArrayItem: PathValueImpl<MyType, `optionalArray.${number}`> = undefined

const optionalArrayItem2: PathValueImpl<string[] | undefined, `${number}`> = undefined
```

[Here](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAsiAq5oF4oG8BQVtQPZmAEtcA7AQwBsBBAJxrJAH4AuKAZ2BsJIHMBtALoYAvhgyhIUWvRABpCCCioSAVwC2AIwg0xE6ADkIAdwAKZYAAsAapRUQAkmrAUAPPAA0UE1AgAPYBAkACZs7JzcPAB8SlDwPv6BIVBkJCBYOIxe8QHBoQAGACRo3ABm2lCywgB0RaXlAErCeek4GRXZiaEA1gq4JbEtrUOZKsEQJdwQQR25sXyyQkNLw1CGpubWtg5OrvDzAp710QA+UKNB45NBg8tDrGtmljYUdo7ObvuHkTfLrLIzSUKaGkDHkICaP1u2EycT8OSS9QgZCCpAoIBBIBcdRoUCs3yhBKgmQeG2erx2LisX0hhOwrBIEAAbtoabd6UyWWysnDOlAeiA+gNaTC+CZFoTWN4ebMgRiwRDaa0YQDQojkaj0XQGFiSGUcXjWYTMlZDQTWOdLgzptKknERmMJlaoOzmTpFThWFAGa7Bi7tABuMQAY1IHDwBGI5GoWpA9gCanuxkemxe23ecEQkE8eXwRFIlAxNTQqk02ia0VQFsdU2DoeA4bzUYxcYgagATIn1k8tm9XBwuLxBFBTlWrtmiiWtDRyzFR1axAu9FAAPIUILJslp3aeKUJWb9iIV2Iq5KpQaZXfw-K1XXlSpF7FQRrNW6Zf427q9frwU1EldrjcewpPYFmpWk-hPWUY3lF93T-WE9wRJEURINEMR1PVcXxOClX-ddSSA94qSfbCcLpL0OTdOC-SopZJRPflBR-YU5jFX96I-KAoJkGDf1whCryfZCNXQx8DTItoTQk8jvU5ajsFk2jnQo11AwwEMSDDXA12XCN82jGQWwTPDANTXsXAzJBs1zSMCxjItJzLPIjznGt1LrPAdL0psYyMjsTIIsyKQPQcBGHM4HTHLiJ3UKcZ0rSKrSAA) is a typescript playground comparing the results using current and new version of `PathValueImpl`.

I encountered this while using `useWatch` on my form containing an optional array field, noticing the returned type wasn't safe since it doesn't enforce handling the case where the result is `undefined`.

This PR:
- updates the `PathValueImpl` type to take optional array fields into consideration
- adds 4 tsd tests for `PathValue`, which uses `PathValueImpl`, to ensure the returned type extends `undefined` when targeting an optional array field
- updates the `Contributing` documentation by replacing the `tsd` type tests command by `test:type`, as I noticed the command wasn't right while following the contributing guide.

By the way, I'm a developper using react-hook-form for professional purposes. I work at [ChapsVision](https://www.chapsvision.com/). I specifically created a professional GitHub account for this PR, that's why it is so young and empty.