### PR TITLE
fix: surface resolver errors for related fields

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1068,7 +1068,7 @@ describe('useForm', () => {
         expect(methods.formState.isValid).toBeFalsy();
       });
 
-      it('should update errors when the resolver returns an error for a different field', async () => {
+      it('should update errors for dependent fields returned by the resolver', async () => {
         const resolver = jest.fn((values: any) => {
           const errors =
             values.brand === 'adidas' && values.country === 'usa'
@@ -1100,7 +1100,10 @@ describe('useForm', () => {
 
           return (
             <form>
-              <input {...register('brand')} placeholder="brand" />
+              <input
+                {...register('brand', { deps: ['country'] })}
+                placeholder="brand"
+              />
               <input {...register('country')} placeholder="country" />
               <p>{errors.country?.message}</p>
             </form>

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1120,6 +1120,59 @@ describe('useForm', () => {
         ).toBeVisible();
       });
 
+      it('should not retarget a changed field when multiple resolver errors are returned', async () => {
+        const resolver = jest.fn((values: any) => {
+          const errors =
+            values.brand === 'adidas'
+              ? {
+                  firstName: {
+                    message: 'firstName error',
+                  },
+                  country: {
+                    message: 'country error',
+                  },
+                }
+              : {};
+
+          return {
+            values,
+            errors,
+          };
+        });
+
+        const App = () => {
+          const {
+            register,
+            formState: { errors },
+          } = useForm({
+            mode: 'onChange',
+            defaultValues: {
+              brand: 'nike',
+            },
+            resolver,
+          });
+
+          return (
+            <form>
+              <input {...register('brand')} placeholder="brand" />
+              <p data-testid="brand-error">{errors.brand?.message}</p>
+            </form>
+          );
+        };
+
+        render(<App />);
+
+        fireEvent.input(screen.getByPlaceholderText('brand'), {
+          target: {
+            value: 'adidas',
+          },
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId('brand-error')).toBeEmptyDOMElement();
+        });
+      });
+
       it('with sync resolver it should contain error if value is invalid with resolver', async () => {
         const resolver = jest.fn((data: any) => {
           if (data.test) {

--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -1068,6 +1068,58 @@ describe('useForm', () => {
         expect(methods.formState.isValid).toBeFalsy();
       });
 
+      it('should update errors when the resolver returns an error for a different field', async () => {
+        const resolver = jest.fn((values: any) => {
+          const errors =
+            values.brand === 'adidas' && values.country === 'usa'
+              ? {
+                  country: {
+                    message: 'country is not supported',
+                  },
+                }
+              : {};
+
+          return {
+            values,
+            errors,
+          };
+        });
+
+        const App = () => {
+          const {
+            register,
+            formState: { errors },
+          } = useForm({
+            mode: 'onChange',
+            defaultValues: {
+              brand: 'nike',
+              country: 'usa',
+            },
+            resolver,
+          });
+
+          return (
+            <form>
+              <input {...register('brand')} placeholder="brand" />
+              <input {...register('country')} placeholder="country" />
+              <p>{errors.country?.message}</p>
+            </form>
+          );
+        };
+
+        render(<App />);
+
+        fireEvent.input(screen.getByPlaceholderText('brand'), {
+          target: {
+            value: 'adidas',
+          },
+        });
+
+        expect(
+          await screen.findByText('country is not supported'),
+        ).toBeVisible();
+      });
+
       it('with sync resolver it should contain error if value is invalid with resolver', async () => {
         const resolver = jest.fn((data: any) => {
           if (data.test) {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1091,13 +1091,9 @@ export function createFormControl<
           previousErrorLookupResult.name || name,
         );
 
-        if (
-          !errorLookupResult.error &&
-          !isEmptyObject(errors) &&
-          Object.keys(errors).length === 1
-        ) {
-          for (const errorName in errors) {
-            const lookupResult = schemaErrorLookup(errors, _fields, errorName);
+        if (!errorLookupResult.error && field._f.deps) {
+          for (const dep of convertToArrayPayload(field._f.deps)) {
+            const lookupResult = schemaErrorLookup(errors, _fields, dep);
 
             if (lookupResult.error) {
               errorLookupResult = lookupResult;

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1085,11 +1085,22 @@ export function createFormControl<
           _fields,
           name,
         );
-        const errorLookupResult = schemaErrorLookup(
+        let errorLookupResult = schemaErrorLookup(
           errors,
           _fields,
           previousErrorLookupResult.name || name,
         );
+
+        if (!errorLookupResult.error && !isEmptyObject(errors)) {
+          for (const errorName in errors) {
+            const lookupResult = schemaErrorLookup(errors, _fields, errorName);
+
+            if (lookupResult.error) {
+              errorLookupResult = lookupResult;
+              break;
+            }
+          }
+        }
 
         error = errorLookupResult.error;
         name = errorLookupResult.name;

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1091,7 +1091,11 @@ export function createFormControl<
           previousErrorLookupResult.name || name,
         );
 
-        if (!errorLookupResult.error && !isEmptyObject(errors)) {
+        if (
+          !errorLookupResult.error &&
+          !isEmptyObject(errors) &&
+          Object.keys(errors).length === 1
+        ) {
           for (const errorName in errors) {
             const lookupResult = schemaErrorLookup(errors, _fields, errorName);
 


### PR DESCRIPTION
This updates the resolver-onChange path so errors returned for related fields are not dropped when the current field lookup misses.

Validation:
- pnpm.cmd test -- src/__tests__/useForm.test.tsx src/__tests__/controller.test.tsx src/__tests__/useFormState.test.tsx --runInBand --watch=false
- pnpm.cmd type