### PR TITLE
📝 docs: fix JSDoc for IsNever, register, and getFieldState (#13410)

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -219,7 +219,7 @@ export type UseFormRegisterReturn<
  * @param name - the path name to the form field value, name is required and unique
  * @param options - register options include validation, disabled, unregister, value as and dependent validation
  *
- * @returns onChange, onBlur, name, ref, and native contribute attribute if browser validation is enabled.
+ * @returns onChange, onBlur, name, ref, and native HTML validation attributes if browser validation is enabled.
  *
  * @example
  * ```tsx
@@ -367,7 +367,7 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
  *
  * @param name - the path name to the form field value.
  *
- * @returns invalid, isDirty, isTouched and error object
+ * @returns invalid, isDirty, isTouched, isValidating, and error object
  *
  * @example
  * ```tsx

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -88,8 +88,8 @@ export type IsAny<T> = 0 extends 1 & T ? true : false;
  * Checks whether the type is never
  * @typeParam T - type which may be never
  * ```
- * IsAny<never> = true
- * IsAny<string> = false
+ * IsNever<never> = true
+ * IsNever<string> = false
  * ```
  */
 export type IsNever<T> = [T] extends [never] ? true : false;


### PR DESCRIPTION
Closes #13410.

This PR fixes three independent JSDoc inaccuracies in `src/types/utils.ts` and `src/types/form.ts`. 
These changes do not affect runtime behavior; they only impact IDE hover/IntelliSense and the generated API report.