### PR TITLE
🧪 test(useFieldArray): regression coverage for descendant setValue key thrashing (#13420)

### DIFF
--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -1372,6 +1372,77 @@ describe('useFieldArray', () => {
       },
     );
 
+    it('should not remount field-array rows on consecutive descendant setValue calls (key thrashing regression, #13420)', async () => {
+      const mountCounts: number[] = [0, 0, 0];
+
+      const Row = ({
+        index,
+        register,
+      }: {
+        index: number;
+        register: UseFormReturn<{
+          test: { name: string }[];
+        }>['register'];
+      }) => {
+        React.useEffect(() => {
+          mountCounts[index] += 1;
+        }, [index]);
+
+        return <input {...register(`test.${index}.name` as const)} />;
+      };
+
+      let setValue: UseFormReturn<{
+        test: { name: string }[];
+      }>['setValue'];
+
+      const Component = () => {
+        const {
+          register,
+          control,
+          setValue: tempSetValue,
+        } = useForm({
+          defaultValues: {
+            test: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+          },
+        });
+        const { fields } = useFieldArray({ name: 'test', control });
+
+        setValue = tempSetValue;
+
+        return (
+          <form>
+            {fields.map((field, i) => (
+              <Row key={field.id} index={i} register={register} />
+            ))}
+          </form>
+        );
+      };
+
+      render(<Component />);
+
+      // Each row mounts exactly once on initial render.
+      expect(mountCounts).toEqual([1, 1, 1]);
+
+      // These are sibling-field writes on the same rows. useFieldArray is
+      // supposed to decouple row rendering from descendant value changes, so
+      // none of the rows should unmount/remount.
+      await act(async () => {
+        setValue('test.0.name', 'a1');
+      });
+      await act(async () => {
+        setValue('test.1.name', 'b1');
+      });
+      await act(async () => {
+        setValue('test.2.name', 'c1');
+      });
+
+      // When useFieldArray receives an array notification for the `test` root
+      // on a descendant setValue, it regenerates every field id, so React
+      // unmounts and remounts every row on each call -> mount counts climb
+      // (key thrashing, the regression introduced by #13420).
+      expect(mountCounts).toEqual([1, 1, 1]);
+    });
+
     it.each(['dirtyFields'])(
       'should unset name from dirtyFieldRef if array field values are not different with default value when formState.%s is defined',
       (property) => {

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -1443,6 +1443,60 @@ describe('useFieldArray', () => {
       expect(mountCounts).toEqual([1, 1, 1]);
     });
 
+    it('should not re-render the useFieldArray host on a descendant setValue (#13420)', async () => {
+      let renderCount = 0;
+
+      let setValue: UseFormReturn<{
+        test: { name: string }[];
+      }>['setValue'];
+
+      const Component = () => {
+        const {
+          register,
+          control,
+          setValue: tempSetValue,
+        } = useForm({
+          defaultValues: {
+            test: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+          },
+        });
+        const { fields } = useFieldArray({ name: 'test', control });
+
+        setValue = tempSetValue;
+        renderCount += 1;
+
+        return (
+          <form>
+            {fields.map((field, i) => (
+              <input key={field.id} {...register(`test.${i}.name` as const)} />
+            ))}
+          </form>
+        );
+      };
+
+      render(<Component />);
+
+      const rendersAfterMount = renderCount;
+
+      // A descendant write only changes a single leaf value; it must not push
+      // a new array snapshot into useFieldArray, so the component owning the
+      // field array should not re-render.
+      await act(async () => {
+        setValue('test.0.name', 'a1');
+      });
+      await act(async () => {
+        setValue('test.1.name', 'b1');
+      });
+      await act(async () => {
+        setValue('test.2.name', 'c1');
+      });
+
+      // #13420 emitted an array notification for the `test` root on every
+      // descendant setValue, which called setFields and re-rendered the host
+      // on every keystroke-equivalent write.
+      expect(renderCount).toBe(rendersAfterMount);
+    });
+
     it.each(['dirtyFields'])(
       'should unset name from dirtyFieldRef if array field values are not different with default value when formState.%s is defined',
       (property) => {


### PR DESCRIPTION
## Proposed Changes

Adds regression coverage for the `useFieldArray` behavior that [#13420](https://github.com/react-hook-form/react-hook-form/pull/13420) regressed (and which is currently reverted on `master`).

#13420 made nested `setValue` emit an array notification for **every** matching registered field-array root. For a registered `useFieldArray({ name: 'test' })`, that meant a descendant write like `setValue('test.0.name', ...)` pushed a fresh array snapshot into the hook, which:

1. **re-rendered the field-array host** on every descendant write, and
2. **regenerated every field `id`**, thrashing React keys so every row unmounted and remounted.

This defeats the core purpose of `useFieldArray` — decoupling row rendering from descendant value changes.

These tests are **green on `master`** (where #13420 is reverted, so descendant `setValue` no longer emits an array notification) and turn **red** if that "notify all matching array roots on nested setValue" behavior is reintroduced.

### Tests added (`src/__tests__/useFieldArray.test.tsx`)

- **`should not remount field-array rows on consecutive descendant setValue calls`** — each row is a child component with a `useEffect` mount counter; three descendant `setValue` calls must not change mount counts (`[1, 1, 1]`). Verified to fail with `[4, 4, 4]` against a tree containing #13420.
- **`should not re-render the useFieldArray host on a descendant setValue`** — counts renders of the component owning `useFieldArray`; descendant `setValue` must not re-render it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — regression coverage only, no source changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)