### PR TITLE
🐞 fix #13592 setValue with shouldDirty not marking dirty state when form is disabled

### DIFF
--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -880,6 +880,57 @@ describe('formState', () => {
     await screen.getByText('0');
   });
 
+  it('should mark field and form as dirty with setValue shouldDirty when the form is disabled', () => {
+    const { result } = renderHook(() =>
+      useForm({
+        disabled: true,
+        defaultValues: {
+          test: 'a',
+        },
+      }),
+    );
+
+    result.current.formState.isDirty;
+    result.current.formState.dirtyFields;
+
+    act(() => {
+      result.current.register('test');
+      result.current.setValue('test', 'b', { shouldDirty: true });
+    });
+
+    expect(result.current.getFieldState('test').isDirty).toBe(true);
+    expect(result.current.formState.isDirty).toBe(true);
+    expect(result.current.formState.dirtyFields).toEqual({ test: true });
+  });
+
+  it('should clear dirty state when setValue restores the default value on a disabled form', () => {
+    const { result } = renderHook(() =>
+      useForm({
+        disabled: true,
+        defaultValues: {
+          test: 'a',
+        },
+      }),
+    );
+
+    result.current.formState.isDirty;
+    result.current.formState.dirtyFields;
+
+    act(() => {
+      result.current.register('test');
+      result.current.setValue('test', 'b', { shouldDirty: true });
+    });
+
+    expect(result.current.formState.isDirty).toBe(true);
+
+    act(() => {
+      result.current.setValue('test', 'a', { shouldDirty: true });
+    });
+
+    expect(result.current.getFieldState('test').isDirty).toBe(false);
+    expect(result.current.formState.isDirty).toBe(false);
+  });
+
   describe('when delay config is set', () => {
     const message = 'required.';
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -441,7 +441,9 @@ export function createFormControl<
       name,
     };
 
-    if (!_options.disabled) {
+    // an explicit programmatic update (e.g. setValue with shouldDirty: true)
+    // opts into dirty tracking even when the form is disabled
+    if (!_options.disabled || shouldDirty === true) {
       if (!isBlurEvent || shouldDirty) {
         const isCurrentFieldPristine = deepEqual(
           get(_defaultValues, name),
@@ -752,10 +754,10 @@ export function createFormControl<
     _names.unMount = new Set();
   };
 
-  const _getDirty: GetIsDirty = (name, data) =>
-    !_options.disabled &&
-    (name && data && set(_formValues, name, data),
-    !deepEqual(_state.mount ? _formValues : _defaultValues, _defaultValues));
+  const _getDirty: GetIsDirty = (name, data) => (
+    name && data && set(_formValues, name, data),
+    !deepEqual(_state.mount ? _formValues : _defaultValues, _defaultValues)
+  );
 
   const _getWatch: WatchInternal<TFieldValues> = (
     names,


### PR DESCRIPTION
Fixes #13592 (confirmed as a bug and assigned to me by @bluebill1049 — this is the focused resubmission of the dirty-state half of #13103, rebased on current master)

## Problem

Calling `setValue(name, value, { shouldDirty: true })` while the form has `disabled: true` never updated `fieldState.isDirty`, `formState.isDirty` or `dirtyFields`:

- `updateTouchAndDirty` short-circuited whenever `_options.disabled` was set, and
- `_getDirty` returned `false` unconditionally for disabled forms, so even when the field-level state was updated, the form-level `isDirty` was recomputed back to `false`.

## Fix

- `updateTouchAndDirty`: an explicit `shouldDirty === true` (programmatic opt-in, e.g. from `setValue`) proceeds even when the form is disabled. User-driven events are unaffected — user input is still blocked by `disabled` itself.
- `_getDirty`: compare current values against defaults regardless of the `disabled` option, so the form-level `isDirty` stays consistent with the values.

## Tests

- New: `setValue(..., { shouldDirty: true })` on a disabled form marks `fieldState.isDirty`, `formState.isDirty` and `dirtyFields`; restoring the default value clears them again.
- Existing `should prevent dirty from updating when the form is disabled` still passes (no `shouldDirty` opt-in there).
- Full suite: 120 suites / 1202 tests pass, lint 0 errors, `tsc --noEmit` clean.