### PR TITLE
docs: replace dead /api links with /docs in 4 locale READMEs

### DIFF
--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -49,7 +49,7 @@
 - [動機](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [ビデオチュートリアル](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [始める](https://react-hook-form.com/get-started)
-- [API](https://react-hook-form.com/api)
+- [API](https://react-hook-form.com/docs)
 - [例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
 - [デモ](https://react-hook-form.com)
 - [Form Builder](https://react-hook-form.com/form-builder)

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -50,7 +50,7 @@
 - [Motivação](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [Video tutorial](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [Como iniciar](https://react-hook-form.com/get-started)
-- [API](https://react-hook-form.com/api)
+- [API](https://react-hook-form.com/docs)
 - [Exemplos](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
 - [Demonstração](https://react-hook-form.com)
 - [Form Builder](https://react-hook-form.com/form-builder)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -43,7 +43,7 @@
 
 - [动机](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [开始](https://react-hook-form.com/get-started)
-- [API](https://react-hook-form.com/api)
+- [API](https://react-hook-form.com/docs)
 - [示例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
 - [Demo](https://react-hook-form.com)
 - [Form Builder](https://react-hook-form.com/form-builder)

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -42,7 +42,7 @@
 - [動機](https://medium.com/@bruce1049/form-validation-with-hook-in-3kb-c5414edf7d64)
 - [影片教學](https://www.youtube.com/watch?v=-mFXqOaqgZk&t)
 - [開始](https://react-hook-form.com/get-started)
-- [API](https://react-hook-form.com/api)
+- [API](https://react-hook-form.com/docs)
 - [範例](https://github.com/bluebill1049/react-hook-form/tree/master/examples)
 - [Demo](https://react-hook-form.com)
 - [Form Builder](https://react-hook-form.com/form-builder)


### PR DESCRIPTION
react-hook-form.com/api returns 404 in the ja-JP, pt-BR, zh-CN, zh-TW locale READMEs. The 11 other locale READMEs already point at react-hook-form.com/docs which returns 200. Replaces the dead /api with /docs in all 4 files.

Batched into a single PR per @bluebill1049's prior request (#13556) to combine parallel locale fixes.