### PR TITLE
fix: sync Controller value from _formValues on render to handle Activ…

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -1514,6 +1514,53 @@ describe('useController', () => {
     rerender({ control: form1Result.current.control });
     expect(result.current.field.value).toBe('form1-value');
   });
+  it('should reflect updated value when parent visibility is toggled (Activity pattern)', async () => {
+    const Component = () => {
+      const { control, setValue } = useForm({
+        defaultValues: { test: '' },
+      });
+      const [activeTab, setActiveTab] = React.useState(0);
+
+      return (
+        <div>
+          {/* Tab 1: visible initially */}
+          <div style={{ display: activeTab === 0 ? 'block' : 'none' }}>
+            <Controller
+              name="test"
+              control={control}
+              render={({ field }) => (
+                <input data-testid="tab1-input" {...field} />
+              )}
+            />
+          </div>
+
+          {/* Tab 2: hidden initially — stays MOUNTED the whole time (Activity pattern) */}
+          <div style={{ display: activeTab === 1 ? 'block' : 'none' }}>
+            <Controller
+              name="test"
+              control={control}
+              render={({ field }) => (
+                <span data-testid="tab2-controller">{field.value}</span>
+              )}
+            />
+          </div>
+
+          <button onClick={() => setActiveTab(1)}>Go to Tab 2</button>
+          <button onClick={() => setValue('test', 'hello')}>Set Value</button>
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByText('Set Value'));
+
+    fireEvent.click(screen.getByText('Go to Tab 2'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tab2-controller').textContent).toBe('hello');
+    });
+  });
 
   it('should update isValid when Controller with required rule re-mounts via checkbox toggle', async () => {
     type FormValues = {

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -79,12 +79,22 @@ export function useController<
     [control, name, defaultValue],
   );
 
-  const value = useWatch({
+  const watchedValue = useWatch({
     control,
     name,
     defaultValue: defaultValueMemo,
     exact,
   }) as FieldPathValue<TFieldValues, TName>;
+
+  const liveValue = get(control._formValues, name) as
+    | FieldPathValue<TFieldValues, TName>
+    | undefined;
+
+  const value = (
+    liveValue !== undefined && liveValue !== watchedValue
+      ? liveValue
+      : watchedValue
+  ) as FieldPathValue<TFieldValues, TName>;
 
   const formState = useFormState({
     control,


### PR DESCRIPTION
Fixes #13381

## Problem

When `Controller` is inside a React Native `Activity` (or any tab layout 
that keeps components mounted but hidden), it shows a stale value when 
the tab becomes visible again.

Steps to reproduce are in the issue with a CodeSandbox link:
https://codesandbox.io/p/sandbox/controller-activity-bug-6tpzdl

## Why

`useController` uses `useWatch` internally. When a component is hidden 
inside an `Activity`, React skips state updates to that subtree. So 
`useWatch` misses the update and holds the old value.

## Fix

`control._formValues` always has the latest value regardless of React's 
render cycle. On each render, if `_formValues` and `useWatch` disagree, 
we use `_formValues` instead. No extra re-renders.

## Changes

- `src/useController.ts` — sync value from `_formValues` on render
- `src/__tests__/useController.test.tsx` — added regression test

## Code of Conduct
- [x] I agree to follow this project's Code of Conduct