### PR TITLE
fix: handle dynamic defaultValues updates in useForm

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -164,6 +164,25 @@ export function useForm<
     }
   }, [control, props.values]);
 
+  // 🆕 Handle dynamic defaultValues changes
+  React.useEffect(() => {
+    if (
+      props.defaultValues &&
+      !deepEqual(props.defaultValues, formState.defaultValues)
+    ) {
+      // Only reset if defaultValues actually changed
+      control._reset(props.defaultValues, {
+        keepValues: true, // don't override user input
+        ...control._options.resetOptions,
+      });
+
+      updateFormState((state) => ({
+        ...state,
+        defaultValues: props.defaultValues,
+      }));
+    }
+  }, [control, props.defaultValues, formState.defaultValues]);
+
   React.useEffect(() => {
     if (!control._state.mount) {
       control._setValid();


### PR DESCRIPTION
Enhance `useForm` to properly handle dynamic updates to defaultValues.

### Summary
Previously, `useForm` did not react correctly when `defaultValues` changed after initialization.  
This update ensures that the form resets only when `defaultValues` actually change, while keeping user inputs intact.

### Changes
- Added a `React.useEffect` in `useForm.ts` to compare `props.defaultValues` with current `formState.defaultValues`.
- Reset the form values only when a change is detected.
- Preserve user-entered values with `keepValues: true`.
- Update `formState.defaultValues` after reset.

### Benefits
- Fixes unexpected behavior when forms receive updated default values dynamically.
- Improves reliability of form state handling in dynamic forms.

