### PR TITLE
fix: recompute isDirty after re-registering a previously unregistered field

### DIFF
--- a/src/__tests__/useForm/unregister.test.tsx
+++ b/src/__tests__/useForm/unregister.test.tsx
@@ -1,4 +1,12 @@
-import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
 import { useForm } from '../../useForm';
 
@@ -51,5 +59,59 @@ describe('unregister', () => {
     });
 
     expect(result.current.getValues()).toEqual({});
+  });
+
+  it('should recompute isDirty after a field is unregistered and re-registered back to its default value (#13397)', async () => {
+    let isDirty: boolean | null = null;
+
+    const App = () => {
+      const { register, watch, formState } = useForm({
+        defaultValues: { showName: true, name: 'default' },
+        shouldUnregister: true,
+      });
+      isDirty = formState.isDirty;
+      const showName = watch('showName');
+
+      return (
+        <form>
+          <input type="checkbox" {...register('showName')} />
+          {showName && <input type="text" {...register('name')} />}
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    const checkbox = screen.getByRole('checkbox');
+
+    fireEvent.click(checkbox);
+    await waitFor(() => expect(isDirty).toBe(true));
+
+    fireEvent.click(checkbox);
+    await waitFor(() => expect(isDirty).toBe(false));
+  });
+
+  it('should not flip isDirty to true when a field with no defaultValue is registered from useEffect', async () => {
+    let isDirty: boolean | null = null;
+
+    const App = () => {
+      const {
+        register,
+        formState: { isDirty: isDirtyState },
+      } = useForm<{ firstName: string; lastName: string }>();
+
+      isDirty = isDirtyState;
+
+      React.useEffect(() => {
+        register('firstName');
+        register('lastName');
+      }, [register]);
+
+      return <form />;
+    };
+
+    render(<App />);
+
+    await waitFor(() => expect(isDirty).toBe(false));
   });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -334,6 +334,7 @@ export function createFormControl<
     const field: Field = get(_fields, name);
 
     if (field) {
+      const wasUnsetInFormValues = isUndefined(get(_formValues, name));
       const defaultValue = get(
         _formValues,
         name,
@@ -350,7 +351,27 @@ export function createFormControl<
           )
         : setFieldValue(name, defaultValue);
 
-      _state.mount && !_state.action && _setValid();
+      if (_state.mount && !_state.action) {
+        _setValid();
+
+        // Re-registering a field after a prior unregister puts its key back
+        // into _formValues, which can flip isDirty back to false (#13397).
+        // Only run when we are currently dirty, otherwise an initial register
+        // for a field with no defaultValue would flip isDirty to true. Reset
+        // paths repopulate _formValues before re-register, so the key is
+        // present then and this branch is skipped (preserves keepDirty).
+        if (
+          wasUnsetInFormValues &&
+          _formState.isDirty &&
+          (_proxyFormState.isDirty || _proxySubscribeFormState.isDirty)
+        ) {
+          const isDirty = _getDirty();
+          if (!isDirty) {
+            _formState.isDirty = false;
+            _subjects.state.next({ ..._formState });
+          }
+        }
+      }
     }
   };
 


### PR DESCRIPTION
Closes #13397.

When `useForm({ shouldUnregister: true })` (or an explicit `unregister` call) removes a field's key from `_formValues`, re-mounting the field calls `updateValidAndValue` which restores the key with its default value. But the form-level `isDirty` is not recomputed against the new `_formValues`, so a form that has returned to its default state still reports `isDirty: true`.

Repro from the issue's CodeSandbox: a checkbox conditionally renders a text input. Toggling the checkbox off unmounts the input (key removed from `_formValues`); toggling back on remounts it (key restored to default value). After the second toggle the form values match the defaults, but `isDirty` stays true.

Recompute `isDirty` inside `updateValidAndValue` when:

- the field key was missing from `_formValues` right before this register populated it (`wasUnsetInFormValues`), and
- a subscriber actually reads `isDirty` (proxy gate, mirrors the existing pattern in `updateTouchAndDirty`).

The `wasUnsetInFormValues` check scopes the change to the re-register-after-unregister case. The `reset()` path repopulates `_formValues` before each field re-registers, so the key is present at this point and the recompute is skipped, preserving `keepDirty: true` (verified against `reset.test.tsx`'s "should not reset if keepStateOption is specified" test, which still passes unchanged).

Test added in `src/__tests__/useForm/unregister.test.tsx`. Full `pnpm test` passes (the single unrelated `useController.test.tsx:1021` flake is pre-existing on master, also reproduces without these changes; will be fixed in a separate PR).
