### PR TITLE
🚄 perf: memoize FormProvider context value to prevent unnecessary rerenders

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -181,7 +181,10 @@ export function useForm<
     control._removeUnmounted();
   });
 
-  _formControl.current.formState = getProxyFormState(formState, control);
+  _formControl.current.formState = React.useMemo(
+    () => getProxyFormState(formState, control),
+    [control, formState],
+  );
 
   return _formControl.current;
 }

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -83,9 +83,69 @@ export const FormProvider = <
 >(
   props: FormProviderProps<TFieldValues, TContext, TTransformedValues>,
 ) => {
-  const { children, ...data } = props;
+  const {
+    children,
+    watch,
+    getValues,
+    getFieldState,
+    setError,
+    clearErrors,
+    setValue,
+    trigger,
+    formState,
+    resetField,
+    reset,
+    handleSubmit,
+    unregister,
+    control,
+    register,
+    setFocus,
+    subscribe,
+  } = props;
+
   return (
-    <HookFormContext.Provider value={data as unknown as UseFormReturn}>
+    <HookFormContext.Provider
+      value={
+        React.useMemo(
+          () => ({
+            watch,
+            getValues,
+            getFieldState,
+            setError,
+            clearErrors,
+            setValue,
+            trigger,
+            formState,
+            resetField,
+            reset,
+            handleSubmit,
+            unregister,
+            control,
+            register,
+            setFocus,
+            subscribe,
+          }),
+          [
+            clearErrors,
+            control,
+            formState,
+            getFieldState,
+            getValues,
+            handleSubmit,
+            register,
+            reset,
+            resetField,
+            setError,
+            setFocus,
+            setValue,
+            subscribe,
+            trigger,
+            unregister,
+            watch,
+          ],
+        ) as unknown as UseFormReturn
+      }
+    >
       {children}
     </HookFormContext.Provider>
   );


### PR DESCRIPTION
This PR adds memoization for `_formControl.current.formState` and also memoizes the entire context, since the context is now fully stable.

Partial work for https://github.com/react-hook-form/react-hook-form/issues/13233