### PR TITLE
chore: clean up imports in deep-equal

### DIFF
--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -1,5 +1,5 @@
-import isObject from './isObject';
 import isDateObject from './isDateObject';
+import isObject from './isObject';
 import isPrimitive from './isPrimitive';
 
 export default function deepEqual(

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -1,5 +1,4 @@
-import isObject from '../utils/isObject';
-
+import isObject from './isObject';
 import isDateObject from './isDateObject';
 import isPrimitive from './isPrimitive';
 


### PR DESCRIPTION
Small small clean up. All other utilities seem to import directly from sibling utility files. But `deepEqual` imports from `../utils/isObject` despite that also being a sibling.

## Proposed Changes

Simplify the imports and make it consistent with the other utilities.

<!-- Fixes # (issue) -->

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes