### PR TITLE
fix(useWatch): prefer form defaultValues over the hook's own defaultValue

### DIFF
--- a/src/__tests__/__snapshots__/useWatch.test.tsx.snap
+++ b/src/__tests__/__snapshots__/useWatch.test.tsx.snap
@@ -4,11 +4,17 @@ exports[`useWatch fieldArray with shouldUnregister true should watch correct inp
 [
   [
     {
-      "id": "0",
       "prop": "test",
     },
     {
-      "id": "1",
+      "prop": "test1",
+    },
+  ],
+  [
+    {
+      "prop": "test",
+    },
+    {
       "prop": "test1",
     },
   ],

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -107,6 +107,23 @@ describe('useWatch', () => {
     expect(result.current).toEqual('test');
   });
 
+  it('should prefer the form default value over its own default value for single input', () => {
+    const { result } = renderHook(() => {
+      const { control } = useForm<{ test: string }>({
+        defaultValues: {
+          test: 'form default',
+        },
+      });
+      return useWatch({
+        control,
+        name: 'test',
+        defaultValue: 'inline fallback',
+      });
+    });
+
+    expect(result.current).toEqual('form default');
+  });
+
   it('should return own default value for array of inputs', () => {
     const { result } = renderHook(() => {
       const { control } = useForm<{ test: string; test1: string }>({});

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -788,13 +788,14 @@ export function createFormControl<
       names,
       _names,
       {
+        // Before mount the form's own default values are the source of truth.
+        // For a single name the caller supplied `defaultValue` is only a
+        // fallback, applied by generateWatchOutput when the path is absent.
         ...(_state.mount
           ? _formValues
-          : isUndefined(defaultValue)
+          : isUndefined(defaultValue) || isString(names)
             ? _defaultValues
-            : isString(names)
-              ? { [names]: defaultValue }
-              : defaultValue),
+            : defaultValue),
       },
       isGlobal,
       defaultValue,

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -788,9 +788,6 @@ export function createFormControl<
       names,
       _names,
       {
-        // Before mount the form's own default values are the source of truth.
-        // For a single name the caller supplied `defaultValue` is only a
-        // fallback, applied by generateWatchOutput when the path is absent.
         ...(_state.mount
           ? _formValues
           : isUndefined(defaultValue) || isString(names)


### PR DESCRIPTION
## Proposed Changes

Fixes #13634

Before the form mounts, `_getWatch` built its value source from `{ [name]: defaultValue }` whenever a string `name` and a `defaultValue` were both supplied. That threw away `useForm({ defaultValues })` for that render, so `useWatch` returned its own fallback even when the form had a real default for the path.

The documented contract is the opposite:

> Fallback value returned before the form has mounted and no current value exists yet. Once the form is mounted, the actual current form value takes precedence over this fallback.

The fix reads from `_defaultValues` for a string name and lets `generateWatchOutput` apply the fallback through `get(values, name, defaultValue)`, which already returns `defaultValue` when the path is genuinely absent. Behaviour for an array of names, and for `useWatch` with no `defaultValue`, is unchanged.

```tsx
const { control } = useForm({ defaultValues: { test: 'form default' } });
const value = useWatch({ control, name: 'test', defaultValue: 'inline fallback' });
// before: 'inline fallback'
// after:  'form default'
```

### Snapshot update

`useWatch › fieldArray with shouldUnregister true › should watch correct input update with single field array input` is the one existing test whose recorded output changes. It passes `fields` from `useFieldArray` as the `defaultValue`, so its first entry used to carry the internal `id` keys; it now reads the form's defaults, which do not. Every later entry in that same snapshot was already `id`-free, so this makes the first render consistent with the rest.

The snapshot also gains one entry. The update that reconciles the pre-mount value with `_formValues` is now a no-op state write (the two are the same reference), and React still renders once before bailing out. The rendered DOM is unchanged — the test's `getByText` assertions pass untouched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

`pnpm test` 1219 passed / 120 suites, `pnpm test:type`, `pnpm type` and `pnpm lint` all clean locally.
