### PR TITLE
fix: preserve dirtyFields reference during recomputation

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -268,14 +268,23 @@ export function createFormControl<
   };
 
   const _updateDirtyFields = () => {
-    _formState.dirtyFields = getDirtyFields(
+    const nextDirtyFields = getDirtyFields(
       _defaultValues,
       _formValues,
       undefined,
       _fields,
     );
-  };
 
+    _formState.dirtyFields ??= {};
+
+    for (const key in _formState.dirtyFields) {
+      if (!(key in nextDirtyFields)) {
+        delete _formState.dirtyFields[key];
+      }
+    }
+
+    Object.assign(_formState.dirtyFields, nextDirtyFields);
+  };
   const _setFieldArray: BatchFieldArrayUpdate = (
     name,
     values = [],


### PR DESCRIPTION
## Summary

This PR preserves the `dirtyFields` object reference during dirty field recomputation instead of replacing it with a newly allocated object.

## Problem

Since the dirty field recomputation replaces `formState.dirtyFields` with a new object, repeated calls to `setValue(..., { shouldDirty: true })` change the object reference even when the set of dirty fields remains unchanged.

This can cause unnecessary React re-renders and break code relying on referential stability.

## Solution

Instead of assigning a new object returned by `getDirtyFields()`, this change reconciles the computed values into the existing `dirtyFields` object.

This preserves the object reference while keeping the dirty field contents synchronized.

## Notes

* No changes to the current dirty-field semantics.
* Existing tests pass successfully.
