### PR TITLE
docs(README.pt-BR): replace dead /pt subdomain links

### DIFF
--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -49,12 +49,12 @@
 
 - [Motivação](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [Video tutorial](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
-- [Como iniciar](https://react-hook-form.com/pt/get-started)
-- [API](https://react-hook-form.com/pt/api)
+- [Como iniciar](https://react-hook-form.com/get-started)
+- [API](https://react-hook-form.com/api)
 - [Exemplos](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
-- [Demonstração](https://react-hook-form.com/pt)
-- [Form Builder](https://react-hook-form.com/pt/form-builder)
-- [FAQs](https://react-hook-form.com/pt/faqs)
+- [Demonstração](https://react-hook-form.com)
+- [Form Builder](https://react-hook-form.com/form-builder)
+- [FAQs](https://react-hook-form.com/faqs)
 
 ## Começo rápido
 


### PR DESCRIPTION
Replaces all 5 dead `https://react-hook-form.com/pt/*` URLs (404 — `/pt/*` Portuguese locale paths retired) with `https://react-hook-form.com/*` English roots (200). Same fix as `README.ja-JP` (PR #13541).