### PR TITLE
docs(README.ru-RU): replace dead Spectrum chat badge

### DIFF
--- a/docs/README.ru-RU.md
+++ b/docs/README.ru-RU.md
@@ -15,7 +15,7 @@
 [![npm](https://img.shields.io/bundlephobia/minzip/react-hook-form?style=for-the-badge)](https://bundlephobia.com/result?p=react-hook-form)
 [![Coverage Status](https://img.shields.io/coveralls/github/bluebill1049/react-hook-form/master?style=for-the-badge)](https://coveralls.io/github/bluebill1049/react-hook-form?branch=master)
 
-[![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/react-hook-form)
+[![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=React+hooks+for+form+validation+without+the+hassle&url=https://github.com/bluebill1049/react-hook-form)&nbsp;[![Join the community on Discord](https://discord.gg/react-hook-form) (Spectrum chat was sunset; the community moved to Discord)
 
 </div>
 


### PR DESCRIPTION
Replaces `spectrum.chat/react-hook-form` and `withspectrum.github.io/badge/badge.svg` (both 404) with `discord.gg/react-hook-form` (200).