### PR TITLE
🐞 fix(setValues): emit whole-form change without stale name/type

### DIFF
--- a/src/__tests__/useForm/setValues.test.tsx
+++ b/src/__tests__/useForm/setValues.test.tsx
@@ -105,6 +105,46 @@ describe('setValues', () => {
     expect(valueNotifications).toHaveLength(1);
   });
 
+  it('should notify the batch update as a whole-form change (no stale name/type)', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ a: string; b: string }>({
+        defaultValues: { a: '1', b: '2' },
+      }),
+    );
+
+    // Drive a single-field change first so `_formState.name`/`type` are
+    // polluted with a stale field label from the prior emit.
+    await act(async () => {
+      result.current.register('a');
+      result.current.setValue('a', 'changed', { shouldValidate: true });
+    });
+
+    const control = result.current.control as any;
+    const nextSpy = jest.spyOn(control._subjects.state, 'next');
+
+    await act(async () => {
+      result.current.setValues({
+        a: '10',
+        b: '20',
+      });
+    });
+
+    const valueNotifications = nextSpy.mock.calls.filter(
+      (call) =>
+        call[0] != null &&
+        typeof call[0] === 'object' &&
+        'values' in (call[0] as Record<string, unknown>),
+    );
+
+    // The terminal bulk emit must announce a whole-form change. Before the
+    // fix it spread the stale `_formState.name`/`type` left over from the
+    // prior single-field change, causing name-gated subscribers to skip it.
+    const terminal = valueNotifications.at(-1)![0] as Record<string, unknown>;
+    expect(terminal.name).toBeUndefined();
+    expect(terminal.type).toBeUndefined();
+    expect(terminal.values).toEqual({ a: '10', b: '20' });
+  });
+
   it('should update controlled input value when setValues is called', async () => {
     const Component = () => {
       const { control, setValues } = useForm({

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -951,7 +951,12 @@ export function createFormControl<
         );
       }
 
-      _subjects.state.next({ ..._formState, values: _formValues });
+      _subjects.state.next({
+        ..._formState,
+        name: undefined,
+        type: undefined,
+        values: _formValues,
+      });
     }
   };
 


### PR DESCRIPTION
## Problem

`setValues` ends with a single terminal notification intended to announce a whole-form change:

```ts
_subjects.state.next({ ..._formState, values: _formValues });
```

But `..._formState` carries a **stale `name` (and `type`)**. The validation / field-state path merges `name` back into `_formState`:

```ts
// _updateValidAndValue / field-state update
_formState = { ..._formState, ...updatedFormState }; // updatedFormState includes `name`
```

So after any prior single-field interaction, `_formState.name` holds that field's name. The bulk emit then re-broadcasts it, and `watch`/`subscribe` consumers read `name`/`type` straight off the payload. Subscribers gated on the notification name (e.g. `if (!name || name.startsWith('items')) recompute()`) see a stale single-field `name`, treat the bulk write as an unrelated single-field change, and **skip the recompute** — so values written via `setValues` never get re-derived/rendered.

`reset` doesn't hit this because it emits a clean object (no `name` ⇒ `undefined`).

## Fix

Make the bulk emit explicitly announce a whole-form change with `name`/`type` of `undefined`, matching `reset` semantics:

```ts
_subjects.state.next({
  ..._formState,
  name: undefined,
  type: undefined,
  values: _formValues,
});
```

## Test

Adds a regression test that pollutes `_formState` via a prior `setValue(..., { shouldValidate: true })`, then asserts the terminal `setValues` notification has `name`/`type` undefined with the full updated values. Verified it fails on the previous code and passes with the fix.

Existing `setValues`, `setValue`, and `reset` suites remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)