### PR TITLE
🐞 fix(useController): resubscribe onChange/onBlur when control changes

### DIFF
--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -1751,7 +1751,7 @@ describe('useController', () => {
     expect(result.current.field.value).toBe('form1-value');
   });
 
-  it('should write onChange/onBlur updates to the newly-passed control (#13163)', async () => {
+  it('should write onChange updates to the newly-passed control (#13163)', async () => {
     type FormValues = {
       name: string;
     };

--- a/src/__tests__/useController.test.tsx
+++ b/src/__tests__/useController.test.tsx
@@ -1751,6 +1751,59 @@ describe('useController', () => {
     expect(result.current.field.value).toBe('form1-value');
   });
 
+  it('should write onChange/onBlur updates to the newly-passed control (#13163)', async () => {
+    type FormValues = {
+      name: string;
+    };
+
+    const { result: form1Result } = renderHook(() =>
+      useForm<FormValues>({
+        defaultValues: {
+          name: '',
+        },
+      }),
+    );
+
+    const { result: form2Result } = renderHook(() =>
+      useForm<FormValues>({
+        defaultValues: {
+          name: '',
+        },
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ control }: { control: Control<FormValues> }) =>
+        useController({
+          control,
+          name: 'name',
+        }),
+      {
+        initialProps: { control: form1Result.current.control },
+      },
+    );
+
+    result.current.field.onChange('form1-typed');
+
+    await waitFor(() => {
+      expect(form1Result.current.getValues('name')).toBe('form1-typed');
+    });
+
+    rerender({ control: form2Result.current.control });
+
+    await waitFor(() => {
+      expect(result.current.field.value).toBe('');
+    });
+
+    result.current.field.onChange('form2-typed');
+
+    await waitFor(() => {
+      expect(form2Result.current.getValues('name')).toBe('form2-typed');
+    });
+
+    expect(form1Result.current.getValues('name')).toBe('form1-typed');
+  });
+
   it('should update isValid when Controller with required rule re-mounts via checkbox toggle', async () => {
     type FormValues = {
       items: { checked: boolean; input: string }[];

--- a/src/useController.ts
+++ b/src/useController.ts
@@ -209,7 +209,7 @@ export function useController<
     const _shouldUnregisterField =
       control._options.shouldUnregister || shouldUnregister;
 
-    control.register(name, {
+    _registerProps.current = control.register(name, {
       ..._props.current.rules,
       ...(isBoolean(_props.current.disabled)
         ? { disabled: _props.current.disabled }


### PR DESCRIPTION
_registerProps was only ever set once via useRef, so switching the control prop kept writing field updates to the original control even though useWatch had already re-subscribed and reads reflected the new one. Store the return value of the existing control.register() call inside the effect that already re-runs on control/name change so writes stay in sync with reads.

Fixes #13163