### PR TITLE
🐞 fix #13331: skip field array validation when mode is onBlur

### DIFF
--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -4531,7 +4531,7 @@ describe('useFieldArray with checkbox', () => {
       expect(checkboxes[3]).not.toBeChecked(); // Option 2
     });
   });
-  
+
   it('should skip validation for field array operations when mode is onBlur', async () => {
     const App = () => {
       const {

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -3889,6 +3889,75 @@ describe('useFieldArray', () => {
 
       expect(screen.queryByAltText('Please enter some data')).toBeNull();
     });
+
+    it('should skip validation for field array operations when mode is onBlur', async () => {
+      const App = () => {
+        const {
+          control,
+          handleSubmit,
+          formState: { errors },
+          register,
+        } = useForm({
+          mode: 'onBlur',
+          defaultValues: {
+            test: [{ name: '' }],
+          },
+        });
+
+        const { append, remove } = useFieldArray({
+          control,
+          name: 'test',
+          rules: {
+            minLength: {
+              value: 2,
+              message: 'Min length should be 2',
+            },
+          },
+        });
+
+        return (
+          <form onSubmit={handleSubmit(noop)}>
+            {errors.test?.root?.message && (
+              <p data-testid="error">{errors.test.root.message}</p>
+            )}
+            {control._fields.test?.map((_, index) => (
+              <input
+                key={index}
+                {...register(`test.${index}.name` as const, {
+                  required: 'Name is required',
+                })}
+                data-testid={`input-${index}`}
+              />
+            ))}
+            <button type="button" onClick={() => append({ name: '' })}>
+              append
+            </button>
+            <button type="button" onClick={() => remove(0)}>
+              remove
+            </button>
+            <button type="submit">submit</button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      // Append a field - validation should be skipped since mode is onBlur
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'append' }));
+      });
+
+      // No error should be shown since we haven't blurred anything
+      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+
+      // Remove a field - validation should also be skipped
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+      });
+
+      // Still no error since mode is onBlur
+      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+    });
   });
 
   describe('with nested field array ', () => {

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -3889,75 +3889,6 @@ describe('useFieldArray', () => {
 
       expect(screen.queryByAltText('Please enter some data')).toBeNull();
     });
-
-    it('should skip validation for field array operations when mode is onBlur', async () => {
-      const App = () => {
-        const {
-          control,
-          handleSubmit,
-          formState: { errors },
-          register,
-        } = useForm({
-          mode: 'onBlur',
-          defaultValues: {
-            test: [{ name: '' }],
-          },
-        });
-
-        const { append, remove } = useFieldArray({
-          control,
-          name: 'test',
-          rules: {
-            minLength: {
-              value: 2,
-              message: 'Min length should be 2',
-            },
-          },
-        });
-
-        return (
-          <form onSubmit={handleSubmit(noop)}>
-            {errors.test?.root?.message && (
-              <p data-testid="error">{errors.test.root.message}</p>
-            )}
-            {control._fields.test?.map((_, index) => (
-              <input
-                key={index}
-                {...register(`test.${index}.name` as const, {
-                  required: 'Name is required',
-                })}
-                data-testid={`input-${index}`}
-              />
-            ))}
-            <button type="button" onClick={() => append({ name: '' })}>
-              append
-            </button>
-            <button type="button" onClick={() => remove(0)}>
-              remove
-            </button>
-            <button type="submit">submit</button>
-          </form>
-        );
-      };
-
-      render(<App />);
-
-      // Append a field - validation should be skipped since mode is onBlur
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'append' }));
-      });
-
-      // No error should be shown since we haven't blurred anything
-      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
-
-      // Remove a field - validation should also be skipped
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: 'remove' }));
-      });
-
-      // Still no error since mode is onBlur
-      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
-    });
   });
 
   describe('with nested field array ', () => {
@@ -4599,5 +4530,73 @@ describe('useFieldArray with checkbox', () => {
       expect(checkboxes[2]).not.toBeChecked(); // Option 1 (copy) (copy)
       expect(checkboxes[3]).not.toBeChecked(); // Option 2
     });
+  });
+  
+  it('should skip validation for field array operations when mode is onBlur', async () => {
+    const App = () => {
+      const {
+        control,
+        handleSubmit,
+        formState: { errors },
+        register,
+      } = useForm({
+        mode: 'onBlur',
+        defaultValues: {
+          test: [{ name: '' }],
+        },
+      });
+
+      const { fields, append, remove } = useFieldArray({
+        control,
+        name: 'test',
+        rules: {
+          minLength: {
+            value: 2,
+            message: 'Min length should be 2',
+          },
+        },
+      });
+
+      return (
+        <form onSubmit={handleSubmit(() => {})}>
+          {errors.test?.root?.message && (
+            <p data-testid="error">{errors.test.root.message}</p>
+          )}
+
+          {fields.map((field, index) => (
+            <input
+              key={field.id}
+              {...register(`test.${index}.name` as const, {
+                required: 'Name is required',
+              })}
+              data-testid={`input-${index}`}
+              defaultValue={field.name} // Important for controlled inputs
+            />
+          ))}
+
+          <button type="button" onClick={() => append({ name: '' })}>
+            append
+          </button>
+          <button type="button" onClick={() => remove(0)}>
+            remove
+          </button>
+          <button type="submit">submit</button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'append' }));
+    });
+
+    expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+    });
+
+    expect(screen.queryByTestId('error')).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -4570,7 +4570,6 @@ describe('useFieldArray with checkbox', () => {
                 required: 'Name is required',
               })}
               data-testid={`input-${index}`}
-              defaultValue={field.name} // Important for controlled inputs
             />
           ))}
 

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -334,11 +334,13 @@ export function useFieldArray<
         ...control._formState,
       } as FormState<TFieldValues>);
 
+    const validationModes = getValidationModes(control._options.mode);
+
     if (
       _actioned.current &&
-      (!getValidationModes(control._options.mode).isOnSubmit ||
-        control._formState.isSubmitted) &&
-      !getValidationModes(control._options.reValidateMode).isOnSubmit
+      (!validationModes.isOnSubmit || control._formState.isSubmitted) &&
+      !getValidationModes(control._options.reValidateMode).isOnSubmit &&
+      !validationModes.isOnBlur
     ) {
       if (control._options.resolver) {
         control._runSchema([name]).then((result) => {


### PR DESCRIPTION
## Issue
When using `useFieldArray` with `mode: 'onBlur'`, validation errors were appearing on untouched fields after field array operations (append, remove, etc.). This was reported in #13331.

## Root Cause
The useEffect in useFieldArray that runs after field array operations was triggering validation regardless of the validation mode. When mode is set to 'onBlur', validation should only occur on blur events, not on field array operations.

## Solution
Added a check to skip validation when the mode is 'onBlur'. This ensures that:
1. Field array operations (append, remove, prepend, insert, swap, move, update, replace) don't trigger validation when mode is 'onBlur'
2. Validation still occurs on blur events as expected
3. The fix is minimal and doesn't affect other validation modes

## Changes
- Modified the validation condition in useFieldArray.ts useEffect to skip validation when `validationModes.isOnBlur` is true

## Testing
- Build passes
- Lint passes
- The fix addresses the specific issue reported in #13331 where errors appear on untouched fields after append/remove/append sequence with `mode: 'onBlur'`

Fixes #13331