### PR TITLE
Fix(getDirtyFields): submit fields with null values when using useForm

### DIFF
--- a/src/__tests__/logic/getDirtyFields.test.ts
+++ b/src/__tests__/logic/getDirtyFields.test.ts
@@ -341,4 +341,39 @@ describe('getDirtyFields', () => {
       ],
     });
   });
+
+  it('should include fields with null values', () => {
+    expect(
+      getDirtyFields(
+        {},
+        {
+          views: null,
+          name: 'test',
+          count: 0,
+        },
+      ),
+    ).toEqual({
+      views: true,
+      name: true,
+      count: true,
+    });
+  });
+
+  it('should mark null values as dirty when comparing with defaultValues', () => {
+    expect(
+      getDirtyFields(
+        {
+          views: null,
+          name: 'test',
+        },
+        {
+          views: null,
+          name: 'other',
+        },
+      ),
+    ).toEqual({
+      views: false,
+      name: true,
+    });
+  });
 });

--- a/src/__tests__/useForm/useFormWithNullValues.test.tsx
+++ b/src/__tests__/useForm/useFormWithNullValues.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useController } from '../../useController';
+import { useForm } from '../../useForm';
+
+describe('useForm with null values (issue #12815)', () => {
+  function NumberInput({
+    control,
+    name = 'views',
+  }: {
+    control: any;
+    name?: string;
+  }) {
+    const { field } = useController({
+      name,
+      control,
+      defaultValue: null,
+    });
+
+    return (
+      <input
+        type="number"
+        value={field.value ?? ''}
+        onChange={(e) =>
+          field.onChange(e.target.value ? Number(e.target.value) : null)
+        }
+        onBlur={field.onBlur}
+        ref={field.ref}
+        data-testid={name}
+      />
+    );
+  }
+
+  it('should submit null value when field is empty and untouched with useForm({ values })', async () => {
+    let submittedData: any;
+
+    function App() {
+      const { control, handleSubmit } = useForm({
+        values: { views: null as null | number },
+      });
+
+      return (
+        <form
+          onSubmit={handleSubmit((data) => {
+            submittedData = data;
+          })}
+        >
+          <NumberInput control={control} />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(submittedData).toEqual({ views: null });
+    });
+  });
+
+  it('should submit null value after user clears the input', async () => {
+    let submittedData: any;
+
+    function App() {
+      const { control, handleSubmit } = useForm({
+        values: { views: null as null | number },
+      });
+
+      return (
+        <form
+          onSubmit={handleSubmit((data) => {
+            submittedData = data;
+          })}
+        >
+          <NumberInput control={control} />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    const input = screen.getByTestId('views') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '42' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(submittedData).toEqual({ views: null });
+    });
+  });
+
+  it('should work with defaultValues (not affected by the bug)', async () => {
+    let submittedData: any;
+
+    function App() {
+      const { control, handleSubmit } = useForm({
+        defaultValues: { views: null as null | number },
+      });
+
+      return (
+        <form
+          onSubmit={handleSubmit((data) => {
+            submittedData = data;
+          })}
+        >
+          <NumberInput control={control} />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(submittedData).toEqual({ views: null });
+    });
+  });
+
+  it('should handle multiple fields with null values', async () => {
+    let submittedData: any;
+
+    function App() {
+      const { control, handleSubmit } = useForm({
+        values: {
+          views: null as null | number,
+          likes: null as null | number,
+          shares: null as null | number,
+        },
+      });
+
+      return (
+        <form
+          onSubmit={handleSubmit((data) => {
+            submittedData = data;
+          })}
+        >
+          <NumberInput control={control} name="views" />
+          <NumberInput control={control} name="likes" />
+          <NumberInput control={control} name="shares" />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    const likesInput = screen.getByTestId('likes');
+    fireEvent.change(likesInput, { target: { value: '100' } });
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(submittedData).toEqual({
+        views: null,
+        likes: 100,
+        shares: null,
+      });
+    });
+  });
+
+  it('should prioritize values over defaultValues when both are set', async () => {
+    let submittedData: any;
+
+    function App() {
+      const { control, handleSubmit } = useForm({
+        defaultValues: { views: 100 as null | number },
+        values: { views: null as null | number },
+      });
+
+      return (
+        <form
+          onSubmit={handleSubmit((data) => {
+            submittedData = data;
+          })}
+        >
+          <NumberInput control={control} />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    const input = screen.getByTestId('views') as HTMLInputElement;
+
+    expect(input.value).toBe('');
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(submittedData).toEqual({ views: null });
+    });
+  });
+
+  it('should work with nested null values', async () => {
+    let submittedData: any;
+
+    function App() {
+      const { register, handleSubmit } = useForm({
+        values: {
+          user: {
+            name: 'John',
+            age: null,
+            email: null,
+          },
+        },
+      });
+
+      return (
+        <form
+          onSubmit={handleSubmit((data) => {
+            submittedData = data;
+          })}
+        >
+          <input {...register('user.name')} />
+          <input {...register('user.age')} />
+          <input {...register('user.email')} />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(submittedData).toEqual({
+        user: {
+          name: 'John',
+          age: null,
+          email: null,
+        },
+      });
+    });
+  });
+});

--- a/src/logic/getDirtyFields.ts
+++ b/src/logic/getDirtyFields.ts
@@ -14,7 +14,7 @@ function markFieldsDirty<T>(data: T, fields: Record<string, any> = {}) {
     if (isTraversable(data[key])) {
       fields[key] = Array.isArray(data[key]) ? [] : {};
       markFieldsDirty(data[key], fields[key]);
-    } else if (!isNullOrUndefined(data[key])) {
+    } else if (!isUndefined(data[key])) {
       fields[key] = true;
     }
   }


### PR DESCRIPTION
## Problem

Fixes #12815

Fields with `null` values are not submitted when using `useForm({ values })` since v7.55.0.

**Before:**
```typescript
const { control, handleSubmit } = useForm({ values: { views: null } });
```
On submit: `{}` (null value is omitted)

**Expected:**
On submit: `{ views: null }`

**Root Cause:**
In `src/logic/getDirtyFields.ts`, the `markFieldsDirty` function used `!isNullOrUndefined(data[key])` which excluded `null` values from being marked as dirty, causing them to be omitted during form submission.

## Solution

Changed the condition to only exclude `undefined` values:

```typescript
} else if (!isUndefined(data[key])) {
  fields[key] = true;
}
```

This allows `null` to be treated as a valid field value while still excluding `undefined` fields.

## Testing

Added 8 tests:
- 2 unit tests in `src/__tests__/logic/getDirtyFields.test.ts`
- 6 integration tests in `src/__tests__/useForm/useFormWithNullValues.test.tsx`

All 968 tests pass.

## Changes

- `src/logic/getDirtyFields.ts`: Changed condition in `markFieldsDirty`
- `src/__tests__/logic/getDirtyFields.test.ts`: Added unit tests
- `src/__tests__/useForm/useFormWithNullValues.test.tsx`: Added integration tests

Backward compatible, no breaking changes.
