### PR TITLE
Fix File setValue overwrites in deepEqual

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -99,6 +99,17 @@ describe('setValue', () => {
     });
   });
 
+  it('should overwrite File values for unregistered fields', () => {
+    const { result } = renderHook(() => useForm<{ avatar: File }>());
+    const fileA = new File(['a'], 'a.svg', { type: 'image/svg+xml' });
+    const fileB = new File(['b'], 'b.jpg', { type: 'image/jpeg' });
+
+    act(() => result.current.setValue('avatar', fileA));
+    act(() => result.current.setValue('avatar', fileB));
+
+    expect(result.current.getValues('avatar')).toBe(fileB);
+  });
+
   it('should set value of multiple checkbox input correctly', async () => {
     const { result } = renderHook(() => useForm<{ test: string[] }>());
 

--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -176,4 +176,22 @@ describe('deepEqual', () => {
     expect(deepEqual({ value: NaN }, { value: 'NaN' })).toBeFalsy();
     expect(deepEqual([NaN], [0])).toBeFalsy();
   });
+
+  it('should compare empty non-plain objects by reference', () => {
+    class EmptyObject {}
+
+    const file = new File(['a'], 'a.svg', { type: 'image/svg+xml' });
+
+    expect(deepEqual(file, file)).toBeTruthy();
+    expect(
+      deepEqual(file, new File(['b'], 'b.jpg', { type: 'image/jpeg' })),
+    ).toBeFalsy();
+    expect(deepEqual(new Blob(['a']), new Blob(['a']))).toBeFalsy();
+    expect(deepEqual(new FormData(), new FormData())).toBeFalsy();
+    expect(
+      deepEqual(new Map([['test', '1']]), new Map([['test', '1']])),
+    ).toBeFalsy();
+    expect(deepEqual(new Set(['test']), new Set(['test']))).toBeFalsy();
+    expect(deepEqual(new EmptyObject(), new EmptyObject())).toBeFalsy();
+  });
 });

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -1,6 +1,10 @@
 import isDateObject from './isDateObject';
 import isObject from './isObject';
+import isPlainObject from './isPlainObject';
 import isPrimitive from './isPrimitive';
+
+const isEmptyObjectWithCustomPrototype = (object: object, keys: string[]) =>
+  keys.length === 0 && !Array.isArray(object) && !isPlainObject(object);
 
 export default function deepEqual(
   object1: any,
@@ -24,6 +28,13 @@ export default function deepEqual(
 
   if (keys1.length !== keys2.length) {
     return false;
+  }
+
+  if (
+    isEmptyObjectWithCustomPrototype(object1, keys1) ||
+    isEmptyObjectWithCustomPrototype(object2, keys2)
+  ) {
+    return Object.is(object1, object2);
   }
 
   if (visited.has(object1) || visited.has(object2)) {


### PR DESCRIPTION
## Proposed Changes

Fixes #13483

- Compare empty non-plain objects by identity in `deepEqual` so distinct `File`, `Blob`, `FormData`, `Map`, `Set`, and class instances no longer look equal only because they have no enumerable keys.
- Add regression coverage for `deepEqual` host objects and for overwriting an unregistered `File` field via `setValue`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
