### PR TITLE
fix: preserve dirtyFields reference stability

### DIFF
--- a/src/__tests__/logic/createFormControl.test.ts
+++ b/src/__tests__/logic/createFormControl.test.ts
@@ -10,6 +10,38 @@ jest.mock('../../utils/isEmptyObject', () => {
 });
 
 describe('createFormControl', () => {
+  it('should keep dirtyFields reference stable when dirty fields do not change', () => {
+    const { control, setValue, subscribe } = createFormControl<{
+      a: string;
+      b: string;
+    }>({
+      defaultValues: {
+        a: '',
+        b: '',
+      },
+    });
+
+    subscribe({
+      formState: {
+        isDirty: true,
+        dirtyFields: true,
+      },
+      callback: jest.fn(),
+    });
+
+    const dirtyFieldsRefs = [];
+
+    for (let i = 0; i < 4; i++) {
+      setValue('a', `x${i}`, { shouldDirty: true });
+      dirtyFieldsRefs.push(control._formState.dirtyFields);
+    }
+
+    expect(control._formState.dirtyFields).toEqual({ a: true });
+    expect(dirtyFieldsRefs[1]).toBe(dirtyFieldsRefs[0]);
+    expect(dirtyFieldsRefs[2]).toBe(dirtyFieldsRefs[0]);
+    expect(dirtyFieldsRefs[3]).toBe(dirtyFieldsRefs[0]);
+  });
+
   it('should call `executeBuiltInValidation` once for a single field', async () => {
     const { register, control } = createFormControl({
       defaultValues: {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -111,6 +111,19 @@ const defaultOptions = {
 
 const FORM_ERROR_TYPE = 'form';
 
+const updateDirtyFields = (
+  dirtyFields: Record<string, unknown>,
+  nextDirtyFields: Record<string, unknown>,
+) => {
+  for (const key in dirtyFields) {
+    if (!(key in nextDirtyFields)) {
+      delete dirtyFields[key];
+    }
+  }
+
+  Object.assign(dirtyFields, nextDirtyFields);
+};
+
 export const DEFAULT_FORM_STATE = {
   submitCount: 0,
   isDirty: false,
@@ -464,11 +477,14 @@ export function createFormControl<
         isPreviousDirty = !!get(_formState.dirtyFields, name);
 
         if (isCurrentFieldPristine !== _formState.isDirty) {
-          _formState.dirtyFields = getDirtyFields(
-            _defaultValues,
-            _formValues,
-            undefined,
-            _fields,
+          updateDirtyFields(
+            _formState.dirtyFields as Record<string, unknown>,
+            getDirtyFields(
+              _defaultValues,
+              _formValues,
+              undefined,
+              _fields,
+            ) as Record<string, unknown>,
           );
         } else {
           isCurrentFieldPristine


### PR DESCRIPTION
Fixes #13608.

## Summary

- Preserve the top-level `dirtyFields` object reference when a recompute finds the same dirty field set.
- Keep the full `getDirtyFields` recompute path so dirty tracking remains accurate.
- Add a regression test covering repeated `setValue(..., { shouldDirty: true })` calls on an already-dirty field.

## Tests

- `pnpm test src/__tests__/logic/createFormControl.test.ts --runInBand --no-watchman`
- `pnpm type`
- `pnpm lint`
- `pnpm test --runInBand --no-watchman`
- `pnpm test:type`
- `pnpm build`
- `pnpm api-extractor`
