### PR TITLE
fix: field array update leaving stale errors and touched state at updated index

### DIFF
--- a/src/__tests__/useFieldArray/update.test.tsx
+++ b/src/__tests__/useFieldArray/update.test.tsx
@@ -699,7 +699,7 @@ describe('update', () => {
     ).toBeVisible();
   });
 
-  it('should not update errors state', async () => {
+  it('should remove stale errors for the updated field', async () => {
     const App = () => {
       const {
         control,
@@ -755,6 +755,127 @@ describe('update', () => {
 
     fireEvent.click(screen.getByRole('button'));
 
-    expect(await screen.findByText('This is required')).toBeVisible();
+    await waitFor(() =>
+      expect(screen.queryByText('This is required')).toBeNull(),
+    );
+  });
+
+  it('should keep errors of other fields when updating an index', async () => {
+    const App = () => {
+      const {
+        control,
+        register,
+        trigger,
+        formState: { errors },
+      } = useForm({
+        defaultValues: {
+          test: [
+            {
+              firstName: '',
+            },
+            {
+              firstName: '',
+            },
+          ],
+        },
+      });
+      const { fields, update } = useFieldArray({
+        name: 'test',
+        control,
+      });
+
+      React.useEffect(() => {
+        trigger();
+      }, [trigger]);
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <input
+              key={field.id}
+              {...register(`test.${i}.firstName` as const, {
+                required: true,
+              })}
+            />
+          ))}
+          <p>{errors?.test?.[0]?.firstName ? 'error0' : 'noError0'}</p>
+          <p>{errors?.test?.[1]?.firstName ? 'error1' : 'noError1'}</p>
+          <button
+            type={'button'}
+            onClick={() =>
+              update(1, {
+                firstName: 'firstName',
+              })
+            }
+          >
+            update
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    expect(await screen.findByText('error0')).toBeVisible();
+    expect(screen.getByText('error1')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByText('noError1')).toBeVisible();
+    expect(screen.getByText('error0')).toBeVisible();
+  });
+
+  it('should clear touched state for the updated field', async () => {
+    const App = () => {
+      const {
+        control,
+        register,
+        formState: { touchedFields },
+      } = useForm({
+        defaultValues: {
+          test: [
+            {
+              firstName: '',
+            },
+          ],
+        },
+      });
+      const { fields, update } = useFieldArray({
+        name: 'test',
+        control,
+      });
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <input
+              key={field.id}
+              {...register(`test.${i}.firstName` as const)}
+            />
+          ))}
+          <p>{touchedFields.test?.[0]?.firstName ? 'touched' : 'untouched'}</p>
+          <button
+            type={'button'}
+            onClick={() =>
+              update(0, {
+                firstName: 'firstName',
+              })
+            }
+          >
+            update
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.blur(screen.getByRole('textbox'));
+
+    expect(await screen.findByText('touched')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'update' }));
+
+    expect(await screen.findByText('untouched')).toBeVisible();
   });
 });

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -334,17 +334,10 @@ export function useFieldArray<
     );
     updateValues(updatedFieldArrayValues);
     setFields([...updatedFieldArrayValues]);
-    control._setFieldArray(
-      name,
-      updatedFieldArrayValues,
-      updateAt,
-      {
-        argA: index,
-        argB: updateValue,
-      },
-      true,
-      false,
-    );
+    control._setFieldArray(name, updatedFieldArrayValues, updateAt, {
+      argA: index,
+      argB: fillEmptyArray(value),
+    });
   };
 
   const replace = (


### PR DESCRIPTION
## Summary

Fix `useFieldArray`'s `update()` leaving stale `errors` and `touchedFields` entries at the updated index. 
Updating an invalid item with a valid value kept showing the old error until another validation event (blur, `trigger()`, submit) occurred.

### Motivation
`update()` was the only field array operation passing `shouldUpdateFieldsAndState: false` to `control._setFieldArray`, so the block that keeps `formState.errors` / `formState.touchedFields` in sync with array operations was skipped entirely.
Reproduction:
1. Register `fields.0.firstName` with a `required` rule.
2. Trigger validation so `errors.fields[0].firstName` is set.
3. Call `update(0, { firstName: 'valid value' })`.
4. The stale "required" error stays visible even though the value is valid.

Since `update()` is documented as an unmount/remount of the field — i.e. equivalent to `remove(index)` + `insert(index, value)`, both of which clear state at that index — stale state surviving `update()` is inconsistent with the other operations.

### What I have done
- `src/useFieldArray.ts`: `update()` now calls `_setFieldArray` the same way as `append`/`prepend`/`insert`, passing an `undefined` placeholder (`fillEmptyArray(value)`) with the default `shouldUpdateFieldsAndState`. 
This clears `errors`, `touchedFields` and the internal field registration at the updated index; the item remounts with a fresh key and re-registers itself.
Array-level `root` errors are preserved by the existing logic in `_setFieldArray`.
- `src/__tests__/useFieldArray/update.test.tsx`:
  - Rewrote `should not update errors state` (which asserted the stale-error
    behavior) as `should remove stale errors for the updated field`.
  - Added `should keep errors of other fields when updating an index`.
  - Added `should clear touched state for the updated field`.
 
### Test Plans
- `pnpm test -- useFieldArray/update.test.tsx` — all 16 tests pass, including the three new/updated cases covering: stale error removal at the updated index, errors at other indexes being preserved, and touched state cleanup.
- `pnpm test` — full suite passes (118 suites / 1228 tests), confirming no regression in the other field array operations.
- `pnpm type` (`tsc --noEmit`) and `pnpm lint` — no errors or new warnings.
- All of the above were run on Node 20 in a clean Docker container (`node:20`, pnpm 10).


### Test Results
```bash
$ docker run --rm -v "$PWD":/app -v rhf_node_modules:/app/node_modules -w /app \
    -e HUSKY=0 -e CI=true node:20 bash -c "npm i -g pnpm@10 --silent && \
    pnpm install --frozen-lockfile --silent && pnpm test -- useFieldArray/update.test.tsx"
PASS Web src/__tests__/useFieldArray/update.test.tsx
  update
    ✓ should remove stale errors for the updated field (13 ms)
    ✓ should keep errors of other fields when updating an index (17 ms)
    ✓ should clear touched state for the updated field (15 ms) ... (13 existing tests also pass)
Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
$ docker run ... bash -c "... pnpm test && pnpm type && pnpm lint"
Test Suites: 118 passed, 118 total
Tests:       1228 passed, 1228 total
Snapshots:   8 passed, 8 total
Time:        82.319 s
> tsc --noEmit
TYPECHECK_OK
LINT_OK
```