### PR TITLE
fix: apply native custom validity to all radio inputs in refs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@swc/core': true
+  cypress: true
+  unrs-resolver: true

--- a/scratch.html
+++ b/scratch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <form id="f">
+    <input type="radio" name="x" value="1" required id="r1">
+    <input type="radio" name="x" value="2" required id="r2">
+    <button type="submit">Submit</button>
+  </form>
+  <button id="test" type="button">Test</button>
+  <script>
+    document.getElementById('test').addEventListener('click', () => {
+      document.getElementById('r1').setCustomValidity('error');
+      // document.getElementById('r1').reportValidity();
+      document.getElementById('r2').setCustomValidity('error');
+      document.getElementById('r1').reportValidity();
+      document.getElementById('r2').reportValidity();
+    });
+  </script>
+</body>
+</html>

--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -2198,6 +2198,55 @@ describe('validateField', () => {
       expect(reportValidity).toHaveBeenCalled();
     });
 
+    it('should invoke setCustomValidity on all refs for invalid input', () => {
+      const setCustomValidity1 = jest.fn();
+      const setCustomValidity2 = jest.fn();
+      const reportValidity1 = jest.fn();
+      const reportValidity2 = jest.fn();
+
+      validateField(
+        {
+          _f: {
+            name: 'test',
+            ref: {
+              setCustomValidity: setCustomValidity1,
+              reportValidity: reportValidity1,
+              name: 'test',
+              value: '',
+            },
+            refs: [
+              {
+                setCustomValidity: setCustomValidity1,
+                reportValidity: reportValidity1,
+                name: 'test',
+                value: '',
+              } as any,
+              {
+                setCustomValidity: setCustomValidity2,
+                reportValidity: reportValidity2,
+                name: 'test',
+                value: '',
+              } as any,
+            ],
+            value: '',
+            required: true,
+            mount: true,
+          },
+        },
+        new Set(),
+        {
+          test: '',
+        },
+        false,
+        true,
+      );
+
+      expect(setCustomValidity1).toHaveBeenCalledWith('');
+      expect(setCustomValidity2).toHaveBeenCalledWith('');
+      expect(reportValidity1).toHaveBeenCalled();
+      expect(reportValidity2).not.toHaveBeenCalled();
+    });
+
     it('should invoke setCustomValidity for invalid input with its message', () => {
       const setCustomValidity = jest.fn();
       const reportValidity = jest.fn();

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -59,7 +59,16 @@ export default async <T extends FieldValues>(
   const inputRef: HTMLInputElement = refs ? refs[0] : (ref as HTMLInputElement);
   const setCustomValidity = (message?: string | boolean) => {
     if (shouldUseNativeValidation && inputRef.reportValidity) {
-      inputRef.setCustomValidity(isBoolean(message) ? '' : message || '');
+      const customMessage = isBoolean(message) ? '' : message || '';
+      if (refs) {
+        refs.forEach((ref) => {
+          if ((ref as HTMLInputElement).setCustomValidity) {
+            (ref as HTMLInputElement).setCustomValidity(customMessage);
+          }
+        });
+      } else {
+        inputRef.setCustomValidity(customMessage);
+      }
       inputRef.reportValidity();
     }
   };

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -62,11 +62,11 @@ export default async <T extends FieldValues>(
       const customMessage = isBoolean(message) ? '' : message || '';
       if (refs) {
         refs.forEach((ref) => {
-          if ((ref as HTMLInputElement).setCustomValidity) {
+          if (ref && (ref as HTMLInputElement).setCustomValidity) {
             (ref as HTMLInputElement).setCustomValidity(customMessage);
           }
         });
-      } else {
+      } else if (inputRef && inputRef.setCustomValidity) {
         inputRef.setCustomValidity(customMessage);
       }
       inputRef.reportValidity();


### PR DESCRIPTION
Fixes #12651 

#### 📋 What is the problem?
When using `shouldUseNativeValidation: true` alongside a radio group natively marked as `required`, the validation strictly behaves differently than standard HTML forms. In native forms, browsers will throw `setCustomValidity` onto **all** radio buttons belonging to the same group. This flags them universally with the `:invalid` CSS pseudoclass.

However, `react-hook-form` was only enforcing `inputRef.setCustomValidity()` against the first registered radio element (`refs[0]`) within `src/logic/validateField.ts`. As a result, only the first option in the group visually updated to show its native invalid validation state inside the DOM.

#### 🛠️ How we debugged it
1. **Identified the Discrepancy:** We compared a pure native HTML form against a React Hook Form representation. The browser successfully assigned `.setCustomValidity` to all native options, while RHF only propagated it to the single `inputRef`.
2. **Traced the Validation Logic:** We tracked `reportValidity` down to `validateField.ts` inside the `setCustomValidity` helper at line ~60. 
3. **Confirmed Array Tracking:** We observed that `react-hook-form` already groups matching radio elements perfectly inside the `refs` property inside `field._f`. The references were there, but the loop was missing.
4. **Tested `reportValidity` Behavior:** Crucially, we realized that calling `.reportValidity()` on *every* element causes the browser to flicker or invoke multiple native UI popups on the screen simultaneously. It's safer to flag all elements with `setCustomValidity`, but only trigger the visual tooltip once on the lead input.

#### 💡 How this issue is fixed
- Updated the `setCustomValidity` closure in `src/logic/validateField.ts`.
- Introduced a loop over the `refs` array (if present). We safely execute `.setCustomValidity(customMessage)` across every linked element.
- Crucially kept `.reportValidity()` **only** triggered on the primary `inputRef`. This guarantees all inputs correctly trigger layout updates (like styling via `:invalid`), but strictly isolates the browser’s native tooltip notification to just the single radio button to avoid browser notification spam/flickering.
- Added comprehensive unit tests inside `src/__tests__/logic/validateField.test.tsx` simulating a multi-ref scenario to verify `setCustomValidity` is invoked accurately across multiple stubs while confirming `reportValidity` is isolated to one interaction.

#### ✅ Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/react-hook-form/react-hook-form/blob/master/CONTRIBUTING.md) doc
- [x] I have fixed the issue described
- [x] I have added unit tests specifically addressing this edge case with radio elements.
- [x] All existing tests successfully pass.