### PR TITLE
fix: update isValid when field disabled state changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "files": [
       {
         "path": "./dist/index.cjs.js",
-        "maxSize": "11.1 kB"
+        "maxSize": "11.2 kB"
       }
     ]
   },

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1125,7 +1125,12 @@ export function createFormControl<
       !!disabled ||
       _names.disabled.has(name)
     ) {
+      const wasDisabled = _names.disabled.has(name);
+      const isDisabled = !!disabled;
+      const disabledStateChanged = wasDisabled !== isDisabled;
+
       disabled ? _names.disabled.add(name) : _names.disabled.delete(name);
+      disabledStateChanged && _state.mount && !_state.action && _setValid();
     }
   };
 


### PR DESCRIPTION
## Proposed Changes

### Problem
When toggling a field's `disabled` state in `mode: 'onChange'`, `isValid` does not automatically recalculate. While disabled fields correctly skip validation, the form state becomes stale when the disabled state changes, causing `isValid` to not reflect the current validation state.

**Example:**
- Start with required field empty → `isValid = false` 
- Disable that field → validation skips it , but `isValid` stays `false` 
- Expected: `isValid = true` (no enabled fields are invalid)

### Solution
Modified `_setDisabledField` to detect when disabled state actually changes and trigger validation automatically.


Fixes #13176 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
