### PR TITLE
🚄 perf: separate control context to prevent unnecessary rerenders

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "files": [
       {
         "path": "./dist/index.cjs.js",
-        "maxSize": "11.2 kB"
+        "maxSize": "11.25 kB"
       }
     ]
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export * from './types';
 export * from './useController';
 export * from './useFieldArray';
 export * from './useForm';
-export * from './useFormContext';
+export { FormProvider, useFormContext } from './useFormContext';
 export * from './useFormState';
 export * from './useWatch';
 export * from './utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export * from './types';
 export * from './useController';
 export * from './useFieldArray';
 export * from './useForm';
-export { FormProvider, useFormContext } from './useFormContext';
+export * from './useFormContext';
 export * from './useFormState';
 export * from './useWatch';
 export * from './utils';

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -19,7 +19,7 @@ import type {
   UseControllerProps,
   UseControllerReturn,
 } from './types';
-import { useFormControlContext } from './useFormContext';
+import { useFormControlContext } from './useFormControlContext';
 import { useFormState } from './useFormState';
 import { useWatch } from './useWatch';
 

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -19,7 +19,7 @@ import type {
   UseControllerProps,
   UseControllerReturn,
 } from './types';
-import { useFormContext } from './useFormContext';
+import { useFormControlContext } from './useFormContext';
 import { useFormState } from './useFormState';
 import { useWatch } from './useWatch';
 
@@ -54,11 +54,15 @@ export function useController<
 >(
   props: UseControllerProps<TFieldValues, TName, TTransformedValues>,
 ): UseControllerReturn<TFieldValues, TName> {
-  const methods = useFormContext<TFieldValues, any, TTransformedValues>();
+  const formControl = useFormControlContext<
+    TFieldValues,
+    any,
+    TTransformedValues
+  >();
   const {
     name,
     disabled,
-    control = methods.control,
+    control = formControl,
     shouldUnregister,
     defaultValue,
     exact = true,

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -38,7 +38,7 @@ import type {
   UseFieldArrayProps,
   UseFieldArrayReturn,
 } from './types';
-import { useFormContext } from './useFormContext';
+import { useFormControlContext } from './useFormContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**
@@ -92,9 +92,13 @@ export function useFieldArray<
     TTransformedValues
   >,
 ): UseFieldArrayReturn<TFieldValues, TFieldArrayName, TKeyName> {
-  const methods = useFormContext();
+  const formControl = useFormControlContext<
+    TFieldValues,
+    any,
+    TTransformedValues
+  >();
   const {
-    control = methods.control,
+    control = formControl,
     name,
     keyName = 'id',
     shouldUnregister,

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -38,7 +38,7 @@ import type {
   UseFieldArrayProps,
   UseFieldArrayReturn,
 } from './types';
-import { useFormControlContext } from './useFormContext';
+import { useFormControlContext } from './useFormControlContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -6,16 +6,10 @@ import type {
   FormProviderProps,
   UseFormReturn,
 } from './types';
+import { HookFormControlContext } from './useFormControlContext';
 
 const HookFormContext = React.createContext<UseFormReturn | null>(null);
 HookFormContext.displayName = 'HookFormContext';
-
-/**
- * Separate context for `control` to prevent unnecessary rerenders.
- * Internal hooks that only need control use this instead of full form context.
- */
-const HookFormControlContext = React.createContext<Control | null>(null);
-HookFormControlContext.displayName = 'HookFormControlContext';
 
 /**
  * This custom hook allows you to access the form context. useFormContext is intended to be used in deeply nested structures, where it would become inconvenient to pass the context as a prop. To be used with {@link FormProvider}.
@@ -53,20 +47,6 @@ export const useFormContext = <
   TTransformedValues = TFieldValues,
 >(): UseFormReturn<TFieldValues, TContext, TTransformedValues> =>
   React.useContext(HookFormContext) as UseFormReturn<
-    TFieldValues,
-    TContext,
-    TTransformedValues
-  >;
-
-/**
- * @internal Internal hook to access only control from context.
- */
-export const useFormControlContext = <
-  TFieldValues extends FieldValues,
-  TContext = any,
-  TTransformedValues = TFieldValues,
->(): Control<TFieldValues, TContext, TTransformedValues> =>
-  React.useContext(HookFormControlContext) as Control<
     TFieldValues,
     TContext,
     TTransformedValues

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -1,9 +1,21 @@
 import React from 'react';
 
-import type { FieldValues, FormProviderProps, UseFormReturn } from './types';
+import type {
+  Control,
+  FieldValues,
+  FormProviderProps,
+  UseFormReturn,
+} from './types';
 
 const HookFormContext = React.createContext<UseFormReturn | null>(null);
 HookFormContext.displayName = 'HookFormContext';
+
+/**
+ * Separate context for `control` to prevent unnecessary rerenders.
+ * Internal hooks that only need control use this instead of full form context.
+ */
+const HookFormControlContext = React.createContext<Control | null>(null);
+HookFormControlContext.displayName = 'HookFormControlContext';
 
 /**
  * This custom hook allows you to access the form context. useFormContext is intended to be used in deeply nested structures, where it would become inconvenient to pass the context as a prop. To be used with {@link FormProvider}.
@@ -41,6 +53,20 @@ export const useFormContext = <
   TTransformedValues = TFieldValues,
 >(): UseFormReturn<TFieldValues, TContext, TTransformedValues> =>
   React.useContext(HookFormContext) as UseFormReturn<
+    TFieldValues,
+    TContext,
+    TTransformedValues
+  >;
+
+/**
+ * @internal Internal hook to access only control from context.
+ */
+export const useFormControlContext = <
+  TFieldValues extends FieldValues,
+  TContext = any,
+  TTransformedValues = TFieldValues,
+>(): Control<TFieldValues, TContext, TTransformedValues> =>
+  React.useContext(HookFormControlContext) as Control<
     TFieldValues,
     TContext,
     TTransformedValues
@@ -146,7 +172,9 @@ export const FormProvider = <
         ) as unknown as UseFormReturn
       }
     >
-      {children}
+      <HookFormControlContext.Provider value={control as Control}>
+        {children}
+      </HookFormControlContext.Provider>
     </HookFormContext.Provider>
   );
 };

--- a/src/useFormControlContext.ts
+++ b/src/useFormControlContext.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import type { Control, FieldValues } from './types';
+
+/**
+ * Separate context for `control` to prevent unnecessary rerenders.
+ * Internal hooks that only need control use this instead of full form context.
+ */
+export const HookFormControlContext = React.createContext<Control | null>(null);
+HookFormControlContext.displayName = 'HookFormControlContext';
+
+/**
+ * @internal Internal hook to access only control from context.
+ */
+export const useFormControlContext = <
+  TFieldValues extends FieldValues,
+  TContext = any,
+  TTransformedValues = TFieldValues,
+>(): Control<TFieldValues, TContext, TTransformedValues> =>
+  React.useContext(HookFormControlContext) as Control<
+    TFieldValues,
+    TContext,
+    TTransformedValues
+  >;

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -6,7 +6,7 @@ import type {
   UseFormStateProps,
   UseFormStateReturn,
 } from './types';
-import { useFormContext } from './useFormContext';
+import { useFormControlContext } from './useFormContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**
@@ -45,8 +45,12 @@ export function useFormState<
 >(
   props?: UseFormStateProps<TFieldValues, TTransformedValues>,
 ): UseFormStateReturn<TFieldValues> {
-  const methods = useFormContext<TFieldValues, any, TTransformedValues>();
-  const { control = methods.control, disabled, name, exact } = props || {};
+  const formControl = useFormControlContext<
+    TFieldValues,
+    any,
+    TTransformedValues
+  >();
+  const { control = formControl, disabled, name, exact } = props || {};
   const [formState, updateFormState] = React.useState(control._formState);
   const _localProxyFormState = React.useRef({
     isDirty: false,

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -6,7 +6,7 @@ import type {
   UseFormStateProps,
   UseFormStateReturn,
 } from './types';
-import { useFormControlContext } from './useFormContext';
+import { useFormControlContext } from './useFormControlContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -12,7 +12,7 @@ import type {
   InternalFieldName,
   UseWatchProps,
 } from './types';
-import { useFormControlContext } from './useFormContext';
+import { useFormControlContext } from './useFormControlContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -12,7 +12,7 @@ import type {
   InternalFieldName,
   UseWatchProps,
 } from './types';
-import { useFormContext } from './useFormContext';
+import { useFormControlContext } from './useFormContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**
@@ -256,9 +256,9 @@ export function useWatch<
 export function useWatch<TFieldValues extends FieldValues>(
   props?: UseWatchProps<TFieldValues>,
 ) {
-  const methods = useFormContext<TFieldValues>();
+  const formControl = useFormControlContext<TFieldValues>();
   const {
-    control = methods.control,
+    control = formControl,
     name,
     defaultValue,
     disabled,


### PR DESCRIPTION
Introduce HookFormControlContext for internal hooks (useController, useFieldArray, useFormState, useWatch) to avoid rerenders when only control is needed.

Currently, even if the context were memoized, there would still be an unnecessary cause for rerenders in these hooks — formState — even though it's not actually used internally. This PR completely breaks the dependency on formState and makes the hooks isolated from the shared context.

I intentionally did not export the new hook in the public API, as I don't think there's a reason to expand it.

Partial work for #13233