### PR TITLE
docs: replace retired /jp, /pt, /zh subdomain links in locale READMEs

### DIFF
--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -1,6 +1,6 @@
 <div align="center">
     <p align="center">
-        <a href="https://react-hook-form.com/jp" title="React Hook Form - Simple React forms validation">
+        <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
             <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
@@ -21,7 +21,7 @@
 
 <div align="center">
     <p align="center">
-        <a href="https://react-hook-form.com/jp" title="React Hook Form - Simple React forms validation">
+        <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
             <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/example.gif" alt="React Hook Form video - React custom hook for form validation" width="100%" />
         </a>
     </p>
@@ -38,7 +38,7 @@
 - React Native との互換性
 - [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Superstruct](https://github.com/ianstormtaylor/superstruct) またはカスタムをサポート
 - ブラウザのネイティブバリデーションをサポート
-- [Form Builder](https://react-hook-form.com/jp/form-builder) でフォームを素早く作成
+- [Form Builder](https://react-hook-form.com/form-builder) でフォームを素早く作成
 
 ## インストール
 
@@ -48,12 +48,12 @@
 
 - [動機](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [ビデオチュートリアル](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
-- [始める](https://react-hook-form.com/jp/get-started)
-- [API](https://react-hook-form.com/jp/api)
+- [始める](https://react-hook-form.com/get-started)
+- [API](https://react-hook-form.com/api)
 - [例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
-- [デモ](https://react-hook-form.com/jp)
-- [Form Builder](https://react-hook-form.com/jp/form-builder)
-- [FAQs](https://react-hook-form.com/jp/faqs)
+- [デモ](https://react-hook-form.com)
+- [Form Builder](https://react-hook-form.com/form-builder)
+- [FAQs](https://react-hook-form.com/faqs)
 
 ## クイックスタート
 

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -49,12 +49,12 @@
 
 - [Motivação](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [Video tutorial](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
-- [Como iniciar](https://react-hook-form.com/pt/get-started)
-- [API](https://react-hook-form.com/pt/api)
+- [Como iniciar](https://react-hook-form.com/get-started)
+- [API](https://react-hook-form.com/api)
 - [Exemplos](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
-- [Demonstração](https://react-hook-form.com/pt)
-- [Form Builder](https://react-hook-form.com/pt/form-builder)
-- [FAQs](https://react-hook-form.com/pt/faqs)
+- [Demonstração](https://react-hook-form.com)
+- [Form Builder](https://react-hook-form.com/form-builder)
+- [FAQs](https://react-hook-form.com/faqs)
 
 ## Começo rápido
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
     <p align="center">
-      <a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation">
+      <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
         <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/logo.png" alt="React Hook Form Logo - hook custom hook for form validation" width="330px" />
       </a>
     </p>
@@ -19,7 +19,7 @@
 
 </div>
 
-<div align="center"><p align="center"><a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/example.gif" alt="React Hook Form Logo - React hook form validation" width="100%" /></a></p></div>
+<div align="center"><p align="center"><a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/example.gif" alt="React Hook Form Logo - React hook form validation" width="100%" /></a></p></div>
 
 <a href="./README.V6.md">English</a> | <a href="./README.zh-TW.md">繁中</a> | 简中 | <a href="./README.ja-JP.md">日本語</a> | <a href="./README.ko-KR.md">한국어</a> | <a href="./README.fr-FR.md">Français</a> | <a href="./README.it-IT.md">Italiano</a> | <a href="./README.pt-BR.md">Português</a> | <a href="./README.es-ES.md">Español</a> | <a href="./README.ru-RU.md">Русский</a> | <a href="./README.de-DE.md">Deutsch</a> | <a href="./README.tr-TR.md">Türkçe</a>
 
@@ -33,7 +33,7 @@
 - 与 React Native 兼容
 - 支持[Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Superstruct](https://github.com/ianstormtaylor/superstruct)或自定义
 - 支持浏览器原生校验
-- 从[这里](https://react-hook-form.com/zh/form-builder)快速构建你的表单
+- 从[这里](https://react-hook-form.com/form-builder)快速构建你的表单
 
 ## 安装
 
@@ -42,12 +42,12 @@
 ## 链接
 
 - [动机](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
-- [开始](https://react-hook-form.com/zh/get-started)
-- [API](https://react-hook-form.com/zh/api)
+- [开始](https://react-hook-form.com/get-started)
+- [API](https://react-hook-form.com/api)
 - [示例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
-- [Demo](https://react-hook-form.com/zh)
-- [Form Builder](https://react-hook-form.com/zh/form-builder)
-- [常见问题](https://react-hook-form.com/zh/faqs)
+- [Demo](https://react-hook-form.com)
+- [Form Builder](https://react-hook-form.com/form-builder)
+- [常见问题](https://react-hook-form.com/faqs)
 
 ## 快速开始
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -1,6 +1,6 @@
 <div align="center">
     <p align="center">
-      <a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation">
+      <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
         <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/logo.png" alt="React Hook Form Logo - hook custom hook for form validation" width="330px" />
       </a>
     </p>
@@ -19,7 +19,7 @@
 
 </div>
 
-<div align="center"><p align="center"><a href="https://react-hook-form.com/zh" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/example.gif" alt="React Hook Form Logo - React hook form validation" width="100%" /></a></p></div>
+<div align="center"><p align="center"><a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation"><img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/docs/example.gif" alt="React Hook Form Logo - React hook form validation" width="100%" /></a></p></div>
 
 <a href="./README.V6.md">English</a> | 繁中 | <a href="./README.zh-CN.md">簡中</a> | <a href="./README.ja-JP.md">日本語</a> | <a href="./README.ko-KR.md">한국어</a> | <a href="./README.fr-FR.md">Français</a> | <a href="./README.it-IT.md">Italiano</a> | <a href="./README.pt-BR.md">Português</a> | <a href="./README.es-ES.md">Español</a> | <a href="./README.ru-RU.md">Русский</a> | <a href="./README.de-DE.md">Deutsch</a> | <a href="./README.tr-TR.md">Türkçe</a>
 
@@ -41,12 +41,12 @@
 
 - [動機](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [影片教學](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
-- [開始](https://react-hook-form.com/zh/get-started)
-- [API](https://react-hook-form.com/zh/api)
+- [開始](https://react-hook-form.com/get-started)
+- [API](https://react-hook-form.com/api)
 - [範例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
-- [Demo](https://react-hook-form.com/zh)
-- [Form Builder](https://react-hook-form.com/zh/form-builder)
-- [常見問題](https://react-hook-form.com/zh/faqs)
+- [Demo](https://react-hook-form.com)
+- [Form Builder](https://react-hook-form.com/form-builder)
+- [常見問題](https://react-hook-form.com/faqs)
 
 ## 快速開始
 


### PR DESCRIPTION
react-hook-form.com previously hosted locale subdomains (/jp, /pt, /zh) that have since been retired. The canonical docs now live at react-hook-form.com without the locale prefix. Updated all 4 locale READMEs (ja-JP, pt-BR, zh-CN, zh-TW) to drop the dead subdomain.

Batch PR per @bluebill1049's request to combine the four locale fixes into a single PR.