### PR TITLE
fix: preserve Controller's defaultValue

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -833,24 +833,22 @@ describe('useController', () => {
       const { isValid } = form.formState;
 
       return (
-        <React.StrictMode>
-          <FormProvider {...form}>
-            <Controller
-              render={({ field }) => (
-                <input value={field.value} onChange={field.onChange} />
-              )}
-              name="name"
-              rules={{
-                required: true,
-              }}
-            />
-            <p>{isValid ? 'valid' : 'not'}</p>
-          </FormProvider>
-        </React.StrictMode>
+        <FormProvider {...form}>
+          <Controller
+            render={({ field }) => (
+              <input value={field.value} onChange={field.onChange} />
+            )}
+            name="name"
+            rules={{
+              required: true,
+            }}
+          />
+          <p>{isValid ? 'valid' : 'not'}</p>
+        </FormProvider>
       );
     };
 
-    render(<App />);
+    render(<App />, { reactStrictMode: true });
 
     await waitFor(() => {
       screen.getByText('not');
@@ -879,18 +877,16 @@ describe('useController', () => {
       } = methods;
 
       return (
-        <React.StrictMode>
-          <FormProvider {...methods}>
-            <form>
-              <Form />
-              {dirtyFields.lastName ? 'dirty' : 'pristine'}
-            </form>
-          </FormProvider>
-        </React.StrictMode>
+        <FormProvider {...methods}>
+          <form>
+            <Form />
+            {dirtyFields.lastName ? 'dirty' : 'pristine'}
+          </form>
+        </FormProvider>
       );
     }
 
-    render(<App />);
+    render(<App />, { reactStrictMode: true });
 
     fireEvent.change(screen.getByRole('textbox'), {
       target: {

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -855,6 +855,43 @@ describe('useController', () => {
     });
   });
 
+  it('should restore defaultValue from Controller with react strict mode double useEffect', async () => {
+    const onSubmit = jest.fn();
+
+    function App() {
+      const { handleSubmit, control } = useForm({
+        shouldUnregister: true,
+      });
+
+      return (
+        <form
+          onSubmit={handleSubmit((data) => {
+            onSubmit(data);
+          })}
+        >
+          <Controller
+            control={control}
+            name="firstName"
+            defaultValue={'luo'}
+            render={({ field }) => <input {...field} />}
+          />
+
+          <button>submit</button>
+        </form>
+      );
+    }
+
+    render(<App />, { reactStrictMode: true });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        firstName: 'luo',
+      });
+    });
+  });
+
   it('should restore defaultValues with react strict mode double useEffect', () => {
     function Form() {
       return (

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -2898,36 +2898,34 @@ describe('useFieldArray', () => {
       });
 
       return (
-        <React.StrictMode>
-          <form onSubmit={handleSubmit(noop)}>
-            {fields.map((field, index) => {
-              return (
-                <div key={field.id}>
-                  <input {...register(`test.${index}.yourDetail.firstName`)} />
-                  <input {...register(`test.${index}.yourDetail.lastName`)} />
-                </div>
-              );
-            })}
-            <button
-              type="button"
-              onClick={() =>
-                append({
-                  yourDetail: {
-                    firstName: 'bill',
-                    lastName: 'luo',
-                  },
-                })
-              }
-            >
-              Append
-            </button>
-            <input type="submit" />
-          </form>
-        </React.StrictMode>
+        <form onSubmit={handleSubmit(noop)}>
+          {fields.map((field, index) => {
+            return (
+              <div key={field.id}>
+                <input {...register(`test.${index}.yourDetail.firstName`)} />
+                <input {...register(`test.${index}.yourDetail.lastName`)} />
+              </div>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() =>
+              append({
+                yourDetail: {
+                  firstName: 'bill',
+                  lastName: 'luo',
+                },
+              })
+            }
+          >
+            Append
+          </button>
+          <input type="submit" />
+        </form>
       );
     }
 
-    render(<App />);
+    render(<App />, { reactStrictMode: true });
 
     fireEvent.click(screen.getByRole('button', { name: 'Append' }));
 

--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -979,11 +979,7 @@ describe('setValue', () => {
         );
       }
 
-      render(
-        <React.StrictMode>
-          <App />
-        </React.StrictMode>,
-      );
+      render(<App />, { reactStrictMode: true });
 
       jest.advanceTimersByTime(10000);
 

--- a/src/__tests__/useFormState.test.tsx
+++ b/src/__tests__/useFormState.test.tsx
@@ -602,14 +602,10 @@ describe('useFormState', () => {
     }
 
     const App = () => {
-      return (
-        <React.StrictMode>
-          <FieldArray />
-        </React.StrictMode>
-      );
+      return <FieldArray />;
     };
 
-    render(<App />);
+    render(<App />, { reactStrictMode: true });
 
     fireEvent.click(screen.getByRole('button', { name: 'add' }));
 

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -212,7 +212,9 @@ export function useController<
     updateMounted(name, true);
 
     if (_shouldUnregisterField) {
-      const value = cloneObject(get(control._options.defaultValues, name));
+      const value = cloneObject(
+        get(control._options.defaultValues, name, _props.current.defaultValue),
+      );
       set(control._defaultValues, name, value);
       if (isUndefined(get(control._formValues, name))) {
         set(control._formValues, name, value);


### PR DESCRIPTION
When `shouldUnregister` is true, the field restoration logic was only considering useForm's `defaultValues` but ignoring the Controller's defaultValue prop. 
This caused the `defaultValue` to be lost with React.Strict Mode.

close https://github.com/react-hook-form/react-hook-form/issues/12670
close https://github.com/react-hook-form/react-hook-form/issues/12798
