### PR TITLE
fix(createFormControl): skip setValid() during batch array updates

### DIFF
--- a/src/__tests__/useFieldArray/prepend.test.tsx
+++ b/src/__tests__/useFieldArray/prepend.test.tsx
@@ -506,6 +506,60 @@ describe('prepend', () => {
 
       expect(resolver).toHaveBeenCalled();
     });
+
+    it('should not invoke resolver per register during prepend; only array-scoped + final isValid', async () => {
+      const resolver = jest
+        .fn()
+        .mockImplementation((values) => ({ values, errors: {} }));
+
+      const App = () => {
+        const { register, formState, control } = useForm<{
+          test: { value: string }[];
+        }>({
+          mode: VALIDATION_MODE.onTouched,
+          resolver,
+          defaultValues: { test: [] },
+        });
+
+        formState.isValid;
+
+        const { fields, prepend } = useFieldArray({ control, name: 'test' });
+
+        return (
+          <form>
+            <input {...register('test' as const)} />
+            {fields.map((f, i) => (
+              <input key={f.id} {...register(`test.${i}.value` as const)} />
+            ))}
+            <button
+              type="button"
+              onClick={() =>
+                prepend([{ value: '1' }, { value: '2' }, { value: '3' }])
+              }
+            >
+              prepend
+            </button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      await waitFor(() =>
+        expect(resolver.mock.calls.length).toBeGreaterThanOrEqual(1),
+      );
+      const initialCalls = resolver.mock.calls.length;
+
+      fireEvent.click(screen.getByRole('button', { name: 'prepend' }));
+
+      await waitFor(async () => {
+        expect((await screen.findAllByRole('textbox')).length).toBe(4);
+      });
+
+      await waitFor(() =>
+        expect(resolver.mock.calls.length).toBe(initialCalls + 2),
+      );
+    });
   });
 
   it('should not omit keyName when provided', async () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -320,7 +320,7 @@ export function createFormControl<
           )
         : setFieldValue(name, defaultValue);
 
-      _state.mount && _setValid();
+      _state.mount && !_state.action && _setValid();
     }
   };
 


### PR DESCRIPTION
## Proposed Changes

### Problem: 
#13129 
When using useFieldArray.replace to update data, the performance becomes very slow and can cause the browser to freeze.
This happens because the entire form validation resolver is triggered for every single replaced field.

### Root cause flow:

1. `replace` is called (it updates `_formValues`, sets fields, and calls `_setFieldArray`).
https://github.com/react-hook-form/react-hook-form/blob/fb6423fee14d28f8768fc97cd46016e86ff471ca/src/useFieldArray.ts#L306-L323
2. React re-renders because the fields have changed; during rendering, the JSX executes `register(name)` for each input.

3. In every single field new registration, `updateValidAndValue` is executed, which internally calls `setValid` .
https://github.com/react-hook-form/react-hook-form/blob/fb6423fee14d28f8768fc97cd46016e86ff471ca/src/logic/createFormControl.ts#L1127-L1136
https://github.com/react-hook-form/react-hook-form/blob/fb6423fee14d28f8768fc97cd46016e86ff471ca/src/logic/createFormControl.ts#L323

4. `setValid` always triggers `_runSchema()` **without any arguments**, which means it validates the **entire form**.
This is the root cause of the performance issue, the whole form is being validated for every newly registered field.
https://github.com/react-hook-form/react-hook-form/blob/fb6423fee14d28f8768fc97cd46016e86ff471ca/src/logic/createFormControl.ts#L190-L192

Please refer to the following CodeSandbox example, which is based on the one from issue #13129.
It now logs how many times the resolver is called.
Open the console, click `add data`, and wait for the execution, this demonstrates that the form validation resolver runs once per field, confirming the issue.
https://codesandbox.io/p/devbox/reslover-isvalid-issue-forked-thzpcv

### Fix: 
When `replace` calls `_setFieldArray`, it raises a flag by setting `_state.action` to `true`, and only resets it to `false` inside a `useEffect`, meaning this happens **after the changes are committed**.
https://github.com/react-hook-form/react-hook-form/blob/fb6423fee14d28f8768fc97cd46016e86ff471ca/src/logic/createFormControl.ts#L234
https://github.com/react-hook-form/react-hook-form/blob/fb6423fee14d28f8768fc97cd46016e86ff471ca/src/useFieldArray.ts#L326

The `register` executions triggered by the re-render occur **before** the commit, so if we add an `_state.action` check inside the `_setValid()` call within `updateValidAndValue`, we can safely skip the validator call during field updates.

This doesn’t mean the validator is skipped entirely, at the end of the `useEffect`, `_setValid()` is called again, ensuring the **form is always validated** with the resolver once the update is complete.
https://github.com/react-hook-form/react-hook-form/blob/fb6423fee14d28f8768fc97cd46016e86ff471ca/src/useFieldArray.ts#L412

Fixes #13129

## Performance Benchmark

The table below compares the execution time before and after the optimization when replacing a batch of fields.

| Fields (size) | Before      | After       | Improvement        |
|---------------|-------------|-------------|---------------------|
| 50 (mid)      | 14 s        | 0.045 s     | ~300× faster        |
| 100 (large)   | 84 s        | 0.087 s     | ~965× faster        |



## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes