### PR TITLE
fix: change spread operator to set name with deprecated names first

### DIFF
--- a/src/watch.tsx
+++ b/src/watch.tsx
@@ -112,7 +112,7 @@ export const Watch = <
   TComputeValue
 >) =>
   render(
-    useWatch({ ...(props as any), name: names }) as WatchRenderValue<
+    useWatch({ name: names, ...(props as any) }) as WatchRenderValue<
       TFieldName,
       TFieldValues,
       TComputeValue


### PR DESCRIPTION
Change spread operator in useWatch hook to set name key with deprecated names props first, then override with new name key if supplied. Currently, if deprecated names prop is refactored to name, the useWatch hook receives name as undefined, the value is cleared and the Watch component will re-render if any key changes.