### PR TITLE
🐞 fix: isDirty false positive with numeric string keys in defaultValues

### DIFF
--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -1137,6 +1137,36 @@ describe('formState', () => {
     });
   });
 
+  it('should report isDirty as false on mount when defaultValues contain numeric string keys (issue #13346)', async () => {
+    function App() {
+      const {
+        register,
+        formState: { isDirty },
+      } = useForm({
+        defaultValues: {
+          items: {
+            '123': { name: 'Alice' },
+            '456': { name: 'Bob' },
+          },
+        },
+      });
+
+      return (
+        <div>
+          <input {...register('items.123.name')} />
+          <input {...register('items.456.name')} />
+          <p>{isDirty ? 'dirty' : 'pristine'}</p>
+        </div>
+      );
+    }
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('pristine')).toBeInTheDocument();
+    });
+  });
+
   it('should not update valid with onBlur mode', async () => {
     function App() {
       const {

--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -90,6 +90,27 @@ describe('deepEqual', () => {
     ).toBeTruthy();
   });
 
+  it('should return true when comparing sparse array against plain object with numeric string keys (issue #13346)', () => {
+    const sparseArray: any[] = [];
+    sparseArray[123] = { name: 'Alice' };
+    sparseArray[456] = { name: 'Bob' };
+
+    const plainObject: any = {
+      '123': { name: 'Alice' },
+      '456': { name: 'Bob' },
+    };
+
+    expect(deepEqual(sparseArray, plainObject)).toBeTruthy();
+    expect(deepEqual(plainObject, sparseArray)).toBeTruthy();
+
+    expect(
+      deepEqual({ items: sparseArray }, { items: plainObject }),
+    ).toBeTruthy();
+    expect(
+      deepEqual({ items: plainObject }, { items: sparseArray }),
+    ).toBeTruthy();
+  });
+
   it('should compare date time object valueOf', () => {
     expect(
       deepEqual({ test: new Date('1990') }, { test: new Date('1990') }),

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -40,8 +40,8 @@ export default function deepEqual(
 
       if (
         (isDateObject(val1) && isDateObject(val2)) ||
-        (isObject(val1) && isObject(val2)) ||
-        (Array.isArray(val1) && Array.isArray(val2))
+        ((isObject(val1) || Array.isArray(val1)) &&
+          (isObject(val2) || Array.isArray(val2)))
           ? !deepEqual(val1, val2, _internal_visited)
           : !Object.is(val1, val2)
       ) {


### PR DESCRIPTION
## Summary

  - Fixes react-hook-form/react-hook-form#13346
  - When `defaultValues` contain objects with numeric string keys (e.g. `{ "123": { name: "Alice" } }`),
    RHF's `set` utility creates sparse arrays for intermediate containers when `_formValues` starts
    empty. This caused `deepEqual` to incorrectly return `false` when comparing a sparse array against
    a plain object at a nested level, making `isDirty` report `true` on mount even though no fields
    had changed.
  - Fixed `deepEqual` to recurse into comparison when one value is an `Array` and the other is a plain
    `Object` (or vice versa), instead of falling back to `Object.is`.

  ## Root cause

  In `deepEqual`, the condition to decide whether to recurse required both values to be the same type
  (both objects OR both arrays):

  (isObject(val1) && isObject(val2)) ||
  (Array.isArray(val1) && Array.isArray(val2))

  When `_formValues.items` is a sparse array and `_defaultValues.items` is a plain object with numeric
  string keys, neither condition matched, so it fell back to `Object.is(array, object)` → `false`,
  incorrectly marking the form as dirty.

  ## Fix

  (isObject(val1) || Array.isArray(val1)) &&
  (isObject(val2) || Array.isArray(val2))

  Since `Object.keys` returns the same numeric string keys for both sparse arrays and plain objects,
  the recursive comparison correctly identifies them as equal when they have the same keys and values.

  ## Test plan

  - [ ] Added unit test in `deepEqual.test.ts` verifying sparse array vs plain object comparison
  - [ ] Added integration test in `formState.test.tsx` verifying `isDirty` stays `false` on mount
        with numeric string key `defaultValues`
  - [ ] All 1060 existing tests pass