### PR TITLE
🐞 fix #13627 keepDirtyValues: reconcile field array rows by id so dirty/touched/error state follows reordered rows

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -437,6 +437,7 @@ export type KeepStateOptions = Partial<{
     keepIsValid: boolean;
     keepSubmitCount: boolean;
     keepFieldsRef: boolean;
+    getRowId: (row: unknown, arrayPath: string) => string | number | undefined;
 }>;
 
 // @public (undocumented)
@@ -1024,8 +1025,8 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:513:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:887:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:514:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:888:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -1025,8 +1025,8 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:514:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:888:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:527:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:909:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/logic/reconcileFieldArraysById.test.ts
+++ b/src/__tests__/logic/reconcileFieldArraysById.test.ts
@@ -195,6 +195,224 @@ describe('reconcileFieldArraysById', () => {
     expect(result.rows.root).toEqual({ type: 'min', message: 'too short' });
   });
 
+  it('should match rows with a custom getRowId', () => {
+    const previousValues = {
+      rows: [
+        { uuid: 'a', name: 'Alpha' },
+        { uuid: 'b', name: 'Bravo' },
+      ],
+    };
+    const nextValues = {
+      rows: [
+        { uuid: 'b', name: 'Bravo' },
+        { uuid: 'a', name: 'Alpha' },
+      ],
+    };
+
+    expect(
+      reconcileFieldArraysById(
+        { rows: [{ name: true }, undefined] },
+        previousValues,
+        nextValues,
+        (row) => (row as { uuid: string }).uuid,
+      ),
+    ).toEqual({
+      rows: [undefined, { name: true }],
+    });
+  });
+
+  it('should let getRowId opt arrays in or out per array path', () => {
+    const previousValues = {
+      keyed: [
+        { key: 'a', name: 'Alpha' },
+        { key: 'b', name: 'Bravo' },
+      ],
+      positional: [
+        { key: 'a', name: 'One' },
+        { key: 'b', name: 'Two' },
+      ],
+    };
+    const nextValues = {
+      keyed: [
+        { key: 'b', name: 'Bravo' },
+        { key: 'a', name: 'Alpha' },
+      ],
+      positional: [
+        { key: 'b', name: 'Two' },
+        { key: 'a', name: 'One' },
+      ],
+    };
+    const tree = {
+      keyed: [{ name: true }, undefined],
+      positional: [{ name: true }, undefined],
+    };
+
+    expect(
+      reconcileFieldArraysById(tree, previousValues, nextValues, (row, path) =>
+        path === 'keyed' ? (row as { key: string }).key : undefined,
+      ),
+    ).toEqual({
+      keyed: [undefined, { name: true }],
+      positional: [{ name: true }, undefined],
+    });
+  });
+
+  it('should call getRowId with the array path including parent row indexes', () => {
+    const previousValues = {
+      groups: [{ id: 'a', items: [{ id: 'x', label: 'one' }] }],
+    };
+    const nextValues = {
+      groups: [{ id: 'a', items: [{ id: 'x', label: 'one' }] }],
+    };
+    const paths = new Set<string>();
+
+    reconcileFieldArraysById(
+      previousValues,
+      previousValues,
+      nextValues,
+      (row, path) => {
+        paths.add(path);
+        return (row as { id: string }).id;
+      },
+    );
+
+    expect(Array.from(paths).sort()).toEqual(['groups', 'groups.0.items']);
+  });
+
+  it('should pass class instances such as File through by reference instead of copying them', () => {
+    const file = new File(['content'], 'avatar.png');
+    class Money {
+      constructor(public amount: number) {}
+    }
+    const price = new Money(10);
+    const previousValues = {
+      avatar: file,
+      price,
+      rows: [{ id: 'a', name: 'Alpha' }],
+    };
+    const nextValues = {
+      avatar: null,
+      price: null,
+      rows: [{ id: 'a', name: 'Alpha' }],
+    };
+
+    const result = reconcileFieldArraysById(
+      previousValues,
+      previousValues,
+      nextValues,
+    );
+
+    expect(result.avatar).toBe(file);
+    expect(result.price).toBe(price);
+  });
+
+  it('should fall back to index behavior when a row id is itself dirty under the default matcher', () => {
+    const previousValues = {
+      rows: [
+        { id: 'edited', name: 'Alpha edited' },
+        { id: 'b', name: 'Bravo' },
+      ],
+    };
+    const nextValues = {
+      rows: [
+        { id: 'a', name: 'Alpha' },
+        { id: 'b', name: 'Bravo' },
+      ],
+    };
+    const dirtyFields = { rows: [{ id: true, name: true }] };
+
+    expect(
+      reconcileFieldArraysById(
+        dirtyFields,
+        previousValues,
+        nextValues,
+        undefined,
+        dirtyFields,
+      ),
+    ).toEqual(dirtyFields);
+
+    expect(
+      reconcileFieldArraysById(
+        previousValues,
+        previousValues,
+        nextValues,
+        undefined,
+        dirtyFields,
+      ),
+    ).toEqual(previousValues);
+  });
+
+  it('should keep matching with a custom getRowId even when the id field is dirty', () => {
+    const previousValues = {
+      rows: [
+        { id: 'edited', key: 'a', name: 'Alpha' },
+        { id: 'b-id', key: 'b', name: 'Bravo' },
+      ],
+    };
+    const nextValues = {
+      rows: [
+        { id: 'b-id', key: 'b', name: 'Bravo' },
+        { id: 'a-id', key: 'a', name: 'Alpha' },
+      ],
+    };
+    const dirtyFields = { rows: [{ id: true }] };
+
+    expect(
+      reconcileFieldArraysById(
+        dirtyFields,
+        previousValues,
+        nextValues,
+        (row) => (row as { key: string }).key,
+        dirtyFields,
+      ),
+    ).toEqual({
+      rows: [undefined, { id: true }],
+    });
+  });
+
+  it('should preserve non-index array properties in the index fallback branch', () => {
+    const previousValues = { rows: [{ name: '' }] };
+    const nextValues = { rows: [{ name: '' }] };
+    const rowsErrors: Record<string, any>[] = [];
+    (rowsErrors as Record<string, any>).root = {
+      type: 'min',
+      message: 'too short',
+    };
+
+    const result: Record<string, any> = reconcileFieldArraysById(
+      { rows: rowsErrors },
+      previousValues,
+      nextValues,
+    );
+
+    expect(result.rows.root).toEqual({ type: 'min', message: 'too short' });
+  });
+
+  it('should match rows whose id flips between number and string', () => {
+    const previousValues = {
+      rows: [
+        { id: 1, name: 'Alpha' },
+        { id: 2, name: 'Bravo' },
+      ],
+    };
+    const nextValues = {
+      rows: [
+        { id: '2', name: 'Bravo' },
+        { id: '1', name: 'Alpha' },
+      ],
+    };
+
+    expect(
+      reconcileFieldArraysById(
+        { rows: [{ name: true }, undefined] },
+        previousValues,
+        nextValues,
+      ),
+    ).toEqual({
+      rows: [undefined, { name: true }],
+    });
+  });
+
   it('should not descend into state leaves that have no matching value container', () => {
     const ref = { focus: () => {} };
     const previousValues = { user: { name: '' } };

--- a/src/__tests__/logic/reconcileFieldArraysById.test.ts
+++ b/src/__tests__/logic/reconcileFieldArraysById.test.ts
@@ -1,0 +1,210 @@
+import reconcileFieldArraysById from '../../logic/reconcileFieldArraysById';
+
+describe('reconcileFieldArraysById', () => {
+  it('should reorder array entries to follow row ids in the next values', () => {
+    const previousValues = {
+      rows: [
+        { id: 'a', name: 'Alpha' },
+        { id: 'b', name: 'Bravo' },
+        { id: 'c', name: 'Charlie' },
+      ],
+    };
+    const nextValues = {
+      rows: [
+        { id: 'c', name: 'Charlie' },
+        { id: 'a', name: 'Alpha' },
+        { id: 'b', name: 'Bravo' },
+      ],
+    };
+
+    expect(
+      reconcileFieldArraysById(previousValues, previousValues, nextValues),
+    ).toEqual({
+      rows: [
+        { id: 'c', name: 'Charlie' },
+        { id: 'a', name: 'Alpha' },
+        { id: 'b', name: 'Bravo' },
+      ],
+    });
+
+    expect(
+      reconcileFieldArraysById(
+        { rows: [{ name: true }, undefined, { name: true }] },
+        previousValues,
+        nextValues,
+      ),
+    ).toEqual({
+      rows: [{ name: true }, { name: true }, undefined],
+    });
+  });
+
+  it('should drop entries for removed rows and leave inserted rows empty', () => {
+    const previousValues = {
+      rows: [
+        { id: 1, name: 'Alpha' },
+        { id: 2, name: 'Bravo' },
+      ],
+    };
+    const nextValues = {
+      rows: [
+        { id: 3, name: 'New' },
+        { id: 2, name: 'Bravo' },
+      ],
+    };
+
+    expect(
+      reconcileFieldArraysById(
+        { rows: [{ name: true }, { name: true }] },
+        previousValues,
+        nextValues,
+      ),
+    ).toEqual({
+      rows: [undefined, { name: true }],
+    });
+  });
+
+  it('should reconcile nested arrays inside matched rows', () => {
+    const previousValues = {
+      rows: [
+        {
+          id: 'a',
+          items: [
+            { id: 'a1', label: 'first' },
+            { id: 'a2', label: 'second' },
+          ],
+        },
+        { id: 'b', items: [{ id: 'b1', label: 'third' }] },
+      ],
+    };
+    const nextValues = {
+      rows: [
+        { id: 'b', items: [{ id: 'b1', label: 'third' }] },
+        {
+          id: 'a',
+          items: [
+            { id: 'a2', label: 'second' },
+            { id: 'a1', label: 'first' },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      reconcileFieldArraysById(
+        { rows: [{ items: [{ label: true }] }, undefined] },
+        previousValues,
+        nextValues,
+      ),
+    ).toEqual({
+      rows: [undefined, { items: [undefined, { label: true }] }],
+    });
+  });
+
+  it('should reconcile nested arrays when parent rows have no ids', () => {
+    const previousValues = {
+      groups: [
+        {
+          items: [
+            { id: 'x', label: 'one' },
+            { id: 'y', label: 'two' },
+          ],
+        },
+      ],
+    };
+    const nextValues = {
+      groups: [
+        {
+          items: [
+            { id: 'y', label: 'two' },
+            { id: 'x', label: 'one' },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      reconcileFieldArraysById(
+        { groups: [{ items: [{ label: true }] }] },
+        previousValues,
+        nextValues,
+      ),
+    ).toEqual({
+      groups: [{ items: [undefined, { label: true }] }],
+    });
+  });
+
+  it('should keep index-based behavior when rows have missing or duplicated ids', () => {
+    const missingIds = {
+      rows: [{ name: 'Alpha' }, { name: 'Bravo' }],
+    };
+    const tree = { rows: [{ name: true }, undefined] };
+
+    expect(
+      reconcileFieldArraysById(tree, missingIds, {
+        rows: [{ name: 'Bravo' }, { name: 'Alpha' }],
+      }),
+    ).toEqual(tree);
+
+    const duplicatedIds = {
+      rows: [
+        { id: 'a', name: 'Alpha' },
+        { id: 'a', name: 'Bravo' },
+      ],
+    };
+
+    expect(
+      reconcileFieldArraysById(tree, duplicatedIds, {
+        rows: [
+          { id: 'a', name: 'Bravo' },
+          { id: 'a', name: 'Alpha' },
+        ],
+      }),
+    ).toEqual(tree);
+  });
+
+  it('should preserve non-index array properties such as root errors', () => {
+    const previousValues = {
+      rows: [
+        { id: 'a', name: 'Alpha' },
+        { id: 'b', name: '' },
+      ],
+    };
+    const nextValues = {
+      rows: [
+        { id: 'b', name: '' },
+        { id: 'a', name: 'Alpha' },
+      ],
+    };
+    const rowsErrors: Record<string, any>[] = [];
+    rowsErrors[1] = { name: { type: 'required', message: 'required' } };
+    (rowsErrors as Record<string, any>).root = {
+      type: 'min',
+      message: 'too short',
+    };
+
+    const result: Record<string, any> = reconcileFieldArraysById(
+      { rows: rowsErrors },
+      previousValues,
+      nextValues,
+    );
+
+    expect(result.rows[0]).toEqual({
+      name: { type: 'required', message: 'required' },
+    });
+    expect(result.rows[1]).toBeUndefined();
+    expect(result.rows.root).toEqual({ type: 'min', message: 'too short' });
+  });
+
+  it('should not descend into state leaves that have no matching value container', () => {
+    const ref = { focus: () => {} };
+    const previousValues = { user: { name: '' } };
+    const nextValues = { user: { name: 'bill' } };
+    const errors = {
+      user: { name: { type: 'required', message: 'required', ref } },
+    };
+
+    const result = reconcileFieldArraysById(errors, previousValues, nextValues);
+
+    expect(result.user.name.ref).toBe(ref);
+  });
+});

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -1367,6 +1367,614 @@ describe('reset', () => {
         rows: [undefined, { name: true }],
       });
     });
+
+    it('should reconcile rows through the values prop refetch flow and stay stable on an identical refetch (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+
+      function App({ rows }: { rows: FormValues['rows'] }) {
+        const { register, control, handleSubmit } = useForm<FormValues>({
+          values: { rows },
+          resetOptions: { keepDirtyValues: true },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <input
+                key={field.key}
+                {...register(`rows.${index}.name`)}
+                placeholder={`row${index}`}
+              />
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      const { rerender } = render(
+        <App
+          rows={[
+            { id: 'a', name: 'Alpha' },
+            { id: 'b', name: 'Bravo' },
+          ]}
+        />,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText('row0'), {
+        target: { value: 'Alpha edited' },
+      });
+
+      const reordered = [
+        { id: 'b', name: 'Bravo updated' },
+        { id: 'a', name: 'Alpha' },
+      ];
+
+      rerender(<App rows={reordered} />);
+      // A refetch returning the identical payload again must not undo the
+      // reconciled state (#13627 described this latch: the corrupted merge
+      // used to become the new defaults, blocking later resyncs).
+      rerender(<App rows={[...reordered]} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          rows: [
+            { id: 'b', name: 'Bravo updated' },
+            { id: 'a', name: 'Alpha edited' },
+          ],
+        }),
+      );
+    });
+
+    it('should merge a moved row at leaf granularity, keeping the dirty leaf and adopting server changes to clean siblings (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string; note: string }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const { register, control, handleSubmit, reset } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { id: 'a', name: 'Alpha', note: 'old note a' },
+              { id: 'b', name: 'Bravo', note: 'old note b' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 'b', name: 'Bravo', note: 'new note b' },
+                { id: 'a', name: 'Alpha', note: 'new note a' },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <React.Fragment key={field.key}>
+                <input
+                  {...register(`rows.${index}.name`)}
+                  placeholder={`name${index}`}
+                />
+                <input
+                  {...register(`rows.${index}.note`)}
+                  placeholder={`note${index}`}
+                />
+              </React.Fragment>
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('name0'), {
+        target: { value: 'Alpha edited' },
+      });
+
+      act(() => doReset!());
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          rows: [
+            { id: 'b', name: 'Bravo', note: 'new note b' },
+            { id: 'a', name: 'Alpha edited', note: 'new note a' },
+          ],
+        }),
+      );
+    });
+
+    it('should adopt a reordering reset entirely and stay pristine when nothing is dirty (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string }[];
+      };
+
+      let currentDirtyFields: object = {};
+      let currentIsDirty = false;
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const {
+          register,
+          control,
+          reset,
+          formState: { dirtyFields, isDirty },
+        } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Bravo' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        currentDirtyFields = dirtyFields;
+        currentIsDirty = isDirty;
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 'b', name: 'Bravo' },
+                { id: 'a', name: 'Alpha' },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form>
+            {fields.map((field, index) => (
+              <input
+                key={field.key}
+                {...register(`rows.${index}.name`)}
+                placeholder={`row${index}`}
+              />
+            ))}
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      act(() => doReset!());
+
+      expect(
+        (screen.getByPlaceholderText('row0') as HTMLInputElement).value,
+      ).toEqual('Bravo');
+      expect(
+        (screen.getByPlaceholderText('row1') as HTMLInputElement).value,
+      ).toEqual('Alpha');
+      expect(currentDirtyFields).toEqual({});
+      expect(currentIsDirty).toBeFalsy();
+    });
+
+    it('should produce the same result when the same reordering reset runs twice (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const { register, control, handleSubmit, reset } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Bravo' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 'b', name: 'Bravo' },
+                { id: 'a', name: 'Alpha' },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <input
+                key={field.key}
+                {...register(`rows.${index}.name`)}
+                placeholder={`row${index}`}
+              />
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('row0'), {
+        target: { value: 'Alpha edited' },
+      });
+
+      act(() => doReset!());
+      act(() => doReset!());
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          rows: [
+            { id: 'b', name: 'Bravo' },
+            { id: 'a', name: 'Alpha edited' },
+          ],
+        }),
+      );
+    });
+
+    it('should repaint fixed-position registered inputs when a dirty row moves without useFieldArray (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string }[];
+      };
+
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const { register, reset } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Bravo' },
+              { id: 'c', name: 'Charlie' },
+            ],
+          },
+        });
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 'c', name: 'Charlie' },
+                { id: 'b', name: 'Bravo' },
+                { id: 'a', name: 'Alpha' },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form>
+            {[0, 1, 2].map((index) => (
+              <input
+                key={index}
+                {...register(`rows.${index}.name`)}
+                placeholder={`row${index}`}
+              />
+            ))}
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('row0'), {
+        target: { value: 'Alpha edited' },
+      });
+
+      act(() => doReset!());
+
+      expect(
+        (screen.getByPlaceholderText('row0') as HTMLInputElement).value,
+      ).toEqual('Charlie');
+      expect(
+        (screen.getByPlaceholderText('row1') as HTMLInputElement).value,
+      ).toEqual('Bravo');
+      expect(
+        (screen.getByPlaceholderText('row2') as HTMLInputElement).value,
+      ).toEqual('Alpha edited');
+    });
+
+    it('should keep a moved dirty Controller field attached to its row (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const { control, handleSubmit, reset } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Bravo' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 'b', name: 'Bravo' },
+                { id: 'a', name: 'Alpha' },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <Controller
+                key={field.key}
+                control={control}
+                name={`rows.${index}.name`}
+                render={({ field: controllerField }) => (
+                  <input {...controllerField} placeholder={`row${index}`} />
+                )}
+              />
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('row0'), {
+        target: { value: 'Alpha edited' },
+      });
+
+      act(() => doReset!());
+
+      expect(
+        (screen.getByPlaceholderText('row1') as HTMLInputElement).value,
+      ).toEqual('Alpha edited');
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          rows: [
+            { id: 'b', name: 'Bravo' },
+            { id: 'a', name: 'Alpha edited' },
+          ],
+        }),
+      );
+    });
+
+    it('should keep a dirty File value intact across a keepDirtyValues reset', () => {
+      const file = new File(['content'], 'avatar.png');
+      const { result } = renderHook(() =>
+        useForm<{ avatar: File | null; name: string }>({
+          defaultValues: { avatar: null, name: 'a' },
+        }),
+      );
+
+      act(() => result.current.setValue('avatar', file, { shouldDirty: true }));
+      act(() =>
+        result.current.reset(
+          { avatar: null, name: 'server' },
+          { keepDirtyValues: true },
+        ),
+      );
+
+      expect(result.current.getValues('avatar')).toBe(file);
+      expect(result.current.getValues('name')).toBe('server');
+    });
+
+    it('should keep edits to a row id field by falling back to index behavior instead of treating the row as replaced (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const { register, control, handleSubmit, reset } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Bravo' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 'a', name: 'Alpha' },
+                { id: 'b', name: 'Bravo' },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <React.Fragment key={field.key}>
+                <input
+                  {...register(`rows.${index}.id`)}
+                  placeholder={`id${index}`}
+                />
+                <input
+                  {...register(`rows.${index}.name`)}
+                  placeholder={`name${index}`}
+                />
+              </React.Fragment>
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('id0'), {
+        target: { value: 'edited-id' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('name0'), {
+        target: { value: 'Alpha edited' },
+      });
+
+      act(() => doReset!());
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          rows: [
+            { id: 'edited-id', name: 'Alpha edited' },
+            { id: 'b', name: 'Bravo' },
+          ],
+        }),
+      );
+    });
+
+    it('should match rows with a custom getRowId reset option (#13627)', async () => {
+      type FormValues = {
+        rows: { uuid: string; name: string }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const { register, control, handleSubmit, reset } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { uuid: 'a', name: 'Alpha' },
+              { uuid: 'b', name: 'Bravo' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { uuid: 'b', name: 'Bravo' },
+                { uuid: 'a', name: 'Alpha' },
+              ],
+            },
+            {
+              keepDirtyValues: true,
+              getRowId: (row) => (row as { uuid: string }).uuid,
+            },
+          );
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <input
+                key={field.key}
+                {...register(`rows.${index}.name`)}
+                placeholder={`row${index}`}
+              />
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('row0'), {
+        target: { value: 'Alpha edited' },
+      });
+
+      act(() => doReset!());
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          rows: [
+            { uuid: 'b', name: 'Bravo' },
+            { uuid: 'a', name: 'Alpha edited' },
+          ],
+        }),
+      );
+    });
   });
 
   it('should allow resetting unmounted field array', () => {

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -964,6 +964,409 @@ describe('reset', () => {
         }),
       );
     });
+
+    it('should keep dirty rows attached to their row by id when incoming values reorder the array (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+      let currentDirtyFields: object = {};
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const {
+          register,
+          control,
+          handleSubmit,
+          reset,
+          formState: { dirtyFields },
+        } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Bravo' },
+              { id: 'c', name: 'Charlie' },
+              { id: 'd', name: 'Delta' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        currentDirtyFields = dirtyFields;
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 'd', name: 'Delta' },
+                { id: 'c', name: 'Charlie' },
+                { id: 'b', name: 'Bravo' },
+                { id: 'a', name: 'Alpha' },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <input
+                key={field.key}
+                {...register(`rows.${index}.name`)}
+                placeholder={`row${index}`}
+              />
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('row0'), {
+        target: { value: 'Alpha edited' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('row1'), {
+        target: { value: 'Bravo edited' },
+      });
+
+      act(() => doReset!());
+
+      expect(
+        (screen.getByPlaceholderText('row0') as HTMLInputElement).value,
+      ).toEqual('Delta');
+      expect(
+        (screen.getByPlaceholderText('row2') as HTMLInputElement).value,
+      ).toEqual('Bravo edited');
+      expect(
+        (screen.getByPlaceholderText('row3') as HTMLInputElement).value,
+      ).toEqual('Alpha edited');
+
+      expect(currentDirtyFields).toEqual({
+        rows: [undefined, undefined, { name: true }, { name: true }],
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          rows: [
+            { id: 'd', name: 'Delta' },
+            { id: 'c', name: 'Charlie' },
+            { id: 'b', name: 'Bravo edited' },
+            { id: 'a', name: 'Alpha edited' },
+          ],
+        }),
+      );
+    });
+
+    it('should drop rows removed by incoming values and adopt inserted rows while keeping a moved dirty row (#13627)', async () => {
+      type FormValues = {
+        rows: { id: number; name: string }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const { register, control, handleSubmit, reset } = useForm<FormValues>({
+          defaultValues: {
+            rows: [
+              { id: 1, name: 'Alpha' },
+              { id: 2, name: 'Bravo' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 3, name: 'New' },
+                { id: 1, name: 'Alpha' },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <input
+                key={field.key}
+                {...register(`rows.${index}.name`)}
+                placeholder={`row${index}`}
+              />
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('row0'), {
+        target: { value: 'Alpha edited' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('row1'), {
+        target: { value: 'Bravo edited' },
+      });
+
+      act(() => doReset!());
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          rows: [
+            { id: 3, name: 'New' },
+            { id: 1, name: 'Alpha edited' },
+          ],
+        }),
+      );
+    });
+
+    it('should reconcile nested arrays by id when both levels reorder (#13627)', async () => {
+      type FormValues = {
+        groups: {
+          id: string;
+          items: { id: string; label: string }[];
+        }[];
+      };
+
+      let submittedValue: FormValues | undefined;
+      let doReset: (() => void) | undefined;
+
+      function Items({
+        control,
+        register,
+        groupIndex,
+      }: {
+        control: Control<FormValues>;
+        register: UseFormRegister<FormValues>;
+        groupIndex: number;
+      }) {
+        const { fields } = useFieldArray({
+          control,
+          name: `groups.${groupIndex}.items`,
+          keyName: 'key',
+        });
+
+        return (
+          <>
+            {fields.map((field, index) => (
+              <input
+                key={field.key}
+                {...register(`groups.${groupIndex}.items.${index}.label`)}
+                placeholder={`g${groupIndex}i${index}`}
+              />
+            ))}
+          </>
+        );
+      }
+
+      function App() {
+        const { register, control, handleSubmit, reset } = useForm<FormValues>({
+          defaultValues: {
+            groups: [
+              {
+                id: 'a',
+                items: [
+                  { id: 'x', label: 'one' },
+                  { id: 'y', label: 'two' },
+                ],
+              },
+              {
+                id: 'b',
+                items: [
+                  { id: 'z', label: 'three' },
+                  { id: 'w', label: 'four' },
+                ],
+              },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'groups',
+          keyName: 'key',
+        });
+
+        doReset = () =>
+          reset(
+            {
+              groups: [
+                {
+                  id: 'b',
+                  items: [
+                    { id: 'w', label: 'four' },
+                    { id: 'z', label: 'three' },
+                  ],
+                },
+                {
+                  id: 'a',
+                  items: [
+                    { id: 'y', label: 'two' },
+                    { id: 'x', label: 'one' },
+                  ],
+                },
+              ],
+            },
+            { keepDirtyValues: true },
+          );
+
+        return (
+          <form
+            onSubmit={handleSubmit((data) => {
+              submittedValue = data;
+            })}
+          >
+            {fields.map((field, index) => (
+              <Items
+                key={field.key}
+                control={control}
+                register={register}
+                groupIndex={index}
+              />
+            ))}
+            <button>submit</button>
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('g0i0'), {
+        target: { value: 'one edited' },
+      });
+
+      act(() => doReset!());
+
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+      await waitFor(() =>
+        expect(submittedValue).toEqual({
+          groups: [
+            {
+              id: 'b',
+              items: [
+                { id: 'w', label: 'four' },
+                { id: 'z', label: 'three' },
+              ],
+            },
+            {
+              id: 'a',
+              items: [
+                { id: 'y', label: 'two' },
+                { id: 'x', label: 'one edited' },
+              ],
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should move errors and touched state along with their row when kept across a reordering reset (#13627)', async () => {
+      type FormValues = {
+        rows: { id: string; name: string }[];
+      };
+
+      let currentErrors: FieldErrors<FormValues> = {};
+      let currentTouched: object = {};
+      let doReset: (() => void) | undefined;
+
+      function App() {
+        const {
+          register,
+          control,
+          handleSubmit,
+          reset,
+          formState: { errors, touchedFields },
+        } = useForm<FormValues>({
+          mode: 'onChange',
+          defaultValues: {
+            rows: [
+              { id: 'a', name: 'Alpha' },
+              { id: 'b', name: 'Bravo' },
+            ],
+          },
+        });
+        const { fields } = useFieldArray({
+          control,
+          name: 'rows',
+          keyName: 'key',
+        });
+
+        currentErrors = errors;
+        currentTouched = touchedFields;
+
+        doReset = () =>
+          reset(
+            {
+              rows: [
+                { id: 'b', name: 'Bravo' },
+                { id: 'a', name: 'Alpha' },
+              ],
+            },
+            {
+              keepDirtyValues: true,
+              keepErrors: true,
+              keepTouched: true,
+            },
+          );
+
+        return (
+          <form onSubmit={handleSubmit(noop)}>
+            {fields.map((field, index) => (
+              <input
+                key={field.key}
+                {...register(`rows.${index}.name`, { required: 'required' })}
+                placeholder={`row${index}`}
+              />
+            ))}
+          </form>
+        );
+      }
+
+      render(<App />);
+
+      fireEvent.change(screen.getByPlaceholderText('row0'), {
+        target: { value: '' },
+      });
+      fireEvent.blur(screen.getByPlaceholderText('row0'));
+
+      await waitFor(() =>
+        expect(currentErrors.rows?.[0]?.name?.message).toEqual('required'),
+      );
+
+      act(() => doReset!());
+
+      await waitFor(() =>
+        expect(currentErrors.rows?.[1]?.name?.message).toEqual('required'),
+      );
+      expect(currentErrors.rows?.[0]).toBeUndefined();
+      expect(currentTouched).toEqual({
+        rows: [undefined, { name: true }],
+      });
+    });
   });
 
   it('should allow resetting unmounted field array', () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1769,26 +1769,37 @@ export function createFormControl<
         // row order first, so the path-based merge below keeps dirty state
         // with its row instead of whichever row now occupies its old index.
         const previousFormValues = _formValues;
+        const previousDirtyFields = _formState.dirtyFields;
         _formValues = reconcileFieldArraysById(
           previousFormValues,
           previousFormValues,
           values,
+          keepStateOptions.getRowId,
+          previousDirtyFields,
         );
         _formState.dirtyFields = reconcileFieldArraysById(
-          _formState.dirtyFields,
+          previousDirtyFields,
           previousFormValues,
           values,
+          keepStateOptions.getRowId,
+          previousDirtyFields,
         );
         _formState.touchedFields = reconcileFieldArraysById(
           _formState.touchedFields,
           previousFormValues,
           values,
+          keepStateOptions.getRowId,
+          previousDirtyFields,
         );
-        _formState.errors = reconcileFieldArraysById(
-          _formState.errors,
-          previousFormValues,
-          values,
-        );
+        if (keepStateOptions.keepErrors) {
+          _formState.errors = reconcileFieldArraysById(
+            _formState.errors,
+            previousFormValues,
+            values,
+            keepStateOptions.getRowId,
+            previousDirtyFields,
+          );
+        }
 
         const fieldsToCheck = new Set([
           ..._names.mount,
@@ -1804,6 +1815,14 @@ export function createFormControl<
 
           if (isDirty && !isUndefined(existingValue)) {
             set(values, fieldName, existingValue);
+            // A kept dirty value normally already sits in its input, but
+            // when array reconciliation moved the row to another index the
+            // input at that index still shows the previous occupant — push
+            // the value into the field refs. Skipped for unmoved fields so
+            // an input being typed in is never rewritten.
+            if (!deepEqual(get(previousFormValues, fieldName), existingValue)) {
+              setValue(fieldName as FieldPath<TFieldValues>, existingValue);
+            }
           } else if (!isDirty && !isUndefined(newValue)) {
             setValue(fieldName as FieldPath<TFieldValues>, newValue);
           }

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -96,6 +96,7 @@ import hasValidation from './hasValidation';
 import isNameInFieldArray from './isNameInFieldArray';
 import isWatched from './isWatched';
 import iterateFieldsByAction from './iterateFieldsByAction';
+import reconcileFieldArraysById from './reconcileFieldArraysById';
 import schemaErrorLookup from './schemaErrorLookup';
 import shouldRenderFormState from './shouldRenderFormState';
 import shouldSubscribeByName from './shouldSubscribeByName';
@@ -1763,6 +1764,32 @@ export function createFormControl<
 
     if (!keepStateOptions.keepValues) {
       if (keepStateOptions.keepDirtyValues) {
+        // When incoming values reorder, insert or remove id-carrying array
+        // rows, realign the current values and per-field state to the new
+        // row order first, so the path-based merge below keeps dirty state
+        // with its row instead of whichever row now occupies its old index.
+        const previousFormValues = _formValues;
+        _formValues = reconcileFieldArraysById(
+          previousFormValues,
+          previousFormValues,
+          values,
+        );
+        _formState.dirtyFields = reconcileFieldArraysById(
+          _formState.dirtyFields,
+          previousFormValues,
+          values,
+        );
+        _formState.touchedFields = reconcileFieldArraysById(
+          _formState.touchedFields,
+          previousFormValues,
+          values,
+        );
+        _formState.errors = reconcileFieldArraysById(
+          _formState.errors,
+          previousFormValues,
+          values,
+        );
+
         const fieldsToCheck = new Set([
           ..._names.mount,
           ...collectDirtyFieldNames(

--- a/src/logic/reconcileFieldArraysById.ts
+++ b/src/logic/reconcileFieldArraysById.ts
@@ -1,0 +1,93 @@
+import isObject from '../utils/isObject';
+import isUndefined from '../utils/isUndefined';
+
+type RowId = string | number;
+
+const getRowId = (row: unknown): RowId | undefined => {
+  if (isObject(row)) {
+    const id = (row as Record<string, unknown>).id;
+    if (typeof id === 'string' || typeof id === 'number') {
+      return id;
+    }
+  }
+  return undefined;
+};
+
+const getRowIdIndexes = (rows: unknown[]): Map<RowId, number> | undefined => {
+  const indexes = new Map<RowId, number>();
+  for (let index = 0; index < rows.length; index++) {
+    const id = getRowId(rows[index]);
+    if (isUndefined(id) || indexes.has(id)) {
+      return undefined;
+    }
+    indexes.set(id, index);
+  }
+  return indexes;
+};
+
+const isContainer = (value: unknown): value is Record<string, any> =>
+  Array.isArray(value) || isObject(value);
+
+/**
+ * Rebuilds a tree that mirrors the previous form values (the values
+ * themselves, dirtyFields, touchedFields or errors) so its array entries
+ * follow row identity instead of index when the incoming values reorder,
+ * insert or remove rows. Rows are matched by their `id` property; an array
+ * whose rows lack unique ids on either side keeps index-based behavior.
+ * Entries for rows the incoming values no longer contain are dropped, and
+ * non-index array properties (e.g. a field array `root` error) are
+ * preserved. Traversal is driven by the two value trees, so state leaves
+ * such as error objects are never descended into.
+ */
+export default function reconcileFieldArraysById<T>(
+  tree: T,
+  previousValues: unknown,
+  nextValues: unknown,
+): T {
+  if (
+    Array.isArray(tree) &&
+    Array.isArray(previousValues) &&
+    Array.isArray(nextValues)
+  ) {
+    const previousIndexes = getRowIdIndexes(previousValues);
+
+    if (previousIndexes && getRowIdIndexes(nextValues)) {
+      const result: Record<string, any> = nextValues.map((nextRow) => {
+        const previousIndex = previousIndexes.get(getRowId(nextRow)!);
+        return isUndefined(previousIndex)
+          ? undefined
+          : reconcileFieldArraysById(
+              tree[previousIndex],
+              previousValues[previousIndex],
+              nextRow,
+            );
+      });
+
+      for (const key in tree) {
+        if (isNaN(+key)) {
+          result[key] = tree[key as keyof typeof tree];
+        }
+      }
+
+      return result as T;
+    }
+  }
+
+  if (isContainer(tree) && isContainer(previousValues)) {
+    const result: Record<string, any> = Array.isArray(tree)
+      ? [...tree]
+      : { ...tree };
+
+    for (const key in result) {
+      result[key] = reconcileFieldArraysById(
+        result[key],
+        previousValues[key],
+        isContainer(nextValues) ? nextValues[key] : undefined,
+      );
+    }
+
+    return result as T;
+  }
+
+  return tree;
+}

--- a/src/logic/reconcileFieldArraysById.ts
+++ b/src/logic/reconcileFieldArraysById.ts
@@ -1,9 +1,13 @@
 import isObject from '../utils/isObject';
+import isPlainObject from '../utils/isPlainObject';
 import isUndefined from '../utils/isUndefined';
 
-type RowId = string | number;
+export type GetRowId = (
+  row: unknown,
+  arrayPath: string,
+) => string | number | undefined;
 
-const getRowId = (row: unknown): RowId | undefined => {
+const defaultGetRowId: GetRowId = (row) => {
   if (isObject(row)) {
     const id = (row as Record<string, unknown>).id;
     if (typeof id === 'string' || typeof id === 'number') {
@@ -13,76 +17,126 @@ const getRowId = (row: unknown): RowId | undefined => {
   return undefined;
 };
 
-const getRowIdIndexes = (rows: unknown[]): Map<RowId, number> | undefined => {
-  const indexes = new Map<RowId, number>();
+const getRowIdIndexes = (
+  rows: unknown[],
+  getRowId: GetRowId,
+  arrayPath: string,
+): Map<string, number> | undefined => {
+  const indexes = new Map<string, number>();
   for (let index = 0; index < rows.length; index++) {
-    const id = getRowId(rows[index]);
-    if (isUndefined(id) || indexes.has(id)) {
+    const id = getRowId(rows[index], arrayPath);
+    if (typeof id !== 'string' && typeof id !== 'number') {
       return undefined;
     }
-    indexes.set(id, index);
+    const key = `${id}`;
+    if (indexes.has(key)) {
+      return undefined;
+    }
+    indexes.set(key, index);
   }
   return indexes;
 };
 
+const hasDirtyRowId = (dirtyRows: unknown): boolean =>
+  Array.isArray(dirtyRows) &&
+  dirtyRows.some(
+    (dirtyRow) =>
+      dirtyRow === true || (isObject(dirtyRow) && !!(dirtyRow as any).id),
+  );
+
 const isContainer = (value: unknown): value is Record<string, any> =>
   Array.isArray(value) || isObject(value);
+
+const isCopyableContainer = (value: unknown): value is Record<string, any> =>
+  Array.isArray(value) || (isObject(value) && isPlainObject(value));
+
+const copyNonIndexKeys = (
+  source: Record<string, any>,
+  target: Record<string, any>,
+) => {
+  for (const key in source) {
+    if (isNaN(+key)) {
+      target[key] = source[key];
+    }
+  }
+};
 
 /**
  * Rebuilds a tree that mirrors the previous form values (the values
  * themselves, dirtyFields, touchedFields or errors) so its array entries
  * follow row identity instead of index when the incoming values reorder,
- * insert or remove rows. Rows are matched by their `id` property; an array
- * whose rows lack unique ids on either side keeps index-based behavior.
- * Entries for rows the incoming values no longer contain are dropped, and
- * non-index array properties (e.g. a field array `root` error) are
+ * insert or remove rows. Rows are matched by `getRowId` — their `id`
+ * property by default — and an array whose rows lack unique ids on either
+ * side keeps index-based behavior, as does an array whose own `id` field is
+ * dirty under the default matcher (an edited id no longer identifies its
+ * row). Entries for rows the incoming values no longer contain are dropped,
+ * and non-index array properties (e.g. a field array `root` error) are
  * preserved. Traversal is driven by the two value trees, so state leaves
- * such as error objects are never descended into.
+ * such as error objects are never descended into, and only arrays and plain
+ * objects are copied — class instances like File pass through by reference.
  */
 export default function reconcileFieldArraysById<T>(
   tree: T,
   previousValues: unknown,
   nextValues: unknown,
+  getRowId?: GetRowId,
+  previousDirtyFields?: unknown,
+  path = '',
 ): T {
+  const matchRow = getRowId || defaultGetRowId;
+
   if (
     Array.isArray(tree) &&
     Array.isArray(previousValues) &&
-    Array.isArray(nextValues)
+    Array.isArray(nextValues) &&
+    !(!getRowId && hasDirtyRowId(previousDirtyFields))
   ) {
-    const previousIndexes = getRowIdIndexes(previousValues);
+    const previousIndexes = getRowIdIndexes(previousValues, matchRow, path);
 
-    if (previousIndexes && getRowIdIndexes(nextValues)) {
-      const result: Record<string, any> = nextValues.map((nextRow) => {
-        const previousIndex = previousIndexes.get(getRowId(nextRow)!);
-        return isUndefined(previousIndex)
-          ? undefined
-          : reconcileFieldArraysById(
-              tree[previousIndex],
-              previousValues[previousIndex],
-              nextRow,
-            );
-      });
+    if (previousIndexes && getRowIdIndexes(nextValues, matchRow, path)) {
+      const result: Record<string, any> = nextValues.map(
+        (nextRow, nextIndex) => {
+          const previousIndex = previousIndexes.get(
+            `${matchRow(nextRow, path)}`,
+          );
+          return isUndefined(previousIndex)
+            ? undefined
+            : reconcileFieldArraysById(
+                tree[previousIndex],
+                previousValues[previousIndex],
+                nextRow,
+                getRowId,
+                isContainer(previousDirtyFields)
+                  ? previousDirtyFields[previousIndex]
+                  : undefined,
+                `${path}.${nextIndex}`,
+              );
+        },
+      );
 
-      for (const key in tree) {
-        if (isNaN(+key)) {
-          result[key] = tree[key as keyof typeof tree];
-        }
-      }
+      copyNonIndexKeys(tree, result);
 
       return result as T;
     }
   }
 
-  if (isContainer(tree) && isContainer(previousValues)) {
+  if (isCopyableContainer(tree) && isContainer(previousValues)) {
     const result: Record<string, any> = Array.isArray(tree)
       ? [...tree]
       : { ...tree };
+
+    if (Array.isArray(tree)) {
+      copyNonIndexKeys(tree, result);
+    }
 
     for (const key in result) {
       result[key] = reconcileFieldArraysById(
         result[key],
         previousValues[key],
         isContainer(nextValues) ? nextValues[key] : undefined,
+        getRowId,
+        isContainer(previousDirtyFields) ? previousDirtyFields[key] : undefined,
+        path ? `${path}.${key}` : key,
       );
     }
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -188,6 +188,19 @@ export type KeepStateOptions = Partial<{
   keepIsValid: boolean;
   keepSubmitCount: boolean;
   keepFieldsRef: boolean;
+  /**
+   * Row identity used by `keepDirtyValues` to reconcile field array rows when
+   * incoming values reorder, insert or remove rows, so dirty, touched and
+   * error state follow their row instead of staying at its old index.
+   *
+   * Defaults to reading each row's `id` property. Return a different key for
+   * rows keyed differently (`(row) => row.uuid`), compose composite keys, or
+   * return `undefined` to keep index-based behavior — per array via the
+   * `arrayPath` argument (e.g. `"rows"` or `"groups.1.items"`) or entirely.
+   * An array falls back to index-based behavior whenever any row on either
+   * side yields no unique key, or (with the default matcher) when a row's
+   * `id` field is itself dirty.
+   */
   getRowId: (row: unknown, arrayPath: string) => string | number | undefined;
 }>;
 
@@ -759,6 +772,14 @@ type ResetAction<TFieldValues> = (formValues: TFieldValues) => TFieldValues;
  *}, {
  *   keepErrors: true,
  *   keepDirty: true
+ *});
+ *
+ * // resync refetched server data while keeping the user's edits;
+ * // field array rows are matched by their id so edits follow their row
+ * // even when the server reorders, inserts or removes rows
+ * reset(serverData, {
+ *   keepDirtyValues: true,
+ *   getRowId: (row) => row.uuid, // optional, defaults to row.id
  *});
  * ```
  */

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -188,6 +188,7 @@ export type KeepStateOptions = Partial<{
   keepIsValid: boolean;
   keepSubmitCount: boolean;
   keepFieldsRef: boolean;
+  getRowId: (row: unknown, arrayPath: string) => string | number | undefined;
 }>;
 
 export type SetFieldValue<TFieldValues extends FieldValues> =


### PR DESCRIPTION
Follow-up to #13628 / closes the array half of #13627.

## Problem

`reset(values, { keepDirtyValues: true })` (and the `values` prop resync it powers) merges dirty fields into the incoming values **by path**, and an array row's path is its index. When a refetch returns the same rows in a different order, still-dirty rows are kept at indices that now hold *different* rows — entries duplicate and others vanish (`[Alpha, Bravo, Charlie, Delta]` with two dirty rows resyncs into `[Alpha, Bravo, Alpha, Bravo]`). #13628 fixed the object half; this PR fixes arrays, nested arrays included.

## Approach

Before the existing per-path dirty merge runs, a new `reconcileFieldArraysById` module realigns the previous form values **and** `dirtyFields`, `touchedFields`, `errors` from the old row order to the incoming row order, matching rows by their `id` property (the zero-config convention proposed in #13627, same as table libraries' `getRowId` default). The existing merge loop then works unchanged — every path refers to the same row on both sides, so dirty leaves stay with their row, clean leaves adopt server values, server-added rows appear and server-removed rows drop.

Addressing the concerns raised in the issue discussion:

- **“touchedFields, errors and validation refs don't follow the row”** — touched and error trees are remapped alongside values (including field array `root` errors). Validation refs are positional by design and self-heal: `useFieldArray` regenerates its keys on reset, so rows remount and re-register against the reconciled values. For fixed-position `register` inputs without `useFieldArray`, a kept-dirty value whose row moved is pushed into the refs explicitly — guarded by a `deepEqual` so an input being typed in during a background refetch is never rewritten (cursor untouched).
- **“only covers the single-key, single-array case”** / **“conflicts with useFieldArray's keyName”** — a new `resetOptions.getRowId?: (row, arrayPath) => string | number | undefined` covers renamed keys (`(row) => row.uuid`), per-array choices via `arrayPath`, composite keys, and per-array opt-out (`undefined` → index behavior). It's deliberately not named `keyName` because it means something different.
- **Safety fallbacks** — an array keeps today's index behavior whenever any row on either side lacks a unique id, and (under the default matcher) when a row's `id` field is itself dirty — an edited id no longer identifies its row, so falling back beats guessing. Ids match across `1`/`"1"` type flips; same-array duplicates fall back.
- **Second-order “latch” from the issue** — gone by construction: `_defaultValues` now stays the pristine server payload instead of a corrupted merge, so identical refetches deep-equal correctly.

Non-plain objects (`File`, `Blob`, class instances) pass through reconciliation by reference — never spread-copied.

## Tests

35 tests target this change (20 unit for the reconcile module, 15 integration in `reset.test.tsx`): reorder repro from the issue, insert/remove with a moved dirty row, nested arrays at both levels (with and without id-carrying parents), errors + touched following rows under `keepErrors`/`keepTouched`, the `values`-prop refetch flow incl. identical-payload stability, idempotent repeated reset, pristine reorder adoption, `Controller` rows, fixed-position `register` repaint, dirty `File` preservation, edited-id fallback, custom `getRowId` (global, per-array, id-flip, duplicate/missing ids), and error-`root`/state-leaf preservation.

The tests were mutation-checked: disabling reconciliation fails exactly the 10 array tests, removing the ref repaint fails exactly its test, and reverting each hardening fix fails its regression test.

Known limitation (unchanged from master): transient async-validation state (`validatingFields`, delayed-error timers) resolving mid-reset still targets old indices; it self-corrects on the next validation cycle.

Docs: JSDoc added for `getRowId` and the `reset` example; happy to send a companion PR to `react-hook-form/documentation` for the `reset`/`values` pages once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
