### PR TITLE
test: add test coverage for isDirty behavior when removing the only field array item (fixes #13334)

### DIFF
--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -28,6 +28,7 @@ import UseFieldArray from './useFieldArray';
 import UseFieldArrayNested from './useFieldArrayNested';
 import CustomSchemaValidation from './customSchemaValidation';
 import WatchFieldArray from './watchUseFieldArray';
+import FieldArrayIsDirty from './fieldArrayIsDirty';
 import UseWatch from './useWatch';
 import FormStateWithNestedFields from './formStateWithNestedFields';
 import UseFieldArrayUnregister from './useFieldArrayUnregister';
@@ -74,6 +75,7 @@ const App = () => {
           path="/UseFieldArrayUnregister"
           element={<UseFieldArrayUnregister />}
         />
+        <Route path="/fieldArrayIsDirty" element={<FieldArrayIsDirty />} />
         <Route path="/reset" element={<Reset />} />
         <Route path="/resetKeepDirty" element={<ResetKeepDirty />} />
         <Route path="/setValue" element={<SetValue />} />

--- a/app/src/fieldArrayIsDirty.tsx
+++ b/app/src/fieldArrayIsDirty.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+
+type FormValues = {
+  data: { id: number; name: string }[];
+};
+
+const defaultValues: FormValues = {
+  data: [{ id: 1, name: 'a' }],
+};
+
+/**
+ * Example demonstrating correct isDirty behavior with useFieldArray.remove()
+ *
+ * Key points:
+ * 1. Do NOT call form.reset() in useEffect on mount - it interferes with dirty tracking
+ * 2. Access formState.isDirty directly to ensure proper subscription
+ * 3. Removing the only default item correctly sets isDirty to true
+ */
+export default function FieldArrayIsDirty() {
+  const form = useForm<FormValues>({ defaultValues });
+
+  // Access formState directly to ensure proper subscription
+  const { isDirty } = form.formState;
+
+  const fieldArray = useFieldArray({ control: form.control, name: 'data' });
+
+  const handleDelete = (index: number) => {
+    fieldArray.remove(index);
+  };
+
+  const handleAdd = () => {
+    const newId =
+      Math.max(0, ...fieldArray.fields.map((f: { id: number }) => f.id)) + 1;
+    fieldArray.append({ id: newId, name: '' });
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>Field Array isDirty Example</h1>
+
+      <div style={{ marginBottom: '20px' }}>
+        {fieldArray.fields.map((field: { id: number }, index: number) => (
+          <div key={field.id} style={{ marginBottom: '10px' }}>
+            <input
+              {...form.register(`data.${index}.name`)}
+              placeholder="Enter name"
+              style={{ marginRight: '10px' }}
+            />
+            <button type="button" onClick={() => handleDelete(index)}>
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleAdd}
+        style={{ marginBottom: '20px' }}
+      >
+        Add Item
+      </button>
+
+      <div
+        style={{
+          padding: '10px',
+          backgroundColor: '#f0f0f0',
+          borderRadius: '4px',
+        }}
+      >
+        <div>
+          <strong>isDirty:</strong> {String(isDirty)}
+        </div>
+        <div>
+          <strong>Items count:</strong> {fieldArray.fields.length}
+        </div>
+      </div>
+
+      <div
+        style={{
+          marginTop: '20px',
+          padding: '10px',
+          backgroundColor: '#e8f4f8',
+          borderRadius: '4px',
+        }}
+      >
+        <h3>Instructions:</h3>
+        <ol>
+          <li>Initially: 1 item with name "a", isDirty = false</li>
+          <li>Click "Delete" on the item</li>
+          <li>✓ isDirty becomes true (array changed from [item] to [])</li>
+          <li>Click "Add Item" - isDirty remains true</li>
+          <li>
+            Type "a" in the new input - isDirty becomes false (matches
+            defaultValues)
+          </li>
+        </ol>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => {
+          console.log('Current values:', form.getValues());
+          console.log('isDirty:', isDirty);
+          console.log('Default values:', defaultValues);
+        }}
+        style={{ marginTop: '20px' }}
+      >
+        Log Form State
+      </button>
+    </div>
+  );
+}

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -132,6 +132,50 @@ describe('remove', () => {
     });
   });
 
+  it('should set isDirty to true when removing the only default item', () => {
+    let formState: any;
+    const Component = () => {
+      const {
+        register,
+        control,
+        formState: tempFormState,
+      } = useForm({
+        defaultValues: {
+          test: [{ name: 'default' }],
+        },
+      });
+      const { fields, remove } = useFieldArray({
+        name: 'test',
+        control,
+      });
+
+      formState = tempFormState;
+      formState.isDirty;
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input {...register(`test.${i}.name` as const)} />
+              <button type={'button'} onClick={() => remove(i)}>
+                remove
+              </button>
+            </div>
+          ))}
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    expect(formState.isDirty).toBeFalsy();
+
+    // Remove the only default item - form should now be dirty
+    fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+
+    expect(formState.isDirty).toBeTruthy();
+  });
+
   it('should update isValid formState when item removed', async () => {
     let formState: any;
     const Component = () => {


### PR DESCRIPTION
### Summary
Adds test coverage and example demonstrating correct `isDirty` behavior when removing the only item from a field array using `useFieldArray.remove()`.

### Related Issue
Fixes #13334

### Changes Made
1. **Added test case** in remove.test.tsx:
   - Tests that `isDirty` correctly updates to `true` when removing the only default item from a field array
   - Verifies the behavior described in issue #13334 works as expected

2. **Created example component** fieldArrayIsDirty.tsx:
   - Demonstrates proper usage of `useFieldArray` with `isDirty` tracking
   - Documents common pitfalls (e.g., calling `reset()` in `useEffect` interferes with dirty tracking)
   - Provides interactive example showing when `isDirty` changes state

3. **Added route** to example app for easy testing

### Testing
- ✅ All existing tests pass
- ✅ New test case passes and verifies expected behavior
- ✅ Linting passes
- ✅ Example component works correctly in demo app

### Notes
The test confirms that `react-hook-form` correctly handles `isDirty` when removing items from field arrays. The issue reported in #13334 appears to be caused by improper usage patterns rather than a library bug. This PR adds documentation and test coverage to prevent similar confusion in the future.
