### PR TITLE
🐞 fix: prevent useFieldArray from marking unrelated fields as dirty

### DIFF
--- a/src/__tests__/useFieldArray/append.test.tsx
+++ b/src/__tests__/useFieldArray/append.test.tsx
@@ -86,6 +86,57 @@ describe('append', () => {
     });
   });
 
+  it('should not mark unrelated fields as dirty when appending to field array', async () => {
+    let dirtyInputs = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyInputs = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ value: 'new' })}>
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    // Append without touching name or age
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(dirtyInputs).toEqual({
+        items: [{ value: true }],
+      });
+    });
+  });
+
   it('should append data into the fields', () => {
     let currentFields: unknown[] = [];
     const Component = () => {

--- a/src/__tests__/useFieldArray/append.test.tsx
+++ b/src/__tests__/useFieldArray/append.test.tsx
@@ -127,7 +127,6 @@ describe('append', () => {
 
     render(<Component />);
 
-    // Append without touching name or age
     fireEvent.click(screen.getByRole('button'));
 
     await waitFor(() => {

--- a/src/__tests__/useFieldArray/dirtyFields.test.tsx
+++ b/src/__tests__/useFieldArray/dirtyFields.test.tsx
@@ -619,4 +619,92 @@ describe('useFieldArray dirtyFields isolation', () => {
       expect(dirtyResult).toHaveProperty('todos');
     });
   });
+
+  it('should only update root branch when nested useFieldArray with indexed name is appended', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        title: string;
+        test: {
+          firstName: string;
+          lastName: string;
+          keyValue: { name: string }[];
+        }[];
+      }>({
+        defaultValues: {
+          title: 'My Form',
+          test: [
+            {
+              firstName: 'Bill',
+              lastName: 'Luo',
+              keyValue: [{ name: '1a' }],
+            },
+          ],
+        },
+      });
+      const { fields: testFields } = useFieldArray({
+        control,
+        name: 'test',
+      });
+      const {
+        fields: keyValueFields,
+        append,
+        remove,
+      } = useFieldArray({
+        control,
+        name: 'test.0.keyValue',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('title')} />
+          {testFields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`test.${i}.firstName` as const)} />
+              <input {...register(`test.${i}.lastName` as const)} />
+            </div>
+          ))}
+          {keyValueFields.map((field, i) => (
+            <input
+              key={field.id}
+              {...register(`test.0.keyValue.${i}.name` as const)}
+            />
+          ))}
+          <button type="button" onClick={() => append({ name: 'new' })}>
+            nestAppend
+          </button>
+          <button
+            type="button"
+            onClick={() => remove(keyValueFields.length - 1)}
+          >
+            nestRemove
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /nestAppend/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('title');
+      expect(dirtyResult).toHaveProperty('test');
+      const testArray = (dirtyResult as any).test;
+      expect(testArray[0]).toHaveProperty('keyValue');
+      expect(testArray[0].keyValue).toEqual([{ name: false }, { name: true }]);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /nestRemove/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('title');
+    });
+  });
 });

--- a/src/__tests__/useFieldArray/dirtyFields.test.tsx
+++ b/src/__tests__/useFieldArray/dirtyFields.test.tsx
@@ -1,0 +1,678 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useFieldArray } from '../../useFieldArray';
+import { useForm } from '../../useForm';
+
+let i = 0;
+
+jest.mock('../../logic/generateId', () => () => String(i++));
+
+/**
+ * Comprehensive tests for useFieldArray dirtyFields bug
+ * Related issues:
+ * - #13054: append/remove marks entire defaultValues as dirty
+ * - #11402: dirtyFields incorrect including unchanged fields after list updates
+ * - #7197:  useFieldArray changes make all fields dirtyFields
+ * - #9932:  dirty fields not cleaned properly after remove
+ */
+describe('useFieldArray dirtyFields isolation', () => {
+  beforeEach(() => {
+    i = 0;
+  });
+
+  // =========================================================
+  // Scenario 1: items만 건드렸을 때 (append)
+  // name, age는 dirtyFields에 포함되면 안 됨
+  // =========================================================
+  it('should only mark items dirty when only items field array is appended', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ value: 'new' })}>
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /append/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toEqual({
+        items: [{ value: true }],
+      });
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+    });
+  });
+
+  // =========================================================
+  // Scenario 2: name과 items 둘 다 건드렸을 때
+  // name: true, items: dirty — age는 포함되면 안 됨
+  // =========================================================
+  it('should mark both name and items dirty when both are modified', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ value: 'new' })}>
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    // 1. name 필드 변경
+    fireEvent.input(screen.getAllByRole('textbox')[0], {
+      target: { value: 'Bob' },
+    });
+
+    // 2. items 배열에 append
+    fireEvent.click(screen.getByRole('button', { name: /append/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+      expect(dirtyResult).toHaveProperty('items');
+      expect(dirtyResult).not.toHaveProperty('age');
+    });
+  });
+
+  // =========================================================
+  // Scenario 3: 두 개의 필드 배열 중 하나만 건드렸을 때
+  // items_copy만 append → items, name, age는 포함 안 됨
+  // =========================================================
+  it('should only mark items_copy dirty when only items_copy is appended (multiple field arrays)', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+        items_copy: { value: string; value2: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+          items_copy: [],
+        },
+      });
+      const itemsArray = useFieldArray({ control, name: 'items' });
+      const itemsCopyArray = useFieldArray({ control, name: 'items_copy' });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {itemsArray.fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          {itemsCopyArray.fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`items_copy.${i}.value` as const)} />
+              <input {...register(`items_copy.${i}.value2` as const)} />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() =>
+              itemsCopyArray.append({ value: 'new', value2: 'new2' })
+            }
+          >
+            appendCopy
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /appendCopy/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toEqual({
+        items_copy: [{ value: true, value2: true }],
+      });
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+      expect(dirtyResult).not.toHaveProperty('items');
+    });
+  });
+
+  // =========================================================
+  // Scenario 4: 두 개의 필드 배열 둘 다 건드렸을 때
+  // items와 items_copy 모두 append → name, age는 포함 안 됨
+  // =========================================================
+  it('should mark both field arrays dirty when both are appended', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+        items_copy: { value: string; value2: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+          items_copy: [],
+        },
+      });
+      const itemsArray = useFieldArray({ control, name: 'items' });
+      const itemsCopyArray = useFieldArray({ control, name: 'items_copy' });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {itemsArray.fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          {itemsCopyArray.fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`items_copy.${i}.value` as const)} />
+              <input {...register(`items_copy.${i}.value2` as const)} />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => itemsArray.append({ value: 'item1' })}
+          >
+            appendItems
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              itemsCopyArray.append({ value: 'copy1', value2: 'copy2' })
+            }
+          >
+            appendCopy
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /appendItems/ }));
+    fireEvent.click(screen.getByRole('button', { name: /appendCopy/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('items');
+      expect(dirtyResult).toHaveProperty('items_copy');
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+    });
+  });
+
+  // =========================================================
+  // Scenario 5: name과 items_copy만 건드렸을 때
+  // name 변경 + items_copy append → age, items는 포함 안 됨
+  // =========================================================
+  it('should mark name and items_copy dirty when both are modified, leaving age and items clean', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+        items_copy: { value: string; value2: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+          items_copy: [],
+        },
+      });
+      const itemsArray = useFieldArray({ control, name: 'items' });
+      const itemsCopyArray = useFieldArray({ control, name: 'items_copy' });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} data-testid="name" />
+          <input {...register('age')} />
+          {itemsArray.fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          {itemsCopyArray.fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`items_copy.${i}.value` as const)} />
+              <input {...register(`items_copy.${i}.value2` as const)} />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() =>
+              itemsCopyArray.append({ value: 'copy1', value2: 'copy2' })
+            }
+          >
+            appendCopy
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    // 1. name 필드 변경
+    fireEvent.input(screen.getByTestId('name'), {
+      target: { value: 'Alice' },
+    });
+
+    // 2. items_copy만 append
+    fireEvent.click(screen.getByRole('button', { name: /appendCopy/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+      expect(dirtyResult).toHaveProperty('items_copy');
+      expect(dirtyResult).not.toHaveProperty('age');
+      expect(dirtyResult).not.toHaveProperty('items');
+    });
+  });
+
+  // =========================================================
+  // Scenario 6: 중첩 필드 배열 (Issue #13054 원본 시나리오)
+  // nonusservices.VATFiling_list append → name, age 포함 안 됨
+  // =========================================================
+  it('should not mark unrelated fields dirty with nested field array path', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        nonusservices: {
+          VATFiling_list: { id: string; value: string }[];
+        };
+      }>({
+        defaultValues: {
+          name: 'John Doe',
+          age: 30,
+          nonusservices: {
+            VATFiling_list: [{ id: '1', value: 'Item 1' }],
+          },
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'nonusservices.VATFiling_list',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input
+                {...register(`nonusservices.VATFiling_list.${i}.id` as const)}
+              />
+              <input
+                {...register(
+                  `nonusservices.VATFiling_list.${i}.value` as const,
+                )}
+              />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => append({ id: '2', value: 'Item 2' })}
+          >
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /append/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+      expect(dirtyResult).toHaveProperty('nonusservices');
+    });
+  });
+
+  // =========================================================
+  // Scenario 7: remove 후에도 관련 없는 필드 dirty 안 됨
+  // (Issue #9932, #11402 관련)
+  // =========================================================
+  it('should not mark unrelated fields dirty after remove operation', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        title: string;
+        description: string;
+        tags: { label: string }[];
+      }>({
+        defaultValues: {
+          title: 'My Post',
+          description: 'Some description',
+          tags: [{ label: 'react' }, { label: 'typescript' }],
+        },
+      });
+      const { fields, remove } = useFieldArray({
+        control,
+        name: 'tags',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('title')} />
+          <input {...register('description')} />
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`tags.${i}.label` as const)} />
+              <button type="button" onClick={() => remove(i)}>
+                remove{i}
+              </button>
+            </div>
+          ))}
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /remove0/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('title');
+      expect(dirtyResult).not.toHaveProperty('description');
+      expect(dirtyResult).toHaveProperty('tags');
+    });
+  });
+
+  // =========================================================
+  // Scenario 8: append 후 remove로 원래 상태로 돌아간 경우
+  // user-modified name은 dirty로 유지되어야 함
+  // =========================================================
+  it('should preserve name dirty state after append then remove reverts array', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          items: [{ value: 'original' }],
+        },
+      });
+      const { fields, append, remove } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} data-testid="name" />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ value: 'new' })}>
+            append
+          </button>
+          <button type="button" onClick={() => remove(fields.length - 1)}>
+            removeLast
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    // 1. name 변경
+    fireEvent.input(screen.getByTestId('name'), {
+      target: { value: 'Changed' },
+    });
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+    });
+
+    // 2. append → name은 여전히 dirty
+    fireEvent.click(screen.getByRole('button', { name: /append/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+      expect(dirtyResult).toHaveProperty('items');
+    });
+
+    // 3. removeLast → 배열은 원래대로, name은 여전히 dirty
+    fireEvent.click(screen.getByRole('button', { name: /removeLast/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+    });
+  });
+
+  // =========================================================
+  // Scenario 9: 여러 번 append해도 관련 없는 필드 오염 안 됨
+  // (Issue #11402 시나리오)
+  // =========================================================
+  it('should not pollute unrelated fields after multiple appends', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        email: string;
+        phone: string;
+        addresses: { street: string; city: string }[];
+      }>({
+        defaultValues: {
+          email: 'john@example.com',
+          phone: '123-456',
+          addresses: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'addresses',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('email')} />
+          <input {...register('phone')} />
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`addresses.${i}.street` as const)} />
+              <input {...register(`addresses.${i}.city` as const)} />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => append({ street: '', city: '' })}
+          >
+            addAddress
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    // 3번 연속 append
+    fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
+    fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
+    fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('email');
+      expect(dirtyResult).not.toHaveProperty('phone');
+      expect(dirtyResult).toHaveProperty('addresses');
+      expect((dirtyResult as any).addresses).toHaveLength(3);
+    });
+  });
+
+  // =========================================================
+  // Scenario 10: 큰 폼에서 필드 배열 조작
+  // 많은 필드가 있을 때 하나의 배열만 건드리면 나머지 전부 깨끗해야 함
+  // =========================================================
+  it('should isolate dirty state in large forms with many fields', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        firstName: string;
+        lastName: string;
+        email: string;
+        phone: string;
+        company: string;
+        todos: { task: string }[];
+      }>({
+        defaultValues: {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'john@test.com',
+          phone: '555-1234',
+          company: 'Acme',
+          todos: [],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        control,
+        name: 'todos',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('firstName')} />
+          <input {...register('lastName')} />
+          <input {...register('email')} />
+          <input {...register('phone')} />
+          <input {...register('company')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`todos.${i}.task` as const)} />
+          ))}
+          <button type="button" onClick={() => append({ task: 'New todo' })}>
+            addTodo
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /addTodo/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).not.toHaveProperty('firstName');
+      expect(dirtyResult).not.toHaveProperty('lastName');
+      expect(dirtyResult).not.toHaveProperty('email');
+      expect(dirtyResult).not.toHaveProperty('phone');
+      expect(dirtyResult).not.toHaveProperty('company');
+      expect(dirtyResult).toHaveProperty('todos');
+    });
+  });
+});

--- a/src/__tests__/useFieldArray/dirtyFields.test.tsx
+++ b/src/__tests__/useFieldArray/dirtyFields.test.tsx
@@ -8,23 +8,11 @@ let i = 0;
 
 jest.mock('../../logic/generateId', () => () => String(i++));
 
-/**
- * Comprehensive tests for useFieldArray dirtyFields bug
- * Related issues:
- * - #13054: append/remove marks entire defaultValues as dirty
- * - #11402: dirtyFields incorrect including unchanged fields after list updates
- * - #7197:  useFieldArray changes make all fields dirtyFields
- * - #9932:  dirty fields not cleaned properly after remove
- */
 describe('useFieldArray dirtyFields isolation', () => {
   beforeEach(() => {
     i = 0;
   });
 
-  // =========================================================
-  // Scenario 1: items만 건드렸을 때 (append)
-  // name, age는 dirtyFields에 포함되면 안 됨
-  // =========================================================
   it('should only mark items dirty when only items field array is appended', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -77,10 +65,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 2: name과 items 둘 다 건드렸을 때
-  // name: true, items: dirty — age는 포함되면 안 됨
-  // =========================================================
   it('should mark both name and items dirty when both are modified', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -122,12 +106,10 @@ describe('useFieldArray dirtyFields isolation', () => {
 
     render(<Component />);
 
-    // 1. name 필드 변경
     fireEvent.input(screen.getAllByRole('textbox')[0], {
       target: { value: 'Bob' },
     });
 
-    // 2. items 배열에 append
     fireEvent.click(screen.getByRole('button', { name: /append/ }));
 
     await waitFor(() => {
@@ -137,10 +119,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 3: 두 개의 필드 배열 중 하나만 건드렸을 때
-  // items_copy만 append → items, name, age는 포함 안 됨
-  // =========================================================
   it('should only mark items_copy dirty when only items_copy is appended (multiple field arrays)', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -205,10 +183,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 4: 두 개의 필드 배열 둘 다 건드렸을 때
-  // items와 items_copy 모두 append → name, age는 포함 안 됨
-  // =========================================================
   it('should mark both field arrays dirty when both are appended', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -278,10 +252,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 5: name과 items_copy만 건드렸을 때
-  // name 변경 + items_copy append → age, items는 포함 안 됨
-  // =========================================================
   it('should mark name and items_copy dirty when both are modified, leaving age and items clean', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -334,12 +304,10 @@ describe('useFieldArray dirtyFields isolation', () => {
 
     render(<Component />);
 
-    // 1. name 필드 변경
     fireEvent.input(screen.getByTestId('name'), {
       target: { value: 'Alice' },
     });
 
-    // 2. items_copy만 append
     fireEvent.click(screen.getByRole('button', { name: /appendCopy/ }));
 
     await waitFor(() => {
@@ -350,10 +318,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 6: 중첩 필드 배열 (Issue #13054 원본 시나리오)
-  // nonusservices.VATFiling_list append → name, age 포함 안 됨
-  // =========================================================
   it('should not mark unrelated fields dirty with nested field array path', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -420,10 +384,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 7: remove 후에도 관련 없는 필드 dirty 안 됨
-  // (Issue #9932, #11402 관련)
-  // =========================================================
   it('should not mark unrelated fields dirty after remove operation', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -476,10 +436,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 8: append 후 remove로 원래 상태로 돌아간 경우
-  // user-modified name은 dirty로 유지되어야 함
-  // =========================================================
   it('should preserve name dirty state after append then remove reverts array', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -521,7 +477,6 @@ describe('useFieldArray dirtyFields isolation', () => {
 
     render(<Component />);
 
-    // 1. name 변경
     fireEvent.input(screen.getByTestId('name'), {
       target: { value: 'Changed' },
     });
@@ -530,7 +485,6 @@ describe('useFieldArray dirtyFields isolation', () => {
       expect(dirtyResult).toHaveProperty('name', true);
     });
 
-    // 2. append → name은 여전히 dirty
     fireEvent.click(screen.getByRole('button', { name: /append/ }));
 
     await waitFor(() => {
@@ -538,7 +492,6 @@ describe('useFieldArray dirtyFields isolation', () => {
       expect(dirtyResult).toHaveProperty('items');
     });
 
-    // 3. removeLast → 배열은 원래대로, name은 여전히 dirty
     fireEvent.click(screen.getByRole('button', { name: /removeLast/ }));
 
     await waitFor(() => {
@@ -546,10 +499,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 9: 여러 번 append해도 관련 없는 필드 오염 안 됨
-  // (Issue #11402 시나리오)
-  // =========================================================
   it('should not pollute unrelated fields after multiple appends', async () => {
     let dirtyResult = {};
     const Component = () => {
@@ -597,7 +546,6 @@ describe('useFieldArray dirtyFields isolation', () => {
 
     render(<Component />);
 
-    // 3번 연속 append
     fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
     fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
     fireEvent.click(screen.getByRole('button', { name: /addAddress/ }));
@@ -610,10 +558,6 @@ describe('useFieldArray dirtyFields isolation', () => {
     });
   });
 
-  // =========================================================
-  // Scenario 10: 큰 폼에서 필드 배열 조작
-  // 많은 필드가 있을 때 하나의 배열만 건드리면 나머지 전부 깨끗해야 함
-  // =========================================================
   it('should isolate dirty state in large forms with many fields', async () => {
     let dirtyResult = {};
     const Component = () => {

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -84,6 +84,55 @@ describe('remove', () => {
     expect(formState.isDirty).toBeFalsy();
   });
 
+  it('should not mark unrelated fields as dirty when removing from field array', async () => {
+    let dirtyInputs = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          items: [{ value: 'first' }, { value: 'second' }],
+        },
+      });
+      const { fields, remove } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyInputs = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`items.${i}.value` as const)} />
+              <button type="button" onClick={() => remove(i)}>
+                remove{i}
+              </button>
+            </div>
+          ))}
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /remove0/i }));
+
+    await waitFor(() => {
+      // name should NOT be in dirtyFields - only items should be affected
+      expect(dirtyInputs).not.toHaveProperty('name');
+      expect(dirtyInputs).toHaveProperty('items');
+    });
+  });
+
   it('should update isValid formState when item removed', async () => {
     let formState: any;
     const Component = () => {

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -127,7 +127,6 @@ describe('remove', () => {
     fireEvent.click(screen.getByRole('button', { name: /remove0/i }));
 
     await waitFor(() => {
-      // name should NOT be in dirtyFields - only items should be affected
       expect(dirtyInputs).not.toHaveProperty('name');
       expect(dirtyInputs).toHaveProperty('items');
     });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -286,7 +286,8 @@ export function createFormControl<
       }
 
       if (_proxyFormState.dirtyFields || _proxySubscribeFormState.dirtyFields) {
-        _formState.dirtyFields = getDirtyFields(_defaultValues, _formValues);
+        const fullDirtyFields = getDirtyFields(_defaultValues, _formValues);
+        set(_formState.dirtyFields, name, get(fullDirtyFields, name));
       }
 
       _subjects.state.next({

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -287,7 +287,8 @@ export function createFormControl<
 
       if (_proxyFormState.dirtyFields || _proxySubscribeFormState.dirtyFields) {
         const fullDirtyFields = getDirtyFields(_defaultValues, _formValues);
-        set(_formState.dirtyFields, name, get(fullDirtyFields, name));
+        const rootName = name.split('.')[0];
+        set(_formState.dirtyFields, rootName, get(fullDirtyFields, rootName));
       }
 
       _subjects.state.next({

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -81,6 +81,7 @@ import getDirtyFields from './getDirtyFields';
 import getEventValue from './getEventValue';
 import getFieldValue from './getFieldValue';
 import getFieldValueAs from './getFieldValueAs';
+import getNodeParentName from './getNodeParentName';
 import getResolverOptions from './getResolverOptions';
 import getRuleValue from './getRuleValue';
 import getValidationModes from './getValidationModes';
@@ -287,7 +288,7 @@ export function createFormControl<
 
       if (_proxyFormState.dirtyFields || _proxySubscribeFormState.dirtyFields) {
         const fullDirtyFields = getDirtyFields(_defaultValues, _formValues);
-        const rootName = name.split('.')[0];
+        const rootName = getNodeParentName(name);
         set(_formState.dirtyFields, rootName, get(fullDirtyFields, rootName));
       }
 


### PR DESCRIPTION
## Proposed Changes

**Problem**

When `useFieldArray` methods (`append`, `remove`, etc.) are called, unrelated fields (`name`, `age`, etc.) incorrectly appear in `dirtyFields`, even though they were never modified by the user.

This happens because `_setFieldArray` replaces the **entire** `_formState.dirtyFields` object with the result of `getDirtyFields(_defaultValues, _formValues)`, which includes `false` entries for all non-dirty fields.

```js
// Before: after append() — name and age were never touched
dirtyFields = { name: false, age: false, items: [{ value: true }] }
```

**Solution**
Instead of replacing the entire `dirtyFields` object, only update the root field array portion using `set()` and `get()`. For nested field arrays (e.g., `test.0.keyValue`), the root name (`test`) is extracted to ensure sibling fields within the same array item are properly included in `dirtyFields`, while unrelated top-level fields remain unaffected.


```js
// After: only the field array portion is updated
dirtyFields = { items: [{ value: true }] }
```

**Changes**

1. `src/logic/createFormControl.ts` — In `_setFieldArray`, compute full dirty fields but only apply the root field array path to `_formState.dirtyFields`
2. `src/__tests__/useFieldArray/append.test.tsx` — Add test for append with unrelated fields
3. `src/__tests__/useFieldArray/remove.test.tsx` — Add test for remove with unrelated fields
4. `src/__tests__/useFieldArray/dirtyFields.test.tsx` — Add 10 comprehensive test scenarios covering single/multiple field arrays, nested paths, large forms, and mixed field modifications

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Fixes

Fixes #13054

Also addresses #11402, #7197

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
