### PR TITLE
tests: add tests for setValue within form.subscribe

### DIFF
--- a/src/__tests__/useForm/subscribe.test.tsx
+++ b/src/__tests__/useForm/subscribe.test.tsx
@@ -352,3 +352,275 @@ describe('subscribe', () => {
     );
   });
 });
+
+describe('call setValue within subscribe', () => {
+  it('should update a dependent field when subscribed field changes', () => {
+    const callbackSpy = jest.fn();
+
+    function App() {
+      const { register, setValue, subscribe } = useForm<{
+        name: string;
+        nameLength: number;
+      }>({
+        defaultValues: {
+          name: '',
+          nameLength: 0,
+        },
+      });
+
+      React.useEffect(() => {
+        return subscribe({
+          name: 'name',
+          exact: true,
+          formState: {
+            values: true,
+          },
+          callback: ({ values }) => {
+            callbackSpy(values);
+            setValue('nameLength', values.name.length);
+          },
+        });
+      }, [setValue, subscribe]);
+
+      return (
+        <form>
+          <input aria-label="name" {...register('name')} />
+          <input aria-label="nameLength" {...register('nameLength')} />
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText('name'), {
+      target: { value: '1' },
+    });
+
+    expect(screen.getByLabelText('nameLength')).toHaveValue('1');
+    expect(callbackSpy).toHaveBeenCalledTimes(1);
+    expect(callbackSpy).toHaveBeenLastCalledWith({
+      name: '1',
+      nameLength: 0,
+    });
+
+    fireEvent.change(screen.getByLabelText('name'), {
+      target: { value: '12' },
+    });
+
+    expect(screen.getByLabelText('nameLength')).toHaveValue('2');
+    expect(callbackSpy).toHaveBeenCalledTimes(2);
+    expect(callbackSpy).toHaveBeenLastCalledWith({
+      name: '12',
+      nameLength: 1,
+    });
+  });
+
+  it('does not infinitely recurse when setValue call is conditional', () => {
+    const callbackSpy = jest.fn();
+    let counter = 0;
+
+    function App() {
+      const { register, setValue, subscribe } = useForm<{
+        name: string;
+        nameLength: number;
+      }>({
+        defaultValues: {
+          name: '',
+          nameLength: 0,
+        },
+      });
+
+      React.useEffect(() => {
+        return subscribe({
+          // Subscribe to entire form
+          formState: {
+            values: true,
+          },
+          callback: ({ name, values }) => {
+            // Should be called twice: once from user typing and one from setValue
+            callbackSpy(values);
+
+            if (name === 'name') {
+              // Only called once due to if statement
+              setValue('nameLength', ++counter);
+            }
+          },
+        });
+      }, [setValue, subscribe]);
+
+      return (
+        <form>
+          <input aria-label="name" {...register('name')} />
+          <input aria-label="nameLength" {...register('nameLength')} />
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText('name'), {
+      target: { value: '1' },
+    });
+
+    expect(screen.getByLabelText('nameLength')).toHaveValue('1');
+    expect(callbackSpy).toHaveBeenCalledTimes(2);
+    expect(callbackSpy).toHaveBeenLastCalledWith({
+      name: '1',
+      nameLength: 1,
+    });
+  });
+
+  it('does not infinitely recurse when setValue call is conditional', () => {
+    const callbackSpy = jest.fn();
+
+    function App() {
+      const { register, setValue, subscribe } = useForm<{
+        name: string;
+        nameLength: number;
+      }>({
+        defaultValues: {
+          name: '',
+          nameLength: 0,
+        },
+      });
+
+      React.useEffect(() => {
+        return subscribe({
+          // Subscribe to entire form
+          formState: {
+            values: true,
+          },
+          callback: ({ values }) => {
+            callbackSpy(values);
+
+            // No if-statement, but the second call sets the value to the current value {nameLength: 1}
+            // and should not trigger the subscribe callback again
+            setValue('nameLength', values.name.length);
+          },
+        });
+      }, [setValue, subscribe]);
+
+      return (
+        <form>
+          <input aria-label="name" {...register('name')} />
+          <input aria-label="nameLength" {...register('nameLength')} />
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText('name'), {
+      target: { value: '1' },
+    });
+
+    expect(screen.getByLabelText('nameLength')).toHaveValue('1');
+    expect(callbackSpy).toHaveBeenCalledTimes(2);
+    expect(callbackSpy).toHaveBeenLastCalledWith({
+      name: '1',
+      nameLength: 1,
+    });
+  });
+
+  it('works when calling reset within subscribe', () => {
+    const callbackSpy = jest.fn();
+
+    function App() {
+      const { register, reset, subscribe } = useForm<{
+        name: string;
+        nameLength: number;
+      }>({
+        defaultValues: {
+          name: '',
+          nameLength: 0,
+        },
+      });
+
+      React.useEffect(() => {
+        return subscribe({
+          name: 'name',
+          formState: {
+            values: true,
+          },
+          callback: ({ name, values }) => {
+            callbackSpy(values);
+
+            if (name === 'name' && values.nameLength === 0) {
+              reset({ name: values.name, nameLength: values.name.length });
+            }
+          },
+        });
+      }, [reset, subscribe]);
+
+      return (
+        <form>
+          <input aria-label="name" {...register('name')} />
+          <input aria-label="nameLength" {...register('nameLength')} />
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText('name'), {
+      target: { value: '1' },
+    });
+
+    expect(screen.getByLabelText('nameLength')).toHaveValue('1');
+    expect(callbackSpy).toHaveBeenCalledTimes(2);
+    expect(callbackSpy).toHaveBeenLastCalledWith({
+      name: '1',
+      nameLength: 1,
+    });
+  });
+
+  it('allows calling setValue with shouldDirty', () => {
+    const callbackSpy = jest.fn();
+    let dirtyFieldsSpy = null;
+
+    function App() {
+      const { register, setValue, subscribe } = useForm<{
+        name: string;
+        nameLength: number;
+      }>({
+        defaultValues: {
+          name: '',
+          nameLength: 0,
+        },
+      });
+
+      React.useEffect(() => {
+        return subscribe({
+          name: 'name',
+          formState: {
+            values: true,
+            dirtyFields: true,
+          },
+          callback: ({ name, values, dirtyFields }) => {
+            callbackSpy(values);
+            dirtyFieldsSpy = dirtyFields;
+
+            if (name === 'name' && values.nameLength === 0) {
+              setValue('nameLength', values.name.length, { shouldDirty: true });
+            }
+          },
+        });
+      }, [setValue, subscribe]);
+
+      return (
+        <form>
+          <input aria-label="name" {...register('name')} />
+          <input aria-label="nameLength" {...register('nameLength')} />
+        </form>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.change(screen.getByLabelText('name'), {
+      target: { value: '1' },
+    });
+
+    expect(dirtyFieldsSpy).toMatchObject({ name: true, nameLength: true });
+  });
+});


### PR DESCRIPTION
This PR adds tests for calling `setValue` within `form.subscribe`. This is related to https://github.com/react-hook-form/react-hook-form/issues/13372