### PR TITLE
Support comparison of objects with .equals() in deepEqual

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "files": [
       {
         "path": "./dist/index.cjs.js",
-        "maxSize": "11.25 kB"
+        "maxSize": "11.35 kB"
       }
     ]
   },

--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -155,4 +155,133 @@ describe('deepEqual', () => {
     expect(deepEqual({ value: NaN }, { value: 'NaN' })).toBeFalsy();
     expect(deepEqual([NaN], [0])).toBeFalsy();
   });
+
+  describe('objects with .equals() method', () => {
+    class ValueObject {
+      constructor(public value: string) {}
+      equals(other: any): boolean {
+        return other instanceof ValueObject && this.value === other.value;
+      }
+    }
+
+    it('should compare objects with .equals() method using value equality', () => {
+      const obj1 = new ValueObject('2025-01-01');
+      const obj2 = new ValueObject('2025-01-01');
+      const obj3 = new ValueObject('2025-01-02');
+
+      expect(deepEqual(obj1, obj2)).toBeTruthy();
+      expect(deepEqual(obj1, obj3)).toBeFalsy();
+    });
+
+    it('should compare nested objects with .equals() method', () => {
+      const date1 = new ValueObject('2025-01-01');
+      const date2 = new ValueObject('2025-01-01');
+      const date3 = new ValueObject('2025-01-02');
+
+      expect(
+        deepEqual({ date: date1, name: 'test' }, { date: date2, name: 'test' }),
+      ).toBeTruthy();
+
+      expect(
+        deepEqual({ date: date1, name: 'test' }, { date: date3, name: 'test' }),
+      ).toBeFalsy();
+    });
+
+    it('should compare objects with .equals() in arrays', () => {
+      const date1 = new ValueObject('2025-01-01');
+      const date2 = new ValueObject('2025-01-01');
+      const date3 = new ValueObject('2025-01-02');
+
+      expect(deepEqual([date1], [date2])).toBeTruthy();
+      expect(deepEqual([date1], [date3])).toBeFalsy();
+    });
+
+    it('should handle objects with .equals() transitioning to/from null', () => {
+      const date = new ValueObject('2025-01-01');
+
+      expect(deepEqual({ value: date }, { value: null })).toBeFalsy();
+      expect(deepEqual({ value: null }, { value: date })).toBeFalsy();
+    });
+
+    it('should handle deeply nested structures with .equals()', () => {
+      const date1 = new ValueObject('2025-01-01');
+      const date2 = new ValueObject('2025-01-01');
+      const date3 = new ValueObject('2025-01-02');
+
+      const nested1 = {
+        user: {
+          profile: {
+            dates: [date1],
+          },
+        },
+      };
+
+      const nested2 = {
+        user: {
+          profile: {
+            dates: [date2],
+          },
+        },
+      };
+
+      const nested3 = {
+        user: {
+          profile: {
+            dates: [date3],
+          },
+        },
+      };
+
+      expect(deepEqual(nested1, nested2)).toBeTruthy();
+      expect(deepEqual(nested1, nested3)).toBeFalsy();
+    });
+
+    it('should handle mixed objects with and without .equals()', () => {
+      const date1 = new ValueObject('2025-01-01');
+      const date2 = new ValueObject('2025-01-01');
+
+      expect(
+        deepEqual(
+          { date: date1, name: 'John', age: 30 },
+          { date: date2, name: 'John', age: 30 },
+        ),
+      ).toBeTruthy();
+
+      expect(
+        deepEqual(
+          { date: date1, name: 'John', age: 30 },
+          { date: date2, name: 'Jane', age: 30 },
+        ),
+      ).toBeFalsy();
+    });
+
+    it('should handle objects with .equals() that have no enumerable properties', () => {
+      class TemporalLike {
+        private _value: string;
+
+        constructor(value: string) {
+          this._value = value;
+        }
+
+        equals(other: any): boolean {
+          return other instanceof TemporalLike && this._value === other._value;
+        }
+
+        toString(): string {
+          return this._value;
+        }
+      }
+
+      const temp1 = new TemporalLike('2025-01-01');
+      const temp2 = new TemporalLike('2025-01-01');
+      const temp3 = new TemporalLike('2025-01-02');
+
+      expect(deepEqual(temp1, temp2)).toBeTruthy();
+      expect(deepEqual(temp1, temp3)).toBeFalsy();
+
+      expect(deepEqual({ date: temp1 }, { date: temp2 })).toBeTruthy();
+
+      expect(deepEqual({ date: temp1 }, { date: temp3 })).toBeFalsy();
+    });
+  });
 });

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -1,3 +1,4 @@
+import hasValueEquals from './hasValueEquals';
 import isDateObject from './isDateObject';
 import isObject from './isObject';
 import isPrimitive from './isPrimitive';
@@ -13,6 +14,10 @@ export default function deepEqual(
 
   if (isDateObject(object1) && isDateObject(object2)) {
     return Object.is(object1.getTime(), object2.getTime());
+  }
+
+  if (hasValueEquals(object1) && hasValueEquals(object2)) {
+    return object1.equals(object2);
   }
 
   const keys1 = Object.keys(object1);
@@ -41,6 +46,7 @@ export default function deepEqual(
       if (
         (isDateObject(val1) && isDateObject(val2)) ||
         (isObject(val1) && isObject(val2)) ||
+        (hasValueEquals(val1) && hasValueEquals(val2)) ||
         (Array.isArray(val1) && Array.isArray(val2))
           ? !deepEqual(val1, val2, _internal_visited)
           : !Object.is(val1, val2)

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -1,6 +1,6 @@
 import type { FieldValues } from '../types';
 
-import { isObjectType } from './isObject';
+import { isObjectType } from './isObjectType';
 
 export const flatten = (obj: FieldValues) => {
   const output: FieldValues = {};

--- a/src/utils/hasValueEquals.ts
+++ b/src/utils/hasValueEquals.ts
@@ -1,0 +1,8 @@
+import isNullOrUndefined from './isNullOrUndefined';
+import { isObjectType } from './isObjectType';
+
+export default (value: unknown): value is { equals: (other: any) => boolean } =>
+  !isNullOrUndefined(value) &&
+  isObjectType(value) &&
+  'equals' in value &&
+  typeof (value as any).equals === 'function';

--- a/src/utils/isObject.ts
+++ b/src/utils/isObject.ts
@@ -1,11 +1,11 @@
+import hasValueEquals from './hasValueEquals';
 import isDateObject from './isDateObject';
 import isNullOrUndefined from './isNullOrUndefined';
-
-export const isObjectType = (value: unknown): value is object =>
-  typeof value === 'object';
+import { isObjectType } from './isObjectType';
 
 export default <T extends object>(value: unknown): value is T =>
   !isNullOrUndefined(value) &&
   !Array.isArray(value) &&
   isObjectType(value) &&
-  !isDateObject(value);
+  !isDateObject(value) &&
+  !hasValueEquals(value);

--- a/src/utils/isObjectType.ts
+++ b/src/utils/isObjectType.ts
@@ -1,0 +1,2 @@
+export const isObjectType = (value: unknown): value is object =>
+  typeof value === 'object';

--- a/src/utils/isPrimitive.ts
+++ b/src/utils/isPrimitive.ts
@@ -1,7 +1,7 @@
 import type { Primitive } from '../types';
 
 import isNullOrUndefined from './isNullOrUndefined';
-import { isObjectType } from './isObject';
+import { isObjectType } from './isObjectType';
 
 export default (value: unknown): value is Primitive =>
   isNullOrUndefined(value) || !isObjectType(value);


### PR DESCRIPTION
## Proposed Changes

Add support for objects with `.equals()` methods (like Temporal API objects) in the `deepEqual` utility function. This fixes incorrect dirty state tracking when using value objects that implement equality through an `.equals()` method.

**Problem**: Temporal API objects and other value objects with `.equals()` methods resulted in `isDirty` being false even though the value clearly changed.

**Solution**: 
- Created `hasValueEquals` helper to detect objects with `.equals()` methods
- Updated `deepEqual` to use `.equals()` for value comparison when available
- Updated `isObject` to exclude objects with `.equals()` from regular object handling
- Added comprehensive test coverage for all edge cases

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
