### PR TITLE
🐞 fix(flatten): preserve File and Blob values as leaf nodes

### DIFF
--- a/src/__tests__/form.test.tsx
+++ b/src/__tests__/form.test.tsx
@@ -343,6 +343,38 @@ describe('Form', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('should include file values in the submitted FormData', async () => {
+    const actionFn = jest.fn<(formData: FormData) => Promise<void>>(
+      async () => {},
+    );
+    const resume = new Blob(['content'], { type: 'text/plain' });
+
+    const App = () => {
+      const { register, control } = useForm({
+        defaultValues: { name: 'bill', resume },
+      });
+
+      return (
+        <Form control={control} action={actionFn}>
+          <input {...register('name')} />
+          <button>Submit</button>
+        </Form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(actionFn).toHaveBeenCalledTimes(1);
+    });
+
+    const formData = actionFn.mock.calls[0][0];
+    expect(formData.get('name')).toBe('bill');
+    expect(formData.get('resume')).toBeInstanceOf(Blob);
+  });
+
   it('should invoke onError when a function action throws', async () => {
     const onError = jest.fn();
     const actionFn = jest.fn(async () => {

--- a/src/__tests__/utils/flatten.test.ts
+++ b/src/__tests__/utils/flatten.test.ts
@@ -43,4 +43,27 @@ describe('flatten', () => {
       label: 'year',
     });
   });
+
+  it('should preserve File and Blob values as leaf nodes and not drop them', () => {
+    const file = new File(['content'], 'resume.pdf');
+    const blob = new Blob(['content']);
+
+    expect(flatten({ name: 'Alice', resume: file, avatar: blob })).toEqual({
+      name: 'Alice',
+      resume: file,
+      avatar: blob,
+    });
+  });
+
+  it('should preserve nested and indexed File values as leaf nodes', () => {
+    const first = new File(['1'], 'first.pdf');
+    const second = new File(['2'], 'second.pdf');
+
+    expect(
+      flatten({ profile: { resume: first }, attachments: [second] }),
+    ).toEqual({
+      'profile.resume': first,
+      'attachments.0': second,
+    });
+  });
 });

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -3,6 +3,10 @@ import type { FieldValues } from '../types';
 import isDateObject from './isDateObject';
 import { isObjectType } from './isObject';
 
+const isFileLike = (value: unknown) =>
+  (typeof Blob !== 'undefined' && value instanceof Blob) ||
+  (typeof File !== 'undefined' && value instanceof File);
+
 export const flatten = (obj: FieldValues) => {
   const output: FieldValues = {};
 
@@ -10,7 +14,8 @@ export const flatten = (obj: FieldValues) => {
     if (
       isObjectType(obj[key]) &&
       obj[key] !== null &&
-      !isDateObject(obj[key])
+      !isDateObject(obj[key]) &&
+      !isFileLike(obj[key])
     ) {
       const nested = flatten(obj[key]);
 


### PR DESCRIPTION
## Proposed Changes

`flatten()` recurses into anything with `typeof value === 'object'`, so a `File`, `Blob` or `FileList` is walked as if it were a plain object. Those objects expose no enumerable own properties, so the recursion returns `{}` and the key is dropped from the output entirely.

`jsonToFormData()` builds the `FormData` that `<Form>` submits out of `flatten()`, so every file in a form silently disappears from the request body:

```js
const resume = new File(['content'], 'resume.pdf');

[...jsonToFormData({ name: 'bill', resume }).keys()];
// ['name'] — resume is gone
```

A `FileList`, which is what `register()` stores for `<input type="file" />`, collapses the same way: `flatten()` recurses into the list, then into each `File`, and every entry vanishes.

This is the same defect #13566 fixed for `Date`, so the fix follows it — file-like values are treated as leaf nodes. Files now reach `FormData.append()` as files, and a `FileList` flattens to `avatar.0`, `avatar.1`, … which is consistent with how `flatten()` already handles arrays.

The check tests `Blob` and `File` separately rather than relying on `File extends Blob`, because the two globals do not always share a prototype chain — in this repo's own jsdom test environment `new File([], 'a.txt') instanceof Blob` is `false`, so a `Blob`-only check would still drop files there.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Verification

Both new tests fail on `master` and pass with the fix:

```
● Form › should include file values in the submitted FormData
● flatten › should preserve File and Blob values as leaf nodes and not drop them
● flatten › should preserve nested and indexed File values as leaf nodes
```

| command | result |
| --- | --- |
| `pnpm test` | 118 suites, 1232 tests passed |
| `pnpm test:type` | passed |
| `pnpm lint` | 0 errors (501 pre-existing warnings, same as `master`) |
| `pnpm build` | passed, including the ESM/CJS export assertions |
| `pnpm api-extractor` | completed successfully, no report changes |
| `pnpm start` + `pnpm e2e` | 89 passed, 1 failed |

The single e2e failure is `setValueAsyncStrictMode › should set async input value correctly`. It fails the same way on unmodified `master` on this machine, so it is not related to this change.
