### PR TITLE
🐞 fix: prevent useWatch re-render when unrelated field validation is …

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -515,6 +515,7 @@ export type ReadFormState = {
     [K in keyof FormStateProxy]: boolean | 'all';
 } & {
     values?: boolean;
+    defaultValues?: boolean | 'all';
     isSubmitted?: boolean | 'all';
     submitCount?: boolean | 'all';
 };
@@ -1013,7 +1014,7 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:509:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:510:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/logic/shouldRenderFormState.test.ts
+++ b/src/__tests__/logic/shouldRenderFormState.test.ts
@@ -16,14 +16,24 @@ describe('shouldRenderFormState', () => {
     expect(result).toBe(true);
   });
 
-  it('should return true when changed keys are more', () => {
+  it('should return matched key when incoming state contains subscribed key among others', () => {
     const proxy = { isValid: true } as ReadFormState;
     const result = shouldRenderFormState(
       { isValid: false, isDirty: true },
       proxy,
       updateFormState,
     );
-    expect(result).toBe(true);
+    expect(result).toBeTruthy();
+  });
+
+  it('should not notify when incoming state keys do not overlap with subscribed keys', () => {
+    const proxy = { values: true } as ReadFormState;
+    const result = shouldRenderFormState(
+      { name: 'secondName', errors: {} },
+      proxy,
+      updateFormState,
+    );
+    expect(result).toBeUndefined();
   });
 
   it('should return true when changed state key is subscribed', () => {

--- a/src/__tests__/logic/shouldRenderFormState.test.ts
+++ b/src/__tests__/logic/shouldRenderFormState.test.ts
@@ -23,7 +23,7 @@ describe('shouldRenderFormState', () => {
       proxy,
       updateFormState,
     );
-    expect(result).toBeTruthy();
+    expect(result).toBe('isValid');
   });
 
   it('should not notify when incoming state keys do not overlap with subscribed keys', () => {

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -181,7 +181,7 @@ describe('useController', () => {
 
     fireEvent.blur(screen.getAllByRole('textbox')[0]);
 
-    expect(renderCounter).toEqual([4, 4]);
+    expect(renderCounter).toEqual([3, 4]);
   });
 
   describe('checkbox', () => {

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -587,7 +587,7 @@ describe('useWatch', () => {
       fireEvent.submit(screen.getByRole('button', { name: /submit/i }));
 
       await waitFor(() => expect(parentCount).toBe(1));
-      expect(childCount).toBe(2);
+      expect(childCount).toBe(1);
 
       parentCount = 0;
       childCount = 0;
@@ -667,8 +667,8 @@ describe('useWatch', () => {
       fireEvent.submit(screen.getByRole('button', { name: /submit/i }));
 
       await waitFor(() => expect(parentCount).toBe(1));
-      expect(childCount).toBe(2);
-      expect(childSecondCount).toBe(2);
+      expect(childCount).toBe(1);
+      expect(childSecondCount).toBe(1);
 
       parentCount = 0;
       childCount = 0;

--- a/src/__tests__/watch.test.tsx
+++ b/src/__tests__/watch.test.tsx
@@ -291,8 +291,8 @@ describe('Watch', () => {
     fireEvent.submit(screen.getByRole('button', { name: /submit/i }));
 
     await waitFor(() => expect(parentCount).toBe(1));
-    expect(childCount).toBe(2);
-    expect(childSecondCount).toBe(2);
+    expect(childCount).toBe(1);
+    expect(childSecondCount).toBe(1);
 
     parentCount = 0;
     childCount = 0;

--- a/src/logic/getProxyFormState.ts
+++ b/src/logic/getProxyFormState.ts
@@ -11,9 +11,7 @@ export default <
   localProxyFormState?: ReadFormState,
   isRoot = true,
 ) => {
-  const result = {
-    defaultValues: control._defaultValues,
-  } as typeof formState;
+  const result = {} as typeof formState;
 
   for (const key in formState) {
     Object.defineProperty(result, key, {
@@ -26,6 +24,22 @@ export default <
 
         localProxyFormState && (localProxyFormState[_key] = true);
         return formState[_key];
+      },
+    });
+  }
+
+  if (!('defaultValues' in formState)) {
+    Object.defineProperty(result, 'defaultValues', {
+      get: () => {
+        const _key = 'defaultValues' as keyof FormState<TFieldValues> &
+          keyof ReadFormState;
+
+        if (control._proxyFormState[_key] !== VALIDATION_MODE.all) {
+          control._proxyFormState[_key] = !isRoot || VALIDATION_MODE.all;
+        }
+
+        localProxyFormState && (localProxyFormState[_key] = true);
+        return control._defaultValues;
       },
     });
   }

--- a/src/logic/getProxyFormState.ts
+++ b/src/logic/getProxyFormState.ts
@@ -28,19 +28,5 @@ export default <
     });
   }
 
-  if (!('defaultValues' in formState)) {
-    Object.defineProperty(result, 'defaultValues', {
-      get: () => {
-        if (control._proxyFormState.defaultValues !== VALIDATION_MODE.all) {
-          control._proxyFormState.defaultValues =
-            !isRoot || VALIDATION_MODE.all;
-        }
-
-        localProxyFormState && (localProxyFormState.defaultValues = true);
-        return control._defaultValues;
-      },
-    });
-  }
-
   return result;
 };

--- a/src/logic/getProxyFormState.ts
+++ b/src/logic/getProxyFormState.ts
@@ -31,14 +31,12 @@ export default <
   if (!('defaultValues' in formState)) {
     Object.defineProperty(result, 'defaultValues', {
       get: () => {
-        const _key = 'defaultValues' as keyof FormState<TFieldValues> &
-          keyof ReadFormState;
-
-        if (control._proxyFormState[_key] !== VALIDATION_MODE.all) {
-          control._proxyFormState[_key] = !isRoot || VALIDATION_MODE.all;
+        if (control._proxyFormState.defaultValues !== VALIDATION_MODE.all) {
+          control._proxyFormState.defaultValues =
+            !isRoot || VALIDATION_MODE.all;
         }
 
-        localProxyFormState && (localProxyFormState[_key] = true);
+        localProxyFormState && (localProxyFormState.defaultValues = true);
         return control._defaultValues;
       },
     });

--- a/src/logic/shouldRenderFormState.ts
+++ b/src/logic/shouldRenderFormState.ts
@@ -21,7 +21,8 @@ export default <T extends FieldValues, K extends ReadFormState>(
 
   return (
     isEmptyObject(formState) ||
-    Object.keys(formState).length >= Object.keys(_proxyFormState).length ||
+    (isRoot &&
+      Object.keys(formState).length >= Object.keys(_proxyFormState).length) ||
     Object.keys(formState).find(
       (key) =>
         _proxyFormState[key as keyof ReadFormState] ===

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -151,6 +151,7 @@ export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
 
 export type ReadFormState = { [K in keyof FormStateProxy]: boolean | 'all' } & {
   values?: boolean;
+  defaultValues?: boolean | 'all';
   isSubmitted?: boolean | 'all';
   submitCount?: boolean | 'all';
 };

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import getProxyFormState from './logic/getProxyFormState';
 import type {
   FieldValues,
+  FormState,
   UseFormStateProps,
   UseFormStateReturn,
 } from './types';
@@ -51,7 +52,11 @@ export function useFormState<
     TTransformedValues
   >();
   const { control = formControl, disabled, name, exact } = props || {};
-  const [formState, updateFormState] = React.useState(control._formState);
+  const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
+    ...control._formState,
+    defaultValues:
+      control._defaultValues as FormState<TFieldValues>['defaultValues'],
+  });
   const _localProxyFormState = React.useRef({
     isDirty: false,
     isLoading: false,
@@ -74,6 +79,8 @@ export function useFormState<
             updateFormState({
               ...control._formState,
               ...formState,
+              defaultValues:
+                control._defaultValues as FormState<TFieldValues>['defaultValues'],
             });
         },
       }),

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -52,11 +52,13 @@ export function useFormState<
     TTransformedValues
   >();
   const { control = formControl, disabled, name, exact } = props || {};
-  const [formState, updateFormState] = React.useState<FormState<TFieldValues>>({
-    ...control._formState,
-    defaultValues:
-      control._defaultValues as FormState<TFieldValues>['defaultValues'],
-  });
+  const [formState, updateFormState] = React.useState<FormState<TFieldValues>>(
+    () => ({
+      ...control._formState,
+      defaultValues:
+        control._defaultValues as FormState<TFieldValues>['defaultValues'],
+    }),
+  );
   const _localProxyFormState = React.useRef({
     isDirty: false,
     isLoading: false,


### PR DESCRIPTION
### Description

Fixes #12925

`useWatch` subscribers re-render when unrelated field validation is triggered via `rules.deps`. This is a regression since v7.55.0 when `_subjects.values` and `_subjects.state` were merged.

### Root cause

In `shouldRenderFormState`, the condition `Object.keys(formState).length >= Object.keys(_proxyFormState).length` acts as a short-circuit that bypasses key-matching. When `trigger()` emits `{ errors: {} }` (1 key) and `useWatch` subscribes with `{ values: true }` (1 key), `1 >= 1` passes despite zero key overlap.

### Changes

- **`shouldRenderFormState.ts`**: Guard the size-based condition with `isRoot` so it only applies to the root `useForm` subscriber. Non-root subscribers now rely on actual key overlap matching.
- **`getProxyFormState.ts`**: `defaultValues` was set as a plain property instead of a tracked getter, so `useFormState` accessing `defaultValues` never registered a subscription. This was masked by the size-based condition but is now properly tracked.
- **Test updates**: Adjusted render count assertions that included spurious re-renders caused by the bug
