### PR TITLE
fix: preserve previous field value when `useController` name changes

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -1379,7 +1379,7 @@ describe('useController', () => {
     expect(renderCounter).toEqual({ test: 4, test_with_suffix: 4 });
   });
 
-  it('should prevent field value leakage when field names change at same position', () => {
+  it('should prevent value leakage and preserve previous field value when name changes', () => {
     type FormValues = {
       type: 'personal' | 'business';
       personalName: string;
@@ -1419,6 +1419,7 @@ describe('useController', () => {
               render={({ field }) => <input {...field} />}
             />
           )}
+          <span data-testid="personal-name-value">{watch('personalName')}</span>
         </div>
       );
     };
@@ -1434,6 +1435,9 @@ describe('useController', () => {
     });
 
     expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('');
+    expect(screen.getByTestId('personal-name-value').textContent).toBe(
+      'John Doe',
+    );
   });
 
   it('should react to changing field name', () => {

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -94,8 +94,6 @@ export function useController<
 
   const _props = React.useRef(props);
 
-  const _previousNameRef = React.useRef<string | undefined>(undefined);
-
   const _registerProps = React.useRef(
     control.register(name, {
       ...props.rules,
@@ -195,11 +193,6 @@ export function useController<
   React.useEffect(() => {
     const _shouldUnregisterField =
       control._options.shouldUnregister || shouldUnregister;
-    const previousName = _previousNameRef.current;
-
-    if (previousName && previousName !== name && !isArrayField) {
-      control.unregister(previousName as FieldPath<TFieldValues>);
-    }
 
     control.register(name, {
       ..._props.current.rules,
@@ -229,8 +222,6 @@ export function useController<
     }
 
     !isArrayField && control.register(name);
-
-    _previousNameRef.current = name;
 
     return () => {
       (


### PR DESCRIPTION
#13041 introduced a potentially unwanted behaviour that when the `useController`'s `name` is changed, the field value for the previous `name` is lost, because it calls `unregister`. This behaviour isn't documented and cannot be toggled off.

The original issue #13039 that #13041 was fixing has been fixed again by #13070. Thus making the changes in #13041 redundant.

This PR reverts the `useController.ts` changes done in #13041, and solely relies on the changes done in #13070 to fix the original #13039 issue.