### PR TITLE
🐞 fix: prevent stale _setValid() calls from overwriting isValid/isValidating

### DIFF
--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -268,6 +268,71 @@ describe('formState', () => {
       await waitFor(() => expect(screen.getByText('valid')).toBeVisible());
       jest.useRealTimers();
     });
+
+    it('should not let a stale whole-form validity check overwrite a newer one', async () => {
+      type FormValues = {
+        username: string;
+        bio: string;
+      };
+
+      const pending: Array<(valid: boolean) => void> = [];
+
+      const App = () => {
+        const {
+          register,
+          formState: { isValid },
+        } = useForm<FormValues>({
+          mode: 'onChange',
+        });
+
+        return (
+          <form>
+            <input
+              data-testid="username"
+              {...register('username', {
+                validate: () =>
+                  new Promise<boolean>((resolve) => {
+                    pending.push(resolve);
+                  }),
+              })}
+            />
+            <input data-testid="bio" {...register('bio')} />
+            <p>{isValid ? 'valid' : 'invalid'}</p>
+          </form>
+        );
+      };
+
+      render(<App />);
+
+      // mount starts the first (soon-to-be-stale) whole-form validity check,
+      // which is waiting on username's validate() to resolve
+      await waitFor(() => expect(pending.length).toBe(1));
+
+      // bio has no validation rules of its own, so this re-triggers another
+      // whole-form validity check while the mount-time one is still pending
+      fireEvent.change(screen.getByTestId('bio'), {
+        target: { value: 'hello' },
+      });
+
+      await waitFor(() => expect(pending.length).toBe(2));
+
+      // the newer check resolves first, correctly reporting the form valid
+      await act(async () => {
+        pending[1](true);
+      });
+      await waitFor(() => expect(screen.getByText('valid')).toBeVisible());
+
+      // the mount-time check was superseded, but its own validate() call
+      // was never told to stop; it resolves after and reports invalid.
+      // Flush with a real macrotask (not just act's microtask draining) so
+      // a stale commit has every chance to land before the final assertion.
+      await act(async () => {
+        pending[0](false);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(screen.getByText('valid')).toBeVisible();
+    });
   });
 
   it('should be a proxy object that returns undefined for unknown properties', () => {

--- a/src/__tests__/useForm/formState.test.tsx
+++ b/src/__tests__/useForm/formState.test.tsx
@@ -333,6 +333,59 @@ describe('formState', () => {
 
       expect(screen.getByText('valid')).toBeVisible();
     });
+
+    it('should not let a stale resolver pass report isValidating as false while a newer one is pending', async () => {
+      type FormValues = {
+        username: string;
+      };
+
+      const pending: Array<() => void> = [];
+
+      const App = () => {
+        const {
+          register,
+          resetField,
+          formState: { isValid, isValidating },
+        } = useForm<FormValues>({
+          mode: 'onChange',
+          resolver: async () =>
+            new Promise((resolve) => {
+              pending.push(() => resolve({ values: {}, errors: {} }));
+            }),
+        });
+        void isValid;
+
+        return (
+          <div>
+            <input data-testid="username" {...register('username')} />
+            <button type="button" onClick={() => resetField('username')}>
+              reset
+            </button>
+            <p>{isValidating ? 'validating' : 'idle'}</p>
+          </div>
+        );
+      };
+
+      render(<App />);
+
+      // mount fires the first (soon-to-be-superseded) resolver pass, via
+      // _setValid's own resolver branch
+      await waitFor(() => expect(pending.length).toBe(1));
+      await waitFor(() => expect(screen.getByText('validating')).toBeVisible());
+
+      // resetField also calls _setValid directly (not onChange's separate
+      // resolver path), firing a second, overlapping pass
+      fireEvent.click(screen.getByText('reset'));
+      await waitFor(() => expect(pending.length).toBe(2));
+
+      // only the FIRST (now-superseded) pass resolves; the second, current
+      // pass is still in flight
+      await act(async () => {
+        pending[0]();
+      });
+
+      expect(screen.getByText('validating')).toBeVisible();
+    });
   });
 
   it('should be a proxy object that returns undefined for unknown properties', () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -234,7 +234,11 @@ export function createFormControl<
       let isValid: boolean;
       if (_options.resolver) {
         isValid = isEmptyObject((await _runSchema()).errors);
-        _updateIsValidating();
+        // Same staleness concern as the isValid commit below: a superseded
+        // call finishing here would otherwise unconditionally clear
+        // validatingFields and report isValidating: false, even while a
+        // newer call is still genuinely in flight.
+        callId === _setValidCallId && _updateIsValidating();
       } else {
         isValid = await executeBuiltInValidation({
           fields: _fields,

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -224,12 +224,6 @@ export function createFormControl<
         _proxySubscribeFormState.isValid ||
         shouldUpdateValid)
     ) {
-      // _setValid is fired-and-forget from many call sites and never
-      // cancelled, so an earlier call can still be awaiting validation when
-      // a later one starts. Track which call is the most recent so a call
-      // that's been superseded by the time its validation resolves doesn't
-      // commit a stale result over a newer one, mirroring the staleness
-      // check onChange already does per-field via _updateIsFieldValueUpdated.
       const callId = ++_setValidCallId;
       let isValid: boolean;
       if (_options.resolver) {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -202,6 +202,8 @@ export function createFormControl<
     state: createSubject(),
   };
 
+  let _setValidCallId = 0;
+
   const shouldDisplayAllAssociatedErrors =
     _options.criteriaMode === VALIDATION_MODE.all;
 
@@ -222,6 +224,13 @@ export function createFormControl<
         _proxySubscribeFormState.isValid ||
         shouldUpdateValid)
     ) {
+      // _setValid is fired-and-forget from many call sites and never
+      // cancelled, so an earlier call can still be awaiting validation when
+      // a later one starts. Track which call is the most recent so a call
+      // that's been superseded by the time its validation resolves doesn't
+      // commit a stale result over a newer one, mirroring the staleness
+      // check onChange already does per-field via _updateIsFieldValueUpdated.
+      const callId = ++_setValidCallId;
       let isValid: boolean;
       if (_options.resolver) {
         isValid = isEmptyObject((await _runSchema()).errors);
@@ -233,7 +242,7 @@ export function createFormControl<
           eventType: EVENTS.VALID,
         });
       }
-      if (isValid !== _formState.isValid) {
+      if (callId === _setValidCallId && isValid !== _formState.isValid) {
         _subjects.state.next({
           isValid,
         });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -228,10 +228,6 @@ export function createFormControl<
       let isValid: boolean;
       if (_options.resolver) {
         isValid = isEmptyObject((await _runSchema()).errors);
-        // Same staleness concern as the isValid commit below: a superseded
-        // call finishing here would otherwise unconditionally clear
-        // validatingFields and report isValidating: false, even while a
-        // newer call is still genuinely in flight.
         callId === _setValidCallId && _updateIsValidating();
       } else {
         isValid = await executeBuiltInValidation({


### PR DESCRIPTION
## Proposed Changes

`_setValid()` is called fire-and-forget from 9 different call sites (mount, setValue, unregister, trigger, resetField, disabled-state changes, etc.) and is never awaited by its callers, with no guard against out-of-order completion. If an earlier call is still awaiting async validation (either a resolver or a field's own `validate`) when a later call starts and finishes first, the earlier call can still commit its now-stale result afterward, silently overwriting the correct, current one. This affects both `formState.isValid` and, for resolver-based forms specifically, `formState.isValidating`.

This gives each `_setValid()` invocation a monotonic call id and skips committing its result if a newer call has started since, mirroring the staleness check `onChange` already does per-field via `_updateIsFieldValueUpdated`. For any normal (non-overlapping) call, this is a no-op: the id always still matches, so behavior is unchanged.

Two commits, found and fixed in sequence:
1. The core `isValid` staleness fix, with a test reproducing a form with an async-validated field and a rule-less field: two rapid changes race, and without the fix the earlier (correct) result gets overwritten by the later, stale one.
2. While reviewing that fix, found `_updateIsValidating()` has the exact same exposure for resolver-based forms (it unconditionally clears `validatingFields` and reports `isValidating: false`), reachable independently of `onChange` (which takes its own separate resolver path, not `_setValid`, when a resolver is configured) via e.g. `resetField()` overlapping a still-pending mount-time validation. Fixed the same way, with its own regression test.

Verified both regression tests fail against the code before each respective fix and pass after. Also verified end-to-end against the actual built `dist/index.cjs.js` (not just source + jest), confirming both fixes hold through the real build pipeline.

Fixes # (no existing issue; found via direct source review and empirical reproduction)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes