### PR TITLE
Refactor stringToPath function for improved parsing

### DIFF
--- a/src/utils/stringToPath.ts
+++ b/src/utils/stringToPath.ts
@@ -1,4 +1,10 @@
 import compact from './compact';
 
 export default (input: string): string[] =>
-  compact(input.replace(/["|']|\]/g, '').split(/\.|\[/));
+  compact(
+    input
+      .replace(/["']/g, '')
+      .split(/(?=\[)|\]/g)
+      .map((x) => (x.startsWith('[') ? x.slice(1) : x.split('.')))
+      .flat(),
+  );


### PR DESCRIPTION
Keys like `a.[1.23].b` are originally intended to construct objects like `{a: {'1.23': b}}`. However, currently, `1.23` is being parsed as an array:

`{a: {1: [empty* 22, b]}}`, which does not match the original intent.

This PR ensures that the content inside `[]` remains unchanged and is used directly as the key.

for this: https://github.com/react-hook-form/react-hook-form/issues/3351