### PR TITLE
feat(types): support flat field arrays

### DIFF
--- a/src/__typetest__/path/eager.test-d.ts
+++ b/src/__typetest__/path/eager.test-d.ts
@@ -50,7 +50,7 @@ import { _ } from '../__fixtures__';
     const actual = _ as ArrayPath<{
       foo: Array<{ bar: string[]; baz: string[] }>;
     }>;
-    expectType<'foo'>(actual);
+    expectType<'foo' | `foo.${number}.bar` | `foo.${number}.baz`>(actual);
   }
 
   /** it should include paths through tuples */ {
@@ -60,7 +60,7 @@ import { _ } from '../__fixtures__';
 
   /** it should include paths through arrays */ {
     const actual = _ as ArrayPath<{ foo: string[][][] }>;
-    expectType<'foo' | `foo.${number}`>(actual);
+    expectType<'foo' | `foo.${number}` | `foo.${number}.${number}`>(actual);
   }
 
   /** it should be able to avoid self-referencing/recursion, not crashing on self-referencing types. */ {

--- a/src/__typetest__/useFieldArray.test-d.ts
+++ b/src/__typetest__/useFieldArray.test-d.ts
@@ -1,0 +1,457 @@
+import { expectType } from 'tsd';
+
+import { useFieldArray } from '../useFieldArray';
+import { useForm } from '../useForm';
+
+/** {@link useFieldArray} flat field array */ {
+  /** it should work with multi-dimensional arrays */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      items: string[][][];
+    };
+
+    const { control } = useForm<FormValues>();
+
+    const {
+      fields: fields1,
+      append: append1,
+      prepend: prepend1,
+      insert: insert1,
+    } = useFieldArray({
+      control,
+      name: 'items',
+    });
+
+    expectType<(string[][] & { key: string })[]>(fields1);
+
+    append1([['a', 'b'], ['c']]);
+    append1([[['a', 'b'], ['c']]]);
+    append1([['a', 'b'], ['c']], { shouldFocus: false });
+    prepend1([['a', 'b'], ['c']]);
+    insert1(0, [['a', 'b'], ['c']]);
+    insert1(0, [['a', 'b'], ['c']], { shouldFocus: false });
+
+    const {
+      fields: fields2,
+      append: append2,
+      prepend: prepend2,
+      insert: insert2,
+    } = useFieldArray({
+      control,
+      name: 'items.0',
+    });
+
+    expectType<(string[] & { key: string })[]>(fields2);
+
+    append2(['a', 'b']);
+    append2([['a', 'b'], ['c']]);
+    append2(['a', 'b'], { shouldFocus: false });
+    prepend2(['a', 'b']);
+    insert2(0, ['a', 'b']);
+
+    const {
+      fields: fields3,
+      append: append3,
+      prepend: prepend3,
+      insert: insert3,
+    } = useFieldArray({
+      control,
+      name: 'items.0.0',
+    });
+
+    expectType<(string & { key: string })[]>(fields3);
+
+    append3('a');
+    append3(['a', 'b']);
+    append3('a', { shouldFocus: false });
+    prepend3('a');
+    insert3(0, 'a');
+  }
+
+  /** it should work with arrays of objects with array properties */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      items: {
+        name: string;
+        tags: string[];
+        categories: number[];
+      }[];
+    };
+
+    const { control } = useForm<FormValues>();
+
+    const {
+      fields: itemFields,
+      append: appendItem,
+      update: updateItem,
+    } = useFieldArray({
+      control,
+      name: 'items',
+    });
+
+    expectType<
+      ({ name: string; tags: string[]; categories: number[] } & {
+        key: string;
+      })[]
+    >(itemFields);
+
+    appendItem({
+      name: 'Item 1',
+      tags: ['tag1', 'tag2'],
+      categories: [1, 2],
+    });
+    appendItem([
+      {
+        name: 'Item 1',
+        tags: ['tag1'],
+        categories: [1],
+      },
+      {
+        name: 'Item 2',
+        tags: ['tag2'],
+        categories: [2],
+      },
+    ]);
+    updateItem(0, {
+      name: 'Updated Item',
+      tags: ['tag1'],
+      categories: [1],
+    });
+
+    const {
+      fields: tagFields,
+      append: appendTag,
+      update: updateTag,
+      replace: replaceTags,
+    } = useFieldArray({
+      control,
+      name: 'items.0.tags',
+    });
+
+    expectType<(string & { key: string })[]>(tagFields);
+
+    appendTag('newTag');
+    appendTag(['tag1', 'tag2']);
+    updateTag(0, 'updatedTag');
+    replaceTags('singleTag');
+    replaceTags(['tag1', 'tag2']);
+
+    const {
+      fields: categoryFields,
+      append: appendCategory,
+      update: updateCategory,
+      replace: replaceCategories,
+    } = useFieldArray({
+      control,
+      name: 'items.0.categories',
+    });
+
+    expectType<(number & { key: string })[]>(categoryFields);
+
+    appendCategory(5);
+    appendCategory([5, 6]);
+    updateCategory(0, 10);
+    replaceCategories(100);
+    replaceCategories([1, 2, 3]);
+  }
+
+  /** it should work with deeply nested array structures */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      groups: {
+        name: string;
+        users: {
+          username: string;
+          permissions: string[];
+        }[];
+      }[];
+    };
+
+    const { control } = useForm<FormValues>();
+
+    const { fields: groupFields, append: appendGroup } = useFieldArray({
+      control,
+      name: 'groups',
+    });
+
+    expectType<
+      ({
+        name: string;
+        users: { username: string; permissions: string[] }[];
+      } & { key: string })[]
+    >(groupFields);
+
+    appendGroup({
+      name: 'Group 1',
+      users: [{ username: 'user1', permissions: ['read'] }],
+    });
+    appendGroup([
+      {
+        name: 'Group 1',
+        users: [{ username: 'user1', permissions: ['read'] }],
+      },
+    ]);
+
+    const { fields: userFields, append: appendUser } = useFieldArray({
+      control,
+      name: 'groups.0.users',
+    });
+
+    expectType<
+      ({ username: string; permissions: string[] } & { key: string })[]
+    >(userFields);
+
+    appendUser({
+      username: 'newUser',
+      permissions: ['read', 'write'],
+    });
+    appendUser([
+      {
+        username: 'user1',
+        permissions: ['read'],
+      },
+      {
+        username: 'user2',
+        permissions: ['write'],
+      },
+    ]);
+
+    const {
+      fields: permissionFields,
+      append: appendPermission,
+      replace: replacePermissions,
+    } = useFieldArray({
+      control,
+      name: 'groups.0.users.0.permissions',
+    });
+
+    expectType<(string & { key: string })[]>(permissionFields);
+
+    appendPermission('delete');
+    appendPermission(['delete', 'admin']);
+    replacePermissions('read');
+    replacePermissions(['read', 'write', 'delete']);
+  }
+
+  /** it should work with all field array methods */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      items: {
+        tags: string[];
+      }[];
+    };
+
+    const { control } = useForm<FormValues>();
+
+    const { append, prepend, insert, update, replace, swap, move, remove } =
+      useFieldArray({
+        control,
+        name: 'items.0.tags',
+      });
+
+    append('tag1');
+    append(['tag1', 'tag2']);
+    append('tag1', { shouldFocus: false });
+    prepend('tag0');
+    prepend(['tag0', 'tag-1']);
+
+    insert(1, 'tag1.5');
+    insert(1, ['tag1', 'tag2']);
+    insert(1, 'tag1.5', { shouldFocus: false });
+
+    update(0, 'updatedTag');
+
+    replace('newTag');
+    replace(['newTag1', 'newTag2']);
+
+    swap(0, 1);
+    move(0, 2);
+
+    remove(0);
+    remove([0, 1]);
+    remove();
+  }
+
+  /** it should work with simple array of objects */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      items: {
+        tags: string[];
+      }[];
+    };
+
+    const { control } = useForm<FormValues>();
+
+    const { append, prepend, insert, update } = useFieldArray({
+      control,
+      name: 'items.0.tags',
+    });
+
+    append('tag');
+    append(['tag1', 'tag2']);
+    prepend('tag');
+    insert(0, 'tag');
+    insert(0, ['tag1', 'tag2']);
+    update(0, 'tag');
+  }
+}
+
+/** {@link useFieldArray} nested field array */ {
+  /** it should work with nested field arrays using dynamic indices */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      items: {
+        name: string;
+        tags: string[];
+      }[];
+    };
+
+    const { control } = useForm<FormValues>();
+
+    const { fields: items, append: appendItem } = useFieldArray({
+      control,
+      name: 'items',
+    });
+
+    expectType<({ name: string; tags: string[] } & { key: string })[]>(items);
+
+    appendItem({ name: 'Item', tags: ['tag1'] });
+
+    const {
+      fields: tagFields,
+      append: appendTag,
+      remove: removeTag,
+    } = useFieldArray({
+      control,
+      name: `items.${0}.tags`,
+    });
+
+    expectType<(string & { key: string })[]>(tagFields);
+
+    appendTag('newTag');
+    appendTag(['tag1', 'tag2']);
+    removeTag(0);
+  }
+
+  /** it should work with deeply nested field arrays */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      groups: {
+        name: string;
+        users: {
+          username: string;
+          roles: string[];
+        }[];
+      }[];
+    };
+
+    const { control } = useForm<FormValues>();
+
+    const { fields: groups, append: appendGroup } = useFieldArray({
+      control,
+      name: 'groups',
+    });
+
+    expectType<
+      ({
+        name: string;
+        users: { username: string; roles: string[] }[];
+      } & { key: string })[]
+    >(groups);
+
+    appendGroup({
+      name: 'Group 1',
+      users: [{ username: 'user1', roles: ['admin'] }],
+    });
+
+    const { fields: userFields, append: appendUser } = useFieldArray({
+      control,
+      name: `groups.${0}.users`,
+    });
+
+    expectType<({ username: string; roles: string[] } & { key: string })[]>(
+      userFields,
+    );
+
+    appendUser({ username: 'newUser', roles: ['user'] });
+
+    const { fields: roleFields, append: appendRole } = useFieldArray({
+      control,
+      name: `groups.${0}.users.${0}.roles`,
+    });
+
+    expectType<(string & { key: string })[]>(roleFields);
+
+    appendRole('moderator');
+    appendRole(['admin', 'moderator']);
+  }
+
+  /** it should work with mixed flat and nested config */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+
+    type FormValues = {
+      projects: {
+        title: string;
+        tasks: {
+          description: string;
+          tags: string[];
+        }[];
+      }[];
+    };
+
+    const { control } = useForm<FormValues>();
+
+    const { fields: projects, append: appendProject } = useFieldArray({
+      control,
+      name: 'projects',
+    });
+
+    expectType<
+      ({
+        title: string;
+        tasks: { description: string; tags: string[] }[];
+      } & { key: string })[]
+    >(projects);
+
+    appendProject({
+      title: 'Project 1',
+      tasks: [{ description: 'Task 1', tags: ['urgent'] }],
+    });
+
+    const { fields: taskFields, append: appendTask } = useFieldArray({
+      control,
+      name: `projects.${0}.tasks`,
+    });
+
+    expectType<({ description: string; tags: string[] } & { key: string })[]>(
+      taskFields,
+    );
+
+    appendTask({ description: 'New Task', tags: ['normal'] });
+
+    const { fields: tagFields1, append: appendTag1 } = useFieldArray({
+      control,
+      name: `projects.${0}.tasks.${0}.tags`,
+    });
+
+    expectType<(string & { key: string })[]>(tagFields1);
+
+    appendTag1('tag1');
+
+    const { fields: tagFields2, append: appendTag2 } = useFieldArray({
+      control,
+      name: 'projects.0.tasks.0.tags',
+    });
+
+    expectType<(string & { key: string })[]>(tagFields2);
+
+    appendTag2('tag2');
+  }
+}

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -80,7 +80,7 @@ type ArrayPathImpl<K extends string | number, V, TraversedTypes> = V extends
     ? string
     : never
   : V extends ReadonlyArray<infer U>
-    ? U extends Primitive | BrowserNativeObject
+    ? U extends BrowserNativeObject
       ? IsAny<V> extends true
         ? string
         : never


### PR DESCRIPTION
This PR adds TypeScript type support for flat field arrays (arrays containing primitive values) in useFieldArray. Previously, useFieldArray only supported arrays of objects, but this change allows primitive arrays such as string[], number[], and multi-dimensional primitive arrays like string[][].

This is a type-only change with no runtime modifications.

## Changes

Type Definition Update:

- Modified ArrayPathImpl in src/types/path/eager.ts to remove the primitive type restriction
- This allows ArrayPath to correctly resolve paths for primitive arrays

Before:

```ts
// Had to wrap primitive values in objects to use with useFieldArray
type FormValues = {
  items: {
    tag: string;
  }[]; // Nested object structure required
};

const { fields, append } = useFieldArray({
  control,
  name: 'items',
});

// fields type: ({ tag: string } & { key: string })[]
// append accepts: { tag: string } | { tag: string }[]
```

After:

```ts
// Can now use primitive arrays directly without wrapping
type FormValues = {
  tags: string[];
};

// ArrayPath<FormValues> now resolves to: 'tags'
// useFieldArray with name: 'tags' works correctly with full type safety

const { fields, append } = useFieldArray({
  control,
  name: 'tags',
});

// fields type: (string & { key: string })[]
// append accepts: string | string[]
```

## Review Point: IDE Type Representation for Primitive Field Arrays

This change allows `useFieldArray` to support primitive arrays by modeling each field as an intersection type:

```ts
(string & { key: string })[]
```

This is necessary to attach the internal `key` property, but it has a noticeable impact on how types are displayed in IDEs.

### Observed Issue

When hovering over `fields` in editors like VSCode, the type is expanded very verbosely due to the structural nature of `string`:

```ts
const { fields } = useFieldArray({ control, name: 'tags' });
// Hover tooltip shows:
const fields: ({
  readonly [index: number]: string;
  toString: () => string;
  charAt: (pos: number) => string;
  // ... all String prototype methods
  key: string;
})[]
```

This makes the type significantly harder to read and may be confusing for users, especially compared to object-based field arrays.

### Current State

* This is a **type-only change** with no runtime impact
* Behavior at runtime is identical to plain strings
* The issue is limited to type representation and developer experience

### Open Question for Reviewers

I’m not fully confident that this IDE experience is acceptable as-is.

I’d like feedback on:

* whether this type representation is acceptable to ship
* whether this should be documented as a known limitation
* or whether we should explore a different modeling approach before merging