### PR TITLE
fix: delay setValue validation errors

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -676,6 +676,63 @@ describe('setValue', () => {
       expect(result.current.formState.errors?.test?.message).toBe('min');
     });
 
+    it('should delay error rendering when setValue validates the field', async () => {
+      const message = 'min';
+
+      const Component = () => {
+        const {
+          register,
+          setValue,
+          formState: { errors },
+        } = useForm<{
+          test: string;
+        }>({
+          delayError: 500,
+          mode: 'onChange',
+          defaultValues: {
+            test: '',
+          },
+        });
+
+        return (
+          <>
+            <input
+              {...register('test', { minLength: { value: 5, message } })}
+            />
+            <button
+              type="button"
+              onClick={() =>
+                setValue('test', 'abc', {
+                  shouldValidate: true,
+                })
+              }
+            >
+              set
+            </button>
+            {errors.test && <p>{errors.test.message}</p>}
+          </>
+        );
+      };
+
+      render(<Component />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'set' }));
+
+      expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(499);
+      });
+
+      expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+      await act(async () => {
+        jest.advanceTimersByTime(1);
+      });
+
+      expect(await screen.findByText(message)).toBeVisible();
+    });
+
     it('should validate input correctly with existing error', async () => {
       const Component = () => {
         const {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -840,16 +840,107 @@ export function createFormControl<
       }
     }
 
-    (options.shouldDirty || options.shouldTouch) &&
-      updateTouchAndDirty(
-        name,
-        fieldValue,
-        options.shouldTouch,
-        options.shouldDirty,
-        true,
-      );
+    const fieldState =
+      options.shouldDirty || options.shouldTouch
+        ? updateTouchAndDirty(
+            name,
+            fieldValue,
+            options.shouldTouch,
+            options.shouldDirty,
+            true,
+          )
+        : undefined;
 
-    options.shouldValidate && trigger(name as Path<TFieldValues>);
+    if (options.shouldValidate) {
+      if (_options.delayError) {
+        const validateSetValue = async () => {
+          const field = get(_fields, name);
+
+          if (!field) {
+            return;
+          }
+
+          let error: FieldError | undefined;
+          let isValid: boolean | undefined;
+
+          if (_options.resolver) {
+            const { errors } = await _runSchema([name as InternalFieldName]);
+            _updateIsValidating([name as InternalFieldName]);
+
+            const previousErrorLookupResult = schemaErrorLookup(
+              _formState.errors,
+              _fields,
+              name as InternalFieldName,
+            );
+            let errorLookupResult = schemaErrorLookup(
+              errors,
+              _fields,
+              previousErrorLookupResult.name || (name as InternalFieldName),
+            );
+
+            if (!errorLookupResult.error && field._f.deps) {
+              for (const dep of convertToArrayPayload(field._f.deps)) {
+                const lookupResult = schemaErrorLookup(errors, _fields, dep);
+
+                if (lookupResult.error) {
+                  errorLookupResult = lookupResult;
+                  break;
+                }
+              }
+            }
+
+            error = errorLookupResult.error;
+            name = errorLookupResult.name;
+            isValid = isEmptyObject(errors);
+          } else {
+            _updateIsValidating([name as InternalFieldName], true);
+            error = (
+              await validateField(
+                field,
+                _names.disabled,
+                _formValues,
+                shouldDisplayAllAssociatedErrors,
+                _options.shouldUseNativeValidation,
+              )
+            )[name as InternalFieldName];
+            _updateIsValidating([name as InternalFieldName]);
+
+            if (error) {
+              isValid = false;
+            } else if (
+              _proxyFormState.isValid ||
+              _proxySubscribeFormState.isValid
+            ) {
+              isValid = await executeBuiltInValidation({
+                fields: _fields,
+                onlyCheckValid: true,
+                name: name as FieldPath<TFieldValues>,
+                eventType: EVENTS.TRIGGER,
+              });
+            }
+          }
+
+          if (field._f.deps) {
+            trigger(
+              field._f.deps as
+                | FieldPath<TFieldValues>
+                | FieldPath<TFieldValues>[],
+            );
+          }
+
+          shouldRenderByError(
+            name as InternalFieldName,
+            isValid,
+            error,
+            fieldState,
+          );
+        };
+
+        void validateSetValue();
+      } else {
+        trigger(name as Path<TFieldValues>);
+      }
+    }
   };
 
   const setFieldValues = <


### PR DESCRIPTION
This updates `setValue(..., { shouldValidate: true })` so `delayError` is respected for programmatic validation, matching the existing delayed error behavior from change/blur paths.

Validation:
- `jest --config ./scripts/jest/jest.config.js --runInBand --watch=false src/__tests__/useForm/setValue.test.tsx`
- `jest --config ./scripts/jest/jest.config.js --runInBand --watch=false src/__tests__/useForm/formState.test.tsx`
- `eslint src/logic/createFormControl.ts src/__tests__/useForm/setValue.test.tsx`
- `prettier --check --single-quote --end-of-line lf src/logic/createFormControl.ts src/__tests__/useForm/setValue.test.tsx`
