### PR TITLE
🚗 perf(setValues): thread skipClone through setFieldValue

### DIFF
--- a/src/__tests__/useForm/setValues.test.tsx
+++ b/src/__tests__/useForm/setValues.test.tsx
@@ -254,4 +254,44 @@ describe('setValues', () => {
     expect(values.a).toBe(nextA);
     expect(values.b).toBe(nextB);
   });
+
+  it('should not deep clone the form tree per field in setFieldValue broadcasts during setValues', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ a: { nested: string } }>({
+        defaultValues: { a: { nested: '1' } },
+      }),
+    );
+
+    // Registering on a non-input element gives the field a ref with no `type`,
+    // which is the setFieldValue branch that broadcasts the form tree. The
+    // value stored in _formValues is reference-preserved regardless of
+    // skipClone, so this optimization is only observable at the broadcast
+    // boundary: the per-field snapshot must be the live tree, not an
+    // O(formSize) deep clone produced once per mounted field.
+    const ref = document.createElement('div');
+    act(() => {
+      result.current.register('a').ref(ref);
+    });
+
+    const deliveredValues: object[] = [];
+    const unsubscribe = result.current.subscribe({
+      formState: { values: true },
+      callback: (data) => deliveredValues.push(data.values),
+    });
+
+    await act(async () => {
+      result.current.setValues({ a: { nested: '10' } });
+    });
+    unsubscribe();
+
+    // The setFieldValue !ref.type branch and the _setValue broadcast both fire
+    // for this field, so a batch produces multiple notifications.
+    expect(deliveredValues.length).toBeGreaterThan(1);
+    // skipClone must be threaded through setFieldValue: every per-field
+    // broadcast reuses the one live form tree. A per-field deep clone would
+    // instead hand subscribers distinct object identities.
+    for (const values of deliveredValues) {
+      expect(values).toBe(deliveredValues[0]);
+    }
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -763,6 +763,7 @@ export function createFormControl<
     name: InternalFieldName,
     value: SetFieldValue<TFieldValues>,
     options: SetValueConfig = {},
+    skipClone = false,
   ) => {
     const field: Field = get(_fields, name);
     let fieldValue: unknown = value;
@@ -814,7 +815,7 @@ export function createFormControl<
           if (!fieldReference.ref.type) {
             _subjects.state.next({
               name,
-              values: cloneObject(_formValues),
+              values: skipClone ? _formValues : cloneObject(_formValues),
             });
           }
         }
@@ -841,6 +842,7 @@ export function createFormControl<
     name: T,
     value: K,
     options: U,
+    skipClone = false,
   ) => {
     for (const fieldKey in value) {
       if (!value.hasOwnProperty(fieldKey)) {
@@ -854,8 +856,8 @@ export function createFormControl<
         isObject(fieldValue) ||
         (field && !field._f)) &&
       !isDateObject(fieldValue)
-        ? setFieldValues(fieldName, fieldValue, options)
-        : setFieldValue(fieldName, fieldValue, options);
+        ? setFieldValues(fieldName, fieldValue, options, skipClone)
+        : setFieldValue(fieldName, fieldValue, options, skipClone);
     }
   };
 
@@ -904,9 +906,9 @@ export function createFormControl<
         isEmptyObject(cloneValue);
 
       if (!field || field._f || isNullOrUndefined(cloneValue) || isEmpty) {
-        setFieldValue(name, cloneValue, options);
+        setFieldValue(name, cloneValue, options, skipClone);
       } else {
-        setFieldValues(name, cloneValue, options);
+        setFieldValues(name, cloneValue, options, skipClone);
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #13445. That commit added a `skipClone` flag to `_setValue` so `setValues` could avoid per-field deep clones — but the flag stopped at `_setValue`. `_setValue` still delegates to `setFieldValue` / `setFieldValues`, and `setFieldValue` does its own `cloneObject(_formValues)` for the state-subject broadcast in the `!fieldReference.ref.type` branch. During `setValues`, that is still a full-tree deep clone **per mounted field** — the exact O(N × formSize) cost #13445 set out to remove.

This threads `skipClone` the rest of the way:

- `setFieldValue` and `setFieldValues` take a `skipClone = false` param.
- The default `false` keeps the reset path (`setFieldValue(name, defaultValue)`) and public `setValue` byte-for-byte unchanged.
- `_setValue` passes its own flag into both call sites, so only `setValues` (`skipClone: true`) skips this remaining clone.

Public API and types are unchanged.

## Test

The only observable effect of this change is object identity at the broadcast boundary (the stored form value is reference-preserved regardless of `skipClone`). The added regression test asserts the concept through the **public `subscribe` API**: every `values` payload delivered during a batch aliases the one live tree, rather than distinct per-field deep clones.

Verified the test fails without the threading and passes with it. 329 related tests (`setValues`, `setValue`, `reset`, `useFieldArray`, `subscribe`) pass; ESLint and Prettier clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)