### PR TITLE
♻️ refactor(types): extract shared ErrorNamespacePath

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -704,8 +704,10 @@ export type UseFieldArrayUpdate<TFieldValues extends FieldValues, TFieldArrayNam
 // @public
 export function useForm<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues>(props?: UseFormProps<TFieldValues, TContext, TTransformedValues>): UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
+// Warning: (ae-forgotten-export) The symbol "ErrorNamespacePath" needs to be exported by the entry point index.d.ts
+//
 // @public
-export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | `root.${string}` | 'root' | 'form' | `form.${string}`) => void;
+export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | ErrorNamespacePath) => void;
 
 // @public
 export const useFormContext: <TFieldValues extends FieldValues, TContext = any, TTransformedValues = TFieldValues>() => UseFormReturn<TFieldValues, TContext, TTransformedValues>;
@@ -802,7 +804,7 @@ export type UseFormReturn<TFieldValues extends FieldValues = FieldValues, TConte
 };
 
 // @public
-export type UseFormSetError<TFieldValues extends FieldValues> = (name: FieldPath<TFieldValues> | `root.${string}` | 'root' | 'form' | `form.${string}`, error: ErrorOption, options?: {
+export type UseFormSetError<TFieldValues extends FieldValues> = (name: FieldPath<TFieldValues> | ErrorNamespacePath, error: ErrorOption, options?: {
     shouldFocus: boolean;
 }) => void;
 
@@ -1016,8 +1018,8 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:511:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:893:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:513:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:887:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -360,6 +360,8 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
   ): [...FieldPathValues<TFieldValues, TFieldNames>];
 };
 
+type ErrorNamespacePath = 'root' | `root.${string}` | 'form' | `form.${string}`;
+
 /**
  * This method will return individual field states. It will be useful when you are trying to retrieve the nested value field state in a type-safe approach.
  *
@@ -567,10 +569,7 @@ export type UseFormClearErrors<TFieldValues extends FieldValues> = (
     | FieldPath<TFieldValues>
     | FieldPath<TFieldValues>[]
     | readonly FieldPath<TFieldValues>[]
-    | `root.${string}`
-    | 'root'
-    | 'form'
-    | `form.${string}`,
+    | ErrorNamespacePath,
 ) => void;
 
 /**
@@ -637,12 +636,7 @@ export type UseFormSetValues<TFieldValues extends FieldValues> = (
  * ```
  */
 export type UseFormSetError<TFieldValues extends FieldValues> = (
-  name:
-    | FieldPath<TFieldValues>
-    | `root.${string}`
-    | 'root'
-    | 'form'
-    | `form.${string}`,
+  name: FieldPath<TFieldValues> | ErrorNamespacePath,
   error: ErrorOption,
   options?: {
     shouldFocus: boolean;


### PR DESCRIPTION
Hello, Bill 😁

While working on something else, I noticed that `UseFormSetError` and
`UseFormClearErrors` repeat the same `root` and `form` error path types, so I
would like to make this small type-only refactor.

### Issue

`UseFormSetError` and `UseFormClearErrors` independently declare the same
additional error paths:

```ts
'root' | `root.${string}` | 'form' | `form.${string}`;
```

### Solution

- Extract the existing path union into an internal `ErrorNamespacePath` type.

### Documentation Question

Form-level validation stores its errors under `errors.form`, but I could not
find documentation explaining whether `form` and `form.*` should be avoided as
registered field names. Would it be helpful to document this potential naming
conflict?