### PR TITLE
fix: prevent setValue with shouldDirty from polluting unrelated dirty fields

### DIFF
--- a/src/__tests__/useFieldArray/dirtyFields.test.tsx
+++ b/src/__tests__/useFieldArray/dirtyFields.test.tsx
@@ -707,4 +707,126 @@ describe('useFieldArray dirtyFields isolation', () => {
       expect(dirtyResult).not.toHaveProperty('title');
     });
   });
+
+  it('should not mark unrelated fields dirty when using setValue with shouldDirty on a field array', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        setValue,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+        },
+      });
+      const { fields } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button
+            type="button"
+            onClick={() =>
+              setValue('items', [{ value: 'new' }], { shouldDirty: true })
+            }
+          >
+            setItems
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /setItems/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toEqual({
+        items: [{ value: true }],
+      });
+      expect(dirtyResult).not.toHaveProperty('name');
+      expect(dirtyResult).not.toHaveProperty('age');
+    });
+  });
+
+  it('should preserve other dirty fields when using setValue with shouldDirty on a field array', async () => {
+    let dirtyResult = {};
+    const Component = () => {
+      const {
+        register,
+        control,
+        setValue,
+        formState: { dirtyFields },
+      } = useForm<{
+        name: string;
+        age: number;
+        items: { value: string }[];
+      }>({
+        defaultValues: {
+          name: 'John',
+          age: 30,
+          items: [],
+        },
+      });
+      const { fields } = useFieldArray({
+        control,
+        name: 'items',
+      });
+
+      dirtyResult = dirtyFields;
+
+      return (
+        <form>
+          <input {...register('name')} data-testid="name" />
+          <input {...register('age')} />
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`items.${i}.value` as const)} />
+          ))}
+          <button
+            type="button"
+            onClick={() =>
+              setValue('items', [{ value: 'new' }], { shouldDirty: true })
+            }
+          >
+            setItems
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.input(screen.getByTestId('name'), {
+      target: { value: 'Changed' },
+    });
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /setItems/ }));
+
+    await waitFor(() => {
+      expect(dirtyResult).toHaveProperty('name', true);
+      expect(dirtyResult).toHaveProperty('items');
+      expect(dirtyResult).not.toHaveProperty('age');
+    });
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -806,9 +806,13 @@ export function createFormControl<
           _proxySubscribeFormState.dirtyFields) &&
         options.shouldDirty
       ) {
+        const fullDirtyFields = getDirtyFields(_defaultValues, _formValues);
+        const rootName = getNodeParentName(name);
+        set(_formState.dirtyFields, rootName, get(fullDirtyFields, rootName));
+
         _subjects.state.next({
           name,
-          dirtyFields: getDirtyFields(_defaultValues, _formValues),
+          dirtyFields: _formState.dirtyFields,
           isDirty: _getDirty(name, cloneValue),
         });
       }


### PR DESCRIPTION
## Summary
- When using `setValue` with `shouldDirty: true` on a field array, unrelated fields were incorrectly marked as dirty
- Root cause: `setValue`'s field array branch was emitting the full `getDirtyFields()` result, which overwrites `_formState.dirtyFields` entirely
- Applied the same fix already used in `_setFieldArray` — selectively update only the relevant root branch using `getNodeParentName()`

## Related
- Follow-up to #13054
- Reported in https://github.com/react-hook-form/react-hook-form/pull/13299#issuecomment-4110254692

## Test plan
- [x] Added test: `setValue` with `shouldDirty` on field array should not mark unrelated fields dirty
- [x] Added test: `setValue` with `shouldDirty` should preserve existing dirty fields
- [x] All existing tests pass (1053/1053)