### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/api-extrator.yml
+++ b/.github/workflows/api-extrator.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           start: pnpm start
           wait-on: 'http://ip6-localhost:3000'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/lock-issue.yml
+++ b/.github/workflows/lock-issue.yml
@@ -15,7 +15,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: 60


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/automation.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/api-extrator.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/compressed-size.yml`
- Updated `cypress-io/github-action` from `v6` to `v7` in `.github/workflows/automation.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/build-test.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/codeql-analysis.yml`
- Updated `dessant/lock-threads` from `v5` to `v6` in `.github/workflows/lock-issue.yml`
