### PR TITLE
test: remove duplicate UseFieldArray slug

### DIFF
--- a/app/src/welcome/index.tsx
+++ b/app/src/welcome/index.tsx
@@ -163,7 +163,6 @@ const items: Item[] = [
       '/useFieldArray/default',
       '/useFieldArray/defaultAndWithoutFocus',
       '/useFieldArray/asyncReset',
-      '/useFieldArray/defaultAndWithoutFocus',
       '/useFieldArray/formState',
     ],
   },


### PR DESCRIPTION
## Summary

Removes a duplicate entry from the `UseFieldArray` demo `slugs` array.

## Changes

- Removed the duplicate `/useFieldArray/defaultAndWithoutFocus` slug.
- No functional changes; this is a small cleanup to keep the demo configuration consistent.

## Testing

- [x] Verified the duplicate entry was removed.
- [x] Confirmed no other demo routes were modified.