### PR TITLE
fix: prevent Date values from being dropped by flatten()

### DIFF
--- a/src/__tests__/utils/flatten.test.ts
+++ b/src/__tests__/utils/flatten.test.ts
@@ -22,4 +22,19 @@ describe('flatten', () => {
       }),
     ).toMatchSnapshot();
   });
+
+  it('should preserve Date values', () => {
+    const date = new Date('2024-01-01');
+    expect(
+      flatten({
+        name: 'Alice',
+        createdAt: date,
+        age: 30,
+      }),
+    ).toEqual({
+      name: 'Alice',
+      createdAt: date,
+      age: 30,
+    });
+  });
 });

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -1,12 +1,13 @@
 import { FieldValues } from '../types';
 
+import isDateObject from './isDateObject';
 import { isObjectType } from './isObject';
 
 export const flatten = (obj: FieldValues) => {
   const output: FieldValues = {};
 
   for (const key of Object.keys(obj)) {
-    if (isObjectType(obj[key]) && obj[key] !== null) {
+    if (isObjectType(obj[key]) && obj[key] !== null && !isDateObject(obj[key])) {
       const nested = flatten(obj[key]);
 
       for (const nestedKey of Object.keys(nested)) {

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -7,7 +7,11 @@ export const flatten = (obj: FieldValues) => {
   const output: FieldValues = {};
 
   for (const key of Object.keys(obj)) {
-    if (isObjectType(obj[key]) && obj[key] !== null && !isDateObject(obj[key])) {
+    if (
+      isObjectType(obj[key]) &&
+      obj[key] !== null &&
+      !isDateObject(obj[key])
+    ) {
       const nested = flatten(obj[key]);
 
       for (const nestedKey of Object.keys(nested)) {


### PR DESCRIPTION
**Problem**
Date objects are silently dropped by `flatten()` because they pass the `isObjectType` check but have no enumerable own properties. This causes form Date values to disappear when building FormData.

**Changes**
- Added `isDateObject` check to treat Date values as leaf nodes in `flatten`
- Added test verifying Date values are preserved

Fixes #13554