### PR TITLE
fix(unset): guard against prototype keyword path traversal

### DIFF
--- a/src/__tests__/utils/unset.test.ts
+++ b/src/__tests__/utils/unset.test.ts
@@ -345,4 +345,25 @@ describe('unset', () => {
       delete Array.prototype.somePolyfill;
     });
   });
+
+  it('should not traverse or delete prototype properties via __proto__ path', () => {
+    const protoPollutionKey = '__rhfTestPolluted__';
+
+    // Simulate Object.prototype being extended (e.g. by another library)
+    (Object.prototype as any)[protoPollutionKey] = 'SENSITIVE';
+
+    try {
+      // Without the fix, unset traverses into Object.prototype via baseGet
+      // and deletes the property from there.
+      unset({}, `__proto__.${protoPollutionKey}`);
+      unset({}, ['__proto__', protoPollutionKey]);
+      unset({}, `constructor.${protoPollutionKey}`);
+      unset({}, `prototype.${protoPollutionKey}`);
+
+      // The prototype property must still exist — unset must be a no-op.
+      expect((Object.prototype as any)[protoPollutionKey]).toBe('SENSITIVE');
+    } finally {
+      delete (Object.prototype as any)[protoPollutionKey];
+    }
+  });
 });

--- a/src/utils/unset.ts
+++ b/src/utils/unset.ts
@@ -1,3 +1,5 @@
+import { PROTOTYPE_KEYWORDS } from '../constants';
+
 import isEmptyObject from './isEmptyObject';
 import isKey from './isKey';
 import isNullOrUndefined from './isNullOrUndefined';
@@ -42,7 +44,9 @@ export default function unset(object: any, path: string | (string | number)[]) {
     : isKey(path)
       ? [path]
       : stringToPath(path);
-
+  if (paths.some((segment) => PROTOTYPE_KEYWORDS.includes(String(segment)))) {
+    return object;
+  }
   const childObject = paths.length === 1 ? object : baseGet(object, paths);
 
   const index = paths.length - 1;


### PR DESCRIPTION
## Summary

`unset()` in `src/utils/unset.ts` traverses path segments through `baseGet()` without checking for prototype-pollution keywords (`__proto__`, `constructor`, `prototype`). This allows callers to inadvertently (or maliciously) delete properties from `Object.prototype`.

`set.ts` already contains an equivalent guard:
```ts
if (PROTOTYPE_KEYWORDS.includes(key)) {
  return;
}
```
but `unset.ts` was never updated to match.

## Bug

```ts
import unset from "./src/utils/unset";

// Prototype extended by some library / JSON merge vulnerability
Object.prototype.polluted = "SENSITIVE";

unset({}, "__proto__.polluted");

console.log({}.polluted); // undefined — deleted from Object.prototype!
```

The same issue occurs with array-form paths (`["__proto__", "polluted"]`) and the `constructor` / `prototype` keywords.

## Fix

After computing the `paths` array in `unset()`, bail out immediately (no-op) if any segment is in `PROTOTYPE_KEYWORDS`, mirroring the guard in `set.ts`.

## Verification

New test added to `src/__tests__/utils/unset.test.ts`:
- **RED** (before fix): test fails — `unset({}, "__proto__.foo")` deleted from `Object.prototype`.
- **GREEN** (after fix): 19/19 tests pass, including the new prototype-guard test.

```
Tests: 19 passed, 19 total
```

Full utils suite still green: 134/134 tests pass.

Closes #13559