### PR TITLE
Update issue template CodeSandbox links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,8 +25,8 @@ body:
     attributes:
       value: |
         V7
-        - [JS](https://codesandbox.io/s/great-paper-deove) Template
-        - [TS](https://codesandbox.io/s/eager-sun-jt4df) Template
+        - [JS](https://codesandbox.io/p/sandbox/react-hook-form-v7-js-kn8g63) Template
+        - [TS](https://codesandbox.io/p/sandbox/happy-rgb-kps3dv) Template
 
         V6
         - [JS](https://codesandbox.io/s/mystifying-keller-5jwf5) Template


### PR DESCRIPTION
This commit updates the react-hook-form V7 JavaScript and TypeScript CodeSandbox links in GitHub issue template. This will ensure that the latest version of `react-hook-form` is used.