### PR TITLE
chore: remove unused field ids ref in useFieldArray

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -104,10 +104,9 @@ export function useFieldArray<
   const ids = React.useRef<string[]>(
     control._getFieldArray(name).map(generateId),
   );
-  const _fieldIds = React.useRef(fields);
+
   const _actioned = React.useRef(false);
 
-  _fieldIds.current = fields;
   control._names.array.add(name);
 
   React.useMemo(


### PR DESCRIPTION
## Summary
Remove dead code left over from PR [#7447](https://github.com/react-hook-form/react-hook-form/pull/7447)

## Changes
- Remove unused `_fieldIds` ref declaration and assignment
- Clean up dead code that was no longer needed after the ids ref separation

## Context
In PR #7447, the useFieldArray implementation was optimized by separating the management of field ids from the main fields ref. However, the `_fieldIds` ref declaration and its assignment (`_fieldIds.current = fields`) remained as dead code after this optimization.

This is a simple refactoring to clean up the unused code with no functional changes.