### PR TITLE
docs: get function with JSDoc comments

### DIFF
--- a/src/utils/get.ts
+++ b/src/utils/get.ts
@@ -1,3 +1,19 @@
+/**
+ * Retrieves a value from a nested object using a path string.
+ * Supports dot notation and array bracket notation for accessing nested properties.
+ * 
+ * @template T - The type of the object to retrieve the value from
+ * @param {T} object - The source object to traverse
+ * @param {string | null} path - The path to the desired property (e.g., "user.name" or "users[0].email")
+ * @param {unknown} [defaultValue] - The value to return if the path is not found or undefined
+ * @returns {any} The value at the specified path, or the defaultValue if not found
+ * 
+ * @example
+ * const obj = { user: { name: 'John', emails: ['john@example.com'] } };
+ * get(obj, 'user.name'); // Returns: 'John'
+ * get(obj, 'user.emails[0]'); // Returns: 'john@example.com'
+ * get(obj, 'user.age', 25); // Returns: 25 (default value)
+ */
 import isKey from './isKey';
 import isNullOrUndefined from './isNullOrUndefined';
 import isObject from './isObject';


### PR DESCRIPTION
## What does this PR do?

Adds comprehensive JSDoc comments to the `get` function, including:
- Clear function description
- Parameter documentation with types
- Return value documentation
- Usage examples

## Related tickets

Closes #[issue_number] (if applicable)

## How to test

- IDE autocomplete should display JSDoc comments
- JSDoc generator tools should properly parse the comments
- No errors in console

## Additional notes

JSDoc follows the project's documentation standards and is compatible with TypeScript intellisense.
