### PR TITLE
fix: resolve late subscription issue for formState properties(isDirty)

### DIFF
--- a/src/__tests__/logic/createFormControl.test.ts
+++ b/src/__tests__/logic/createFormControl.test.ts
@@ -62,4 +62,68 @@ describe('createFormControl', () => {
 
     expect(isEmptyObject).toHaveBeenCalledTimes(3);
   });
+
+  describe('isDirty state updates without subscription', () => {
+    it('should keep _formState.isDirty up-to-date even when not subscribed', () => {
+      const { register, control } = createFormControl({
+        defaultValues: {
+          name: '',
+        },
+      });
+
+      expect(control._proxyFormState.isDirty).toBe(false);
+
+      const ref = document.createElement('input');
+      ref.name = 'name';
+      const { onChange } = register('name', {});
+      onChange({ target: { name: 'name', value: '' } });
+      register('name', {}).ref(ref);
+
+      expect(control._formState.isDirty).toBe(false);
+
+      onChange({ target: { name: 'name', value: 'John' } });
+
+      expect(control._formState.isDirty).toBe(true);
+      expect(control._proxyFormState.isDirty).toBe(false);
+
+      onChange({ target: { name: 'name', value: '' } });
+      expect(control._formState.isDirty).toBe(false);
+    });
+
+    it('should correctly update isDirty when multiple fields change without subscription', () => {
+      const { register, control } = createFormControl({
+        defaultValues: {
+          firstName: '',
+          lastName: '',
+        },
+      });
+
+      expect(control._proxyFormState.isDirty).toBe(false);
+
+      const firstNameRef = document.createElement('input');
+      firstNameRef.name = 'firstName';
+      const { onChange: onChangeFirstName } = register('firstName', {});
+      onChangeFirstName({ target: { name: 'firstName', value: '' } });
+      register('firstName', {}).ref(firstNameRef);
+
+      const lastNameRef = document.createElement('input');
+      lastNameRef.name = 'lastName';
+      const { onChange: onChangeLastName } = register('lastName', {});
+      onChangeLastName({ target: { name: 'lastName', value: '' } });
+      register('lastName', {}).ref(lastNameRef);
+
+      onChangeFirstName({ target: { name: 'firstName', value: 'John' } });
+      expect(control._formState.isDirty).toBe(true);
+      expect(control._proxyFormState.isDirty).toBe(false);
+
+      onChangeLastName({ target: { name: 'lastName', value: 'Doe' } });
+      expect(control._formState.isDirty).toBe(true);
+
+      onChangeFirstName({ target: { name: 'firstName', value: '' } });
+      expect(control._formState.isDirty).toBe(true);
+
+      onChangeLastName({ target: { name: 'lastName', value: '' } });
+      expect(control._formState.isDirty).toBe(false);
+    });
+  });
 });

--- a/src/__tests__/useFormState.test.tsx
+++ b/src/__tests__/useFormState.test.tsx
@@ -738,7 +738,7 @@ describe('useFormState', () => {
 
     fireEvent.click(screen.getByRole('button'));
 
-    expect(await screen.queryByText('dirty')).toBeNull();
+    expect(await screen.findByText('dirty')).toBeVisible();
     expect(await screen.findByText('valid')).toBeVisible();
   });
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -341,10 +341,14 @@ export function createFormControl<
 
     if (!_options.disabled) {
       if (!isBlurEvent || shouldDirty) {
+        // Calculate isDirty to keep internal state up to date
+        const currentIsDirty = _getDirty();
+        isPreviousDirty = _formState.isDirty;
+        _formState.isDirty = currentIsDirty;
+
         if (_proxyFormState.isDirty || _proxySubscribeFormState.isDirty) {
-          isPreviousDirty = _formState.isDirty;
-          _formState.isDirty = output.isDirty = _getDirty();
-          shouldUpdateField = isPreviousDirty !== output.isDirty;
+          output.isDirty = currentIsDirty;
+          shouldUpdateField = isPreviousDirty !== currentIsDirty;
         }
 
         const isCurrentFieldPristine = deepEqual(

--- a/src/utils/hasTruthyValue.ts
+++ b/src/utils/hasTruthyValue.ts
@@ -1,0 +1,30 @@
+export default function hasTruthyValue(obj: any): boolean {
+  if (!obj) {
+    return false;
+  }
+
+  if (obj === true) {
+    return true;
+  }
+
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length; i++) {
+      if (hasTruthyValue(obj[i])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (typeof obj === 'object') {
+    const keys = Object.keys(obj as Record<string, unknown>);
+    for (let i = 0; i < keys.length; i++) {
+      const v = (obj as Record<string, unknown>)[keys[i]];
+      if (hasTruthyValue(v)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
This fixes the issue where components subscribing to formState properties (like isDirty, dirtyFields) after form values have changed would receive stale state values.

Problem:
- Issue: [https://github.com/react-hook-form/react-hook-form/issues/13017](https://github.com/react-hook-form/react-hook-form/issues/13017)

Solution:
Always keep _formState.isDirty up-to-date regardless of subscription status in updateTouchAndDirty()

Fixes: #[issue-number]