### PR TITLE
fix: enhance cloneObject to handle Blob instances correctly

### DIFF
--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -9,8 +9,9 @@ export default function cloneObject<T>(data: T): T {
 
   const isFileListInstance =
     typeof FileList !== 'undefined' && data instanceof FileList;
+  const isBlobInstance = typeof Blob !== 'undefined' && data instanceof Blob;
 
-  if (isWeb && (data instanceof Blob || isFileListInstance)) {
+  if (isWeb && (isBlobInstance || isFileListInstance)) {
     return data;
   }
 


### PR DESCRIPTION
The PR fix `cloneObject`  to safely handle environments where `Blob` is undefined by guarding the `instanceof Blob` check, preventing runtime errors in SSR/Node-like/webview runtimes. Added regression tests to cover the “Blob not defined” case and to ensure plain objects containing a `Blob` are still cloned when `isWeb` is false

https://github.com/react-hook-form/react-hook-form/issues/12864