### PR TITLE
fix: avoid resetting value when destroying one of multiple Controllers with identical names when `shouldUnregister = true`

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -749,6 +749,55 @@ describe('useController', () => {
     expect(data).toBeUndefined();
   });
 
+  it('should not unregister field when one of multiple controllers with the same name unmounts and shouldUnregister is true', async () => {
+    let data: unknown;
+
+    function Input<T extends FieldValues>({
+      control,
+      name,
+    }: {
+      control: Control<T>;
+      name: FieldPath<T>;
+    }) {
+      useController({
+        control,
+        name,
+      });
+
+      return null;
+    }
+
+    const App = () => {
+      const { control, getValues } = useForm<{
+        test: string;
+      }>({
+        defaultValues: {
+          test: 'test',
+        },
+        shouldUnregister: true,
+      });
+      const [showDuplicate, setShowDuplicate] = React.useState(true);
+
+      data = getValues('test');
+
+      return (
+        <div>
+          <Input control={control} name={'test'} />
+          {showDuplicate && <Input control={control} name={'test'} />}
+          <button onClick={() => setShowDuplicate(false)}>remove</button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    expect(data).toEqual('test');
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(data).toEqual('test');
+  });
+
   it('should always get the latest value for onBlur event', async () => {
     const watchResults: unknown[] = [];
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -152,6 +152,7 @@ export function createFormControl<
     array: new Set(),
     watch: new Set(),
   };
+  const _controllerCount = new Map<InternalFieldName, number>();
   let delayErrorCallback: DelayCallback | null;
   let timer = 0;
   const defaultProxyFormState: ReadFormState = {
@@ -1578,6 +1579,7 @@ export function createFormControl<
       _disableForm,
       _subjects,
       _proxyFormState,
+      _controllerCount,
       get _fields() {
         return _fields;
       },

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -872,6 +872,7 @@ export type Control<
   ) => void;
   _focusError: () => boolean | undefined;
   _disableForm: (disabled?: boolean) => void;
+  _controllerCount: Map<InternalFieldName, number>;
   _subscribe: FromSubscribe<TFieldValues>;
   register: UseFormRegister<TFieldValues>;
   handleSubmit: UseFormHandleSubmit<TFieldValues, TTransformedValues>;


### PR DESCRIPTION
### Description
This pull request introduces a fix for handling multiple controllers registered under the same field name with `shouldUnregister = true`. The changes ensure that a field is only unregistered when all controllers for that field have unmounted, preventing premature unregistration and maintaining correct form state. The main updates involve tracking controller counts and updating the unregister logic.

As I don't have full understanding of the inner workings of the library, I'm unsure if this is the correct implementation.
* Maybe `_names.mount` should be converted to a `Map<string, number>` instead of keeping a separate `Map`?
* Should the logic reside in `createFormControl.register/unregister` instead of having it in `useController`?
Any pointers for a better implementation is welcomed.

### Issue
The issue arises when `shouldUnregister = true` and you have multiple `<Controller name="same" />` in your form. Conditionally hiding one of them causes the form to loose the input value - even though one of the `<Controller name="same" />` are still rendered.

Having two `<Controller name="same" />` live at the same time can be very useful when e.g. implementing a "simple"- and "advanced"-mode toggle in a form. In my case, I'm conditionally rendering an `<Controller name="same" />` in the "simple"-mode UI, as well as in the "advanced"-mode UI (DOM placement differs, so react won't keep the "simple" one as we switch over to "advanced"). In order to keep the value when switching mode, I always render a third `<Controller name="same" render={({ fields }) => <input type="hidden"  name="same" {...fields} />} />`.