### PR TITLE
🧪 test: cover Blob in FieldErrors type tests

### DIFF
--- a/src/__typetest__/errors.test-d.ts
+++ b/src/__typetest__/errors.test-d.ts
@@ -72,21 +72,26 @@ import { _ } from './__fixtures__';
       date: Date;
       file: File;
       fileList: FileList;
+      blob: Blob;
       record: {
         date: Date;
         file: File;
         fileList: FileList;
+        blob: Blob;
       };
     }>;
     const recordDate = actual.record?.date;
     const recordFile = actual.record?.file;
     const recordFileList = actual.record?.fileList;
+    const recordBlob = actual.record?.blob;
     type _t1 = Expect<Equal<typeof actual.date, FieldError | undefined>>;
     type _t2 = Expect<Equal<typeof actual.file, FieldError | undefined>>;
     type _t3 = Expect<Equal<typeof actual.fileList, FieldError | undefined>>;
     type _t4 = Expect<Equal<typeof recordDate, FieldError | undefined>>;
     type _t5 = Expect<Equal<typeof recordFile, FieldError | undefined>>;
     type _t6 = Expect<Equal<typeof recordFileList, FieldError | undefined>>;
+    type _t7 = Expect<Equal<typeof actual.blob, FieldError | undefined>>;
+    type _t8 = Expect<Equal<typeof recordBlob, FieldError | undefined>>;
   }
 
   /** it should handle field name conflicts with FieldError properties correctly */


### PR DESCRIPTION
Hello, Bill 😁

The existing `FieldErrors` type test explicitly includes `Blob` in its description:

```ts
/** it should not treat Date, File, FileList or Blob as record fields */
```

However, `Blob` was missing from the actual test cases.

This PR adds top-level and nested `Blob` assertions so the test matches its description.