### PR TITLE
fix(flatten): preserve Date values as leaf nodes

### DIFF
--- a/src/__tests__/utils/flatten.test.ts
+++ b/src/__tests__/utils/flatten.test.ts
@@ -22,4 +22,25 @@ describe('flatten', () => {
       }),
     ).toMatchSnapshot();
   });
+
+  it('should preserve Date values as leaf nodes and not drop them', () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+
+    expect(flatten({ name: 'Alice', createdAt: date, age: 30 })).toEqual({
+      name: 'Alice',
+      createdAt: date,
+      age: 30,
+    });
+  });
+
+  it('should preserve nested Date values as leaf nodes', () => {
+    const start = new Date('2024-01-01');
+    const end = new Date('2024-12-31');
+
+    expect(flatten({ range: { start, end }, label: 'year' })).toEqual({
+      'range.start': start,
+      'range.end': end,
+      label: 'year',
+    });
+  });
 });

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -1,12 +1,17 @@
 import type { FieldValues } from '../types';
 
+import isDateObject from './isDateObject';
 import { isObjectType } from './isObject';
 
 export const flatten = (obj: FieldValues) => {
   const output: FieldValues = {};
 
   for (const key of Object.keys(obj)) {
-    if (isObjectType(obj[key]) && obj[key] !== null) {
+    if (
+      isObjectType(obj[key]) &&
+      obj[key] !== null &&
+      !isDateObject(obj[key])
+    ) {
       const nested = flatten(obj[key]);
 
       for (const nestedKey of Object.keys(nested)) {


### PR DESCRIPTION
Same fix as #13562 (already merged to `main`) but targeting `master`. Includes multi-line formatting to pass lint, closes #13554.