### PR TITLE
docs(README.zh-CN): replace dead /zh subdomain links

### DIFF
--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
     <p align="center">
-      <a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation">
+      <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
         <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/logo.png" alt="React Hook Form Logo - hook custom hook for form validation" width="330px" />
       </a>
     </p>
@@ -19,7 +19,7 @@
 
 </div>
 
-<div align="center"><p align="center"><a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/example.gif" alt="React Hook Form Logo - React hook form validation" width="100%" /></a></p></div>
+<div align="center"><p align="center"><a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/example.gif" alt="React Hook Form Logo - React hook form validation" width="100%" /></a></p></div>
 
 <a href="./README.V6.md">English</a> | <a href="./README.zh-TW.md">繁中</a> | 简中 | <a href="./README.ja-JP.md">日本語</a> | <a href="./README.ko-KR.md">한국어</a> | <a href="./README.fr-FR.md">Français</a> | <a href="./README.it-IT.md">Italiano</a> | <a href="./README.pt-BR.md">Português</a> | <a href="./README.es-ES.md">Español</a> | <a href="./README.ru-RU.md">Русский</a> | <a href="./README.de-DE.md">Deutsch</a> | <a href="./README.tr-TR.md">Türkçe</a>
 
@@ -33,7 +33,7 @@
 - 与 React Native 兼容
 - 支持[Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Superstruct](https://github.com/ianstormtaylor/superstruct)或自定义
 - 支持浏览器原生校验
-- 从[这里](https://react-hook-form.com/zh/form-builder)快速构建你的表单
+- 从[这里](https://react-hook-form.com/form-builder)快速构建你的表单
 
 ## 安装
 
@@ -42,12 +42,12 @@
 ## 链接
 
 - [动机](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
-- [开始](https://react-hook-form.com/zh/get-started)
-- [API](https://react-hook-form.com/zh/api)
+- [开始](https://react-hook-form.com/get-started)
+- [API](https://react-hook-form.com/api)
 - [示例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
-- [Demo](https://react-hook-form.com/zh)
-- [Form Builder](https://react-hook-form.com/zh/form-builder)
-- [常见问题](https://react-hook-form.com/zh/faqs)
+- [Demo](https://react-hook-form.com)
+- [Form Builder](https://react-hook-form.com/form-builder)
+- [常见问题](https://react-hook-form.com/faqs)
 
 ## 快速开始
 


### PR DESCRIPTION
Replaces all 8 dead `https://react-hook-form.com/zh/*` URLs (404 — `/zh/*` Chinese locale paths retired) with `https://react-hook-form.com/*` English roots (200). Same fix as `README.ja-JP` (PR #13541).