### PR TITLE
fix(flatten): preserve Date values as leaf nodes

### DIFF
--- a/src/__tests__/utils/flatten.test.ts
+++ b/src/__tests__/utils/flatten.test.ts
@@ -22,4 +22,25 @@ describe('flatten', () => {
       }),
     ).toMatchSnapshot();
   });
+
+  it('should preserve Date values as leaf nodes and not drop them', () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+
+    expect(flatten({ name: 'Alice', createdAt: date, age: 30 })).toEqual({
+      name: 'Alice',
+      createdAt: date,
+      age: 30,
+    });
+  });
+
+  it('should preserve nested Date values as leaf nodes', () => {
+    const start = new Date('2024-01-01');
+    const end = new Date('2024-12-31');
+
+    expect(flatten({ range: { start, end }, label: 'year' })).toEqual({
+      'range.start': start,
+      'range.end': end,
+      label: 'year',
+    });
+  });
 });

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -1,12 +1,13 @@
 import type { FieldValues } from '../types';
 
+import isDateObject from './isDateObject';
 import { isObjectType } from './isObject';
 
 export const flatten = (obj: FieldValues) => {
   const output: FieldValues = {};
 
   for (const key of Object.keys(obj)) {
-    if (isObjectType(obj[key]) && obj[key] !== null) {
+    if (isObjectType(obj[key]) && obj[key] !== null && !isDateObject(obj[key])) {
       const nested = flatten(obj[key]);
 
       for (const nestedKey of Object.keys(nested)) {


### PR DESCRIPTION
## Bug

`flatten()` in `src/utils/flatten.ts` silently drops `Date` values from the flattened output. The `<Form>` component uses `flatten()` to build the `FormData` sent on form submission (`src/form.tsx:65`), so any form field holding a `Date` value is omitted from the server payload entirely.

Closes #13554

## Root cause

```ts
// Before fix — in src/utils/flatten.ts
if (isObjectType(obj[key]) && obj[key] !== null) {
```

`isObjectType(value)` is `typeof value === 'object'`, which is `true` for `Date` instances. Because `Object.keys(new Date())` returns `[]`, the inner loop is a no-op and the date is silently discarded.

## Fix

Add `!isDateObject(obj[key])` to the guard so that `Date` values fall through to the leaf branch and are preserved:

```ts
// After fix
if (isObjectType(obj[key]) && obj[key] !== null && !isDateObject(obj[key])) {
```

## Verification

```
pnpm test -- --testPathPatterns="src/__tests__/utils/flatten" --no-coverage
```

- 2 new regression tests go **RED → GREEN** (Date dropped / preserved).
- Existing snapshot test remains **GREEN** and unmodified.
- Full suite: **1184/1184 tests pass** across all 120 test suites.

> AI-assisted contribution.