### PR TITLE
fix: use DeepPartialSkipArrayKey for WatchObserver value parameter

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -959,7 +959,7 @@ export type WatchInternal<TFieldValues> = (fieldNames?: InternalFieldName | Inte
 export type WatchName<TFieldValues extends FieldValues> = FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | undefined;
 
 // @public (undocumented)
-export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartial<TFieldValues>, info: {
+export type WatchObserver<TFieldValues extends FieldValues> = (value: DeepPartialSkipArrayKey<TFieldValues>, info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;
     values?: unknown;
@@ -985,7 +985,7 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:501:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:506:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -20,7 +20,12 @@ import type {
   FieldPathValues,
 } from './path';
 import type { Resolver } from './resolvers';
-import type { DeepMap, DeepPartial, Noop } from './utils';
+import type {
+  DeepMap,
+  DeepPartial,
+  DeepPartialSkipArrayKey,
+  Noop,
+} from './utils';
 import type { RegisterOptions } from './validator';
 
 declare const $NestedValue: unique symbol;
@@ -876,7 +881,7 @@ export type Control<
 };
 
 export type WatchObserver<TFieldValues extends FieldValues> = (
-  value: DeepPartial<TFieldValues>,
+  value: DeepPartialSkipArrayKey<TFieldValues>,
   info: {
     name?: FieldPath<TFieldValues>;
     type?: EventType;


### PR DESCRIPTION
## Summary
Fixes #13269

Changes `WatchObserver` type to use `DeepPartialSkipArrayKey` instead of `DeepPartial` for the value parameter. This prevents unnecessary `undefined` injection when field values are arrays, such as multi-value select inputs.

## Changes
- Updated import in `src/types/form.ts` to include `DeepPartialSkipArrayKey`
- Changed `WatchObserver` type definition to use `DeepPartialSkipArrayKey<TFieldValues>` instead of `DeepPartial<TFieldValues>`

## Type Improvement
**Before:**
```typescript
const { watch } = useFormContext<{ selectedOptions: string[] }>();

watch(({ selectedOptions }) => {
  // selectedOptions has type (string | undefined)[] | undefined
});
```

**After:**
```typescript
const { watch } = useFormContext<{ selectedOptions: string[] }>();

watch(({ selectedOptions }) => {
  // selectedOptions has type string[] | undefined
});
```

## Testing
- All existing tests pass (1036 tests)
- TypeScript type check passes
- No breaking changes, as `DeepPartialSkipArrayKey` still handles optional fields correctly

## Note
This is a pure type improvement with no runtime changes. The `DeepPartialSkipArrayKey` type already exists in the codebase and is used in other places like `useWatch`.