### PR TITLE
Implemented fix, added tests

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -2823,5 +2823,140 @@ describe('useForm', () => {
         expect(screen.queryByText('required')).not.toBeInTheDocument(),
       );
     });
+
+    it('should use error message from object return value', async () => {
+      const App = () => {
+        const {
+          register,
+          formState: { errors },
+          handleSubmit,
+        } = useForm({
+          validate: ({ formValues }) => {
+            if (formValues.firstName) {
+              return true;
+            }
+
+            return {
+              firstName: {
+                message: 'first name is required',
+                type: 'required',
+              },
+            };
+          },
+          defaultValues: {
+            firstName: '',
+          },
+        });
+
+        return (
+          <form onSubmit={handleSubmit(() => {})}>
+            <input {...register('firstName')} />
+            <p data-testid="msg">{(errors as any).form?.firstName?.message}</p>
+            <button>submit</button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('msg').textContent).toBe(
+          'first name is required',
+        ),
+      );
+    });
+
+    it('should preserve custom error type from object return value', async () => {
+      let capturedErrors: any;
+
+      const App = () => {
+        const {
+          register,
+          formState: { errors },
+          handleSubmit,
+        } = useForm({
+          validate: ({ formValues }) => {
+            if (formValues.firstName) {
+              return true;
+            }
+
+            return { firstName: { message: 'err', type: 'customType' } };
+          },
+          defaultValues: {
+            firstName: '',
+          },
+        });
+
+        capturedErrors = errors;
+
+        return (
+          <form onSubmit={handleSubmit(() => {})}>
+            <input {...register('firstName')} />
+            <button>submit</button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect((capturedErrors as any).form?.firstName?.type).toBe(
+          'customType',
+        ),
+      );
+    });
+
+    it('should clear object return errors when form becomes valid', async () => {
+      const App = () => {
+        const {
+          register,
+          formState: { errors },
+          handleSubmit,
+        } = useForm({
+          validate: ({ formValues }) => {
+            if (formValues.firstName) {
+              return true;
+            }
+
+            return { firstName: { message: 'first name is required' } };
+          },
+          defaultValues: {
+            firstName: '',
+          },
+        });
+
+        return (
+          <form onSubmit={handleSubmit(() => {})}>
+            <input {...register('firstName')} />
+            <p data-testid="msg">{(errors as any).form?.firstName?.message}</p>
+            <button>submit</button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('msg').textContent).toBe(
+          'first name is required',
+        ),
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'test' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(screen.getByTestId('msg').textContent).toBe(''),
+      );
+    });
   });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -581,8 +581,8 @@ export function createFormControl<
 
           if (error) {
             setError(`${FORM_ERROR_TYPE}.${key}`, {
-              message: isString(result.message) ? result.message : '',
-              type: INPUT_VALIDATION_RULES.validate,
+              message: isString(error.message) ? error.message : '',
+              type: error.type || INPUT_VALIDATION_RULES.validate,
             });
           }
         }


### PR DESCRIPTION
Fixes issue #13436, ensures that when the validator returns an object, the message is preserved. Also, since the user is required to return a type on the object, made sure that it also is preserved (if specified, otherwise fallback to default)