### PR TITLE
test: fix duplicate-word typos in test descriptions

### DIFF
--- a/src/__tests__/logic/iterateFieldsByAction.test.ts
+++ b/src/__tests__/logic/iterateFieldsByAction.test.ts
@@ -138,7 +138,7 @@ describe('iterateFieldsByAction', () => {
     expect(focus).toHaveBeenCalledWith('last');
   });
 
-  it('should should recursively drill into objects and break out of all loops on first focus', () => {
+  it('should recursively drill into objects and break out of all loops on first focus', () => {
     const focus = jest.fn();
     const notFocus = jest.fn();
     iterateFieldsByAction(

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -1810,7 +1810,7 @@ describe('register', () => {
     ).toEqual('textarea');
   });
 
-  it('should should trigger deps validation', async () => {
+  it('should trigger deps validation', async () => {
     const App = () => {
       const { register, getValues, formState } = useForm<{
         firstName: string;
@@ -1853,7 +1853,7 @@ describe('register', () => {
     await waitForElementToBeRemoved(screen.queryByText('error'));
   });
 
-  it('should should trigger deps validation with schema validation', async () => {
+  it('should trigger deps validation with schema validation', async () => {
     const App = () => {
       type Form = {
         firstName: string;


### PR DESCRIPTION
Three duplicate-word typos in test descriptions:

- `src/__tests__/useForm/register.test.tsx:1813`
- `src/__tests__/useForm/register.test.tsx:1856`
- `src/__tests__/logic/iterateFieldsByAction.test.ts:141`
