### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 ### Install
 
     npm install react-hook-form
+    deno install react-hook-form
 
 ### Quickstart
 


### PR DESCRIPTION
👋 Bartek from the Deno team here.

## Proposed Changes

The install instructions list npm, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install react-hook-form
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install react-hook-form`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it to a docs site instead.

## Type of change

- [x] This change requires a documentation update (docs-only change)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
