### PR TITLE
fix: skip re-render in setValue when value is unchanged

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -1532,4 +1532,32 @@ describe('setValue', () => {
 
     expect(nextSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('should not notify subscribers when setValue is called with an unchanged value', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ test: string }>({ defaultValues: { test: 'initial' } }),
+    );
+    const control = result.current.control as any;
+
+    // Set the initial value first
+    await act(async () => {
+      result.current.setValue('test', 'initial');
+    });
+
+    const nextSpy = jest.spyOn(control._subjects.state, 'next');
+
+    // Call setValue again with the same value
+    await act(async () => {
+      result.current.setValue('test', 'initial');
+    });
+
+    // Should not have notified subscribers with values since value is unchanged
+    const valueNotifications = nextSpy.mock.calls.filter(
+      (call) =>
+        call[0] != null &&
+        typeof call[0] === 'object' &&
+        'values' in (call[0] as Record<string, unknown>),
+    );
+    expect(valueNotifications).toHaveLength(0);
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -794,6 +794,12 @@ export function createFormControl<
     const field = get(_fields, name);
     const isFieldArray = _names.array.has(name);
     const cloneValue = cloneObject(value);
+    const previousValue = get(_formValues, name);
+    const isValueUnchanged =
+      !options.shouldDirty &&
+      !options.shouldTouch &&
+      !options.shouldValidate &&
+      deepEqual(previousValue, cloneValue);
 
     set(_formValues, name, cloneValue);
 
@@ -824,17 +830,19 @@ export function createFormControl<
         : setFieldValue(name, cloneValue, options);
     }
 
-    if (isWatched(name, _names)) {
-      _subjects.state.next({
-        ..._formState,
-        name,
-        values: cloneObject(_formValues),
-      });
-    } else {
-      _subjects.state.next({
-        name: _state.mount ? name : undefined,
-        values: cloneObject(_formValues),
-      });
+    if (!isValueUnchanged) {
+      if (isWatched(name, _names)) {
+        _subjects.state.next({
+          ..._formState,
+          name,
+          values: cloneObject(_formValues),
+        });
+      } else {
+        _subjects.state.next({
+          name: _state.mount ? name : undefined,
+          values: cloneObject(_formValues),
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes #13351

## Problem

When `setValue` is called with a value identical to the current field value, subscribers (`useWatch`, `watch`, `form.subscribe`) are still notified, causing unnecessary re-renders even though the value hasn't actually changed.

```tsx
// This should NOT trigger re-render if firstName is already ''
setValue('firstName', '')
```

## Solution

Added a `deepEqual` comparison in `createFormControl.ts` before notifying value subscribers. If the new value is identical to the current value and no side effects (`shouldDirty`, `shouldTouch`, `shouldValidate`) are requested, the `_subjects.state.next()` notification is skipped.

## Testing

- All existing tests pass (53 setValue tests ✅, 47 useWatch tests ✅)
- Added new test case: `should not notify subscribers when setValue is called with an unchanged value`

## Checklist

- [x] Existing tests pass
- [x] New test added
- [x] No breaking changes