### PR TITLE
chore: clean cloneObject logic

### DIFF
--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -23,7 +23,7 @@ export default function cloneObject<T>(data: T): T {
   const copy = isArray ? [] : Object.create(Object.getPrototypeOf(data));
 
   for (const key in data) {
-    if (data.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
       copy[key] = cloneObject(data[key]);
     }
   }

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -3,30 +3,29 @@ import isPlainObject from './isPlainObject';
 import isWeb from './isWeb';
 
 export default function cloneObject<T>(data: T): T {
-  let copy: any;
-  const isArray = Array.isArray(data);
-  const isFileListInstance =
-    typeof FileList !== 'undefined' ? data instanceof FileList : false;
-
   if (data instanceof Date) {
-    copy = new Date(data);
-  } else if (
-    !(isWeb && (data instanceof Blob || isFileListInstance)) &&
-    (isArray || isObject(data))
-  ) {
-    copy = isArray ? [] : Object.create(Object.getPrototypeOf(data));
+    return new Date(data) as any;
+  }
 
-    if (!isArray && !isPlainObject(data)) {
-      copy = data;
-    } else {
-      for (const key in data) {
-        if (data.hasOwnProperty(key)) {
-          copy[key] = cloneObject(data[key]);
-        }
-      }
-    }
-  } else {
+  const isFileListInstance =
+    typeof FileList !== 'undefined' && data instanceof FileList;
+
+  if (isWeb && (data instanceof Blob || isFileListInstance)) {
     return data;
+  }
+
+  const isArray = Array.isArray(data);
+
+  if (!isArray && !(isObject(data) && isPlainObject(data))) {
+    return data;
+  }
+
+  const copy = isArray ? [] : Object.create(Object.getPrototypeOf(data));
+
+  for (const key in data) {
+    if (data.hasOwnProperty(key)) {
+      copy[key] = cloneObject(data[key]);
+    }
   }
 
   return copy;


### PR DESCRIPTION
I noticed that there were multiple noop branches when cloning an object and tried simplifying it.

# Pull Request Template

## Proposed Changes

Remove the duplicate logic.

Also changed the call to `hasOwnProperty` based on the [`no-prototype-builtin`](https://eslint.org/docs/latest/rules/no-prototype-builtins) rule from ESLint.

## Motivation

* Can feasibly improve code coverage moving forwards by keeping the branches concise and easily readable.
  * e.g. If more edge cases are added in the future and need to be tested.
* Other than that, this is a mostly inconsequential minor clean-up chore.

## Follow up

* I can make the code more concise by combining the `isWeb...` and `!isArray` blocks.
* I can add comments explaining why certain conditions exist.
* I can emove excessive newlines.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes