### PR TITLE
fix(createFormControl): add iOS Safari focus workaround for already-focused error fields

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       return require('./cypress/plugins/index.ts')(on, config);
     },
     baseUrl: 'http://localhost:3000/',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       return require('./cypress/plugins/index.ts')(on, config);
     },
     baseUrl: 'http://localhost:3000/',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,4 +94,11 @@ export default tseslint.config(
       '@typescript-eslint/ban-ts-comment': 'off',
     },
   },
+  {
+    files: ['cypress.config.ts', 'scripts/**/*.js'],
+    rules: {
+      '@typescript-eslint/no-var-requires': 'off',
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
 );

--- a/scripts/apiExtractor.js
+++ b/scripts/apiExtractor.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
 const fs = require('fs');
 const path = require('path');

--- a/scripts/apiExtractor.js
+++ b/scripts/apiExtractor.js
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-var-requires */
 const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
 const fs = require('fs');
 const path = require('path');

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,0 +1,27 @@
+export const isIOS = () => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const ua = navigator.userAgent;
+
+  const isiOS = /iPhone|iPad|iPod/i.test(ua);
+  return isiOS;
+};
+
+export const isSafari = () => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const ua = navigator.userAgent;
+
+  const isSafari =
+    /Safari/i.test(ua) && !/Chrome|CriOS|FxiOS|EdgiOS|OPiOS/i.test(ua);
+
+  return isSafari;
+};
+
+export const isIOSSafari = () => {
+  return isSafari() && isIOS();
+};

--- a/src/utils/requestAnimation.ts
+++ b/src/utils/requestAnimation.ts
@@ -1,5 +1,0 @@
-export const raf =
-  typeof window !== 'undefined' &&
-  typeof window.requestAnimationFrame === 'function'
-    ? window.requestAnimationFrame.bind(window)
-    : (cb: FrameRequestCallback) => setTimeout(cb, 0);

--- a/src/utils/requestAnimation.ts
+++ b/src/utils/requestAnimation.ts
@@ -1,0 +1,5 @@
+export const raf =
+  typeof window !== 'undefined' &&
+  typeof window.requestAnimationFrame === 'function'
+    ? window.requestAnimationFrame.bind(window)
+    : (cb: FrameRequestCallback) => setTimeout(cb, 0);


### PR DESCRIPTION
## 🔧 Fix: iOS Safari focus behavior
Fixes #13059

Problem
	•	On iOS Safari, when the error field is already focused, calling focus() does nothing.
	•	This means that calling handleSubmit() repeatedly does not scroll the page to the first error.
	•	RHF’s _focusError() relies on .focus() to scroll to invalid fields.

Resolution

A Safari-only fallback was added:
	1.	blur() the element
	2.	scrollIntoView() in the next frame
	3.	focus() again in the following frame

This sequence reliably triggers scrolling behavior on iOS Safari.

All other browsers maintain current behavior.


## 🧹 Chore: Fix ESLint rule mismatch

ESLint was failing during pre-commit because:
	•	cypress.config.ts
	•	scripts/apiExtractor.js

use require(), but the active rule @typescript-eslint/no-var-requires disallowed it.

These files are Node-based, so the rule is now disabled for them explicitly.

---

### ✔️ Changes Included
	•	Add focusWithSafariHack for iOS Safari inside createFormControl
	•	Apply blur → scrollIntoView → focus workaround only when needed
	•	Keep behavior unchanged for non-Safari browsers
	•	Disable @typescript-eslint/no-var-requires for Node config files
	•	Ensure ESLint + Husky pre-commit now pass


### 💡 Proposal / Maintainer Feedback Request

This workaround slightly increases the bundle size and currently fails the `bundlewatch` check  
(`dist/index.cjs.js` exceeds the 11KB gzip limit by ~0.15KB).

Before attempting any deeper refactoring to offset the added bytes, I wanted to ask for feedback:

**Would this iOS Safari focus-fix be acceptable in principle,  
or should this behavior be handled externally at the application level instead?**

If adding this logic to the core is not desirable due to size constraints,  
I’m happy to:

- move the fix into a separate helper that users can opt-in to import, or
- update documentation with a recommended workaround pattern, or
- explore alternative implementations that avoid bundle size impact.

Please let me know your preferred direction — once confirmed,  
I will update the PR accordingly. 🙏