### PR TITLE
docs(README.zh-TW): fix broken /zh/api link

### DIFF
--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -42,7 +42,7 @@
 - [動機](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [影片教學](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [開始](https://react-hook-form.com/zh/get-started)
-- [API](https://react-hook-form.com/zh/api)
+- [API](https://react-hook-form.com/docs)
 - [範例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
 - [Demo](https://react-hook-form.com/zh)
 - [Form Builder](https://react-hook-form.com/zh/form-builder)


### PR DESCRIPTION
The \`/zh/api\` page returns 404. All other locale READMEs (V6, V7.ja-JP, V7.zh-CN, ar-AR, de-DE, es-ES, fr-FR, it-IT, ko-KR, ru-RU, tr-TR) already point at \`/docs\` for the API reference, so this brings zh-TW in line.