### PR TITLE
fix: treat React elements as opaque leaves in deepEqual

### DIFF
--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -157,7 +157,9 @@ describe('deepEqual', () => {
   });
 
   it('should treat React elements as opaque and not recurse into internals', () => {
-    const REACT_ELEMENT_TYPE = Symbol.for ? Symbol.for('react.element') : 0xeac7;
+    const REACT_ELEMENT_TYPE = Symbol.for
+      ? Symbol.for('react.element')
+      : 0xeac7;
 
     const element1 = {
       $$typeof: REACT_ELEMENT_TYPE,

--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -155,4 +155,33 @@ describe('deepEqual', () => {
     expect(deepEqual({ value: NaN }, { value: 'NaN' })).toBeFalsy();
     expect(deepEqual([NaN], [0])).toBeFalsy();
   });
+
+  it('should treat React elements as opaque and not recurse into internals', () => {
+    const REACT_ELEMENT_TYPE = Symbol.for ? Symbol.for('react.element') : 0xeac7;
+
+    const element1 = {
+      $$typeof: REACT_ELEMENT_TYPE,
+      type: 'div',
+      key: null,
+      ref: null,
+      props: { children: 'Hello' },
+      _owner: { memoizedProps: { params: new Proxy({}, {}) } },
+    };
+
+    const element2 = {
+      $$typeof: REACT_ELEMENT_TYPE,
+      type: 'div',
+      key: null,
+      ref: null,
+      props: { children: 'World' },
+      _owner: { memoizedProps: { params: new Proxy({}, {}) } },
+    };
+
+    expect(deepEqual(element1, element2)).toBeFalsy();
+    expect(deepEqual(element1, element1)).toBeTruthy();
+
+    const formA = { label: element1, value: 'opt1' };
+    const formB = { label: element2, value: 'opt1' };
+    expect(deepEqual(formA, formB)).toBeFalsy();
+  });
 });

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -5,7 +5,11 @@ import isPrimitive from './isPrimitive';
 const REACT_ELEMENT_TYPE = Symbol.for ? Symbol.for('react.element') : 0xeac7;
 
 function isReactElement(obj: any): boolean {
-  return obj != null && typeof obj === 'object' && obj.$$typeof === REACT_ELEMENT_TYPE;
+  return (
+    obj != null &&
+    typeof obj === 'object' &&
+    obj.$$typeof === REACT_ELEMENT_TYPE
+  );
 }
 
 export default function deepEqual(

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -2,17 +2,34 @@ import isDateObject from './isDateObject';
 import isObject from './isObject';
 import isPrimitive from './isPrimitive';
 
+const REACT_ELEMENT_TYPE = Symbol.for ? Symbol.for('react.element') : 0xeac7;
+
+function isReactElement(obj: any): boolean {
+  return obj != null && typeof obj === 'object' && obj.$$typeof === REACT_ELEMENT_TYPE;
+}
+
 export default function deepEqual(
   object1: any,
   object2: any,
   _internal_visited = new WeakSet(),
 ) {
+  if (object1 === object2) {
+    return true;
+  }
+
   if (isPrimitive(object1) || isPrimitive(object2)) {
     return Object.is(object1, object2);
   }
 
   if (isDateObject(object1) && isDateObject(object2)) {
     return Object.is(object1.getTime(), object2.getTime());
+  }
+
+  // Treat React elements as opaque leaves to avoid traversing
+  // internal properties like _owner that may contain Proxies or
+  // deeply nested framework internals (e.g. Next.js params/searchParams).
+  if (isReactElement(object1) || isReactElement(object2)) {
+    return false;
   }
 
   const keys1 = Object.keys(object1);


### PR DESCRIPTION
Fixes #13415

When form values contain React elements (e.g. option objects with JSX labels), `deepEqual` recurses into internal React properties like `_owner`, which points at the current Fiber on client renders. In Next.js 16, this walks into `params`/`searchParams` Proxies and triggers `warnForSyncAccess` dev warnings.

**Changes:**

- Added `object1 === object2` reference equality check at the top of `deepEqual` — this is both a performance optimization and prevents any traversal of identical references
- Added `isReactElement` check using `$$typeof === Symbol.for('react.element')` to treat React elements as opaque leaves. When either argument is a React element, comparison falls back to reference equality (same ref = equal, different ref = not equal)

This prevents `deepEqual` from recursing into `_owner` Fiber trees and also avoids issues with any future changes that might break the accidental identity-equality protection.

**Test:** Added test case verifying React elements with different internal structures are treated as opaque — different elements return `false`, same reference returns `true`, and nested elements in form values don't cause recursion into `_owner`.
