### PR TITLE
fix new FieldArrayComponent and add export to index

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -192,6 +192,9 @@ export type Field = {
 export type FieldArray<TFieldValues extends FieldValues = FieldValues, TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>> = FieldArrayPathValue<TFieldValues, TFieldArrayName> extends ReadonlyArray<infer U> | null | undefined ? U : never;
 
 // @public
+export const FieldArrayComponent: <TFieldValues extends FieldValues = FieldValues, TName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>, TKeyName extends string = "id">(props: FieldArrayProps<TFieldValues, TName, TKeyName>) => ReactElement<unknown, string | JSXElementConstructor<any>>;
+
+// @public
 export type FieldArrayMethodProps = {
     shouldFocus?: boolean;
     focusIndex?: number;

--- a/scripts/rollup/all-exports.json
+++ b/scripts/rollup/all-exports.json
@@ -1,5 +1,6 @@
 [
   "Controller",
+  "FieldArrayComponent",
   "Form",
   "FormProvider",
   "FormStateSubscribe",

--- a/src/fieldArraycomponent.tsx
+++ b/src/fieldArraycomponent.tsx
@@ -19,7 +19,7 @@ import { useFieldArray } from './useFieldArray';
  *
  *   return (
  *     <form>
- *       <FieldArray
+ *       <FieldArrayComponent
  *         control={control}
  *         name="test"
  *         render={({ fields }) =>
@@ -33,7 +33,7 @@ import { useFieldArray } from './useFieldArray';
  * }
  * ```
  */
-const FieldArray = <
+const FieldArrayComponent = <
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',
@@ -41,4 +41,4 @@ const FieldArray = <
   props: FieldArrayProps<TFieldValues, TName, TKeyName>,
 ) => props.render(useFieldArray<TFieldValues, TName, TKeyName>(props));
 
-export { FieldArray };
+export { FieldArrayComponent };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './controller';
+export * from './fieldArraycomponent';
 export * from './form';
 export * from './formStateSubscribe';
 export * from './logic';


### PR DESCRIPTION
New FieldArray component was not added to src/index.ts

When adding export, FieldArray clashes with type FieldArray.
Renamed FieldArray to FieldArrayComponent and added to export. Open to other name suggestions?