### PR TITLE
fix: handle null parent when unregistering nested field

### DIFF
--- a/src/__tests__/nested-null.test.tsx
+++ b/src/__tests__/nested-null.test.tsx
@@ -3,27 +3,26 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { useForm } from '../useForm';
 
-function TestComponent({ onSubmit }: { onSubmit: (data: any) => void }) {
-  const { register, handleSubmit } = useForm<{
-    example: { inner?: string } | null;
-  }>({
-    defaultValues: {
-      example: null,
-    },
-  });
-
-  return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <input {...register('example.inner')} />
-      <button type="submit">Submit</button>
-    </form>
-  );
-}
-
 describe('nested null bug', () => {
   it('should not keep parent as null and allow nested value', async () => {
+    function TestComponent() {
+      const { register, handleSubmit } = useForm<{
+        example: { inner?: string } | null;
+      }>({
+        defaultValues: {
+          example: null,
+        },
+      });
+
+      return (
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <input {...register('example.inner')} />
+          <button type="submit">Submit</button>
+        </form>
+      );
+    }
     const onSubmit = jest.fn();
-    render(<TestComponent onSubmit={onSubmit} />);
+    render(<TestComponent />);
 
     fireEvent.click(screen.getByText('Submit'));
 
@@ -33,5 +32,35 @@ describe('nested null bug', () => {
         expect.anything(),
       );
     });
+  });
+
+  it('should not throw when unregistering nested field with null parent', () => {
+    function TestComponent() {
+      const { register, unregister } = useForm<{
+        example: { nested?: { deep?: string } } | null;
+      }>({
+        defaultValues: {
+          example: null,
+        },
+        shouldUnregister: false,
+      });
+
+      return (
+        <form>
+          <input {...register('example.nested.deep')} />
+          <button
+            type="button"
+            onClick={() => unregister('example.nested.deep')}
+          >
+            Unregister
+          </button>
+        </form>
+      );
+    }
+    render(<TestComponent />);
+
+    expect(() => {
+      fireEvent.click(screen.getByText('Unregister'));
+    }).not.toThrow();
   });
 });

--- a/src/utils/unset.ts
+++ b/src/utils/unset.ts
@@ -11,7 +11,12 @@ function baseGet(object: any, updatePath: (string | number)[]) {
   let index = 0;
 
   while (index < length) {
-    object = isNullOrUndefined(object) ? index++ : object[updatePath[index++]];
+    if (isNullOrUndefined(object)) {
+      object = undefined;
+      break;
+    }
+    object = object[updatePath[index]];
+    index++;
   }
 
   return object;

--- a/src/utils/unset.ts
+++ b/src/utils/unset.ts
@@ -1,5 +1,6 @@
 import isEmptyObject from './isEmptyObject';
 import isKey from './isKey';
+import isNullOrUndefined from './isNullOrUndefined';
 import isObject from './isObject';
 import isString from './isString';
 import isUndefined from './isUndefined';
@@ -10,7 +11,7 @@ function baseGet(object: any, updatePath: (string | number)[]) {
   let index = 0;
 
   while (index < length) {
-    object = isUndefined(object) ? index++ : object[updatePath[index++]];
+    object = isNullOrUndefined(object) ? index++ : object[updatePath[index++]];
   }
 
   return object;


### PR DESCRIPTION
When I was debugging the issue fixed by #13395, I came into this `unregister` bug because `useController` calls `unregister` when the `Controller` `name` changes:

```tsx
function Example() {
  const { register, unregister } = useForm({
    defaultValues: { example: null },
    shouldUnregister: false,
  });

  return (
    <form>
      <input {...register('example.nested.deep')} />
      <button onClick={() => unregister('example.nested.deep')}>
        Unregister
      </button>
    </form>
  );
}
```

Clicking the "Unregister" button would result in an error of `TypeError: Cannot read properties of null (reading 'nested')`.

This PR fixes it by updating the `baseGet` to use `isNullOrUndefined()` instead of just `isUndefined()`.