### PR TITLE
🐞 fix: restore promise return from controller onChange

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -37,6 +37,43 @@ describe('useController', () => {
     render(<Component />);
   });
 
+  it('should return a promise-like value from field.onChange', async () => {
+    let onChangeResult: any;
+
+    const Component = () => {
+      const { control } = useForm<{ test: string }>();
+      const { field } = useController({
+        control,
+        name: 'test',
+        defaultValue: '',
+      });
+
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            onChangeResult = field.onChange({
+              target: {
+                name: 'test',
+                value: 'next',
+              },
+              type: 'change',
+            });
+          }}
+        >
+          change
+        </button>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'change' }));
+
+    expect(onChangeResult).toBeInstanceOf(Promise);
+    await expect(onChangeResult).resolves.toBeDefined();
+  });
+
   it('component using the hook can be memoized', async () => {
     function App() {
       const form = useForm({

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -146,7 +146,7 @@ export function useController<
         });
       }
 
-      _registerProps.current.onChange({
+      return _registerProps.current.onChange({
         target: {
           value: getEventValue(event),
           name: name as InternalFieldName,


### PR DESCRIPTION
## What
Restore the return value from `field.onChange` in `useController`.

## Why
After the 7.78.0 rewrite, `field.onChange` stopped returning the promise-like result from the underlying register handler, which breaks callers that chain `then(...)` or `await` it.

## Validation
- `jest --config ./scripts/jest/jest.config.js --runInBand --watch=false src/__tests__/useController.test.tsx`
- `eslint src/useController.ts src/__tests__/useController.test.tsx`
- `prettier --check --single-quote --end-of-line lf src/useController.ts src/__tests__/useController.test.tsx`