### PR TITLE
feat: add useFormDebug hook for development debugging

### DIFF
--- a/scripts/rollup/all-exports.json
+++ b/scripts/rollup/all-exports.json
@@ -12,6 +12,7 @@
   "useFieldArray",
   "useForm",
   "useFormContext",
+  "useFormDebug",
   "useFormState",
   "useWatch"
 ]

--- a/src/__tests__/useFormDebug.test.tsx
+++ b/src/__tests__/useFormDebug.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useFieldArray } from '../useFieldArray';
+import { useForm } from '../useForm';
+import { FormProvider } from '../useFormContext';
+import { useFormDebug } from '../useFormDebug';
+
+describe('useFormDebug', () => {
+  it('should return formState with all properties', () => {
+    const Component = () => {
+      const { register, control } = useForm({
+        defaultValues: {
+          test: '',
+        },
+      });
+      const { formState } = useFormDebug({ control });
+
+      return (
+        <div>
+          <input {...register('test')} />
+          <p data-testid="isDirty">{formState.isDirty ? 'dirty' : 'clean'}</p>
+          <p data-testid="isValid">{formState.isValid ? 'valid' : 'invalid'}</p>
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    expect(screen.getByTestId('isDirty')).toHaveTextContent('clean');
+    expect(screen.getByTestId('isValid')).toHaveTextContent('valid');
+  });
+
+  it('should return current form values', async () => {
+    const Component = () => {
+      const { register, control } = useForm({
+        defaultValues: {
+          name: 'initial',
+        },
+      });
+      const { values } = useFormDebug({ control });
+
+      return (
+        <div>
+          <input {...register('name')} />
+          <p data-testid="values">{values.name}</p>
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    expect(screen.getByTestId('values')).toHaveTextContent('initial');
+
+    fireEvent.input(screen.getByRole('textbox'), {
+      target: { value: 'updated' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('values')).toHaveTextContent('updated');
+    });
+  });
+
+  it('should return registered field names', async () => {
+    const Component = () => {
+      const { register, control } = useForm();
+      const { registeredFields } = useFormDebug({ control });
+
+      return (
+        <div>
+          <input {...register('firstName')} />
+          <input {...register('lastName')} />
+          <p data-testid="fields">{registeredFields.join(',')}</p>
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('fields')).toHaveTextContent(
+        'firstName,lastName',
+      );
+    });
+  });
+
+  it('should return field array names', async () => {
+    const Component = () => {
+      const { register, control } = useForm({
+        defaultValues: {
+          items: [{ name: 'test' }],
+        },
+      });
+      const { fields } = useFieldArray({ control, name: 'items' });
+      const { fieldArrays } = useFormDebug({ control });
+
+      return (
+        <div>
+          {fields.map((field, index) => (
+            <input key={field.id} {...register(`items.${index}.name`)} />
+          ))}
+          <p data-testid="arrays">{fieldArrays.join(',')}</p>
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('arrays')).toHaveTextContent('items');
+    });
+  });
+
+  it('should track render count', () => {
+    const Component = () => {
+      const { register, control } = useForm({
+        defaultValues: {
+          test: '',
+        },
+      });
+      const { renderCount } = useFormDebug({ control });
+
+      return (
+        <div>
+          <input {...register('test')} />
+          <p data-testid="count">{renderCount}</p>
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    // The render count should be a positive number after initial render
+    const count = parseInt(screen.getByTestId('count').textContent || '0');
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it('should work with FormProvider', () => {
+    const Child = () => {
+      const { formState, values } = useFormDebug();
+
+      return (
+        <div>
+          <p data-testid="isDirty">{formState.isDirty ? 'dirty' : 'clean'}</p>
+          <p data-testid="name">{values.name}</p>
+        </div>
+      );
+    };
+
+    const Component = () => {
+      const methods = useForm({
+        defaultValues: {
+          name: 'test',
+        },
+      });
+
+      return (
+        <FormProvider {...methods}>
+          <input {...methods.register('name')} />
+          <Child />
+        </FormProvider>
+      );
+    };
+
+    render(<Component />);
+
+    expect(screen.getByTestId('isDirty')).toHaveTextContent('clean');
+    expect(screen.getByTestId('name')).toHaveTextContent('test');
+  });
+
+  it('should update formState when form becomes dirty', async () => {
+    const Component = () => {
+      const { register, control } = useForm({
+        defaultValues: {
+          test: '',
+        },
+      });
+      const { formState } = useFormDebug({ control });
+
+      return (
+        <div>
+          <input {...register('test')} />
+          <p data-testid="isDirty">{formState.isDirty ? 'dirty' : 'clean'}</p>
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    expect(screen.getByTestId('isDirty')).toHaveTextContent('clean');
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'changed' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('isDirty')).toHaveTextContent('dirty');
+    });
+  });
+
+  it('should show errors in formState', async () => {
+    const Component = () => {
+      const { register, control, handleSubmit } = useForm({
+        defaultValues: {
+          test: '',
+        },
+      });
+      const { formState } = useFormDebug({ control });
+
+      return (
+        <form onSubmit={handleSubmit(() => {})}>
+          <input {...register('test', { required: 'Required' })} />
+          <p data-testid="hasError">
+            {formState.errors.test ? 'error' : 'no-error'}
+          </p>
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    expect(screen.getByTestId('hasError')).toHaveTextContent('no-error');
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hasError')).toHaveTextContent('error');
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './useController';
 export * from './useFieldArray';
 export * from './useForm';
 export * from './useFormContext';
+export * from './useFormDebug';
 export * from './useFormState';
 export * from './useWatch';
 export * from './utils';

--- a/src/useFormDebug.ts
+++ b/src/useFormDebug.ts
@@ -1,0 +1,184 @@
+import React from 'react';
+
+import getProxyFormState from './logic/getProxyFormState';
+import type {
+  Control,
+  FieldValues,
+  FormState,
+  InternalFieldName,
+} from './types';
+import { useFormControlContext } from './useFormControlContext';
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+
+/**
+ * Props for the useFormDebug hook.
+ */
+export type UseFormDebugProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TTransformedValues = TFieldValues,
+> = {
+  /**
+   * Control object from useForm.
+   */
+  control?: Control<TFieldValues, any, TTransformedValues>;
+};
+
+/**
+ * Return type for the useFormDebug hook.
+ */
+export type UseFormDebugReturn<TFieldValues extends FieldValues = FieldValues> =
+  {
+    /**
+     * Complete form state including all properties.
+     */
+    formState: FormState<TFieldValues>;
+    /**
+     * Current form values.
+     */
+    values: TFieldValues;
+    /**
+     * Set of registered field names.
+     */
+    registeredFields: string[];
+    /**
+     * Set of field array names.
+     */
+    fieldArrays: string[];
+    /**
+     * Number of times this hook has been rendered.
+     */
+    renderCount: number;
+  };
+
+/**
+ * A development-focused hook that provides enhanced visibility into form state for debugging.
+ * This hook subscribes to ALL form state changes and returns comprehensive debugging information.
+ *
+ * @remarks
+ * This hook is intended for development and debugging purposes.
+ * It subscribes to all form state properties which may impact performance.
+ *
+ * [API](https://react-hook-form.com/docs/useformdebug)
+ *
+ * @param props - useFormDebug props
+ *
+ * @returns debug information including formState, values, registered fields, and render count
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const { register, control } = useForm();
+ *   const debug = useFormDebug({ control });
+ *
+ *   console.log('Form Debug:', debug);
+ *
+ *   return (
+ *     <form>
+ *       <input {...register('name')} />
+ *       <pre>{JSON.stringify(debug, null, 2)}</pre>
+ *     </form>
+ *   );
+ * }
+ * ```
+ */
+export function useFormDebug<
+  TFieldValues extends FieldValues = FieldValues,
+  TTransformedValues = TFieldValues,
+>(
+  props?: UseFormDebugProps<TFieldValues, TTransformedValues>,
+): UseFormDebugReturn<TFieldValues> {
+  const formControl = useFormControlContext<
+    TFieldValues,
+    any,
+    TTransformedValues
+  >();
+  const { control = formControl } = props || {};
+
+  const [formState, updateFormState] = React.useState(control._formState);
+  const [values, setValues] = React.useState<TFieldValues>(
+    control._formValues as TFieldValues,
+  );
+  const renderCount = React.useRef(0);
+
+  // Track all form state properties
+  const _localProxyFormState = React.useRef({
+    isDirty: true,
+    isLoading: true,
+    dirtyFields: true,
+    touchedFields: true,
+    validatingFields: true,
+    isValidating: true,
+    isValid: true,
+    errors: true,
+  });
+
+  renderCount.current++;
+
+  // Subscribe to form state changes
+  useIsomorphicLayoutEffect(
+    () =>
+      control._subscribe({
+        formState: _localProxyFormState.current,
+        callback: (newFormState) => {
+          updateFormState({
+            ...control._formState,
+            ...newFormState,
+          });
+          setValues(control._formValues as TFieldValues);
+        },
+      }),
+    [control],
+  );
+
+  // Set valid state on mount
+  React.useEffect(() => {
+    control._setValid(true);
+  }, [control]);
+
+  // Get registered field names
+  const registeredFields = React.useMemo(() => {
+    const fieldNames: string[] = [];
+    const collectFieldNames = (
+      fields: Record<string, any>,
+      prefix = '',
+    ): void => {
+      for (const key in fields) {
+        const fullPath = prefix ? `${prefix}.${key}` : key;
+        const field = fields[key];
+        if (field && field._f) {
+          fieldNames.push(fullPath);
+        } else if (field && typeof field === 'object') {
+          collectFieldNames(field, fullPath);
+        }
+      }
+    };
+    collectFieldNames(control._fields as Record<string, any>);
+    return fieldNames;
+  }, [control._fields]);
+
+  // Get field array names
+  const fieldArrays = React.useMemo(
+    () => Array.from(control._names.array as Set<InternalFieldName>),
+
+    [control._names.array],
+  );
+
+  const proxyFormState = React.useMemo(
+    () =>
+      getProxyFormState(
+        formState,
+        control,
+        _localProxyFormState.current,
+        false,
+      ),
+    [formState, control],
+  );
+
+  return {
+    formState: proxyFormState,
+    values,
+    registeredFields,
+    fieldArrays,
+    renderCount: renderCount.current,
+  };
+}


### PR DESCRIPTION
## Proposed Changes

Added a new [useFormDebug](cci:1://file:///c:/Users/kurtd/Desktop/react-hook-form/src/useFormDebug.ts:52:0-183:1) hook that provides enhanced visibility into form state for development and debugging purposes.

**Features:**
- Returns complete `formState` (isDirty, isValid, errors, dirtyFields, touchedFields, etc.)
- Returns current form `values`
- Returns list of `registeredFields` 
- Returns list of `fieldArrays`
- Tracks `renderCount` for performance debugging

**Usage Example:**
```tsx
const { formState, values, registeredFields, fieldArrays, renderCount } = useFormDebug({ control });