### PR TITLE
fix: prevent duplicate subscription trigger in setValue

### DIFF
--- a/src/__tests__/issue-13206.test.tsx
+++ b/src/__tests__/issue-13206.test.tsx
@@ -1,0 +1,18 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useForm } from '../useForm';
+
+test('setValue should notify observers exactly once when field is watched', async () => {
+  const { result } = renderHook(() => useForm());
+  const control = result.current.control as any;
+
+  control._names.watch.add('test');
+
+  const nextSpy = jest.spyOn(control._subjects.state, 'next');
+
+  await act(async () => {
+    result.current.setValue('test', 'value');
+  });
+
+  expect(nextSpy).toHaveBeenCalledTimes(1);
+});

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -730,11 +730,18 @@ export function createFormControl<
         : setFieldValue(name, cloneValue, options);
     }
 
-    isWatched(name, _names) && _subjects.state.next({ ..._formState, name });
-    _subjects.state.next({
-      name: _state.mount ? name : undefined,
-      values: cloneObject(_formValues),
-    });
+    if (isWatched(name, _names)) {
+      _subjects.state.next({
+        ..._formState,
+        name,
+        values: cloneObject(_formValues),
+      });
+    } else {
+      _subjects.state.next({
+        name: _state.mount ? name : undefined,
+        values: cloneObject(_formValues),
+      });
+    }
   };
 
   const onChange: ChangeHandler = async (event) => {


### PR DESCRIPTION
## Description

Closes #13206

This PR fixes a bug where the subscription callback triggers twice when a field is both watched (via `useWatch` or `watch`) and subscribed to.

## Problem

In the `setValue` function within `createFormControl.ts`, the state update notification (`_subjects.state.next`) was being triggered twice under specific conditions:

1.  First, inside the `if (isWatched(name, _names))` block.
2.  Second, unconditionally at the end of the function.

This caused subscribers to receive duplicate events for a single value change.

## Solution

I refactored the notification logic in `setValue` to use an `if/else` block. Now, `_subjects.state.next` is guaranteed to be called **exactly once**:

-   **If Watched:** Sends the update including the full form state and values.
-   **If Not Watched:** Sends the standard update logic.

## Testing

I have added a reproduction test case in `src/__tests__/issue-13206.test.tsx`.
This test spies on `control._subjects.state.next` to verify that it is invoked exactly once when `setValue` is called on a watched field.

```ts
// Key verification logic in the test
expect(nextSpy).toHaveBeenCalledTimes(1);
```

> [!NOTE]  
> I created a separate test file (src/__tests__/issue-13206.test.tsx) to isolate the reproduction case and ensure clarity for this specific issue.
>
> If you prefer, I am happy to:
> - Move this test case into src/__tests__/useForm/setValue.test.tsx
> - Or remove the file entirely if the existing regression tests are considered sufficient.