### PR TITLE
fix: preserve watch updates on field array unmount fixes #13375

### DIFF
--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -21,6 +21,7 @@ import { useFieldArray } from '../useFieldArray';
 import { useForm } from '../useForm';
 import { FormProvider } from '../useFormContext';
 import { useFormState } from '../useFormState';
+import { useWatch } from '../useWatch';
 import noop from '../utils/noop';
 
 let i = 0;
@@ -2921,6 +2922,110 @@ describe('useFieldArray', () => {
 
     expect(screen.getAllByRole('textbox').length).toEqual(2);
   });
+
+  type Methods = {
+    append: (value: { value: string }) => void;
+    prepend: (value: { value: string }) => void;
+    insert: (index: number, value: { value: string }) => void;
+  };
+
+  it.each([
+    {
+      action: 'append',
+      expectedValues: ['firstItem', 'newItem'],
+      mutate: (methods: Methods) => methods.append({ value: 'newItem' }),
+    },
+    {
+      action: 'prepend',
+      expectedValues: ['newItem', 'firstItem'],
+      mutate: (methods: Methods) => methods.prepend({ value: 'newItem' }),
+    },
+    {
+      action: 'insert',
+      expectedValues: ['newItem', 'firstItem'],
+      mutate: (methods: Methods) => methods.insert(0, { value: 'newItem' }),
+    },
+  ])(
+    'should update watched field array when $action and unmount happen in one event',
+    ({ action, expectedValues, mutate }) => {
+      type FormValues = {
+        list: {
+          value: string;
+        }[];
+      };
+
+      const Display = ({ control }: { control: Control<FormValues> }) => {
+        const list = useWatch({ control, name: 'list' }) || [];
+
+        return (
+          <div data-testid="list-display">
+            {list.map((item, index) => (
+              <p key={index}>{item.value}</p>
+            ))}
+          </div>
+        );
+      };
+
+      const Dialog = ({
+        control,
+        onClose,
+      }: {
+        control: Control<FormValues>;
+        onClose: () => void;
+      }) => {
+        const { append, prepend, insert } = useFieldArray({
+          control,
+          name: 'list',
+        });
+
+        return (
+          <button
+            type="button"
+            onClick={() => {
+              mutate({ append, prepend, insert });
+              onClose();
+            }}
+          >
+            {action}
+          </button>
+        );
+      };
+
+      const App = () => {
+        const { control } = useForm<FormValues>({
+          defaultValues: {
+            list: [{ value: 'firstItem' }],
+          },
+        });
+        const [open, setOpen] = React.useState(true);
+
+        return (
+          <>
+            <Display control={control} />
+            {open ? (
+              <Dialog control={control} onClose={() => setOpen(false)} />
+            ) : (
+              <button type="button" onClick={() => setOpen(true)}>
+                open
+              </button>
+            )}
+          </>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.click(screen.getByRole('button', { name: action }));
+
+      const renderedValues = screen
+        .getByTestId('list-display')
+        .querySelectorAll('p');
+
+      expect(
+        Array.from(renderedValues, (element) => element.textContent),
+      ).toEqual(expectedValues);
+    },
+  );
 
   it('should append deep nested field array correctly with strict mode', async () => {
     function App() {

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -424,6 +424,9 @@ export function useFieldArray<
     !get(control._formValues, name) && control._setFieldArray(name);
 
     return () => {
+      const shouldKeepFieldArrayValues = !(
+        control._options.shouldUnregister || shouldUnregister
+      );
       const updateMounted = (name: InternalFieldName, value: boolean) => {
         const field: Field = get(control._fields, name);
         if (field && field._f) {
@@ -431,7 +434,14 @@ export function useFieldArray<
         }
       };
 
-      control._options.shouldUnregister || shouldUnregister
+      if (_actioned.current && shouldKeepFieldArrayValues) {
+        control._subjects.state.next({
+          name,
+          values: cloneObject(control._formValues) as TFieldValues,
+        });
+      }
+
+      !shouldKeepFieldArrayValues
         ? control.unregister(name as FieldPath<TFieldValues>)
         : updateMounted(name, false);
     };

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -441,9 +441,9 @@ export function useFieldArray<
         });
       }
 
-      !shouldKeepFieldArrayValues
-        ? control.unregister(name as FieldPath<TFieldValues>)
-        : updateMounted(name, false);
+      shouldKeepFieldArrayValues
+        ? updateMounted(name, false)
+        : control.unregister(name as FieldPath<TFieldValues>);
     };
   }, [name, control, keyName, shouldUnregister]);
 


### PR DESCRIPTION
Fixes #13375

## Problem

When `append` is triggered from a conditionally mounted component (e.g. a dialog) and that component unmounts immediately within the same event, `useWatch` consumers for that field array may miss the update.

In the reproduction case, clicking **append + close** does not immediately display the appended item. The item only appears after the component is remounted.

Steps to reproduce are in the issue with a CodeSandbox link:
https://codesandbox.io/p/sandbox/relaxed-leftpad-p7trfw

## Why

`useFieldArray` mutates the form values, but in this specific *append-and-immediate-unmount* sequence, the hook instance that performed the mutation is torn down before watchers receive a final state notification.

As a result, `useWatch` subscribers may not reflect the latest field array values.

## Fix

During `useFieldArray` cleanup, emit one final state update with the latest `formValues`, **only when**:

- An array action occurred in that hook instance (`_actioned.current`), and  
- Values are retained (`shouldUnregister` is `false` at both form and hook level)

This ensures proper synchronization with `useWatch` without altering existing unregister behavior.

## Changes

### `src/useFieldArray.ts`
- Added `shouldKeepFieldArrayValues` guard in cleanup
- Emit `control._subjects.state.next({ name, values })` during cleanup for the *actioned + retained values* case
- Preserved existing unregister and mount behavior

### `src/__tests__/useFieldArray.test.tsx`
- Added regression test:
  - Verifies that **append + immediate unmount in a single event** updates watched sibling list immediately

## Code of Conduct
- [x] I agree to follow this project's Code of Conduct