### PR TITLE
test: fix "allow to" grammar in test descriptions

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -2769,7 +2769,7 @@ describe('useForm', () => {
     });
   });
 
-  it('should allow to submit a form with disabled form fields', async () => {
+  it('should allow submitting a form with disabled form fields', async () => {
     function App() {
       const { register, getFieldState, formState, handleSubmit } = useForm();
 

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -910,7 +910,7 @@ describe('reset', () => {
     });
   });
 
-  it('should allow to reset unmounted field array', () => {
+  it('should allow resetting unmounted field array', () => {
     type FormValues = {
       test: { name: string }[];
     };

--- a/src/__tests__/useForm/setError.test.tsx
+++ b/src/__tests__/useForm/setError.test.tsx
@@ -104,7 +104,7 @@ describe('setError', () => {
     expect(await screen.findByText('no')).toBeVisible();
   });
 
-  it('should allow to set global error', async () => {
+  it('should allow setting global error', async () => {
     const onSubmit = jest.fn();
 
     type Errors = {

--- a/src/__tests__/utils/unset.test.ts
+++ b/src/__tests__/utils/unset.test.ts
@@ -16,7 +16,7 @@ describe('unset', () => {
     expect(unset(test, '')).toEqual(test);
   });
 
-  it('should allow to unset flat keep', () => {
+  it('should allow unsetting flat keep', () => {
     const test = {
       'test.is.flat': 'test',
       test: {


### PR DESCRIPTION
`allow` does not take a bare to-infinitive; it needs an object (`allow X to ...`) or a gerund. Four test descriptions use the ungrammatical `allow to <verb>`, fixed to the gerund:

- `src/__tests__/useForm.test.tsx`
- `src/__tests__/useForm/reset.test.tsx`
- `src/__tests__/useForm/setError.test.tsx`
- `src/__tests__/utils/unset.test.ts`
