### PR TITLE
test(utils): add unit tests for isDateObject

### DIFF
--- a/src/__tests__/utils/isDateObject.test.ts
+++ b/src/__tests__/utils/isDateObject.test.ts
@@ -1,0 +1,17 @@
+import isDateObject from '../../utils/isDateObject';
+
+describe('isDateObject', () => {
+  it('should return true when value is a Date object', () => {
+    expect(isDateObject(new Date())).toBe(true);
+  });
+
+  it('should return false when value is not a Date object', () => {
+    expect(isDateObject('2021-01-01')).toBe(false);
+    expect(isDateObject(1609459200000)).toBe(false);
+    expect(isDateObject({})).toBe(false);
+    expect(isDateObject(null)).toBe(false);
+    expect(isDateObject(undefined)).toBe(false);
+    expect(isDateObject([])).toBe(false);
+    expect(isDateObject(() => {})).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds unit tests for the `isDateObject` utility.

The tests verify that the function:
- Returns `true` for Date objects
- Returns `false` for non-Date values (string, number, object, null, undefined, array, function)

This improves test coverage and ensures consistent behavior of the utility.

Closes #13304