### PR TITLE
fix(useForm): recompute isValid after reset when values update asynchronously

### DIFF
--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -226,6 +226,48 @@ describe('formState', () => {
 
       expect(await screen.findByText('invalid')).toBeVisible();
     });
+
+    it('should set isValid to true after async values provide valid data', async () => {
+      jest.useFakeTimers();
+
+      const App = () => {
+        const [value, setValue] = React.useState<{ name: string } | undefined>(
+          undefined,
+        );
+
+        React.useEffect(() => {
+          const t = setTimeout(() => setValue({ name: 'Mike' }), 2000);
+          return () => clearTimeout(t);
+        }, []);
+
+        const {
+          register,
+          formState: { isValid },
+        } = useForm<{ name: string }>({
+          defaultValues: { name: '' },
+          values: value ?? { name: '' },
+          mode: 'onBlur',
+        });
+
+        return (
+          <div>
+            <input {...register('name', { required: true })} />
+            <p>{isValid ? 'valid' : 'invalid'}</p>
+          </div>
+        );
+      };
+
+      render(<App />);
+
+      expect(screen.getByText('invalid')).toBeVisible();
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      await waitFor(() => expect(screen.getByText('valid')).toBeVisible());
+      jest.useRealTimers();
+    });
   });
 
   it('should be a proxy object that returns undefined for unknown properties', () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1454,8 +1454,6 @@ export function createFormControl<
       isSubmitting: false,
       defaultValues: _defaultValues as FormState<TFieldValues>['defaultValues'],
     });
-
-    !keepStateOptions.keepIsValid && _setValid();
   };
 
   const reset: UseFormReset<TFieldValues> = (formValues, keepStateOptions) =>

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1454,6 +1454,8 @@ export function createFormControl<
       isSubmitting: false,
       defaultValues: _defaultValues as FormState<TFieldValues>['defaultValues'],
     });
+
+    !keepStateOptions.keepIsValid && _setValid();
   };
 
   const reset: UseFormReset<TFieldValues> = (formValues, keepStateOptions) =>

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -157,6 +157,9 @@ export function useForm<
         keepFieldsRef: true,
         ...control._options.resetOptions,
       });
+      if (!control._options.resetOptions?.keepIsValid) {
+        control._setValid();
+      }
       _values.current = props.values;
       updateFormState((state) => ({ ...state }));
     } else {


### PR DESCRIPTION
## Proposed Changes

### Problem: 
When props.values are set asynchronously, formState.isValid wasn’t recalculated because reset() sets control._state.mount = true, so the useForm mount effect that calls _setValid() no longer runs.

### Root cause flow:
1. values are set asynchronously.
2. useForm effect runs due to props.values change:

https://github.com/react-hook-form/react-hook-form/blob/49226985f4c1b1486b96b6ccbf68a18c3165550d/src/useForm.ts#L154-L165

3. _reset() is called.
4. After reset, control._state.mount becomes true following the changes in #13091, so the mount effect below doesn’t call _setValid() anymore:
https://github.com/react-hook-form/react-hook-form/blob/49226985f4c1b1486b96b6ccbf68a18c3165550d/src/useForm.ts#L167-L171

### Fix: 
Recompute validity at the end of _reset() while respecting keep-state options.

Fixes #13123

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
