### PR TITLE
fix(subscribe): report isDirty consistently with formState

### DIFF
--- a/src/__tests__/useForm/subscribe.test.tsx
+++ b/src/__tests__/useForm/subscribe.test.tsx
@@ -281,4 +281,50 @@ describe('subscribe', () => {
     expect(callbackFn).toHaveBeenCalledTimes(1);
     expect(capturedValues).toEqual({ test: 'hello' });
   });
+
+  it('should report isDirty as true when subscribed values differ from defaultValues', async () => {
+    let capturedIsDirty: boolean | undefined;
+
+    const App = () => {
+      const { register, subscribe } = useForm({
+        defaultValues: {
+          name: '',
+          description: '',
+        },
+      });
+
+      React.useEffect(() => {
+        return subscribe({
+          formState: {
+            values: true,
+          },
+          callback: (data) => {
+            capturedIsDirty = data.isDirty;
+          },
+        });
+      }, [subscribe]);
+
+      return (
+        <form>
+          <input {...register('name')} />
+          <input {...register('description')} />
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    // Make the form dirty through one field, then blur it.
+    fireEvent.input(screen.getAllByRole('textbox')[1], {
+      target: { name: 'description', value: 'a description' },
+    });
+    fireEvent.blur(screen.getAllByRole('textbox')[1]);
+
+    // Editing another field must keep isDirty true as values still differ.
+    fireEvent.input(screen.getAllByRole('textbox')[0], {
+      target: { name: 'name', value: 'a name' },
+    });
+
+    expect(capturedIsDirty).toBe(true);
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1312,6 +1312,10 @@ export function createFormControl<
             values: snapshot,
             ..._formState,
             ...formState,
+            // `_formState.isDirty` is only recomputed when a consumer subscribes
+            // to `isDirty`, so deliver the canonical value to keep the subscribe
+            // path consistent with `formState.isDirty`/`useFormState`.
+            isDirty: _getDirty(),
             defaultValues:
               _defaultValues as FormState<TFieldValues>['defaultValues'],
           });


### PR DESCRIPTION
Closes #13093

## Problem
`form.subscribe(...)` delivered a stale `isDirty` when the subscriber did not explicitly select `isDirty` (e.g. subscribing only to `values`, as in the issue's reproduction). It reported `false` even when current `values` differ from `defaultValues`.

## Cause
`_formState.isDirty` is only recomputed in `updateTouchAndDirty` when a consumer is subscribed to `isDirty`. Subscribers that read `isDirty` from the delivered payload without selecting it received the stale value, diverging from `formState.isDirty` / `useFormState`.

## Fix
Deliver the canonical `_getDirty()` value in the `subscribe` callback so the subscribe path stays consistent with `formState.isDirty`. `_getDirty()` uses the same deep-equality comparison as the rest of the dirty logic and is side-effect free when called with no arguments.

## Tests
Added a regression test in `src/__tests__/useForm/subscribe.test.tsx` that sets `defaultValues`, dirties a field, blurs it, edits another field, and asserts the subscribe callback reports `isDirty === true`. Full suite passes (1111 tests).