### PR TITLE
Bugfix/setvalues usecontroller rerender issue

### DIFF
--- a/src/__tests__/useForm/setValues.test.tsx
+++ b/src/__tests__/useForm/setValues.test.tsx
@@ -5,9 +5,11 @@ import {
   render,
   renderHook,
   screen,
+  waitFor,
 } from '@testing-library/react';
 
 import { Controller } from '../../controller';
+import { useController } from '../../useController';
 import { useForm } from '../../useForm';
 
 describe('setValues', () => {
@@ -222,5 +224,98 @@ describe('setValues', () => {
     expect(screen.getByLabelText('firstName')).toHaveValue('John');
     expect(screen.getByLabelText('lastName')).toHaveValue('Smith');
     expect(screen.getByLabelText('city')).toHaveValue('New York');
+  });
+
+  it('should trigger re-render in useController components when using setValues', async () => {
+    function TestField({ control, name }: { control: any; name: string }) {
+      const { field } = useController({ name, control });
+
+      return (
+        <input
+          data-testid={name}
+          value={field.value ?? ''}
+          onChange={(e) => field.onChange(e.target.value)}
+        />
+      );
+    }
+
+    function App() {
+      const methods = useForm<{ field1: string; field2: string }>({
+        defaultValues: {
+          field1: 'initial1',
+          field2: 'initial2',
+        },
+        mode: 'onChange',
+      });
+
+      return (
+        <div>
+          <form>
+            <TestField control={methods.control} name="field1" />
+            <TestField control={methods.control} name="field2" />
+            <button
+              data-testid="submit"
+              disabled={!methods.formState.isValid}
+              type="button"
+            >
+              Submit
+            </button>
+          </form>
+          <button
+            data-testid="set-values"
+            type="button"
+            onClick={() => {
+              methods.setValues(
+                { field1: 'updated1', field2: 'updated2' },
+                { shouldValidate: true, shouldDirty: true },
+              );
+            }}
+          >
+            Set Values
+          </button>
+          <div data-testid="form-state">
+            isValid: {String(methods.formState.isValid)}
+          </div>
+        </div>
+      );
+    }
+
+    render(<App />);
+
+    const field1 = screen.getByTestId('field1');
+    const field2 = screen.getByTestId('field2');
+    const setValuesBtn = screen.getByTestId('set-values');
+    const submitBtn = screen.getByTestId('submit');
+    const formState = screen.getByTestId('form-state');
+
+    // Initial state
+    expect(field1).toHaveValue('initial1');
+    expect(field2).toHaveValue('initial2');
+
+    // Clear fields to make form invalid
+    fireEvent.change(field1, { target: { value: '' } });
+    fireEvent.change(field2, { target: { value: '' } });
+
+    await waitFor(() => {
+      expect(field1).toHaveValue('');
+      expect(field2).toHaveValue('');
+      expect(submitBtn).toBeDisabled();
+    });
+
+    // Click setValues button
+    fireEvent.click(setValuesBtn);
+
+    // Form state should be updated (this works)
+    await waitFor(() => {
+      expect(formState.textContent).toContain('isValid: true');
+    });
+
+    // BUG: DOM inputs are NOT updated even though form state is correct
+    // This demonstrates the bug where useController components don't re-render
+    await waitFor(() => {
+      expect(field1).toHaveValue('updated1');
+      expect(field2).toHaveValue('updated2');
+      expect(submitBtn).toBeEnabled();
+    });
   });
 });


### PR DESCRIPTION
# Bug: setValues doesn't trigger re-renders in useController components

We found this issue here:
 https://github.com/scaleway/ultraviolet/pull/6405/changes#diff-28ddd88366712fb65daf3c1d41a70aa3e2c5738a4ae3deafcd50d90785b85016R153

## Summary

When using `setValues` with components that use `useController`, the form state is updated correctly but the DOM does not re-render properly.

## Test Results

```bash
npm test -- src/__tests__/useForm/setValues.test.tsx --testNamePattern="should trigger re-render"
```

**Fails with:**
```
expect(element).toHaveValue('updated1')
Expected: updated1
Received: ''
HTML shows:
<input data-testid="field1" value="" />           ❌ Not updated
<input data-testid="field2" value="updated2" />   ✅ Updated
<div data-testid="form-state">isValid: true</div> ✅ Form state correct
```

## Key Findings

1. **Form state IS updated correctly** - `isValid` becomes `true`
2. **field2 IS updated** - Second field works
3. **field1 is NOT updated** - First field remains empty
4. **Inconsistent behavior** - Some fields update, others don't

## Expected Behavior

```typescript
setValues({ field1: 'a', field2: 'b' }, { shouldValidate: true })
// Should update:
// - formState.isValid ✅
// - field1.value ✅
// - field2.value ✅
```

## Actual Behavior

```typescript
setValues({ field1: 'a', field2: 'b' }, { shouldValidate: true })
// Updates:
// - formState.isValid ✅
// - field1.value ❌ (stays empty)
// - field2.value ✅
```

## Workaround

Use `setValue` (singular) for each field:

```typescript
setValue('field1', 'a', { shouldValidate: true })
setValue('field2', 'b', { shouldValidate: true })
```

## Impact

This bug affects:
- All custom field components using `useController`
- Bulk form updates (loading saved data, resetting forms)
- Form state consistency between internal state and UI
- Any library building on top of React Hook Form with custom field components

## Related

- Issue: (to be created)
- Documentation: https://react-hook-form.com/docs/useform/setvalues
- useController: https://react-hook-form.com/docs/usecontroller