### PR TITLE
fix(validation): batch isValidating state updates with validation result

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -66,6 +66,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
     _runSchema: (names: InternalFieldName[]) => Promise<{
         errors: FieldErrors;
     }>;
+    _updateIsValidating: (names?: InternalFieldName[], isValidating?: boolean) => void;
     _focusError: () => boolean | undefined;
     _disableForm: (disabled?: boolean) => void;
     _subscribe: FromSubscribe<TFieldValues>;

--- a/src/__tests__/useForm/resolver.test.tsx
+++ b/src/__tests__/useForm/resolver.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
 import type { FieldErrors } from '../../types/errors';
 import { useForm } from '../../useForm';
+import { useFormState } from '../../useFormState';
 import noop from '../../utils/noop';
 import sleep from '../../utils/sleep';
 
@@ -297,5 +304,144 @@ describe('resolver', () => {
         timeout: 3000,
       }),
     ).toBeVisible();
+  });
+
+  describe('resolver state batching', () => {
+    const createResolver = () => async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return {
+        errors: {
+          test: { type: 'required', message: 'Required' },
+        },
+      };
+    };
+
+    const StateTracker = ({
+      control,
+      onEmit,
+    }: {
+      control: any;
+      onEmit: (state: { errors: any; isValidating: boolean }) => void;
+    }) => {
+      const { errors, isValidating } = useFormState({ control });
+
+      React.useEffect(() => {
+        onEmit({ errors: { ...errors }, isValidating });
+      }, [errors, isValidating, onEmit]);
+
+      return null;
+    };
+
+    it('should batch state updates in onChange mode', async () => {
+      const stateEmissions: Array<{ errors: any; isValidating: boolean }> = [];
+
+      const App = () => {
+        const { register, control } = useForm({
+          resolver: createResolver(),
+          mode: 'onChange',
+        });
+
+        return (
+          <form>
+            <input {...register('test')} />
+            <StateTracker
+              control={control}
+              onEmit={(state) => stateEmissions.push(state)}
+            />
+          </form>
+        );
+      };
+
+      render(<App />);
+      stateEmissions.length = 0;
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
+
+      await waitFor(() => {
+        expect(stateEmissions.some((s) => s.errors.test)).toBe(true);
+      });
+
+      // Should be 2 emissions, not 3
+      expect(stateEmissions).toHaveLength(2);
+      expect(stateEmissions[0]).toEqual({ errors: {}, isValidating: true });
+      expect(stateEmissions[1].errors.test).toBeDefined();
+      expect(stateEmissions[1].isValidating).toBe(false);
+    });
+
+    it('should batch state updates in onBlur mode', async () => {
+      const stateEmissions: Array<{ errors: any; isValidating: boolean }> = [];
+
+      const App = () => {
+        const { register, control } = useForm({
+          resolver: createResolver(),
+          mode: 'onBlur',
+        });
+
+        return (
+          <form>
+            <input {...register('test')} />
+            <StateTracker
+              control={control}
+              onEmit={(state) => stateEmissions.push(state)}
+            />
+          </form>
+        );
+      };
+
+      render(<App />);
+      stateEmissions.length = 0;
+
+      fireEvent.focus(screen.getByRole('textbox'));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
+      fireEvent.blur(screen.getByRole('textbox'));
+
+      await waitFor(() => {
+        expect(stateEmissions.some((s) => s.errors.test)).toBe(true);
+      });
+
+      // Should be 2 emissions, not 3
+      expect(stateEmissions).toHaveLength(2);
+      expect(stateEmissions[0]).toEqual({ errors: {}, isValidating: true });
+      expect(stateEmissions[1].errors.test).toBeDefined();
+      expect(stateEmissions[1].isValidating).toBe(false);
+    });
+
+    it('should batch state updates when using trigger', async () => {
+      const stateEmissions: Array<{ errors: any; isValidating: boolean }> = [];
+
+      const App = () => {
+        const { register, control, trigger } = useForm({
+          resolver: createResolver(),
+        });
+
+        return (
+          <form>
+            <input {...register('test')} />
+            <StateTracker
+              control={control}
+              onEmit={(state) => stateEmissions.push(state)}
+            />
+            <button type="button" onClick={() => trigger('test')}>
+              Trigger
+            </button>
+          </form>
+        );
+      };
+
+      render(<App />);
+      stateEmissions.length = 0;
+
+      fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+      await waitFor(() => {
+        expect(stateEmissions.some((s) => s.errors.test)).toBe(true);
+      });
+
+      // Should be 2 emissions, not 3
+      expect(stateEmissions).toHaveLength(2);
+      expect(stateEmissions[0]).toEqual({ errors: {}, isValidating: true });
+      expect(stateEmissions[1].errors.test).toBeDefined();
+      expect(stateEmissions[1].isValidating).toBe(false);
+    });
   });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -187,10 +187,13 @@ export function createFormControl<
         _proxySubscribeFormState.isValid ||
         shouldUpdateValid)
     ) {
-      const isValid = _options.resolver
-        ? isEmptyObject((await _runSchema()).errors)
-        : await executeBuiltInValidation(_fields, true);
-
+      let isValid: boolean;
+      if (_options.resolver) {
+        isValid = isEmptyObject((await _runSchema()).errors);
+        _updateIsValidating();
+      } else {
+        isValid = await executeBuiltInValidation(_fields, true);
+      }
       if (isValid !== _formState.isValid) {
         _subjects.state.next({
           isValid,
@@ -444,12 +447,12 @@ export function createFormControl<
         _options.shouldUseNativeValidation,
       ),
     );
-    _updateIsValidating(name);
     return result;
   };
 
   const executeSchemaAndUpdateState = async (names?: InternalFieldName[]) => {
     const { errors } = await _runSchema(names);
+    _updateIsValidating(names);
 
     if (names) {
       for (const name of names) {
@@ -809,6 +812,7 @@ export function createFormControl<
 
       if (_options.resolver) {
         const { errors } = await _runSchema([name]);
+        _updateIsValidating([name]);
 
         _updateIsFieldValueUpdated(fieldValue);
 
@@ -1251,6 +1255,7 @@ export function createFormControl<
 
       if (_options.resolver) {
         const { errors, values } = await _runSchema();
+        _updateIsValidating();
         _formState.errors = errors;
         fieldValues = cloneObject(values);
       } else {
@@ -1517,6 +1522,7 @@ export function createFormControl<
       setError,
       _subscribe,
       _runSchema,
+      _updateIsValidating,
       _focusError,
       _getWatch,
       _getDirty,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -861,6 +861,10 @@ export type Control<
     name: FieldName<any>;
   }) => void;
   _runSchema: (names: InternalFieldName[]) => Promise<{ errors: FieldErrors }>;
+  _updateIsValidating: (
+    names?: InternalFieldName[],
+    isValidating?: boolean,
+  ) => void;
   _focusError: () => boolean | undefined;
   _disableForm: (disabled?: boolean) => void;
   _subscribe: FromSubscribe<TFieldValues>;

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -338,6 +338,7 @@ export function useFieldArray<
     ) {
       if (control._options.resolver) {
         control._runSchema([name]).then((result) => {
+          control._updateIsValidating([name]);
           const error = get(result.errors, name);
           const existingError = get(control._formState.errors, name);
 


### PR DESCRIPTION
## Proposed Changes

Issue #13156 reports an unexpected transition in `formState.isValidating` when using a resolver. During validation, `isValidating` briefly flips from `true` to `false` **before** the resolver has finished updating `errors`, which makes the form temporarily look valid even though validation hasn’t finished yet.

After investigating, the cause is that the current implementation updates `isValidating` **inside an async function containing an** `await`, which breaks React’s state batching. As a result, the `isValidating: false` update is emitted **separately** from the subsequent `errors` and other updates.

Relevant code:
https://github.com/react-hook-form/react-hook-form/blob/1536f7c2181b1adcce873c23142945afec05075c/src/logic/createFormControl.ts#L435-L449

Because the second `_updateIsValidating` runs after an awaited promise, React flushes it independently, creating an intermediate inconsistent state:

- `isValidating === false`
- `errors[field] === undefined`

This is exactly what the reproduction shows.

## Changes

To ensure `isValidating: false` is batched together with the resolver result and the following state updates, the call to `_updateIsValidating(name)` has been moved out of `_runSchema` and placed immediately after the await `_runSchema(...)` call.

This guarantees the state transition occurs in the same flush as the resolver output, preventing the temporary invalid intermediate state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

fixes: #13156 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes