### PR TITLE
fix: safely access field._f during register 

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -1588,4 +1588,27 @@ describe('useController', () => {
       expect(screen.getByText('invalid')).toBeVisible();
     });
   });
+
+  it('can register field array property before field array root', () => {
+    const Component = () => {
+      const { control } = useForm<{
+        test: string;
+        test1: { test: string }[];
+      }>();
+
+      useController({
+        name: 'test1.0.test',
+        control,
+      });
+
+      useController({
+        name: 'test1',
+        control,
+      });
+
+      return null;
+    };
+
+    render(<Component />);
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1277,7 +1277,7 @@ export function createFormControl<
     const disabledIsDefined =
       isBoolean(options.disabled) || isBoolean(_options.disabled);
     const shouldRevalidateRemount =
-      !_names.registerName.has(name) && field && !field._f.mount;
+      !_names.registerName.has(name) && field && field._f && !field._f.mount;
 
     set(_fields, name, {
       ...(field || {}),


### PR DESCRIPTION
Resolves #13364 .

The `register` does not null-check `field._f`, which throws an error if `field` is an array.

```ts
useController({ name: 'test1.0.test' })

// Current value of _fields after first register
const _fields = {
  test1: [
    {
      test: { _f }
    }
  ]
}

useController({ name: 'test1' })

// Logic in `register` causes error.
const field = _fields.test1
const shouldRevalidateRemount = !_names.registerName.has(name) && field && !field._f.mount;

// Fix with one extra check.
const shouldRevalidateRemount = !_names.registerName.has(name) && field && field._f && !field._f.mount;
```