### PR TITLE
fix(useWatch): reconcile stale values after Activity reconnect

### DIFF
--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -1283,6 +1283,149 @@ describe('useWatch', () => {
   });
 
   describe('reset', () => {
+    it('should synchronize watched and controlled values after Activity restoration', () => {
+      type FormValues = {
+        name: string;
+      };
+
+      let getName = (): string => {
+        throw new Error('Form methods are not initialized.');
+      };
+
+      const ActivityContent = ({
+        control,
+      }: {
+        control: Control<FormValues>;
+      }) => {
+        const name = useWatch({ control, name: 'name' });
+
+        return (
+          <>
+            <span data-testid="watched-name">{name}</span>
+            <Controller
+              control={control}
+              name="name"
+              render={({ field }) => (
+                <input data-testid="controlled-name" {...field} />
+              )}
+            />
+          </>
+        );
+      };
+
+      const Component = () => {
+        const { control, getValues, reset, setValue } = useForm<FormValues>({
+          defaultValues: {
+            name: 'initial',
+          },
+        });
+        const [mode, setMode] = React.useState<'hidden' | 'visible'>('visible');
+
+        getName = () => getValues('name');
+
+        return (
+          <>
+            <button type="button" onClick={() => setMode('hidden')}>
+              Hide
+            </button>
+            <button type="button" onClick={() => reset({ name: 'updated' })}>
+              Reset
+            </button>
+            <button
+              type="button"
+              onClick={() => setValue('name', 'updated in place')}
+            >
+              Update
+            </button>
+            <button type="button" onClick={() => setMode('visible')}>
+              Show
+            </button>
+            <React.Activity mode={mode}>
+              <ActivityContent control={control} />
+            </React.Activity>
+          </>
+        );
+      };
+
+      render(
+        <React.StrictMode>
+          <Component />
+        </React.StrictMode>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Hide' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+
+      expect(getName()).toBe('updated');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+      expect(screen.getByTestId('watched-name')).toHaveTextContent('updated');
+      expect(screen.getByTestId('controlled-name')).toHaveValue('updated');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Hide' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+
+      expect(getName()).toBe('updated in place');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+      expect(screen.getByTestId('watched-name')).toHaveTextContent(
+        'updated in place',
+      );
+      expect(screen.getByTestId('controlled-name')).toHaveValue(
+        'updated in place',
+      );
+    });
+
+    it('should synchronize an initially hidden Activity on first subscription', () => {
+      type FormValues = {
+        name: string;
+      };
+
+      const ActivityContent = ({
+        control,
+      }: {
+        control: Control<FormValues>;
+      }) => {
+        const name = useWatch({ control, name: 'name' });
+
+        return <span data-testid="watched-name">{name}</span>;
+      };
+
+      const Component = () => {
+        const { control, reset } = useForm<FormValues>({
+          defaultValues: {
+            name: 'initial',
+          },
+        });
+        const [mode, setMode] = React.useState<'hidden' | 'visible'>('hidden');
+
+        return (
+          <>
+            <button type="button" onClick={() => reset({ name: 'updated' })}>
+              Reset
+            </button>
+            <button type="button" onClick={() => setMode('visible')}>
+              Show
+            </button>
+            <React.Activity mode={mode}>
+              <ActivityContent control={control} />
+            </React.Activity>
+          </>
+        );
+      };
+
+      render(<Component />);
+
+      expect(screen.getByTestId('watched-name')).toHaveTextContent('initial');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+      expect(screen.getByTestId('watched-name')).toHaveTextContent('updated');
+    });
+
     it('should return updated default value with watched field after reset', async () => {
       type FormValues = {
         test: string;

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -271,6 +271,14 @@ export function useWatch<TFieldValues extends FieldValues>(
 
   const _prevControl = React.useRef(control);
   const _prevName = React.useRef(name);
+  const _didCleanup = React.useRef(false);
+  const _subscribed = React.useRef(false);
+  const _prevEffectDeps = React.useRef<{
+    control: typeof control;
+    exact: typeof exact;
+    name: typeof name;
+    refreshValue: typeof refreshValue;
+  } | null>(null);
 
   _compute.current = compute;
 
@@ -282,6 +290,9 @@ export function useWatch<TFieldValues extends FieldValues>(
 
     return _compute.current ? _compute.current(defaultValue) : defaultValue;
   });
+  const _value = React.useRef(value);
+
+  _value.current = value;
 
   const getCurrentOutput = React.useCallback(
     (values?: TFieldValues) => {
@@ -325,16 +336,39 @@ export function useWatch<TFieldValues extends FieldValues>(
   );
 
   useIsomorphicLayoutEffect(() => {
-    if (
-      _prevControl.current !== control ||
-      !deepEqual(_prevName.current, name)
-    ) {
+    const controlOrNameChanged =
+      _prevControl.current !== control || !deepEqual(_prevName.current, name);
+    const effectDepsChanged =
+      _prevEffectDeps.current === null ||
+      _prevEffectDeps.current.control !== control ||
+      _prevEffectDeps.current.exact !== exact ||
+      _prevEffectDeps.current.name !== name ||
+      _prevEffectDeps.current.refreshValue !== refreshValue;
+    const getWatchSnapshot = () => {
+      const watchValue = control._getWatch(
+        name as InternalFieldName,
+        _defaultValue.current as DeepPartialSkipArrayKey<TFieldValues>,
+      );
+
+      return _compute.current ? _compute.current(watchValue) : watchValue;
+    };
+
+    if (controlOrNameChanged) {
       _prevControl.current = control;
       _prevName.current = name;
       refreshValue();
+    } else if (
+      (_didCleanup.current && !effectDepsChanged) ||
+      (!_subscribed.current && !deepEqual(_value.current, getWatchSnapshot()))
+    ) {
+      refreshValue();
     }
 
-    return control._subscribe({
+    _didCleanup.current = false;
+    _subscribed.current = true;
+    _prevEffectDeps.current = { control, exact, name, refreshValue };
+
+    const unsubscribe = control._subscribe({
       name,
       formState: {
         values: true,
@@ -344,6 +378,11 @@ export function useWatch<TFieldValues extends FieldValues>(
         refreshValue(formState.values);
       },
     });
+
+    return () => {
+      _didCleanup.current = true;
+      unsubscribe();
+    };
   }, [control, exact, name, refreshValue]);
 
   React.useEffect(() => control._removeUnmounted());


### PR DESCRIPTION
Fixes #13625

## Summary

Fix `useWatch` returning stale values when a subscriber is restored from a hidden React `Activity` boundary.

While Activity is hidden, `useWatch`'s layout effect unsubscribes but React preserves the hook's local state. If `reset()` or `setValue()` runs during that window, reconnecting the subscription did not reconcile the preserved snapshot because refresh only ran when `control` or `name` changed.

## Approach

Extend the existing subscription effect to detect genuine reconnects (cleanup + remount with unchanged deps) and refresh when the local snapshot differs from `control._getWatch`. No new public API, no new abstractions.

Compared to #13626: ~44 lines in `useWatch.ts` vs ~115, no new helpers/imports, same core tests.

## Test plan

- [x] Hide Activity → reset → show: `useWatch` and controlled input show `"updated"`
- [x] Hide Activity → setValue → show: values reconcile
- [x] Initially hidden Activity → reset → show: first subscription syncs
- [x] StrictMode wrapper in Activity test
- [x] `pnpm test` — 1220 tests pass
- [x] `pnpm test:type` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm build` — pass
- [x] `pnpm api-extractor` — pass
- [ ] `pnpm e2e` — not run locally (requires `pnpm start` app setup with pnpm v11 / Node 22 per CONTRIBUTING)