### PR TITLE
🐞 fix #13641 stale render re-creating field array path vacated by array action

### DIFF
--- a/reports/api-extractor.md.api.md
+++ b/reports/api-extractor.md.api.md
@@ -45,6 +45,7 @@ export type Control<TFieldValues extends FieldValues = FieldValues, TContext = a
     _state: {
         mount: boolean;
         action: boolean;
+        actionNames: Map<InternalFieldName, number>;
         watch: boolean;
     };
     _reset: UseFormReset<TFieldValues>;
@@ -1030,7 +1031,7 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 // Warnings were encountered during analysis:
 //
 // src/types/form.ts:513:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:887:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:888:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useFieldArray/append.test.tsx
+++ b/src/__tests__/useFieldArray/append.test.tsx
@@ -680,4 +680,120 @@ describe('append', () => {
       await screen.findByText('{"test":[{"id":"whatever","test":"1234"}]}'),
     ).toBeVisible();
   });
+
+  it('should keep the value of a controlled field mounted in the same commit as an append to another field array', async () => {
+    let getValues: () => unknown = () => ({});
+
+    const OtherInput = ({ control }: { control: Control<FormValues> }) => {
+      const { field } = useController({
+        control,
+        name: 'b.1.value',
+        defaultValue: 'mounted-with-append',
+      });
+      return <input {...field} />;
+    };
+
+    type FormValues = {
+      a: { value: string }[];
+      b: { value: string }[];
+    };
+
+    const App = () => {
+      const [extra, setExtra] = React.useState(false);
+      const methods = useForm<FormValues>({
+        defaultValues: { a: [{ value: 'a0' }], b: [{ value: 'b0' }] },
+      });
+      getValues = methods.getValues;
+      const { fields: aFields, append } = useFieldArray({
+        control: methods.control,
+        name: 'a',
+      });
+      useFieldArray({ control: methods.control, name: 'b' });
+
+      return (
+        <div>
+          <p>{aFields.length}</p>
+          {extra && <OtherInput control={methods.control} />}
+          <button
+            type="button"
+            onClick={() => {
+              append({ value: 'a1' });
+              setExtra(true);
+            }}
+          >
+            append
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await act(async () => {});
+
+    expect(getValues()).toEqual({
+      a: [{ value: 'a0' }, { value: 'a1' }],
+      b: [{ value: 'b0' }, { value: 'mounted-with-append' }],
+    });
+  });
+
+  it('should materialize a controlled field staged at the end of the array appended to in the same commit', async () => {
+    type FormValues = { test: { value: string }[] };
+
+    let getValues: () => unknown = () => ({});
+
+    const StagedInput = ({
+      control,
+      index,
+    }: {
+      control: Control<FormValues>;
+      index: number;
+    }) => {
+      const { field } = useController({
+        control,
+        name: `test.${index}.value` as const,
+        defaultValue: 'staged-by-user',
+      });
+      return <input {...field} />;
+    };
+
+    const App = () => {
+      const methods = useForm<FormValues>({
+        defaultValues: { test: [{ value: 't0' }] },
+      });
+      getValues = methods.getValues;
+      const { fields, append } = useFieldArray({
+        control: methods.control,
+        name: 'test',
+      });
+      const [staged, setStaged] = React.useState(false);
+
+      return (
+        <div>
+          {staged && (
+            <StagedInput control={methods.control} index={fields.length} />
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              append({ value: 't1' });
+              setStaged(true);
+            }}
+          >
+            append
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await act(async () => {});
+
+    expect(getValues()).toEqual({
+      test: [{ value: 't0' }, { value: 't1' }, { value: 'staged-by-user' }],
+    });
+  });
 });

--- a/src/__tests__/useFieldArray/move.test.tsx
+++ b/src/__tests__/useFieldArray/move.test.tsx
@@ -9,8 +9,11 @@ import {
 } from '@testing-library/react';
 
 import { VALIDATION_MODE } from '../../constants';
+import { Controller } from '../../controller';
+import type { Control, UseFormGetValues } from '../../types';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import { useWatch } from '../../useWatch';
 import noop from '../../utils/noop';
 
 let i = 0;
@@ -460,5 +463,180 @@ describe('move', () => {
         '{"test":[{"id":"whatever1","test":"12341"},{"id":"whatever0","test":"12340"}]}',
       ),
     ).toBeVisible();
+  });
+
+  describe('when a render still holds the pre-move arrangement', () => {
+    type NestedFormValues = {
+      steps: { approvers: { value: string }[] }[];
+    };
+
+    const nestedDefaultValues: NestedFormValues = {
+      steps: [
+        { approvers: [{ value: 'a1' }] },
+        { approvers: [{ value: 'b1' }, { value: 'b2' }] },
+        { approvers: [{ value: 'c1' }] },
+      ],
+    };
+
+    const Step = ({
+      index,
+      control,
+    }: {
+      index: number;
+      control: Control<NestedFormValues>;
+    }) => {
+      const step = useWatch({ control, name: `steps.${index}` as const });
+
+      return (
+        <div>
+          {(step?.approvers ?? []).map((_: unknown, j: number) => (
+            <Controller
+              key={j}
+              control={control}
+              name={`steps.${index}.approvers.${j}.value` as const}
+              render={({ field, fieldState }) => (
+                <span>
+                  <input {...field} />
+                  {fieldState.error ? 'err' : ''}
+                </span>
+              )}
+            />
+          ))}
+        </div>
+      );
+    };
+
+    // Red on the parent commit only while React commits the synchronous
+    // setError pass before the transition pass; the index-keyed test below
+    // covers the same guard without that scheduling dependency.
+    it('should not materialize a vacated path when a leaf re-renders before the move commits', async () => {
+      let getValues: UseFormGetValues<NestedFormValues> = () => ({}) as never;
+
+      const App = () => {
+        const methods = useForm<NestedFormValues>({
+          defaultValues: nestedDefaultValues,
+        });
+        getValues = methods.getValues;
+        const { fields, move } = useFieldArray({
+          control: methods.control,
+          name: 'steps',
+        });
+
+        return (
+          <div>
+            {fields.map((field, i) => (
+              <Step key={field.id} index={i} control={methods.control} />
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                React.startTransition(() => move(1, 2));
+                methods.setError('steps', { type: 'server', message: 'x' });
+              }}
+            >
+              move
+            </button>
+          </div>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.click(screen.getByRole('button'));
+      await act(async () => {});
+
+      expect(
+        getValues().steps.map((step) => (step.approvers ?? []).length),
+      ).toEqual([1, 1, 2]);
+    });
+
+    it('should keep guarding the moved array when another array acts in the same handler', async () => {
+      type TwoArrayValues = NestedFormValues & { others: { value: string }[] };
+
+      let getValues: UseFormGetValues<TwoArrayValues> = () => ({}) as never;
+
+      const App = () => {
+        const methods = useForm<TwoArrayValues>({
+          defaultValues: { ...nestedDefaultValues, others: [{ value: 'o1' }] },
+        });
+        getValues = methods.getValues;
+        const { fields, move } = useFieldArray({
+          control: methods.control,
+          name: 'steps',
+        });
+        const { append } = useFieldArray({
+          control: methods.control,
+          name: 'others',
+        });
+
+        return (
+          <div>
+            {fields.map((_, i) => (
+              <Step
+                key={i}
+                index={i}
+                control={
+                  methods.control as unknown as Control<NestedFormValues>
+                }
+              />
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                move(1, 2);
+                append({ value: 'o2' });
+              }}
+            >
+              move
+            </button>
+          </div>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.click(screen.getByRole('button'));
+      await act(async () => {});
+
+      expect(
+        getValues().steps.map((step) => (step.approvers ?? []).length),
+      ).toEqual([1, 1, 2]);
+      expect(getValues().others).toEqual([{ value: 'o1' }, { value: 'o2' }]);
+    });
+
+    it('should not resize nested arrays when index-keyed children render the pre-move arrangement', async () => {
+      let getValues: UseFormGetValues<NestedFormValues> = () => ({}) as never;
+
+      const App = () => {
+        const methods = useForm<NestedFormValues>({
+          defaultValues: nestedDefaultValues,
+        });
+        getValues = methods.getValues;
+        const { fields, move } = useFieldArray({
+          control: methods.control,
+          name: 'steps',
+        });
+
+        return (
+          <div>
+            {fields.map((_, i) => (
+              <Step key={i} index={i} control={methods.control} />
+            ))}
+            <button type="button" onClick={() => move(1, 2)}>
+              move
+            </button>
+          </div>
+        );
+      };
+
+      render(<App />);
+
+      fireEvent.click(screen.getByRole('button'));
+      await act(async () => {});
+
+      expect(
+        getValues().steps.map((step) => (step.approvers ?? []).length),
+      ).toEqual([1, 1, 2]);
+    });
   });
 });

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -11,8 +11,10 @@ import {
 import { VALIDATION_MODE } from '../../constants';
 import { Controller } from '../../controller';
 import type { Control, DeepMap, FieldError } from '../../types';
+import { useController } from '../../useController';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import { useWatch } from '../../useWatch';
 import noop from '../../utils/noop';
 
 jest.useFakeTimers();
@@ -1501,5 +1503,207 @@ describe('remove', () => {
     fireEvent.click(screen.getByRole('button', { name: 'append' }));
     expect(screen.getByTestId('fields-count')).toHaveTextContent('1');
     expect(screen.getAllByRole('textbox')).toHaveLength(1);
+  });
+
+  it('should not resize nested arrays when index-keyed children render the pre-remove arrangement', async () => {
+    type NestedFormValues = {
+      steps: { approvers: { value: string }[] }[];
+    };
+
+    let getValues: () => NestedFormValues = () => ({ steps: [] });
+
+    const Step = ({
+      index,
+      control,
+    }: {
+      index: number;
+      control: Control<NestedFormValues>;
+    }) => {
+      const step = useWatch({ control, name: `steps.${index}` as const });
+
+      return (
+        <div>
+          {(step?.approvers ?? []).map((_: unknown, j: number) => (
+            <Controller
+              key={j}
+              control={control}
+              name={`steps.${index}.approvers.${j}.value` as const}
+              render={({ field }) => <input {...field} />}
+            />
+          ))}
+        </div>
+      );
+    };
+
+    const App = () => {
+      const methods = useForm<NestedFormValues>({
+        defaultValues: {
+          steps: [
+            { approvers: [{ value: 'a1' }] },
+            { approvers: [{ value: 'b1' }, { value: 'b2' }] },
+            { approvers: [{ value: 'c1' }] },
+          ],
+        },
+      });
+      getValues = methods.getValues;
+      const { fields, remove } = useFieldArray({
+        control: methods.control,
+        name: 'steps',
+      });
+
+      return (
+        <div>
+          {fields.map((_, i) => (
+            <Step key={i} index={i} control={methods.control} />
+          ))}
+          <button type="button" onClick={() => remove(0)}>
+            remove
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+    await act(async () => {});
+
+    expect(
+      getValues().steps.map((step) => (step.approvers ?? []).length),
+    ).toEqual([2, 1]);
+  });
+
+  it('should not resurrect removed items when the list itself renders from useWatch', async () => {
+    type NestedFormValues = {
+      steps: { approvers: { value: string }[] }[];
+    };
+
+    let getValues: () => NestedFormValues = () => ({ steps: [] });
+
+    const Step = ({
+      index,
+      control,
+    }: {
+      index: number;
+      control: Control<NestedFormValues>;
+    }) => {
+      const step = useWatch({ control, name: `steps.${index}` as const });
+
+      return (
+        <div>
+          {(step?.approvers ?? []).map((_: unknown, j: number) => (
+            <Controller
+              key={j}
+              control={control}
+              name={`steps.${index}.approvers.${j}.value` as const}
+              render={({ field }) => <input {...field} />}
+            />
+          ))}
+        </div>
+      );
+    };
+
+    const App = () => {
+      const methods = useForm<NestedFormValues>({
+        defaultValues: {
+          steps: [
+            { approvers: [{ value: 'a1' }] },
+            { approvers: [{ value: 'b1' }, { value: 'b2' }] },
+            { approvers: [{ value: 'c1' }] },
+          ],
+        },
+      });
+      getValues = methods.getValues;
+      const { remove } = useFieldArray({
+        control: methods.control,
+        name: 'steps',
+      });
+      const steps = useWatch({ control: methods.control, name: 'steps' }) || [];
+
+      return (
+        <div>
+          {steps.map((_, i) => (
+            <Step key={i} index={i} control={methods.control} />
+          ))}
+          <button type="button" onClick={() => remove(0)}>
+            remove
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+    await act(async () => {});
+
+    expect(
+      getValues().steps.map((step) => (step.approvers ?? []).length),
+    ).toEqual([2, 1]);
+  });
+
+  // A registration at an index the action just vacated is indistinguishable
+  // from the stale re-registration that resurrects removed items, so it is
+  // treated as stale; staging a replacement belongs to insert() or update(),
+  // and staging past the pre-action end still materializes (see append tests).
+  it('should treat a controlled field staged at a vacated index as the stale arrangement', async () => {
+    type FormValues = { test: { value: string }[] };
+
+    let getValues: () => unknown = () => ({});
+
+    const StagedInput = ({ control }: { control: Control<FormValues> }) => {
+      const { field } = useController({
+        control,
+        name: 'test.2.value',
+        defaultValue: 'replacement',
+      });
+      return <input {...field} />;
+    };
+
+    const App = () => {
+      const methods = useForm<FormValues>({
+        defaultValues: {
+          test: [{ value: 't0' }, { value: 't1' }, { value: 't2' }],
+        },
+      });
+      getValues = methods.getValues;
+      const { fields, remove } = useFieldArray({
+        control: methods.control,
+        name: 'test',
+      });
+      const [staged, setStaged] = React.useState(false);
+
+      return (
+        <div>
+          {fields.map((field, i) => (
+            <Controller
+              key={field.id}
+              control={methods.control}
+              name={`test.${i}.value` as const}
+              render={({ field }) => <input {...field} />}
+            />
+          ))}
+          {staged && <StagedInput control={methods.control} />}
+          <button
+            type="button"
+            onClick={() => {
+              remove(2);
+              setStaged(true);
+            }}
+          >
+            remove
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+    await act(async () => {});
+
+    expect(getValues()).toEqual({
+      test: [{ value: 't0' }, { value: 't1' }],
+    });
   });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -178,6 +178,7 @@ export function createFormControl<
     : (cloneObject(_defaultValues) as TFieldValues);
   let _state = {
     action: false,
+    actionNames: new Map<InternalFieldName, number>(),
     mount: false,
     watch: false,
     keepIsValid: false,
@@ -300,6 +301,13 @@ export function createFormControl<
   ) => {
     if (args && method && !_options.disabled) {
       _state.action = true;
+      if (!_state.actionNames.has(name)) {
+        const preActionFields = get(_fields, name);
+        _state.actionNames.set(
+          name,
+          Array.isArray(preActionFields) ? preActionFields.length : 0,
+        );
+      }
       if (shouldUpdateFieldsAndState && Array.isArray(get(_fields, name))) {
         const fieldValues = method(get(_fields, name), args.argA, args.argB);
         shouldSetValues && set(_fields, name, fieldValues);
@@ -386,6 +394,55 @@ export function createFormControl<
     return false;
   };
 
+  const hasOutOfRangeArrayIndex = (name: InternalFieldName) => {
+    if (!_state.actionNames.size) {
+      return false;
+    }
+
+    const segments = stringToPath(name);
+    let ownerDepth = 0;
+    let ownerPreActionLength = 0;
+
+    for (const [actionName, preActionLength] of _state.actionNames) {
+      const actionSegments = stringToPath(actionName);
+
+      if (
+        actionSegments.length > ownerDepth &&
+        actionSegments.length <= segments.length &&
+        actionSegments.every((segment, i) => segment === segments[i])
+      ) {
+        ownerDepth = actionSegments.length;
+        ownerPreActionLength = preActionLength;
+      }
+    }
+
+    if (!ownerDepth) {
+      return false;
+    }
+
+    let node: unknown = _formValues;
+
+    for (let i = 0; i < segments.length; i++) {
+      if (isNullOrUndefined(node)) {
+        return false;
+      }
+
+      const key = segments[i];
+
+      if (Array.isArray(node) && +key >= node.length) {
+        // At the acted array itself, an index inside the pre-action bounds
+        // is one the action vacated, while an index beyond them is a caller
+        // staging an entry the action never owned. Below the acted array
+        // every out-of-range index comes from a stale arrangement.
+        return i === ownerDepth ? +key < ownerPreActionLength : i > ownerDepth;
+      }
+
+      node = (node as Record<string, unknown>)[key];
+    }
+
+    return false;
+  };
+
   const updateValidAndValue = (
     name: InternalFieldName,
     shouldSkipSetValueAs: boolean,
@@ -395,7 +452,10 @@ export function createFormControl<
     const field: Field = get(_fields, name);
 
     if (field) {
-      if (hasExplicitNullIntermediate(name)) {
+      // A render that still holds a pre-action field array arrangement can
+      // register a path the array operation has just removed; materializing
+      // it would resize the array, so leave `_formValues` untouched.
+      if (hasExplicitNullIntermediate(name) || hasOutOfRangeArrayIndex(name)) {
         return;
       }
 
@@ -1887,6 +1947,7 @@ export function createFormControl<
     _state.watch = !!_options.shouldUnregister;
     _state.keepIsValid = !!keepStateOptions.keepIsValid;
     _state.action = false;
+    _state.actionNames.clear();
 
     if (!keepStateOptions.keepErrors) {
       _formState.errors = {};

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -878,6 +878,7 @@ export type Control<
   _state: {
     mount: boolean;
     action: boolean;
+    actionNames: Map<InternalFieldName, number>;
     watch: boolean;
   };
   _reset: UseFormReset<TFieldValues>;

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -372,10 +372,12 @@ export function useFieldArray<
 
   React.useEffect(() => {
     if (disabled) {
+      control._state.actionNames.delete(name);
       return;
     }
 
     control._state.action = false;
+    control._state.actionNames.delete(name);
 
     isWatched(name, control._names) &&
       control._subjects.state.next({
@@ -492,6 +494,8 @@ export function useFieldArray<
     }
 
     return () => {
+      control._state.actionNames.delete(name);
+
       if (disabled) {
         return;
       }


### PR DESCRIPTION
## Proposed Changes

Fixes #13641

A component that still holds a pre-action field array arrangement can `register` a
path the array operation has just removed. `register` runs during render via
`useController` (the `useRef(control.register(name, { value }))` argument is evaluated
on every render), re-creates the path in `_fields` as a new field, and
`updateValidAndValue` materializes the stale value into `_formValues` — resizing a
nested array or resurrecting a removed item. The issue above has the full mechanism
and an instrumented write sequence from a real app.

This change records each acted-on array together with its pre-action registered length
(`_state.actionNames: Map<InternalFieldName, number>`, captured from `_fields` before
the method applies) and makes `updateValidAndValue` skip the materialization for a
path under an acted array when its out-of-range crossing sits:

- below the acted array (a nested array inside a moved/removed item — always a stale
  arrangement), or
- at the acted array itself on an index inside its pre-action bounds (an index the
  action vacated).

Indices beyond the pre-action bounds still materialize, so staging a controlled field
past the end of the acted array in the same commit keeps working. Arrays untouched by
the handler are never affected: one handler acting on several arrays keeps a scope per
array. Each entry clears where the action flag resets, when the owning `useFieldArray`
unmounts or becomes disabled, and on `reset`, so a leaked action flag cannot suppress
registrations indefinitely.

Regression tests cover: the reported shape (`move` with `useWatch`-derived leaves,
both a transition-interleaved render and an index-keyed render), `remove` with a
`useWatch`-driven list (item resurrection), a controlled field mounted in the same
commit as an append to another array, a controlled field staged at the end of the
appended array itself, and a two-array handler (`move` + `append`). Each test was
verified to fail against the guard-less baseline or an earlier revision of the guard.

Two boundaries of the heuristic are pinned by tests instead of being hidden. A
controlled field staged at an index the action just vacated is indistinguishable from
the stale re-registration and is treated as stale — `insert` / `update` express that
intent, and before this change such a registration materialized the removed item's old
value rather than the staged one whenever form defaults covered it. And the pre-action
bound counts registered fields, so a row that never registered an input (conditionally
rendered rows) cannot raise it.

Bundle size cost is +164 bytes gzip (13224 -> 13388 on `dist/index.cjs.js`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
