### PR TITLE
fix: useFieldArray re-renders when setValue targets nested array path (#13260)

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -1589,4 +1589,45 @@ describe('setValue', () => {
       data: [{ id: true, name: true }],
     });
   });
+
+  it('should re-render useFieldArray fields when setValue targets a nested array path - issue #13260', () => {
+    type FormValues = {
+      items: { value: number }[];
+    };
+
+    const App = () => {
+      const { control, setValue } = useForm<FormValues>({
+        defaultValues: {
+          items: [{ value: 0 }, { value: 0 }, { value: 0 }],
+        },
+      });
+      const { fields } = useFieldArray({ control, name: 'items' });
+
+      return (
+        <div>
+          {fields.map((field, index) => (
+            <span key={field.id} data-testid={`item-${index}`}>
+              {field.value}
+            </span>
+          ))}
+          <button
+            type="button"
+            onClick={() => setValue('items.1.value', 42, { shouldDirty: true })}
+          >
+            update
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    expect(screen.getByTestId('item-1').textContent).toBe('0');
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /update/i }));
+    });
+
+    expect(screen.getByTestId('item-1').textContent).toBe('42');
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -868,6 +868,19 @@ export function createFormControl<
     if (!isValueUnchanged) {
       const watched = isWatched(name, _names);
 
+      if (!isFieldArray && isNameInFieldArray(_names.array, name)) {
+        const arrayName = [..._names.array].find(
+          (arrName) =>
+            name.startsWith(arrName + '.') &&
+            !isNaN(Number(name.slice(arrName.length + 1).split('.')[0])),
+        );
+        arrayName &&
+          _subjects.array.next({
+            name: arrayName,
+            values: cloneObject(_formValues),
+          });
+      }
+
       _subjects.state.next({
         ...(watched && _formState),
         name: _state.mount || watched ? name : undefined,


### PR DESCRIPTION
## Proposed Changes

`setValue('items.1.value', x)` writes to `_formValues` correctly but only emits on `_subjects.state`. `useFieldArray` subscribes to `_subjects.array`, so its rendered `fields[i]` snapshot stays stale until an `append`/`update`/`replace` forces a remount, contradicting the docs which explicitly recommend `setValue` for in-place updates without remount.

This change detects when a `setValue` target sits inside a registered field array (via the existing `_names.array` set + `isNameInFieldArray` helper) and additionally emits on `_subjects.array` with the array root path, mirroring the existing field-array-root branch. `useFieldArray` then re-renders in place.

Fixes #13260

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added a test that proves the fix works
- [x] New and existing tests pass locally with my changes (`useForm` + `useFieldArray` suites: 439 + 205 passing)

## Test plan

- [x] New regression test in `src/__tests__/useForm/setValue.test.tsx` (\"issue #13260\") asserts that `useFieldArray` re-renders the affected item after `setValue('items.1.value', 42)`
- [x] All 11 `useFieldArray` test suites still pass (205/205)
- [x] All 25 `useForm` test suites still pass (439/439)