### PR TITLE
fix: allow revalidation on fields with existing errors after trigger()

### DIFF
--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -940,6 +940,90 @@ describe('trigger', () => {
     expect(count).toEqual(2);
   });
 
+  it('should clear error on user input after trigger() sets it when form is not submitted', async () => {
+    const App = () => {
+      const {
+        register,
+        trigger,
+        formState: { errors },
+      } = useForm<{ test: string }>({
+        mode: 'onSubmit',
+        reValidateMode: 'onChange',
+      });
+
+      return (
+        <div>
+          <input
+            {...register('test', { required: 'This field is required' })}
+            placeholder="test"
+          />
+          <button type="button" onClick={() => trigger('test')}>
+            trigger
+          </button>
+          {errors.test && <span>{errors.test.message}</span>}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'trigger' }));
+
+    expect(await screen.findByText('This field is required')).toBeVisible();
+
+    fireEvent.change(screen.getByPlaceholderText('test'), {
+      target: { value: 'filled' },
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText('This field is required'),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('should clear error on blur after trigger() sets it when reValidateMode is onBlur', async () => {
+    const App = () => {
+      const {
+        register,
+        trigger,
+        formState: { errors },
+      } = useForm<{ test: string }>({
+        mode: 'onSubmit',
+        reValidateMode: 'onBlur',
+      });
+
+      return (
+        <div>
+          <input
+            {...register('test', { required: 'required' })}
+            placeholder="test"
+          />
+          <button type="button" onClick={() => trigger('test')}>
+            trigger
+          </button>
+          {errors.test && <span>{errors.test.message}</span>}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'trigger' }));
+
+    expect(await screen.findByText('required')).toBeVisible();
+
+    fireEvent.change(screen.getByPlaceholderText('test'), {
+      target: { value: 'filled' },
+    });
+
+    fireEvent.blur(screen.getByPlaceholderText('test'));
+
+    await waitFor(() =>
+      expect(screen.queryByText('required')).not.toBeInTheDocument(),
+    );
+  });
+
   it('should update validatingFields form states correctly when trigger() called', async () => {
     jest.useFakeTimers();
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -863,12 +863,15 @@ export function createFormControl<
         : getEventValue(event);
       const isBlurEvent =
         event.type === EVENTS.BLUR || event.type === EVENTS.FOCUS_OUT;
-      // When a field already has an error (e.g. set by trigger()), allow
-      // revalidation based on reValidateMode so the error can be cleared
-      // by user input even if the form hasn't been submitted yet.
+      // When mode is onSubmit and a field already has an error (e.g. set
+      // by trigger()), allow revalidation based on reValidateMode so the
+      // error can be cleared by user input even if the form hasn't been
+      // submitted yet. Other modes (onBlur, onChange) already revalidate
+      // on their respective events, so this only applies to onSubmit.
       const shouldRevalidateExistingError =
         !!get(_formState.errors, name) &&
         !_formState.isSubmitted &&
+        validationModeBeforeSubmit.isOnSubmit &&
         ((validationModeAfterSubmit.isOnChange && !isBlurEvent) ||
           (validationModeAfterSubmit.isOnBlur && isBlurEvent));
       const shouldSkipValidation =

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -863,19 +863,28 @@ export function createFormControl<
         : getEventValue(event);
       const isBlurEvent =
         event.type === EVENTS.BLUR || event.type === EVENTS.FOCUS_OUT;
+      // When a field already has an error (e.g. set by trigger()), allow
+      // revalidation based on reValidateMode so the error can be cleared
+      // by user input even if the form hasn't been submitted yet.
+      const shouldRevalidateExistingError =
+        !!get(_formState.errors, name) &&
+        !_formState.isSubmitted &&
+        ((validationModeAfterSubmit.isOnChange && !isBlurEvent) ||
+          (validationModeAfterSubmit.isOnBlur && isBlurEvent));
       const shouldSkipValidation =
         (!hasValidation(field._f) &&
           !props.validate &&
           !_options.resolver &&
           !get(_formState.errors, name) &&
           !field._f.deps) ||
-        skipValidation(
+        (skipValidation(
           isBlurEvent,
           get(_formState.touchedFields, name),
           _formState.isSubmitted,
           validationModeAfterSubmit,
           validationModeBeforeSubmit,
-        );
+        ) &&
+          !shouldRevalidateExistingError);
       const watched = isWatched(name, _names, isBlurEvent);
 
       set(_formValues, name, fieldValue);


### PR DESCRIPTION
Closes #13276
Related: https://github.com/orgs/react-hook-form/discussions/11422

When `trigger()` is called manually to validate fields, it shows errors but doesn't set `isSubmitted` to `true`. After that, typing in the field doesn't clear the error because `skipValidation` uses the pre-submit `mode` (e.g. `onSubmit`) which skips onChange validation entirely.

The core problem is that `skipValidation` decides whether to revalidate based on `isSubmitted`, but `trigger()` doesn't set that flag (and it shouldn't — it's not a submission). So fields with errors from `trigger()` get stuck.

The fix: when a field already has an error AND the form hasn't been submitted yet, check if the current event matches `reValidateMode` (default: `onChange`). If it does, don't skip — let the validation run so the error can be cleared.

This only kicks in when:
1. The field has an existing error (e.g. from `trigger()`)
2. `isSubmitted` is `false` (after actual submission, the existing logic handles it)
3. The event type matches `reValidateMode`

So normal form behavior is unchanged — this just unblocks the specific case where `trigger()` errors are stuck.