### PR TITLE
fix: track visited pairs in deepEqual to avoid false positives with shared object references

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -2486,6 +2486,29 @@ describe('useForm', () => {
     });
   });
 
+  it('should update form values when rerendered values reuse an object reference', async () => {
+    type FormValues = {
+      home: { street: string };
+      work: { street: string };
+    };
+
+    const { result, rerender } = renderHook(
+      ({ values }: { values: FormValues }) => useForm<FormValues>({ values }),
+      {
+        initialProps: {
+          values: { home: { street: 'a' }, work: { street: 'b' } },
+        },
+      },
+    );
+
+    expect(result.current.getValues('work.street')).toBe('b');
+
+    const shared = { street: 'a' };
+    rerender({ values: { home: shared, work: shared } });
+
+    expect(result.current.getValues('work.street')).toBe('a');
+  });
+
   it('should keep defaultValues if set keep default values is true on reset option', async () => {
     type FormValues = {
       firstName: string;

--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -146,6 +146,35 @@ describe('deepEqual', () => {
     expect(deepEqual(a, b)).toBeFalsy();
   });
 
+  it('should not treat different values as equal when one side reuses an object reference', () => {
+    const shared = { value: 1 };
+
+    expect(
+      deepEqual(
+        { first: shared, second: shared },
+        { first: { value: 1 }, second: { value: 2 } },
+      ),
+    ).toBeFalsy();
+
+    expect(
+      deepEqual(
+        { first: { value: 1 }, second: { value: 2 } },
+        { first: shared, second: shared },
+      ),
+    ).toBeFalsy();
+
+    expect(
+      deepEqual([shared, shared], [{ value: 1 }, { value: 9 }]),
+    ).toBeFalsy();
+
+    expect(
+      deepEqual(
+        { first: shared, second: shared },
+        { first: { value: 1 }, second: { value: 1 } },
+      ),
+    ).toBeTruthy();
+  });
+
   it('should return true when comparing NaN values', () => {
     expect(deepEqual(NaN, NaN)).toBeTruthy();
 

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -9,7 +9,7 @@ const isEmptyObjectWithCustomPrototype = (object: object, keys: string[]) =>
 export default function deepEqual(
   object1: any,
   object2: any,
-  visited = new WeakSet(),
+  visited = new WeakMap<object, WeakSet<object>>(),
 ) {
   if (object1 === object2) {
     return true;
@@ -37,12 +37,17 @@ export default function deepEqual(
     return Object.is(object1, object2);
   }
 
-  if (visited.has(object1) || visited.has(object2)) {
+  const visitedPairs = visited.get(object1);
+
+  if (visitedPairs && visitedPairs.has(object2)) {
     return true;
   }
 
-  visited.add(object1);
-  visited.add(object2);
+  if (visitedPairs) {
+    visitedPairs.add(object2);
+  } else {
+    visited.set(object1, new WeakSet([object2]));
+  }
 
   for (const key of keys1) {
     const val1 = object1[key];


### PR DESCRIPTION
## Proposed Changes

`deepEqual` returns false positives for plain, non-circular structures that reuse an object reference.

```js
const shared = { value: 1 };
deepEqual({ first: shared, second: shared }, { first: { value: 1 }, second: { value: 2 } });
// => true, expected false (second differs: 1 vs 2)
```

Root cause: the circular-reference guard introduced in #12914 keeps one shared `WeakSet` of every object ever visited and short-circuits to `true` when *either* side has been seen before. The first comparison of `shared` vs `{ value: 1 }` adds both to the set, so when the traversal reaches `second`, `shared` is already "visited" and `{ value: 2 }` is never actually compared. Equality is decided by visit history rather than by structure.

This is user-visible through the `values` prop: `useForm` compares incoming `values` against the previous ones with `deepEqual`, so a rerender whose `values` reuse one object reference is silently ignored and the form keeps stale values (repro included as a `useForm` test).

This PR tracks visited **pairs** (`WeakMap<object, WeakSet<object>>`) instead of individual objects, which is the standard approach for cycle detection in structural equality. Termination for circular structures is still guaranteed: each `(object1, object2)` pair is recorded before recursing and there are finitely many pairs, so any cycle eventually revisits the same pair and short-circuits.

Fixes # (no open issue; the regression was introduced by #12914)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

Verified locally: new unit tests + the `useForm` regression test fail on `master` and pass with the fix; the existing circular-reference tests from #12914 still pass; `jest` on `deepEqual`/`useForm`/`formState`/`setValue` suites → 173 passed; `pnpm test:type`, `pnpm lint`, `pnpm build` (incl. ESM/CJS export assertions) and `pnpm api-extractor` all pass; `dist/index.cjs.js` stays within the bundlewatch budget (12.25 kB gzip < 12.5 kB).
