### PR TITLE
🐞 fix(deepEqual): empty array and empty plain object should not be equal

### DIFF
--- a/src/__tests__/utils/deepEqual.test.ts
+++ b/src/__tests__/utils/deepEqual.test.ts
@@ -223,4 +223,11 @@ describe('deepEqual', () => {
     expect(deepEqual(new Set(['test']), new Set(['test']))).toBeFalsy();
     expect(deepEqual(new EmptyObject(), new EmptyObject())).toBeFalsy();
   });
+
+  it('should return false when comparing an empty array with an empty plain object', () => {
+    expect(deepEqual([], {})).toBeFalsy();
+    expect(deepEqual({}, [])).toBeFalsy();
+    expect(deepEqual({ items: [] }, { items: {} })).toBeFalsy();
+    expect(deepEqual({ items: {} }, { items: [] })).toBeFalsy();
+  });
 });

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -37,6 +37,10 @@ export default function deepEqual(
     return Object.is(object1, object2);
   }
 
+  if (keys1.length === 0 && Array.isArray(object1) !== Array.isArray(object2)) {
+    return false;
+  }
+
   const visitedPairs = visited.get(object1);
 
   if (visitedPairs && visitedPairs.has(object2)) {

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -37,7 +37,7 @@ export default function deepEqual(
     return Object.is(object1, object2);
   }
 
-  if (keys1.length === 0 && Array.isArray(object1) !== Array.isArray(object2)) {
+  if (!keys1.length && Array.isArray(object1) !== Array.isArray(object2)) {
     return false;
   }
 


### PR DESCRIPTION
## Bug

`deepEqual([], {})` and `deepEqual({}, [])` return `true` when they should return `false`. An empty array and an empty plain object are different types and must not compare as equal.

The same fault surfaces in nested comparisons — e.g. `deepEqual({ items: [] }, { items: {} })` returns `true` — which causes `isDirty` to stay `false` after a field's value changes from an empty array to an empty object or vice versa.

**Root cause.** When both objects have zero enumerable keys the key-length check passes, and neither `isEmptyObjectWithCustomPrototype` guard fires (`[]` is excluded by `Array.isArray` and `{}` is excluded by `isPlainObject`), so the function falls through to the empty loop and returns `true`.

## Fix

Add one early-return guard right after the custom-prototype check:

```ts
if (keys1.length === 0 && Array.isArray(object1) !== Array.isArray(object2)) {
  return false;
}
```

The guard fires **only** when both containers are empty and their array-ness differs. It preserves the intentional sparse-array / plain-object compatibility introduced in #13347 (those containers have ≥ 1 key and are unaffected).

## Verification

```
pnpm test -- deepEqual
```

> Test Suites: 1 passed, 1 total  
> Tests: 12 passed, 12 total (11 pre-existing + 1 new)

The new test cases that were **red** before this commit:
- `deepEqual([], {})   // false ✓`
- `deepEqual({}, [])   // false ✓`
- `deepEqual({ items: [] }, { items: {} })  // false ✓`
- `deepEqual({ items: {} }, { items: [] })  // false ✓`

> AI-assisted development was used in preparing this pull request.