### PR TITLE
fix: expose resetDefaultValues through form context

### DIFF
--- a/src/__tests__/useFormContext.test.tsx
+++ b/src/__tests__/useFormContext.test.tsx
@@ -531,6 +531,44 @@ describe('FormProvider', () => {
     consoleSpy.mockRestore();
   });
 
+  it('should expose resetDefaultValues from useFormContext', async () => {
+    const Child = () => {
+      const { resetDefaultValues, formState } = useFormContext<{
+        name: string;
+      }>();
+
+      return (
+        <button
+          data-testid="reset-default-values"
+          onClick={() => resetDefaultValues({ name: 'updated' })}
+        >
+          {formState.defaultValues?.name}
+        </button>
+      );
+    };
+
+    const App = () => {
+      const methods = useForm<{ name: string }>({
+        defaultValues: { name: 'initial' },
+      });
+      return (
+        <FormProvider {...methods}>
+          <Child />
+        </FormProvider>
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reset-default-values'));
+    });
+
+    expect(screen.getByTestId('reset-default-values').textContent).toBe(
+      'updated',
+    );
+  });
+
   it('should expose setValues from useFormContext', async () => {
     const Child = () => {
       const { setValues, getValues } = useFormContext<{

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -99,6 +99,7 @@ export const FormProvider = <
   formState,
   resetField,
   reset,
+  resetDefaultValues,
   handleSubmit,
   unregister,
   control,
@@ -106,7 +107,9 @@ export const FormProvider = <
   setFocus,
   subscribe,
 }: FormProviderProps<TFieldValues, TContext, TTransformedValues>) => {
-  const memoizedValue = React.useMemo(
+  const memoizedValue = React.useMemo<
+    UseFormReturn<TFieldValues, TContext, TTransformedValues>
+  >(
     () => ({
       watch,
       getValues,
@@ -119,6 +122,7 @@ export const FormProvider = <
       formState,
       resetField,
       reset,
+      resetDefaultValues,
       handleSubmit,
       unregister,
       control,
@@ -135,6 +139,7 @@ export const FormProvider = <
       handleSubmit,
       register,
       reset,
+      resetDefaultValues,
       resetField,
       setError,
       setFocus,


### PR DESCRIPTION
## Proposed Changes

`useForm` exposes `resetDefaultValues`, but `FormProvider` omitted it from the
memoized context value. Consumers therefore received `undefined` from
`useFormContext()` and crashed when calling the method.

- Forward `resetDefaultValues` through `FormProvider` and include it in the
  memo dependency list.
- Type the memoized context value as the complete generic `UseFormReturn`, so
  future method omissions are caught by TypeScript.
- Add a regression test that calls `resetDefaultValues` from a nested context
  consumer and verifies the updated defaults are propagated.

Fixes #13597

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
