### PR TITLE
fix: keep dirtyFields boolean for registered array fields

### DIFF
--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -712,6 +712,128 @@ describe('formState', () => {
     expect(dirtyFieldsState).toEqual({});
   });
 
+  it('should keep dirtyFields as boolean for a registered multiple select with isDirty', async () => {
+    let dirtyFieldsState: Record<string, unknown> = {};
+    let isDirtyState = false;
+
+    function App() {
+      const {
+        register,
+        formState: { dirtyFields, isDirty },
+      } = useForm<{ fruits: string[] }>({
+        defaultValues: {
+          fruits: [],
+        },
+      });
+
+      dirtyFieldsState = dirtyFields;
+      isDirtyState = isDirty;
+
+      return (
+        <select
+          multiple
+          data-testid="fruits"
+          {...register('fruits', {
+            validate: (value) =>
+              value.length > 0 || 'Please select at least one fruit',
+          })}
+        >
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+          <option value="orange">Orange</option>
+        </select>
+      );
+    }
+
+    render(<App />);
+
+    const fruits = screen.getByTestId('fruits') as HTMLSelectElement;
+
+    // Multiple select values are read from selectedOptions during change.
+    fruits.options[0].selected = true;
+    fireEvent.change(fruits);
+
+    await waitFor(() => {
+      expect(isDirtyState).toBe(true);
+      expect(dirtyFieldsState).toEqual({ fruits: true });
+    });
+  });
+
+  it('should keep all dirty registered multiple selects as booleans with isDirty', async () => {
+    let dirtyFieldsState: Record<string, unknown> = {};
+    let isDirtyState = false;
+
+    function App() {
+      const {
+        register,
+        formState: { dirtyFields, isDirty },
+      } = useForm<{ colors: string[]; fruits: string[] }>({
+        defaultValues: {
+          colors: [],
+          fruits: [],
+        },
+      });
+
+      dirtyFieldsState = dirtyFields;
+      isDirtyState = isDirty;
+
+      return (
+        <>
+          <select
+            multiple
+            data-testid="fruits"
+            {...register('fruits', {
+              validate: (value) =>
+                value.length > 0 || 'Please select at least one fruit',
+            })}
+          >
+            <option value="apple">Apple</option>
+            <option value="banana">Banana</option>
+            <option value="orange">Orange</option>
+          </select>
+          <select
+            multiple
+            data-testid="colors"
+            {...register('colors', {
+              validate: (value) =>
+                value.length > 0 || 'Please select at least one color',
+            })}
+          >
+            <option value="red">Red</option>
+            <option value="green">Green</option>
+            <option value="blue">Blue</option>
+          </select>
+        </>
+      );
+    }
+
+    render(<App />);
+
+    const fruits = screen.getByTestId('fruits') as HTMLSelectElement;
+    const colors = screen.getByTestId('colors') as HTMLSelectElement;
+
+    // Multiple select values are read from selectedOptions during change.
+    fruits.options[0].selected = true;
+    fireEvent.change(fruits);
+
+    await waitFor(() => {
+      expect(isDirtyState).toBe(true);
+      expect(dirtyFieldsState).toEqual({ fruits: true });
+    });
+
+    // A second array-valued field should not reshape the first dirty field.
+    colors.options[0].selected = true;
+    fireEvent.change(colors);
+
+    await waitFor(() => {
+      expect(isDirtyState).toBe(true);
+      expect(dirtyFieldsState).toEqual({
+        colors: true,
+        fruits: true,
+      });
+    });
+  });
+
   it('should update isDirty with getFieldState at child component', () => {
     type FormValues = {
       test?: string;

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -262,8 +262,30 @@ export function createFormControl<
     }
   };
 
+  const getDirtyFieldsWithRegisteredArrays = (formValues: FieldValues) => {
+    const dirtyFields = getDirtyFields(_defaultValues, formValues);
+
+    for (const fieldName of _names.mount) {
+      const formValue = get(formValues, fieldName);
+      const defaultValue = get(_defaultValues, fieldName);
+
+      // Registered array-valued fields are dirty boolean leaves; useFieldArray
+      // roots and indexed descendants keep structural dirty fields.
+      if (
+        (Array.isArray(formValue) || Array.isArray(defaultValue)) &&
+        !_names.array.has(fieldName) &&
+        !isNameInFieldArray(_names.array, fieldName) &&
+        !deepEqual(defaultValue, formValue)
+      ) {
+        set(dirtyFields, fieldName, true);
+      }
+    }
+
+    return dirtyFields;
+  };
+
   const _updateDirtyFields = () => {
-    _formState.dirtyFields = getDirtyFields(_defaultValues, _formValues);
+    _formState.dirtyFields = getDirtyFieldsWithRegisteredArrays(_formValues);
   };
 
   const _setFieldArray: BatchFieldArrayUpdate = (
@@ -452,7 +474,7 @@ export function createFormControl<
         isPreviousDirty = !!get(_formState.dirtyFields, name);
 
         if (isCurrentFieldPristine !== _formState.isDirty) {
-          _formState.dirtyFields = getDirtyFields(_defaultValues, _formValues);
+          _updateDirtyFields();
         } else {
           isCurrentFieldPristine
             ? unset(_formState.dirtyFields, name)
@@ -1691,7 +1713,7 @@ export function createFormControl<
       if (keepStateOptions.keepDirtyValues) {
         const fieldsToCheck = new Set([
           ..._names.mount,
-          ...Object.keys(getDirtyFields(_defaultValues, _formValues)),
+          ...Object.keys(getDirtyFieldsWithRegisteredArrays(_formValues)),
         ]);
         for (const fieldName of Array.from(fieldsToCheck)) {
           const isDirty = get(_formState.dirtyFields, fieldName);
@@ -1807,10 +1829,10 @@ export function createFormControl<
         ? {}
         : keepStateOptions.keepDirtyValues
           ? keepStateOptions.keepDefaultValues && _formValues
-            ? getDirtyFields(_defaultValues, _formValues)
+            ? getDirtyFieldsWithRegisteredArrays(_formValues)
             : _formState.dirtyFields
           : keepStateOptions.keepDefaultValues && formValues
-            ? getDirtyFields(_defaultValues, formValues)
+            ? getDirtyFieldsWithRegisteredArrays(formValues)
             : keepStateOptions.keepDirty
               ? _formState.dirtyFields
               : {},
@@ -1890,7 +1912,7 @@ export function createFormControl<
     _defaultValues = cloneObject(values) as Partial<typeof _defaultValues>;
 
     if (!options.keepDirty) {
-      const newDirtyFields = getDirtyFields(_defaultValues, _formValues);
+      const newDirtyFields = getDirtyFieldsWithRegisteredArrays(_formValues);
       _formState.dirtyFields = newDirtyFields as typeof _formState.dirtyFields;
       _formState.isDirty = !isEmptyObject(newDirtyFields);
     }


### PR DESCRIPTION
## Proposed Changes

This PR fixes an inconsistency where `dirtyFields` can become structurally shaped for a normal registered field whose value is an array when `isDirty` is also subscribed.

```js
defaultValues: {
  fruits: [],
}

// after selecting one option in a registered multiple select
dirtyFields;
// => { fruits: [true] }, expected { fruits: true }
```

Root cause: when `isDirty` is subscribed, `updateTouchAndDirty` can recompute `dirtyFields` from the full form values via `getDirtyFields`. That helper intentionally returns structural dirty state for arrays, which is correct for `useFieldArray`, but not for a regular registered field whose value happens to be an array, such as a multiple select.

Without the `isDirty` subscription, the incremental dirty-field path marks the registered field as a boolean leaf:

```js
{ fruits: true }
```

This PR keeps the full recomputation behavior needed for `isDirty` / `dirtyFields` synchronization, then normalizes dirty mounted registered non-`useFieldArray` array-valued fields back to boolean leaves. `useFieldArray` roots and indexed descendants continue to use structural dirty state.

Regression tests were added for:

- a single registered multiple select with both `isDirty` and `dirtyFields` subscribed, covering the #13584 reproduction
- two registered multiple selects, ensuring a dirty array-valued field is not reshaped when another array-valued field changes

Fixes #13584

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes

## Verification

```sh
pnpm test -- --runTestsByPath src/__tests__/useForm/formState.test.tsx --watchman=false
pnpm test -- --runTestsByPath src/__tests__/useFieldArray/dirtyFields.test.tsx --watchman=false
pnpm test -- --runTestsByPath src/__tests__/logic/getDirtyFields.test.ts --watchman=false
pnpm exec eslint src/logic/createFormControl.ts src/__tests__/useForm/formState.test.tsx --cache --no-warn-ignored
pnpm type
pnpm test:type
```
