### PR TITLE
🐞 fix(setValues): don't re-grow field array when removing an element

### DIFF
--- a/src/__tests__/useForm/setValues.test.tsx
+++ b/src/__tests__/useForm/setValues.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@testing-library/react';
 
 import { Controller } from '../../controller';
+import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
 
 describe('setValues', () => {
@@ -333,5 +334,83 @@ describe('setValues', () => {
     for (const values of deliveredValues) {
       expect(values).toBe(deliveredValues[0]);
     }
+  });
+
+  it('should not leave a stale element behind when setValues removes a field-array item', async () => {
+    let getValues: ReturnType<
+      typeof useForm<{ test: { name: string }[] }>
+    >['getValues'];
+
+    let setValues: ReturnType<
+      typeof useForm<{ test: { name: string }[] }>
+    >['setValues'];
+
+    const Component = () => {
+      const {
+        register,
+        control,
+        getValues: tempGetValues,
+        setValues: tempSetValues,
+      } = useForm({
+        defaultValues: {
+          test: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+        },
+      });
+      const { fields } = useFieldArray({ name: 'test', control });
+
+      getValues = tempGetValues;
+      setValues = tempSetValues;
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`test.${i}.name` as const)} />
+          ))}
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    // Shrink the array via the batch API. The removed row's input is still
+    // mounted when setValues iterates _names.mount, so its leaf path must not
+    // be written back and re-grow the array with a phantom { name: undefined }.
+    await act(async () => {
+      setValues({ test: [{ name: 'a' }, { name: 'b' }] });
+    });
+
+    expect(getValues('test')).toEqual([{ name: 'a' }, { name: 'b' }]);
+  });
+
+  it('should still propagate an explicitly set undefined value to a mounted field', async () => {
+    let getValues: ReturnType<typeof useForm<{ name?: string }>>['getValues'];
+
+    let setValues: ReturnType<typeof useForm<{ name?: string }>>['setValues'];
+
+    const Component = () => {
+      const {
+        register,
+        getValues: tempGetValues,
+        setValues: tempSetValues,
+      } = useForm<{ name?: string }>({
+        defaultValues: { name: 'a' },
+      });
+
+      getValues = tempGetValues;
+      setValues = tempSetValues;
+
+      return <input {...register('name')} />;
+    };
+
+    render(<Component />);
+
+    // undefined is a valid field value: an explicitly provided undefined leaf
+    // is present in the tree (own key) and must clear the mounted input.
+    await act(async () => {
+      setValues({ name: undefined });
+    });
+
+    expect(getValues('name')).toBeUndefined();
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -939,12 +939,35 @@ export function createFormControl<
       };
 
       for (const fieldName of _names.mount) {
-        _setValue(
-          fieldName as FieldPath<TFieldValues>,
-          get(updatedFormValues, fieldName),
-          {},
-          true,
-        );
+        const segments = isKey(fieldName)
+          ? [fieldName]
+          : stringToPath(fieldName);
+        let container: any = _formValues;
+        let pathExists = true;
+
+        // Walk the merged tree by own keys so a present-but-undefined leaf
+        // (a legitimate value) is still synced, while a path that no longer
+        // resolves -- e.g. a field-array element removed by shrinking the
+        // array -- is skipped. Pushing the latter through _setValue would let
+        // setFieldValue re-create the path and re-grow the array with a
+        // phantom { ...: undefined } entry.
+        for (const segment of segments) {
+          if (
+            container === null ||
+            typeof container !== 'object' ||
+            !Object.prototype.hasOwnProperty.call(container, segment)
+          ) {
+            pathExists = false;
+            break;
+          }
+          container = container[segment];
+        }
+
+        if (!pathExists) {
+          continue;
+        }
+
+        _setValue(fieldName as FieldPath<TFieldValues>, container, {}, true);
       }
 
       _subjects.state.next({


### PR DESCRIPTION
## Summary

Calling the `setValues` batch API with a shortened field-array (removing an element) left a phantom `{ ...: undefined }` entry behind, re-growing the array back to its original length.

### Root cause

`setValues` merges the shrunk array into `_formValues` correctly, then loops over `_names.mount`. The removed row's leaf path (e.g. `test.2.name`) is still in `_names.mount` because React hasn't unmounted/re-rendered yet, so it gets pushed through `_setValue`. `setFieldValue`'s unconditional `set(_formValues, name, …)` then re-creates the path, re-growing the array.

### Fix

The loop now walks the merged tree by own keys:
- A path that no longer resolves (a removed array index) is **skipped**.
- A present-but-`undefined` leaf is **still synced**, since `undefined` is a valid field value (e.g. `setValues({ a: undefined })` must still clear a mounted input).

It also reads the merged-authoritative value instead of the raw partial, so unspecified top-level keys are no longer clobbered.

## Tests

Added to `src/__tests__/useForm/setValues.test.tsx`:
1. `should not leave a stale element behind when setValues removes a field-array item` — regression repro (red before the fix).
2. `should still propagate an explicitly set undefined value to a mounted field` — guards against the structural check over-skipping legitimate `undefined` clears.

Full suite: **1116/1116 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)