### PR TITLE
fix(types): correct PathValueImpl type inference

### DIFF
--- a/src/__typetest__/useController.test-d.ts
+++ b/src/__typetest__/useController.test-d.ts
@@ -1,0 +1,85 @@
+import { expectNotType, expectType } from 'tsd';
+
+import { useController } from '../useController';
+
+/** {@link useController} */ {
+  /** it should NOT infer never[] when defaultValue is empty array without explicit types */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    const { field } = useController({
+      name: 'items' as string,
+      defaultValue: [],
+    });
+
+    expectNotType<never>(field.name);
+    expectNotType<never[]>(field.value);
+
+    if (Array.isArray(field.value)) {
+      field.value.includes('test');
+      field.value.push('test');
+    }
+  }
+
+  /** it should work correctly with explicit type parameters */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      items: string[];
+    };
+
+    const { field } = useController<FormValues, 'items'>({
+      name: 'items',
+      defaultValue: [],
+    });
+
+    expectType<string[]>(field.value);
+    expectType<'items'>(field.name);
+  }
+
+  /** it should work with optional array fields */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      optionalItems?: string[];
+    };
+
+    const { field } = useController<FormValues, 'optionalItems'>({
+      name: 'optionalItems',
+      defaultValue: undefined,
+    });
+
+    expectType<string[] | undefined>(field.value);
+  }
+
+  /** it should work with nested array access */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      nested: {
+        items: number[];
+      };
+    };
+
+    const { field } = useController<FormValues, 'nested.items'>({
+      name: 'nested.items',
+      defaultValue: [],
+    });
+
+    expectType<number[]>(field.value);
+  }
+
+  /** it should handle array of objects */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      users: Array<{ id: string; name: string }>;
+    };
+
+    const { field } = useController<FormValues, 'users'>({
+      name: 'users',
+      defaultValue: [],
+    });
+
+    expectType<Array<{ id: string; name: string }>>(field.value);
+  }
+}

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -165,7 +165,7 @@ type PathValueImpl<T, P extends string> = T extends any
       : P extends `${ArrayKey}`
         ? T extends ReadonlyArray<infer V>
           ? V
-          : undefined extends T
+          : T extends undefined
             ? undefined
             : never
         : never


### PR DESCRIPTION
## Problem

In v7.64.0, commit 8d61561b422c9974baf92fbafab570d1764e91bd changed `PathValueImpl` to support optional array fields,
However, the condition `undefined extends T` is too broad and interferes with TypeScript’s reverse type inference, so in some cases the inferred type ends up as `never`

ex)
```ts
const { field } = useController({ name: 'items', defaultValue: [] });
// error: Type 'string' is not assignable to type 'never'
```

## Solution

```ts
// src/types/path/eager.ts

- : undefined extends T
+ : T extends undefined
```

This keeps the support for optional array fields introduced in [PR #13057](https://github.com/react-hook-form/react-hook-form/pull/13057)while restoring correct type inference.

## Testing

- All existing tests continue to pass
- Added a type test for this issue in `src/__typetest__/useController.test-d.ts`


## Related Issues
Fixes #13081 
Related to [PR #13057](https://github.com/react-hook-form/react-hook-form/pull/13057)