### PR TITLE
🐞 fix: reset internal errors when clearErrors() is called without arguments

### DIFF
--- a/src/__tests__/logic/createFormControl.test.ts
+++ b/src/__tests__/logic/createFormControl.test.ts
@@ -62,4 +62,24 @@ describe('createFormControl', () => {
 
     expect(isEmptyObject).toHaveBeenCalledTimes(3);
   });
+
+  it('should clear the entire internal errors state when `clearErrors()` is called without arguments', () => {
+    const { setError, clearErrors, getFieldState, control } =
+      createFormControl<{
+        foo: string;
+        bar: string;
+      }>();
+
+    setError('foo', { type: 'required' });
+    setError('bar', { type: 'required' });
+
+    expect(getFieldState('foo').invalid).toBe(true);
+    expect(control._formState.errors).not.toEqual({});
+
+    clearErrors();
+
+    expect(getFieldState('foo').invalid).toBe(false);
+    expect(getFieldState('bar').invalid).toBe(false);
+    expect(control._formState.errors).toEqual({});
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1306,8 +1306,9 @@ export function createFormControl<
         });
       });
     } else {
+      _formState.errors = {};
       _subjects.state.next({
-        errors: {},
+        errors: _formState.errors,
       });
     }
   };


### PR DESCRIPTION
Hello, Bill 😁

While working on something else, I happened to discover this bug and would like to fix it.

### Issue

When `clearErrors()` is called without arguments while using a standalone `createFormControl()`, the subscriber payload contains an empty `errors` object, but the internal errors state is not cleared.

As a result, `getFieldState(name).invalid` continues to return `true` even after all errors have been cleared.

### Cause

This regression was introduced in #9778 and was first released in v7.43.0.

As part of the package-size optimization, the direct reset of `_formState.errors` was removed. The implementation only emitted an empty errors object to subscribers:

```ts
_subjects.state.next({
  errors: name ? _formState.errors : {},
});
```

With `useForm()`, the React subscriber merges the emitted state through `_setFormState()`, which hides the inconsistency.

However, `createFormControl()` API introduced in #11522 and released in v7.55.0. Without a subscriber, the emitted event does not update `_formState.errors`, so `getFieldState()` continues to read the stale errors.

### Solution

- Restore the direct reset of `_formState.errors` when `clearErrors()` is called without arguments.
- Emit the updated `_formState.errors` so the internal state and subscriber payload remain consistent.
- Add a regression test covering standalone `createFormControl()` usage without a subscriber.

### Tests

- Added a regression test verifying that `getFieldState()` no longer reports stale errors after `clearErrors()`.