### PR TITLE
fix: trigger() normalizes field-array root errors to .root path (#13104)

### DIFF
--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -11,9 +11,11 @@ import {
 import { VALIDATION_MODE } from '../../constants';
 import type {
   Control,
+  FieldErrors,
   FieldPath,
   FieldValues,
   FormState,
+  Resolver,
   UseFormGetFieldState,
 } from '../../types';
 import { useController } from '../../useController';
@@ -1036,7 +1038,7 @@ describe('trigger', () => {
   it('should put resolver errors for a registered field array under root - issue #13104', async () => {
     type FormValues = { items: { name: string }[] };
 
-    const resolver = async (values: FormValues) => {
+    const resolver: Resolver<FormValues> = async (values) => {
       if (!values.items || values.items.length < 1) {
         return {
           values: {},
@@ -1051,7 +1053,7 @@ describe('trigger', () => {
       return { values, errors: {} };
     };
 
-    let triggerErrors: any;
+    let triggerErrors: FieldErrors<FormValues> | undefined;
 
     const App = () => {
       const {
@@ -1060,7 +1062,7 @@ describe('trigger', () => {
         formState: { errors },
       } = useForm<FormValues>({
         defaultValues: { items: [] },
-        resolver: resolver as any,
+        resolver,
       });
 
       // Registers `items` in `_names.array` so RHF treats it as a field array root.

--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -17,6 +17,7 @@ import type {
   UseFormGetFieldState,
 } from '../../types';
 import { useController } from '../../useController';
+import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
 import { FormProvider } from '../../useFormContext';
 import { useFormState } from '../../useFormState';
@@ -1029,6 +1030,59 @@ describe('trigger', () => {
       expect(getFieldState('test1').isValidating).toBe(false);
       expect(getFieldState('test2.sub').isValidating).toBe(false);
       expect(formState.validatingFields).toStrictEqual({});
+    });
+  });
+
+  it('should put resolver errors for a registered field array under root - issue #13104', async () => {
+    type FormValues = { items: { name: string }[] };
+
+    const resolver = async (values: FormValues) => {
+      if (!values.items || values.items.length < 1) {
+        return {
+          values: {},
+          errors: {
+            items: {
+              type: 'min',
+              message: 'at_least_1_item',
+            },
+          },
+        };
+      }
+      return { values, errors: {} };
+    };
+
+    let triggerErrors: any;
+
+    const App = () => {
+      const {
+        control,
+        trigger,
+        formState: { errors },
+      } = useForm<FormValues>({
+        defaultValues: { items: [] },
+        resolver: resolver as any,
+      });
+
+      // Registers `items` in `_names.array` so RHF treats it as a field array root.
+      useFieldArray({ control, name: 'items' });
+
+      triggerErrors = errors;
+
+      return (
+        <button type="button" onClick={() => trigger('items')}>
+          trigger
+        </button>
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+    });
+
+    await waitFor(() => {
+      expect(triggerErrors.items?.root?.message).toBe('at_least_1_item');
     });
   });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -516,7 +516,13 @@ export function createFormControl<
       for (const name of names) {
         const error = get(errors, name);
         error
-          ? set(_formState.errors, name, error)
+          ? _names.array.has(name)
+            ? updateFieldArrayRootError(
+                _formState.errors,
+                { [name]: error },
+                name,
+              )
+            : set(_formState.errors, name, error)
           : unset(_formState.errors, name);
       }
     } else {


### PR DESCRIPTION
## Proposed Changes

`trigger()` and `handleSubmit()` write the same logical field-array root error to different paths:

- After `trigger('items')` (resolver path) the error sits at `errors.items.message`
- After `handleSubmit()` it ends up at `errors.items.root.message`

Consumers that read `useController({ name: 'items' }).fieldState.error` had to handle both `.message` and `.root.message` for the same validation outcome. This is the issue raised in #13104.

The cause is in `executeSchemaAndUpdateState` (`createFormControl.ts`), which writes the resolver's array error directly via `set(_formState.errors, name, error)` regardless of whether the name is registered as a field array. The non-resolver path (`executeBuiltInValidation`) already routes through `updateFieldArrayRootError` for `isFieldArrayRoot` names.

This change matches that branch: when the validated name is in `_names.array`, route the resolver error through `updateFieldArrayRootError` so the final path is consistently `errors.<arrayName>.root.message` regardless of entry point.

Fixes #13104

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added a test that proves the fix works
- [x] New and existing tests pass locally with my changes (438/438 in `useForm`, 205/205 in `useFieldArray`)

## Test plan

- [x] New regression test in `src/__tests__/useForm/trigger.test.tsx` (\"issue #13104\") asserts that `trigger('items')` with a resolver leaves errors at `items.root.message` when `items` is registered via `useFieldArray`
- [x] `useForm` test suites still pass (438/438)
- [x] `useFieldArray` test suites still pass (205/205)