### PR TITLE
fix(reset): preserve isValid state when keepIsValid option is used

### DIFF
--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -1849,4 +1849,125 @@ describe('reset', () => {
       screen.queryByText('Description must be at least 5 characters'),
     ).not.toBeInTheDocument();
   });
+
+  it('should keep isValid value when reset is called with keepIsValid option', async () => {
+    let formState: { isValid: boolean } = { isValid: false };
+
+    const App = () => {
+      const {
+        register,
+        reset,
+        formState: { isValid },
+      } = useForm({
+        defaultValues: { name: 'Mike' },
+        mode: 'onChange',
+      });
+
+      formState = { isValid };
+
+      return (
+        <div>
+          <p>
+            <input {...register('name', { required: true })} />
+          </p>
+          <button
+            onClick={() => {
+              reset({ name: '' }, { keepIsValid: true });
+            }}
+          >
+            reset
+          </button>
+          <p>is valid: {isValid ? 'true' : 'false'}</p>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+
+    await waitFor(() => {
+      expect(screen.getByText('is valid: true')).toBeInTheDocument();
+    });
+
+    expect(formState).toEqual({ isValid: true });
+    expect(input.value).toBe('Mike');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'reset' }));
+    });
+
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('is valid: true')).toBeInTheDocument();
+    expect(formState).toEqual({ isValid: true });
+  });
+
+  it('should keep isValid value when form has resetOptions.keepIsValid configured', async () => {
+    let formState: { isValid: boolean } = { isValid: false };
+
+    const App = () => {
+      const {
+        register,
+        reset,
+        formState: { isValid },
+      } = useForm({
+        defaultValues: { name: 'Mike' },
+        mode: 'onChange',
+        resetOptions: {
+          keepIsValid: true,
+        },
+      });
+
+      formState = { isValid };
+
+      return (
+        <div>
+          <p>
+            <input {...register('name', { required: true })} />
+          </p>
+          <button
+            onClick={() => {
+              reset({ name: '' });
+            }}
+          >
+            reset
+          </button>
+          <p>is valid: {isValid ? 'true' : 'false'}</p>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+
+    await waitFor(() => {
+      expect(screen.getByText('is valid: true')).toBeInTheDocument();
+    });
+
+    expect(formState).toEqual({ isValid: true });
+    expect(input.value).toBe('Mike');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'reset' }));
+    });
+
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('is valid: true')).toBeInTheDocument();
+    expect(formState).toEqual({ isValid: true });
+  });
 });

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -1875,7 +1875,14 @@ describe('reset', () => {
               reset({ name: '' }, { keepIsValid: true });
             }}
           >
-            reset
+            reset with keepIsValid
+          </button>
+          <button
+            onClick={() => {
+              reset({ name: '' });
+            }}
+          >
+            reset without keepIsValid
           </button>
           <p>is valid: {isValid ? 'true' : 'false'}</p>
         </div>
@@ -1893,8 +1900,11 @@ describe('reset', () => {
     expect(formState).toEqual({ isValid: true });
     expect(input.value).toBe('Mike');
 
+    // Reset with keepIsValid
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'reset' }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'reset with keepIsValid' }),
+      );
     });
 
     await waitFor(() => {
@@ -1907,6 +1917,25 @@ describe('reset', () => {
 
     expect(screen.getByText('is valid: true')).toBeInTheDocument();
     expect(formState).toEqual({ isValid: true });
+
+    // Reset without keepIsValid
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'reset without keepIsValid' }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Verify isValid value is false after reset without keepIsValid
+    expect(screen.getByText('is valid: false')).toBeInTheDocument();
+    expect(formState).toEqual({ isValid: false });
   });
 
   it('should keep isValid value when form has resetOptions.keepIsValid configured', async () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -143,6 +143,7 @@ export function createFormControl<
     action: false,
     mount: false,
     watch: false,
+    keepIsValid: false,
   };
   let _names: Names = {
     mount: new Set(),
@@ -184,6 +185,9 @@ export function createFormControl<
     };
 
   const _setValid = async (shouldUpdateValid?: boolean) => {
+    if (_state.keepIsValid) {
+      return;
+    }
     if (
       !_options.disabled &&
       (_proxyFormState.isValid ||
@@ -1428,6 +1432,7 @@ export function createFormControl<
       (!_options.shouldUnregister && !isEmptyObject(values));
 
     _state.watch = !!_options.shouldUnregister;
+    _state.keepIsValid = !!keepStateOptions.keepIsValid;
     _state.action = false;
 
     // Clear errors synchronously to prevent validation errors on subsequent submissions
@@ -1480,7 +1485,7 @@ export function createFormControl<
       isFunction(formValues)
         ? (formValues as Function)(_formValues as TFieldValues)
         : formValues,
-      keepStateOptions,
+      { ..._options.resetOptions, ...keepStateOptions },
     );
 
   const setFocus: UseFormSetFocus<TFieldValues> = (name, options = {}) => {


### PR DESCRIPTION
## Proposed Changes

I noticed that the keepIsValid reset option wasn’t working correctly. After calling reset, the isValid state should remain preserved when keepIsValid is enabled. Since I couldn’t find any existing examples or test coverage for this behavior, I added two test cases to verify it. Please review and confirm whether these tests reflect the expected behavior.

## Changes

I added a `keepIsValid` flag to `createFormControl`, which is set only when `keepStateOptions.keepIsValid` is true. When this flag is active, the `_setValid` function (typically triggered after the re-render following a `reset`) will exit early, preventing the valid state from being updated.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
