### PR TITLE
fix: handle nested field when parent defaultValue is null

### DIFF
--- a/src/__tests__/nested-null.test.tsx
+++ b/src/__tests__/nested-null.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useForm } from '../useForm';
+
+function TestComponent() {
+  const { register, handleSubmit } = useForm<{
+    example: { inner?: string } | null;
+  }>({
+    defaultValues: {
+      example: null,
+    },
+  });
+  const onSubmit = (data: any) => {
+    (window as any).submittedData = data;
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('example.inner')} />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+
+describe('nested null bug', () => {
+  it('should not keep parent as null and allow nested value', async () => {
+    render(<TestComponent />);
+
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      const result = (window as any).submittedData;
+
+      expect(result).toEqual({
+        example: { inner: '' },
+      });
+    });
+  });
+});

--- a/src/__tests__/nested-null.test.tsx
+++ b/src/__tests__/nested-null.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { useForm } from '../useForm';
 
-function TestComponent() {
+function TestComponent({ onSubmit }: { onSubmit: (data: any) => void }) {
   const { register, handleSubmit } = useForm<{
     example: { inner?: string } | null;
   }>({
@@ -11,9 +11,6 @@ function TestComponent() {
       example: null,
     },
   });
-  const onSubmit = (data: any) => {
-    (window as any).submittedData = data;
-  };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -25,16 +22,16 @@ function TestComponent() {
 
 describe('nested null bug', () => {
   it('should not keep parent as null and allow nested value', async () => {
-    render(<TestComponent />);
+    const onSubmit = jest.fn();
+    render(<TestComponent onSubmit={onSubmit} />);
 
     fireEvent.click(screen.getByText('Submit'));
 
     await waitFor(() => {
-      const result = (window as any).submittedData;
-
-      expect(result).toEqual({
-        example: { inner: '' },
-      });
+      expect(onSubmit).toHaveBeenCalledWith(
+        { example: { inner: '' } },
+        expect.anything(),
+      );
     });
   });
 });

--- a/src/utils/get.ts
+++ b/src/utils/get.ts
@@ -13,13 +13,16 @@ export default <T>(
     return defaultValue;
   }
 
-  const result = (isKey(path) ? [path] : stringToPath(path)).reduce(
-    (result, key) =>
-      isNullOrUndefined(result) ? result : result[key as keyof T & object],
-    object,
-  );
+  const paths = isKey(path) ? [path] : stringToPath(path);
 
-  return isUndefined(result) || result === object || result === null
+  const result = paths.reduce<any>((result, key, index) => {
+    if (result === null && index < paths.length) {
+      return undefined;
+    }
+    return isNullOrUndefined(result) ? result : result[key];
+  }, object);
+
+  return isUndefined(result) || result === object
     ? isUndefined(object[path as keyof T])
       ? defaultValue
       : object[path as keyof T]

--- a/src/utils/get.ts
+++ b/src/utils/get.ts
@@ -19,7 +19,7 @@ export default <T>(
     object,
   );
 
-  return isUndefined(result) || result === object
+  return isUndefined(result) || result === object || result === null
     ? isUndefined(object[path as keyof T])
       ? defaultValue
       : object[path as keyof T]

--- a/src/utils/get.ts
+++ b/src/utils/get.ts
@@ -15,11 +15,8 @@ export default <T>(
 
   const paths = isKey(path) ? [path] : stringToPath(path);
 
-  const result = paths.reduce<any>((result, key, index) => {
-    if (result === null && index < paths.length) {
-      return undefined;
-    }
-    return isNullOrUndefined(result) ? result : result[key];
+  const result = paths.reduce<any>((result, key) => {
+    return isNullOrUndefined(result) ? undefined : result[key];
   }, object);
 
   return isUndefined(result) || result === object


### PR DESCRIPTION
Fixes #13345

###  Problem
When a parent field in `defaultValues` is `null`, registering a nested field (e.g. `example.inner`) results in incorrect behavior.

The nested value is not properly initialized.

### Solution
- Preserved existing traversal logic
- Fixed handling of `null` parent values
- Ensures nested field can be registered correctly

###  Tests
- Added test to reproduce issue
- Verified correct output:
  { example: { inner: "" } }

###  Notes
- Matches browser behavior for empty inputs
- No regressions (all tests passing)