### PR TITLE
Fix : ensure the isValidating is set when trigger is called programma…

### DIFF
--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -270,6 +270,45 @@ describe('formState', () => {
     });
   });
 
+  //added
+  it('should toggle isValidating when trigger is called asynchronously', async () => {
+    jest.useFakeTimers();
+
+    const resolver = jest.fn(async () => ({
+      values: {},
+      errors: {},
+    }));
+
+    const { result } = renderHook(() =>
+      useForm({
+        resolver,
+      }),
+    );
+
+    expect(result.current.formState.isValidating).toBe(false);
+
+    act(() => {
+      setTimeout(() => {
+        result.current.trigger();
+      }, 100);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    // wait until validation completes
+    await waitFor(() =>
+      expect(result.current.formState.isValidating).toBe(false),
+    );
+
+    // resolver must have been called
+    expect(resolver).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
+  //here
   it('should be a proxy object that returns undefined for unknown properties', () => {
     const { result } = renderHook(() => useForm());
 


### PR DESCRIPTION
Fixes an issue where calling trigger() asynchronously (e.g. via setTimeout or useEffect)
does not toggle isValidating to true.

This ensures isValidating is set when trigger() starts and reliably reset after validation.

Closes #13218
