### PR TITLE
fix: deepEqual short-circuits on host objects with no own keys

### DIFF
--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -169,6 +169,34 @@ describe('deepEqual', () => {
     ).toBeTruthy();
   });
 
+  it('should distinguish distinct File/Blob instances with no own enumerable keys (issue #13483)', () => {
+    const a = new File(['a'], 'a.svg', { type: 'image/svg+xml' });
+    const b = new File(['b'], 'b.jpg', { type: 'image/jpeg' });
+
+    expect(deepEqual(a, b)).toBeFalsy();
+    expect(deepEqual(a, a)).toBeTruthy();
+
+    const blobA = new Blob(['a'], { type: 'text/plain' });
+    const blobB = new Blob(['b'], { type: 'text/plain' });
+
+    expect(deepEqual(blobA, blobB)).toBeFalsy();
+    expect(deepEqual(blobA, blobA)).toBeTruthy();
+  });
+
+  it('should distinguish distinct Map/Set instances with no own enumerable keys', () => {
+    const m1 = new Map([['k', 1]]);
+    const m2 = new Map([['k', 2]]);
+
+    expect(deepEqual(m1, m2)).toBeFalsy();
+    expect(deepEqual(m1, m1)).toBeTruthy();
+
+    const s1 = new Set([1]);
+    const s2 = new Set([2]);
+
+    expect(deepEqual(s1, s2)).toBeFalsy();
+    expect(deepEqual(s1, s1)).toBeTruthy();
+  });
+
   it('should return false when comparing NaN with other values', () => {
     expect(deepEqual({ value: NaN }, { value: 0 })).toBeFalsy();
     expect(deepEqual({ value: NaN }, { value: undefined })).toBeFalsy();

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -26,6 +26,16 @@ export default function deepEqual(
     return false;
   }
 
+  if (
+    keys1.length === 0 &&
+    !Array.isArray(object1) &&
+    !Array.isArray(object2) &&
+    (Object.getPrototypeOf(object1) !== Object.prototype ||
+      Object.getPrototypeOf(object2) !== Object.prototype)
+  ) {
+    return Object.is(object1, object2);
+  }
+
   if (visited.has(object1) || visited.has(object2)) {
     return true;
   }


### PR DESCRIPTION
Closes #13483.

`Object.keys()` on a `File` / `Blob` / `FormData` / `Map` / `Set` returns `[]`, because all their state lives on prototype getters. `deepEqual`'s empty-keys loop then falls through to `return true`, so two distinct host-object instances compare equal.

Pre-7.76.0 this was harmless because the `_formValues` write in `setValue` ran unconditionally. #13422 wrapped it in `if (!isValueUnchanged)`, which makes the false positive observable: a second `setValue('avatar', anotherFile)` is dropped, the resolver re-runs against the stale `File`, and the previous validation error never clears. Reporter's repro on the issue.

The fix: when both sides have zero own enumerable keys, neither is an array, and at least one's prototype isn't `Object.prototype`, fall back to `Object.is`. Plain `{}` still equals `{}` via the (empty) loop, and `[]` still equals `[]`.

Added two regression cases to `deepEqual.test.ts` covering `File` / `Blob` and `Map` / `Set`. Full suite (1133 tests) green locally.