### PR TITLE
✨ fix(types): allow undefined value with async defaultValues in Contr…

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -101,7 +101,7 @@ export type ControllerProps<TFieldValues extends FieldValues = FieldValues, TNam
 export type ControllerRenderProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> = {
     onChange: (...event: any[]) => void;
     onBlur: Noop;
-    value: FieldPathValue<TFieldValues, TName>;
+    value: FieldPathValue<TFieldValues, TName> | undefined;
     disabled?: boolean;
     name: TName;
     ref: RefCallBack;

--- a/src/__typetest__/controller.test-d.ts
+++ b/src/__typetest__/controller.test-d.ts
@@ -1,0 +1,13 @@
+import { expectType } from 'tsd';
+
+import type { ControllerRenderProps } from '../types';
+
+type FormValues = {
+  test: string;
+};
+
+/** {@link Controller} */ {
+  /** it should include undefined in value type */
+  const props = {} as ControllerRenderProps<FormValues, 'test'>;
+  expectType<string | undefined>(props.value);
+}

--- a/src/__typetest__/useController.test-d.ts
+++ b/src/__typetest__/useController.test-d.ts
@@ -32,7 +32,7 @@ import { useController } from '../useController';
       defaultValue: [],
     });
 
-    expectType<string[]>(field.value);
+    expectType<string[] | undefined>(field.value);
     expectType<'items'>(field.name);
   }
 
@@ -65,7 +65,7 @@ import { useController } from '../useController';
       defaultValue: [],
     });
 
-    expectType<number[]>(field.value);
+    expectType<number[] | undefined>(field.value);
   }
 
   /** it should handle array of objects */ {
@@ -80,6 +80,6 @@ import { useController } from '../useController';
       defaultValue: [],
     });
 
-    expectType<Array<{ id: string; name: string }>>(field.value);
+    expectType<Array<{ id: string; name: string }> | undefined>(field.value);
   }
 }

--- a/src/types/controller.ts
+++ b/src/types/controller.ts
@@ -26,7 +26,7 @@ export type ControllerRenderProps<
 > = {
   onChange: (...event: any[]) => void;
   onBlur: Noop;
-  value: FieldPathValue<TFieldValues, TName>;
+  value: FieldPathValue<TFieldValues, TName> | undefined;
   disabled?: boolean;
   name: TName;
   ref: RefCallBack;


### PR DESCRIPTION
Fixes #13125

### Summary

When using `useForm` with `defaultValues: async () => {...}`, the first render
provides `field.value` as `undefined`, while the TypeScript types currently infer
a non-nullable value. This type mismatch can cause runtime errors if the user
assumes `field.value` is always defined.

### What this PR changes

- Updates `ControllerRenderProps['value']` to include `undefined` for the initial
  async defaultValues resolution.
- Adds a dedicated type test for this scenario.
- Updates existing type tests to reflect the corrected typing.
- No runtime logic is changed.

### Impact

This is a type-level fix that aligns TypeScript with real runtime behavior.
It may expose new TS errors where user code assumed `field.value` was always
defined, but it prevents runtime crashes and improves type safety.

### Tests

- Type tests updated and passing.
- Reproduction case verified.
- No regressions observed.
