### PR TITLE
Allow subscribe formState to track submit state

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -514,6 +514,8 @@ export type ReadFormState = {
     [K in keyof FormStateProxy]: boolean | 'all';
 } & {
     values?: boolean;
+    isSubmitted?: boolean | 'all';
+    submitCount?: boolean | 'all';
 };
 
 // @public (undocumented)
@@ -1006,7 +1008,7 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:507:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:509:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useForm/subscribe.test.tsx
+++ b/src/__tests__/useForm/subscribe.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import type { UseFormSubscribe } from '../../types';
 import { useForm } from '../../useForm';
@@ -119,5 +119,42 @@ describe('subscribe', () => {
     });
 
     expect(callbackFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should allow subscribing to submit state updates', async () => {
+    const callbackFn = jest.fn();
+
+    const App = () => {
+      const { handleSubmit, subscribe } = useForm();
+
+      React.useEffect(() => {
+        return subscribe({
+          formState: {
+            isSubmitted: true,
+            submitCount: true,
+          },
+          callback: callbackFn,
+        });
+      }, [subscribe]);
+
+      return (
+        <form onSubmit={handleSubmit(() => undefined)}>
+          <button type="submit">Submit</button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(callbackFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isSubmitted: true,
+          submitCount: 1,
+        }),
+      ),
+    );
   });
 });

--- a/src/__typetest__/form.test-d.ts
+++ b/src/__typetest__/form.test-d.ts
@@ -130,6 +130,26 @@ const schema = z.object({
   }
 }
 
+/** {@link UseFormSubscribe} */ {
+  /** it should allow subscribing to submit state fields */ {
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const { subscribe } = useForm<{
+      test: string;
+    }>();
+
+    subscribe({
+      formState: {
+        isSubmitted: true,
+        submitCount: true,
+      },
+      callback: (state) => {
+        expectType<boolean | undefined>(state.isSubmitted);
+        expectType<number | undefined>(state.submitCount);
+      },
+    });
+  }
+}
+
 export function mockZodResolver<Input extends FieldValues, Context, Output>(
   schema: z.ZodSchema<Output, any, Input>,
   schemaOptions?: Partial<z.ParseParams>,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -151,6 +151,8 @@ export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
 
 export type ReadFormState = { [K in keyof FormStateProxy]: boolean | 'all' } & {
   values?: boolean;
+  isSubmitted?: boolean | 'all';
+  submitCount?: boolean | 'all';
 };
 
 export type FormState<TFieldValues extends FieldValues> = {


### PR DESCRIPTION
## Summary

This PR allows `useForm().subscribe({ formState: ... })` to subscribe to `isSubmitted` and `submitCount`.

These fields already exist on `FormState` and are available in the subscription callback payload, but they were not part of `ReadFormState`, so TypeScript rejected them in the subscription options.

## Changes

- add optional `isSubmitted` and `submitCount` support to `ReadFormState`
- keep `FormStateProxy` unchanged to avoid affecting existing `useFormState` behavior
- add a runtime test for submit-state subscriptions
- add a type test covering the new subscription keys
- update the API extractor report

## Why

This makes the `subscribe` API more consistent:
- the callback payload can already include submit state
- the subscription selector can now explicitly request it as well

## Testing

- `pnpm test -- src/__tests__/useForm/subscribe.test.tsx src/__tests__/useForm.test.tsx src/__tests__/useForm/reset.test.tsx`
- `pnpm type`
- `pnpm exec tsd src/__typetest__ --files form.test-d.ts`
- `pnpm api-extractor:build`
