### PR TITLE
feat: accept external isPending in useForm to sync React 19 useActionState

### DIFF
--- a/src/__tests__/useForm/isPending.test.tsx
+++ b/src/__tests__/useForm/isPending.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useForm } from '../../useForm';
+
+describe('useForm isPending option', () => {
+  it('should reflect initial isPending value on formState.isSubmitting', async () => {
+    const { result } = renderHook((props: any) => useForm(props), {
+      initialProps: { isPending: true },
+    });
+
+    await waitFor(() => expect(result.current.formState.isSubmitting).toBe(true));
+  });
+
+  it('should sync formState.isSubmitting when isPending prop changes', async () => {
+    const { result, rerender } = renderHook((props: any) => useForm(props), {
+      initialProps: { isPending: false },
+    });
+
+    expect(result.current.formState.isSubmitting).toBe(false);
+
+    act(() => rerender({ isPending: true }));
+
+    await waitFor(() =>
+      expect(result.current.formState.isSubmitting).toBe(true),
+    );
+
+    act(() => rerender({ isPending: false }));
+
+    await waitFor(() =>
+      expect(result.current.formState.isSubmitting).toBe(false),
+    );
+  });
+});

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -94,6 +94,7 @@ const defaultOptions = {
   mode: VALIDATION_MODE.onSubmit,
   reValidateMode: VALIDATION_MODE.onChange,
   shouldFocusError: true,
+  isPending: false,
 } as const;
 
 export function createFormControl<

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -156,6 +156,7 @@ export function createFormControl<
   let timer = 0;
   const _proxyFormState: ReadFormState = {
     isDirty: false,
+    isSubmitting: false,
     dirtyFields: false,
     validatingFields: false,
     touchedFields: false,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -113,6 +113,12 @@ export type UseFormProps<
   defaultValues: DefaultValues<TFieldValues> | AsyncDefaultValues<TFieldValues>;
   values: TFieldValues;
   errors: FieldErrors<TFieldValues>;
+  /**
+   * External pending/submission state (for example from React 19 useActionState).
+   * When provided, react-hook-form will sync `formState.isSubmitting` with this
+   * value so external action state and RHF's internal state stay consistent.
+   */
+  isPending?: boolean;
   resetOptions: Parameters<UseFormReset<TFieldValues>>[1];
   resolver: Resolver<TFieldValues, TContext, TTransformedValues>;
   context: TContext;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -141,6 +141,7 @@ export type FieldNamesMarkedBoolean<TFieldValues extends FieldValues> = DeepMap<
 
 export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
   isDirty: boolean;
+  isSubmitting: boolean;
   isValidating: boolean;
   dirtyFields: FieldNamesMarkedBoolean<TFieldValues>;
   touchedFields: FieldNamesMarkedBoolean<TFieldValues>;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -133,6 +133,14 @@ export function useForm<
     }
   }, [control, props.errors]);
 
+  // Sync external pending state (e.g. React 19's useActionState) with RHF
+  // so formState.isSubmitting reflects external submission state.
+  React.useEffect(() => {
+    if (typeof props.isPending !== 'undefined') {
+      control._subjects.state.next({ isSubmitting: !!props.isPending });
+    }
+  }, [control, props.isPending]);
+
   React.useEffect(() => {
     props.shouldUnregister &&
       control._subjects.state.next({

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -137,7 +137,11 @@ export function useForm<
   // so formState.isSubmitting reflects external submission state.
   React.useEffect(() => {
     if (typeof props.isPending !== 'undefined') {
+      // update internal control state and React state so subscribers and
+      // consumers of `formState` see the change regardless of proxy
+      control._formState.isSubmitting = !!props.isPending;
       control._subjects.state.next({ isSubmitting: !!props.isPending });
+      updateFormState((s) => ({ ...s, isSubmitting: !!props.isPending }));
     }
   }, [control, props.isPending]);
 


### PR DESCRIPTION
Summary:

Add an optional `isPending` option to `useForm` so external pending/submission state (for example from React 19's `useActionState`) can be passed into react-hook-form. When provided, RHF will sync `formState.isSubmitting` to the provided value.

What changed:
- Add `isPending?: boolean` to `UseFormProps` (`src/types/form.ts`).
- Add default `isPending: false` to `defaultOptions` in `src/logic/createFormControl.ts`.
- Add an effect in `src/useForm.ts` to sync `props.isPending` to internal control state and `formState.isSubmitting`.
- Include `isSubmitting` in the form proxy types so subscribers can opt-in to updates.
- Add unit tests: `src/__tests__/useForm/isPending.test.tsx`.

Testing:
- Ran full test suite: 110 suites passed, 977 tests passed.

Notes:
- This only syncs `isSubmitting`. If you want other flags (submitCount, isSubmitted, isSubmitSuccessful) synced from external action state, we can extend the API.


<img width="1184" height="483" alt="image" src="https://github.com/user-attachments/assets/31a3f8fc-a896-42da-b67d-60d9134d229a" />
<img width="970" height="769" alt="image" src="https://github.com/user-attachments/assets/0a597d72-0ed9-418c-b686-11e74b606115" />
<img width="1043" height="370" alt="image" src="https://github.com/user-attachments/assets/6a08b185-c4a4-4f98-9ac0-14511295dcf8" />

Resolves :
https://github.com/react-hook-form/react-hook-form/issues/13112