### PR TITLE
✨ feat: add getErrors method to read form errors without subscription

### DIFF
--- a/reports/api-extractor.api.md
+++ b/reports/api-extractor.api.md
@@ -169,6 +169,9 @@ export type EmptyObject = {
 };
 
 // @public (undocumented)
+export type ErrorNamespacePath = 'root' | `root.${string}` | 'form' | `form.${string}`;
+
+// @public (undocumented)
 export type ErrorOption = {
     message?: Message;
     type?: LiteralUnion<keyof RegisterOptions, string>;
@@ -385,6 +388,9 @@ export type FromSubscribe<TFieldValues extends FieldValues> = <TFieldNames exten
 
 // @public (undocumented)
 export const get: <T>(object: T, path?: string | null, defaultValue?: unknown) => any;
+
+// @public
+export type GetErrorsResult<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues> | ErrorNamespacePath> = TName extends 'root' ? (Record<string, GlobalError> & GlobalError) | undefined : TName extends ErrorNamespacePath ? GlobalError | undefined : TName extends FieldPath<TFieldValues> ? FieldPathError<TFieldValues, TName> | undefined : never;
 
 // @public (undocumented)
 export type GetIsDirty = <TName extends InternalFieldName, TData>(name?: TName, data?: TData) => boolean;
@@ -716,13 +722,20 @@ export type UseFieldArrayUpdate<TFieldValues extends FieldValues, TFieldArrayNam
 // @public
 export function useForm<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues>(props?: UseFormProps<TFieldValues, TContext, TTransformedValues>): UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
-// Warning: (ae-forgotten-export) The symbol "ErrorNamespacePath" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type UseFormClearErrors<TFieldValues extends FieldValues> = (name?: FieldPath<TFieldValues> | FieldPath<TFieldValues>[] | readonly FieldPath<TFieldValues>[] | ErrorNamespacePath) => void;
 
 // @public
 export const useFormContext: <TFieldValues extends FieldValues, TContext = any, TTransformedValues = TFieldValues>() => UseFormReturn<TFieldValues, TContext, TTransformedValues>;
+
+// @public
+export type UseFormGetErrors<TFieldValues extends FieldValues> = {
+    (name?: undefined): FieldErrors<TFieldValues>;
+    <TName extends FieldPath<TFieldValues> | ErrorNamespacePath>(name: TName): GetErrorsResult<TFieldValues, TName>;
+    <TNames extends (FieldPath<TFieldValues> | ErrorNamespacePath)[]>(names: readonly [...TNames]): {
+        [K in keyof TNames]: GetErrorsResult<TFieldValues, TNames[K]>;
+    };
+};
 
 // @public
 export type UseFormGetFieldState<TFieldValues extends FieldValues> = <TFieldName extends FieldPath<TFieldValues>>(name: TFieldName, formState?: FormState_2<TFieldValues>) => {
@@ -797,6 +810,7 @@ export type UseFormResetField<TFieldValues extends FieldValues> = <TFieldName ex
 export type UseFormReturn<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues> = {
     watch: UseFormWatch<TFieldValues>;
     getValues: UseFormGetValues<TFieldValues>;
+    getErrors: UseFormGetErrors<TFieldValues>;
     getFieldState: UseFormGetFieldState<TFieldValues>;
     setError: UseFormSetError<TFieldValues>;
     clearErrors: UseFormClearErrors<TFieldValues>;
@@ -1030,8 +1044,8 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:513:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:888:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:583:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:958:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useForm/getErrors.test.tsx
+++ b/src/__tests__/useForm/getErrors.test.tsx
@@ -1,0 +1,298 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from '@testing-library/react';
+
+import { createFormControl } from '../../logic/createFormControl';
+import { useFieldArray } from '../../useFieldArray';
+import { useForm } from '../../useForm';
+import { FormProvider, useFormContext } from '../../useFormContext';
+
+describe('getErrors', () => {
+  it('should return the entire errors object without an argument', () => {
+    const { result } = renderHook(() =>
+      useForm<{ foo: string; bar: string }>(),
+    );
+
+    act(() => {
+      result.current.setError('foo', { type: 'required', message: 'foo err' });
+      result.current.setError('bar', { type: 'required', message: 'bar err' });
+    });
+
+    expect(result.current.getErrors()).toEqual({
+      foo: { type: 'required', message: 'foo err', ref: undefined },
+      bar: { type: 'required', message: 'bar err', ref: undefined },
+    });
+  });
+
+  it('should return a single field error', () => {
+    const { result } = renderHook(() => useForm<{ foo: string }>());
+
+    act(() => {
+      result.current.setError('foo', { type: 'required', message: 'foo err' });
+    });
+
+    expect(result.current.getErrors('foo')).toEqual({
+      type: 'required',
+      message: 'foo err',
+      ref: undefined,
+    });
+  });
+
+  it('should return errors in the requested order, including missing entries', () => {
+    const { result } = renderHook(() =>
+      useForm<{ foo: string; bar: string; baz: string }>(),
+    );
+
+    act(() => {
+      result.current.setError('foo', { type: 'required' });
+      result.current.setError('bar', { type: 'min' });
+    });
+
+    expect(result.current.getErrors(['foo', 'baz', 'bar'])).toEqual([
+      { type: 'required', ref: undefined },
+      undefined,
+      { type: 'min', ref: undefined },
+    ]);
+  });
+
+  it('should return undefined when no error is stored for a path', () => {
+    const { result } = renderHook(() => useForm<{ foo: string }>());
+
+    expect(result.current.getErrors('foo')).toBeUndefined();
+  });
+
+  it('should return stored errors without running validation', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ foo: string }>({ mode: 'onSubmit' }),
+    );
+    const validate = jest.fn(() => 'required');
+
+    result.current.register('foo', { validate });
+
+    expect(result.current.getErrors()).toEqual({});
+    expect(validate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.trigger();
+    });
+
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(result.current.getErrors('foo')).toEqual(
+      expect.objectContaining({ type: 'validate', message: 'required' }),
+    );
+  });
+
+  it('should reflect the setError -> getErrors -> clearErrors -> getErrors transition', () => {
+    const { result } = renderHook(() => useForm<{ foo: string }>());
+
+    act(() => {
+      result.current.setError('foo', { type: 'required' });
+    });
+    expect(result.current.getErrors('foo')).toEqual({
+      type: 'required',
+      ref: undefined,
+    });
+
+    act(() => {
+      result.current.clearErrors();
+    });
+    expect(result.current.getErrors()).toEqual({});
+  });
+
+  describe('global errors', () => {
+    it('should include root and form global errors', () => {
+      const { result } = renderHook(() => useForm<{ foo: string }>());
+
+      act(() => {
+        result.current.setError('root.server', {
+          type: 'server',
+          message: 'server down',
+        });
+        result.current.setError('form', {
+          type: 'form',
+          message: 'form error',
+        });
+      });
+
+      expect(result.current.getErrors('root.server')).toEqual(
+        expect.objectContaining({ type: 'server', message: 'server down' }),
+      );
+      expect(result.current.getErrors('form')).toEqual(
+        expect.objectContaining({ type: 'form', message: 'form error' }),
+      );
+    });
+
+    it('should read a nested form error via its full path', () => {
+      const { result } = renderHook(() => useForm<{ foo: string }>());
+
+      act(() => {
+        result.current.setError('form.custom', {
+          type: 'server',
+          message: 'x',
+        });
+      });
+
+      expect(result.current.getErrors('form.custom')).toEqual(
+        expect.objectContaining({ type: 'server', message: 'x' }),
+      );
+    });
+  });
+
+  describe('nested and array field paths', () => {
+    it('should return the nested error tree for a parent object path', () => {
+      const { result } = renderHook(() =>
+        useForm<{ user: { name: string } }>(),
+      );
+
+      act(() => {
+        result.current.setError('user.name', { type: 'required' });
+      });
+
+      expect(result.current.getErrors('user')).toEqual({
+        name: { type: 'required', ref: undefined },
+      });
+    });
+
+    it('should return the nested error tree for an array parent path', () => {
+      const { result } = renderHook(() =>
+        useForm<{ items: { name: string }[] }>(),
+      );
+
+      act(() => {
+        result.current.setError('items.0.name', { type: 'required' });
+      });
+
+      expect(result.current.getErrors('items')).toEqual([
+        { name: { type: 'required', ref: undefined } },
+      ]);
+      expect(result.current.getErrors('items')).toEqual(
+        result.current.getFieldState('items').error,
+      );
+    });
+  });
+
+  it('should not re-render a component that only calls getErrors when setError fires', () => {
+    let renderCount = 0;
+    let setError!: ReturnType<typeof useForm<{ foo: string }>>['setError'];
+    let getErrors!: ReturnType<typeof useForm<{ foo: string }>>['getErrors'];
+
+    const Reader = () => {
+      renderCount++;
+      const methods = useForm<{ foo: string }>();
+      setError = methods.setError;
+      getErrors = methods.getErrors;
+      // read via getErrors only — no formState subscription
+      getErrors();
+      return null;
+    };
+
+    render(<Reader />);
+
+    const before = renderCount;
+
+    act(() => {
+      setError('foo', { type: 'required' });
+    });
+
+    // no subscription to formState.errors => no re-render
+    expect(renderCount).toBe(before);
+    // but the error is still readable on demand
+    expect(getErrors('foo')).toEqual({ type: 'required', ref: undefined });
+  });
+
+  it('should expose getErrors on createFormControl and its formControl', () => {
+    const formControl = createFormControl<{ foo: string }>();
+
+    expect(typeof formControl.getErrors).toBe('function');
+    expect(typeof formControl.formControl.getErrors).toBe('function');
+
+    formControl.setError('foo', { type: 'required' });
+    expect(formControl.getErrors('foo')).toEqual({
+      type: 'required',
+      ref: undefined,
+    });
+    expect(formControl.formControl.getErrors('foo')).toEqual({
+      type: 'required',
+      ref: undefined,
+    });
+
+    formControl.clearErrors();
+    expect(formControl.getErrors()).toEqual({});
+  });
+
+  it('should expose getErrors through FormProvider and useFormContext at runtime', () => {
+    const Child = () => {
+      const { getErrors, setError } = useFormContext<{ foo: string }>();
+      const [shown, setShown] = React.useState('none');
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            setError('foo', { type: 'required', message: 'ctx error' });
+            setShown(getErrors('foo')?.message ?? 'none');
+          }}
+        >
+          {shown}
+        </button>
+      );
+    };
+
+    const App = () => {
+      const methods = useForm<{ foo: string }>();
+      return (
+        <FormProvider {...methods}>
+          <Child />
+        </FormProvider>
+      );
+    };
+
+    render(<App />);
+    expect(screen.getByRole('button')).toHaveTextContent('none');
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toHaveTextContent('ctx error');
+  });
+
+  it('should protect internal errors from top-level mutations', () => {
+    const { result } = renderHook(() => useForm<{ foo: string }>());
+
+    act(() => {
+      result.current.setError('foo', { type: 'required' });
+    });
+
+    const errors = result.current.getErrors();
+    delete errors.foo;
+
+    expect(result.current.getErrors('foo')).toEqual({
+      type: 'required',
+      ref: undefined,
+    });
+  });
+
+  it('should read a field-array root error', async () => {
+    type FormValues = { items: { name: string }[] };
+    const { result } = renderHook(() => {
+      const form = useForm<FormValues>({ defaultValues: { items: [] } });
+      useFieldArray({
+        control: form.control,
+        name: 'items',
+        rules: { required: 'at least one item is required' },
+      });
+      return form;
+    });
+
+    await act(async () => {
+      await result.current.trigger('items');
+    });
+
+    // Field-array validation stores an array-level error under `.root`.
+    const itemsError = result.current.getErrors('items');
+    expect(itemsError?.root?.message).toBe('at least one item is required');
+  });
+});

--- a/src/__typetest__/getErrors.test-d.ts
+++ b/src/__typetest__/getErrors.test-d.ts
@@ -1,0 +1,164 @@
+import type {
+  FieldError,
+  FieldErrors,
+  FieldValues,
+  GetErrorsResult,
+  GlobalError,
+} from '../types';
+import { useForm } from '../useForm';
+
+import type { Equal, Expect } from './__fixtures__';
+import { _ } from './__fixtures__';
+
+/** {@link UseFormGetErrors} */ {
+  type FormValues = {
+    email: string;
+    name: string;
+    user: { name: string };
+    items: { name: string }[];
+  };
+
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const { getErrors, getFieldState } = useForm<FormValues>();
+
+  /** it should return the full FieldErrors object without an argument */
+  {
+    const actual = getErrors();
+    type _t = Expect<Equal<typeof actual, FieldErrors<FormValues>>>;
+  }
+
+  /** it should type `root` as an indexable record so `?.server` is accessible */
+  {
+    const actual = getErrors('root');
+    type _t = Expect<
+      Equal<
+        typeof actual,
+        (Record<string, GlobalError> & GlobalError) | undefined
+      >
+    >;
+    // record access is allowed
+    actual?.server;
+  }
+
+  /** it should type `root.${string}`, `form`, `form.${string}` as GlobalError */
+  {
+    const rootChild = getErrors('root.server');
+    const form = getErrors('form');
+    const formChild = getErrors('form.custom');
+    type _t1 = Expect<Equal<typeof rootChild, GlobalError | undefined>>;
+    type _t2 = Expect<Equal<typeof form, GlobalError | undefined>>;
+    type _t3 = Expect<Equal<typeof formChild, GlobalError | undefined>>;
+  }
+
+  /** it should prioritize error namespaces over matching field paths */
+  {
+    type ShadowedFieldValues = {
+      root: { server: string };
+      form: { field: string };
+    };
+
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const getShadowedErrors = useForm<ShadowedFieldValues>().getErrors;
+    const root = getShadowedErrors('root');
+    const rootChild = getShadowedErrors('root.server');
+    const form = getShadowedErrors('form');
+    const formChild = getShadowedErrors('form.field');
+
+    type _t1 = Expect<
+      Equal<
+        typeof root,
+        (Record<string, GlobalError> & GlobalError) | undefined
+      >
+    >;
+    type _t2 = Expect<Equal<typeof rootChild, GlobalError | undefined>>;
+    type _t3 = Expect<Equal<typeof form, GlobalError | undefined>>;
+    type _t4 = Expect<Equal<typeof formChild, GlobalError | undefined>>;
+  }
+
+  /** it should resolve precise leaf, parent, and array field error nodes */
+  {
+    const leaf = getErrors('email');
+    const nestedLeaf = getErrors('user.name');
+    const parent = getErrors('user');
+    const arrayItemLeaf = getErrors('items.0.name');
+    const arrayParent = getErrors('items');
+    type _t1 = Expect<Equal<typeof leaf, FieldError | undefined>>;
+    type _t2 = Expect<Equal<typeof nestedLeaf, FieldError | undefined>>;
+    type _t3 = Expect<
+      Equal<
+        typeof parent,
+        NonNullable<FieldErrors<FormValues>['user']> | undefined
+      >
+    >;
+    type _t4 = Expect<Equal<typeof arrayItemLeaf, FieldError | undefined>>;
+    type _t5 = Expect<
+      Equal<
+        typeof arrayParent,
+        NonNullable<FieldErrors<FormValues>['items']> | undefined
+      >
+    >;
+  }
+
+  /** it should match the precise getFieldState error type */
+  {
+    const getErrorsResult = getErrors('items');
+    const getFieldStateResult = getFieldState('items').error;
+    type _t = Expect<Equal<typeof getErrorsResult, typeof getFieldStateResult>>;
+  }
+
+  /** it should distribute over a union input */
+  {
+    const actual = getErrors(_ as 'email' | 'root');
+    type _t = Expect<
+      Equal<
+        typeof actual,
+        FieldError | (Record<string, GlobalError> & GlobalError) | undefined
+      >
+    >;
+  }
+
+  /** it should distribute over field paths with different error shapes */
+  {
+    const actual = getErrors(_ as 'email' | 'items');
+    type _t = Expect<
+      Equal<
+        typeof actual,
+        FieldError | NonNullable<FieldErrors<FormValues>['items']> | undefined
+      >
+    >;
+  }
+
+  /** it should preserve tuple arity for an array of paths */
+  {
+    const names = ['email', 'items', 'root', 'form'] as const;
+    const actual = getErrors(names);
+    type _t = Expect<
+      Equal<
+        typeof actual,
+        [
+          FieldError | undefined,
+          NonNullable<FieldErrors<FormValues>['items']> | undefined,
+          (Record<string, GlobalError> & GlobalError) | undefined,
+          GlobalError | undefined,
+        ]
+      >
+    >;
+  }
+
+  /** it should preserve the flat error fallback for generic forms */
+  {
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const loose = useForm<any>().getErrors('anything');
+    const fieldValues = useForm<FieldValues>().getErrors('anything');
+    type _t1 = Expect<Equal<typeof loose, FieldError | undefined>>;
+    type _t2 = Expect<Equal<typeof fieldValues, FieldError | undefined>>;
+  }
+
+  /** it should reject an unknown field path */
+  {
+    // @ts-expect-error unknown path is not assignable to FieldPath | ErrorNamespacePath
+    getErrors('nonExistentField');
+    // @ts-expect-error GetErrorsResult also constrains its path argument
+    type _t = GetErrorsResult<FormValues, 'nonExistentField'>;
+  }
+}

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -33,6 +33,7 @@ import type {
   Subjects,
   TriggerConfig,
   UseFormClearErrors,
+  UseFormGetErrors,
   UseFormGetFieldState,
   UseFormGetValues,
   UseFormHandleSubmit,
@@ -1376,6 +1377,15 @@ export function createFormControl<
         : fieldNames.map((name) => get(values, name));
   };
 
+  const getErrors: UseFormGetErrors<TFieldValues> = (
+    fieldNames?: InternalFieldName | ReadonlyArray<InternalFieldName>,
+  ) =>
+    isUndefined(fieldNames)
+      ? { ..._formState.errors }
+      : isString(fieldNames)
+        ? get(_formState.errors, fieldNames)
+        : fieldNames.map((name) => get(_formState.errors, name));
+
   const getFieldState: UseFormGetFieldState<TFieldValues> = (
     name,
     formState,
@@ -2135,6 +2145,7 @@ export function createFormControl<
     setValue,
     setValues,
     getValues,
+    getErrors,
     reset,
     resetField,
     resetDefaultValues,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -3,7 +3,12 @@ import type React from 'react';
 import type { VALIDATION_MODE } from '../constants';
 import type { Subject, Subscription } from '../utils/createSubject';
 
-import type { ErrorOption, FieldErrors, FieldPathError } from './errors';
+import type {
+  ErrorOption,
+  FieldErrors,
+  FieldPathError,
+  GlobalError,
+} from './errors';
 import type { EventType } from './events';
 import type { FieldArray } from './fieldArray';
 import type {
@@ -360,7 +365,72 @@ export type UseFormGetValues<TFieldValues extends FieldValues> = {
   ): [...FieldPathValues<TFieldValues, TFieldNames>];
 };
 
-type ErrorNamespacePath = 'root' | `root.${string}` | 'form' | `form.${string}`;
+export type ErrorNamespacePath =
+  | 'root'
+  | `root.${string}`
+  | 'form'
+  | `form.${string}`;
+
+/** Resolves the error type returned for a single `getErrors` path. */
+export type GetErrorsResult<
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues> | ErrorNamespacePath,
+> = TName extends 'root'
+  ? (Record<string, GlobalError> & GlobalError) | undefined
+  : TName extends ErrorNamespacePath
+    ? GlobalError | undefined
+    : TName extends FieldPath<TFieldValues>
+      ? FieldPathError<TFieldValues, TName> | undefined
+      : never;
+
+/** Gets currently stored form errors without subscribing or running validation. */
+export type UseFormGetErrors<TFieldValues extends FieldValues> = {
+  /**
+   * Get all currently stored form errors without subscribing or running validation.
+   *
+   * @returns Form errors.
+   *
+   * @example
+   * ```tsx
+   * const errors = getErrors();
+   * ```
+   */
+  (name?: undefined): FieldErrors<TFieldValues>;
+
+  /**
+   * Get a currently stored field or global error without subscribing or running validation.
+   *
+   * @param name - The path to the error.
+   *
+   * @returns The error at the given path.
+   *
+   * @example
+   * ```tsx
+   * const emailError = getErrors("email");
+   * ```
+   */
+  <TName extends FieldPath<TFieldValues> | ErrorNamespacePath>(
+    name: TName,
+  ): GetErrorsResult<TFieldValues, TName>;
+
+  /**
+   * Get currently stored errors for multiple paths without subscribing or running validation.
+   *
+   * @param names - An array of error paths.
+   *
+   * @returns Errors for the given paths in the same order.
+   *
+   * @example
+   * ```tsx
+   * const [emailError, nameError] = getErrors(["email", "name"]);
+   * ```
+   */
+  <TNames extends (FieldPath<TFieldValues> | ErrorNamespacePath)[]>(
+    names: readonly [...TNames],
+  ): {
+    [K in keyof TNames]: GetErrorsResult<TFieldValues, TNames[K]>;
+  };
+};
 
 /**
  * This method will return individual field states. It will be useful when you are trying to retrieve the nested value field state in a type-safe approach.
@@ -932,6 +1002,7 @@ export type UseFormReturn<
 > = {
   watch: UseFormWatch<TFieldValues>;
   getValues: UseFormGetValues<TFieldValues>;
+  getErrors: UseFormGetErrors<TFieldValues>;
   getFieldState: UseFormGetFieldState<TFieldValues>;
   setError: UseFormSetError<TFieldValues>;
   clearErrors: UseFormClearErrors<TFieldValues>;

--- a/src/useFormContext.tsx
+++ b/src/useFormContext.tsx
@@ -90,6 +90,7 @@ export const FormProvider = <
   children,
   watch,
   getValues,
+  getErrors,
   getFieldState,
   setError,
   clearErrors,
@@ -113,6 +114,7 @@ export const FormProvider = <
     () => ({
       watch,
       getValues,
+      getErrors,
       getFieldState,
       setError,
       clearErrors,
@@ -134,6 +136,7 @@ export const FormProvider = <
       clearErrors,
       control,
       formState,
+      getErrors,
       getFieldState,
       getValues,
       handleSubmit,


### PR DESCRIPTION
Hello, Bill 😁

Thank you for always responding and reviewing so quickly, even while you are busy with the v8 work.

I found the proposal in #12853 interesting, so I prepared a draft implementation of `getErrors`.

### Motivation

- Reads current errors on demand without adding a form-state subscription.
- Complements `setError` and `clearErrors` with familiar `getValues`-style call shapes.

I’m opening this PR as a draft and would appreciate your feedback on whether it aligns with RHF’s API direction and whether the proposed scope is appropriate.

### Situation

The existing ways to access errors in React Hook Form each have their own limitations.

`formState.errors` and `subscribe` are subscription-based, while `getFieldState` can only read one field at a time. Therefore, reading all errors on demand without subscribing currently requires accessing the private `control._formState.errors`.

### Proposal

I would like to propose a `getErrors` method with call shapes similar to `getValues`.

- `getErrors()` returns all currently stored errors.
- `getErrors(name)` returns the error for one field or error namespace.
- `getErrors(names)` returns multiple errors while preserving tuple order and length.

`getErrors` only reads the currently stored errors. It does not run validation or subscribe to form state.