### PR TITLE
fix: prevent exception in cloneObject when Blob is not defined

### DIFF
--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -7,11 +7,13 @@ export default function cloneObject<T>(data: T): T {
     return new Date(data) as any;
   }
 
-  const isFileListInstance =
-    typeof FileList !== 'undefined' && data instanceof FileList;
-
-  if (isWeb && (data instanceof Blob || isFileListInstance)) {
-    return data;
+  if (isWeb) {
+    const isBlobInstance = typeof Blob !== 'undefined' && data instanceof Blob;
+    const isFileListInstance =
+      typeof FileList !== 'undefined' && data instanceof FileList;
+    if (isBlobInstance || isFileListInstance) {
+      return data;
+    }
   }
 
   const isArray = Array.isArray(data);


### PR DESCRIPTION
This PR prevents a runtime exception in cloneObject when `Blob` is not available in the global scope.

Although cloneObject already checks for a “web-like” environment there are embedded or constrained runtimes where these globals exist but Blob does not. In these cases, the current instanceof Blob check throws:

`Right-hand side of 'instanceof' is not an object`

This change adds a defensive guard to ensure `Blob` is defined before performing the `instanceof` comparison, following the same pattern already used for `FileList`.

**What changed**

Adds a typeof Blob !== 'undefined' guard before instanceof Blob

Aligns Blob handling with the existing FileList safeguard

Prevents exceptions in embedded or partial DOM environments

**Why**

Some embedded environments expose window, document, and HTMLElement without providing a global Blob implementation. This guard allows cloneObject to execute safely in those environments without altering behavior in standard browsers.

**Notes**
No new tests were added, as covering this case would require mutating the global Blob, which could affect other tests, and there were no existing tests for undefined FileList.