### PR TITLE
🚷 feat: add `disabled` option to useFieldArray

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -675,6 +675,7 @@ export type UseFieldArrayProps<TFieldValues extends FieldValues = FieldValues, T
     rules?: {
         validate?: Validate<FieldArray<TFieldValues, TFieldArrayName>[], TFieldValues> | Record<string, Validate<FieldArray<TFieldValues, TFieldArrayName>[], TFieldValues>>;
     } & Pick<RegisterOptions<TFieldValues>, 'maxLength' | 'minLength' | 'required'>;
+    disabled?: boolean;
     shouldUnregister?: boolean;
 };
 

--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -83,6 +83,48 @@ describe('useFieldArray', () => {
       ]);
     });
 
+    it('should not initialize missing nested field array values when disabled', () => {
+      type FormValues = {
+        name: string;
+        union:
+          | {
+              type: 'empty';
+            }
+          | {
+              type: 'array';
+              values: { value: string }[];
+            };
+      };
+
+      const { result } = renderHook(() => {
+        const methods = useForm<FormValues>({
+          defaultValues: {
+            name: '',
+            union: {
+              type: 'empty',
+            },
+          },
+        });
+
+        return {
+          ...methods,
+          fieldArray: useFieldArray({
+            control: methods.control,
+            name: 'union.values',
+            disabled: true,
+          }),
+        };
+      });
+
+      expect(result.current.fieldArray.fields).toEqual([]);
+      expect(result.current.getValues()).toEqual({
+        name: '',
+        union: {
+          type: 'empty',
+        },
+      });
+    });
+
     it('should render with FormProvider', () => {
       const Provider = ({ children }: { children: React.ReactNode }) => {
         const methods = useForm();

--- a/src/types/fieldArray.ts
+++ b/src/types/fieldArray.ts
@@ -24,6 +24,7 @@ export type UseFieldArrayProps<
     RegisterOptions<TFieldValues>,
     'maxLength' | 'minLength' | 'required'
   >;
+  disabled?: boolean;
   shouldUnregister?: boolean;
 };
 

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -101,6 +101,7 @@ export function useFieldArray<
     control = formControl,
     name,
     keyName = 'id',
+    disabled,
     shouldUnregister,
     rules,
   } = props;
@@ -424,7 +425,9 @@ export function useFieldArray<
   }, [fields, name, control]);
 
   React.useEffect(() => {
-    !get(control._formValues, name) && control._setFieldArray(name);
+    !disabled &&
+      !get(control._formValues, name) &&
+      control._setFieldArray(name);
 
     return () => {
       const shouldKeepFieldArrayValues = !(
@@ -448,7 +451,7 @@ export function useFieldArray<
         ? updateMounted(name, false)
         : control.unregister(name as FieldPath<TFieldValues>);
     };
-  }, [name, control, keyName, shouldUnregister]);
+  }, [name, control, keyName, disabled, shouldUnregister]);
 
   return {
     swap: React.useCallback(swap, [updateValues, name, control]),


### PR DESCRIPTION
## What
Add a `disabled` option to `useFieldArray` to skip mount-time field-array initialization.

## Why
`useFieldArray` currently materializes missing nested arrays on mount, which mutates form values for discriminated unions and similar conditional shapes. With `disabled: true`, callers can opt out of that initialization and keep absent nested arrays absent.

## Validation
- `node_modules\\.bin\\jest.CMD --config ./scripts/jest/jest.config.js --runInBand --watch=false src/__tests__/useFieldArray.test.tsx`
- `node_modules\\.bin\\eslint.CMD src/useFieldArray.ts src/types/fieldArray.ts src/__tests__/useFieldArray.test.tsx`
- `node_modules\\.bin\\prettier.CMD --check --single-quote --end-of-line lf src/useFieldArray.ts src/types/fieldArray.ts src/__tests__/useFieldArray.test.tsx`
