### PR TITLE
🐞 fix: #13320 formState.isValid incorrect on Controller re-mount

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -1514,4 +1514,78 @@ describe('useController', () => {
     rerender({ control: form1Result.current.control });
     expect(result.current.field.value).toBe('form1-value');
   });
+
+  it('should update isValid when Controller with required rule re-mounts via checkbox toggle', async () => {
+    type FormValues = {
+      items: { checked: boolean; input: string }[];
+    };
+
+    const InputField = ({
+      control,
+      index,
+    }: {
+      control: Control<FormValues>;
+      index: number;
+    }) => (
+      <Controller
+        control={control}
+        rules={{ required: 'Input is required' }}
+        name={`items.${index}.input`}
+        render={({ field }) => <input placeholder="Enter" {...field} />}
+      />
+    );
+
+    const App = () => {
+      const { control, formState, handleSubmit } = useForm({
+        mode: 'all',
+        defaultValues: {
+          items: [{ checked: false, input: '' }],
+        },
+      });
+
+      return (
+        <form onSubmit={handleSubmit(noop)}>
+          <Controller
+            name="items.0.checked"
+            control={control}
+            render={({ field }) => (
+              <>
+                <input
+                  type="checkbox"
+                  checked={field.value}
+                  onChange={(e) => field.onChange(e.target.checked)}
+                />
+                {field.value && <InputField control={control} index={0} />}
+              </>
+            )}
+          />
+          <p>{formState.isValid ? 'valid' : 'invalid'}</p>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('valid')).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(screen.getByText('invalid')).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(screen.getByText('valid')).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(screen.getByText('invalid')).toBeVisible();
+    });
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1250,10 +1250,13 @@ export function createFormControl<
     }
   };
 
+  let _registerFromRef = false;
+
   const register: UseFormRegister<TFieldValues> = (name, options = {}) => {
     let field = get(_fields, name);
     const disabledIsDefined =
       isBoolean(options.disabled) || isBoolean(_options.disabled);
+    const isRemount = field && field._f && !field._f.mount && !_registerFromRef;
 
     set(_fields, name, {
       ...(field || {}),
@@ -1273,6 +1276,9 @@ export function createFormControl<
           : _options.disabled,
         name,
       });
+      if (isRemount && _state.mount && !_state.action) {
+        _setValid();
+      }
     } else {
       updateValidAndValue(name, true, options.value);
     }
@@ -1296,7 +1302,12 @@ export function createFormControl<
       onBlur: onChange,
       ref: (ref: HTMLInputElement | null): void => {
         if (ref) {
-          register(name, options);
+          _registerFromRef = true;
+          try {
+            register(name, options);
+          } finally {
+            _registerFromRef = false;
+          }
           field = get(_fields, name);
 
           const fieldRef = isUndefined(ref.value)


### PR DESCRIPTION
to resolve #13320

Hello. I have created this PR to fix the issue where formState.isValid stays incorrect when a Controller
with validation rules re-mounts. 😁

### Issue

`formState.isValid` remains true when a Controller with a required rule unmounts and re-mounts via
conditional rendering (e.g., checkbox toggle).

### Cause

The register function's if (field) branch (re-registration path) only calls `_setDisabledField()` — it never
calls `_setValid()`. So after re-mount, the form's validity is not re-evaluated.

### Solution

Added `_setValid()` call in the register function when a previously unmounted field is re-registered. A
`_registerFromRef` flag prevents false positives from the ref callback cycle during normal re-renders.

### Changes

- Added re-mount detection and `_setValid()` call in register function (`createFormControl.ts`)
- Added `_registerFromRef` flag with try-finally to distinguish ref callback calls
- Added test case reproducing the exact issue scenario