### PR TITLE
fix: preserve values with shouldUnregister

### DIFF
--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -379,34 +379,6 @@ describe('validateField', () => {
           _f: {
             mount: true,
             name: 'test',
-            valueAsNumber: true,
-            ref: { name: 'test', value: 'e' },
-            required: true,
-          },
-        },
-        new Set(),
-        {
-          test: NaN,
-        },
-        false,
-      ),
-    ).toEqual({
-      test: {
-        type: 'required',
-        message: '',
-        ref: {
-          name: 'test',
-          value: 'e',
-        },
-      },
-    });
-
-    expect(
-      await validateField(
-        {
-          _f: {
-            mount: true,
-            name: 'test',
             ref: { name: 'test', type: 'file', value: '' },
             required: true,
             value: {},

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -2273,49 +2273,46 @@ describe('useForm', () => {
     });
   });
 
-  it(
-    'should submit mounted values from values prop when shouldUnregister is true',
-    async () => {
-      const onSubmit = jest.fn();
-      const onInvalid = jest.fn();
+  it('should submit mounted values from values prop when shouldUnregister is true', async () => {
+    const onSubmit = jest.fn();
+    const onInvalid = jest.fn();
 
-      const App = () => {
-        const { register, handleSubmit } = useForm<{
-          firstName: string;
-          age: string;
-        }>({
-          values: {
-            firstName: 'test',
-            age: '',
-          },
-          shouldUnregister: true,
-        });
+    const App = () => {
+      const { register, handleSubmit } = useForm<{
+        firstName: string;
+        age: string;
+      }>({
+        values: {
+          firstName: 'test',
+          age: '',
+        },
+        shouldUnregister: true,
+      });
 
-        return (
-          <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
-            <input {...register('firstName', { required: true })} />
-            <button>submit</button>
-          </form>
-        );
-      };
-
-      render(<App />);
-
-      expect(screen.getByRole('textbox')).toHaveValue('test');
-
-      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
-
-      await waitFor(() =>
-        expect(onSubmit).toHaveBeenCalledWith(
-          {
-            firstName: 'test',
-          },
-          expect.anything(),
-        ),
+      return (
+        <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+          <input {...register('firstName', { required: true })} />
+          <button>submit</button>
+        </form>
       );
-      expect(onInvalid).not.toHaveBeenCalled();
-    },
-  );
+    };
+
+    render(<App />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('test');
+
+    fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          firstName: 'test',
+        },
+        expect.anything(),
+      ),
+    );
+    expect(onInvalid).not.toHaveBeenCalled();
+  });
 
   it('should only update async form values which are not interacted', async () => {
     type FormValues = {

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -2273,46 +2273,49 @@ describe('useForm', () => {
     });
   });
 
-  it('should submit mounted values when shouldUnregister is true', async () => {
-    const onSubmit = jest.fn();
-    const onInvalid = jest.fn();
+  it(
+    'should submit mounted values from values prop when shouldUnregister is true',
+    async () => {
+      const onSubmit = jest.fn();
+      const onInvalid = jest.fn();
 
-    const App = () => {
-      const { register, handleSubmit } = useForm<{
-        firstName: string;
-        age: string;
-      }>({
-        values: {
-          firstName: 'test',
-          age: '',
-        },
-        shouldUnregister: true,
-      });
+      const App = () => {
+        const { register, handleSubmit } = useForm<{
+          firstName: string;
+          age: string;
+        }>({
+          values: {
+            firstName: 'test',
+            age: '',
+          },
+          shouldUnregister: true,
+        });
 
-      return (
-        <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
-          <input {...register('firstName', { required: true })} />
-          <button>submit</button>
-        </form>
+        return (
+          <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+            <input {...register('firstName', { required: true })} />
+            <button>submit</button>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      expect(screen.getByRole('textbox')).toHaveValue('test');
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          {
+            firstName: 'test',
+          },
+          expect.anything(),
+        ),
       );
-    };
-
-    render(<App />);
-
-    expect(screen.getByRole('textbox')).toHaveValue('test');
-
-    fireEvent.click(screen.getByRole('button', { name: 'submit' }));
-
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(
-        {
-          firstName: 'test',
-        },
-        expect.anything(),
-      ),
-    );
-    expect(onInvalid).not.toHaveBeenCalled();
-  });
+      expect(onInvalid).not.toHaveBeenCalled();
+    },
+  );
 
   it('should only update async form values which are not interacted', async () => {
     type FormValues = {

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -2273,6 +2273,47 @@ describe('useForm', () => {
     });
   });
 
+  it('should submit mounted values when shouldUnregister is true', async () => {
+    const onSubmit = jest.fn();
+    const onInvalid = jest.fn();
+
+    const App = () => {
+      const { register, handleSubmit } = useForm<{
+        firstName: string;
+        age: string;
+      }>({
+        values: {
+          firstName: 'test',
+          age: '',
+        },
+        shouldUnregister: true,
+      });
+
+      return (
+        <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+          <input {...register('firstName', { required: true })} />
+          <button>submit</button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('test');
+
+    fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        {
+          firstName: 'test',
+        },
+        expect.anything(),
+      ),
+    );
+    expect(onInvalid).not.toHaveBeenCalled();
+  });
+
   it('should only update async form values which are not interacted', async () => {
     type FormValues = {
       test: string;

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1674,11 +1674,19 @@ export function createFormControl<
         }
       }
 
-      _formValues = _options.shouldUnregister
-        ? keepStateOptions.keepDefaultValues
+      if (_options.shouldUnregister) {
+        _formValues = keepStateOptions.keepDefaultValues
           ? (cloneObject(_defaultValues) as TFieldValues)
-          : ({} as TFieldValues)
-        : (cloneObject(values) as TFieldValues);
+          : ({} as TFieldValues);
+
+        if (keepStateOptions.keepFieldsRef) {
+          for (const fieldName of _names.mount) {
+            set(_formValues, fieldName, get(values, fieldName));
+          }
+        }
+      } else {
+        _formValues = cloneObject(values) as TFieldValues;
+      }
 
       _subjects.array.next({
         values: { ...values },


### PR DESCRIPTION
## Proposed Changes

Fixes #13314

When `useForm({ values, shouldUnregister: true })` receives values, the reset path updates the mounted field refs and then clears `_formValues` because `shouldUnregister` is enabled. That leaves the input displaying the `values` prop while submit/validation reads an empty form value.

This keeps `_formValues` populated from currently mounted field names when the `values` prop reset uses `keepFieldsRef`, so mounted fields submit correctly while unmounted keys from `values` are still excluded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

Local checks run:

- `nvm exec 22 ./node_modules/.bin/jest --config ./scripts/jest/jest.config.js src/__tests__/useForm.test.tsx --runInBand --runTestsByPath`
- `nvm exec 22 ./node_modules/.bin/jest --config ./scripts/jest/jest.config.js src/__tests__/useForm.test.tsx src/__tests__/useForm/reset.test.tsx src/__tests__/useForm/formState.test.tsx src/__tests__/useFormState.test.tsx --runInBand --runTestsByPath`
- `nvm exec 22 ./node_modules/.bin/tsc --noEmit`
- `nvm exec 22 ./node_modules/.bin/tsc -p src/__typetest__/tsconfig.json`
- `nvm exec 22 ./node_modules/.bin/eslint src/logic/createFormControl.ts src/__tests__/useForm.test.tsx`
- `nvm exec 22 ./node_modules/.bin/eslint . --cache` exits 0 with the existing repo warnings
- `nvm exec 22 ./node_modules/.bin/prettier --config .prettierrc --check src/logic/createFormControl.ts src/__tests__/useForm.test.tsx`
- `nvm exec 22 ./node_modules/.bin/rimraf dist && nvm exec 22 ./node_modules/.bin/rollup --bundleConfigAsCjs -c ./scripts/rollup/rollup.config.js && nvm exec 22 node ./scripts/rollup/assert-esm-exports.mjs && nvm exec 22 node ./scripts/rollup/assert-cjs-exports.cjs`
- `nvm exec 22 ./node_modules/.bin/bundlewatch`

`nvm exec 22 ./node_modules/.bin/jest --config ./scripts/jest/jest.config.js --ci --runInBand` currently fails in the existing `src/__tests__/logic/validateField.test.tsx` valueAsNumber/NaN required assertion. The same isolated test fails under Node 22 without touching `validateField`, so I left that unrelated path out of this PR.
