### PR TITLE
docs: fix "allows to" grammar in setFocus JSDoc example

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -268,7 +268,7 @@ export type SetFocusOptions = Partial<{
  * useEffect(() => {
  *   setFocus("name");
  * }, [setFocus])
- * // shouldSelect allows to select input's content on focus
+ * // shouldSelect allows selecting input's content on focus
  * <button onClick={() => setFocus("name", { shouldSelect: true })}>Focus</button>
  * ```
  */


### PR DESCRIPTION
Grammar fix in the `setFocus` JSDoc example comment: `allows to select` -> `allows selecting`. `allow` takes a gerund, not a bare to-infinitive.