### PR TITLE
🧹 refactor: remove unreachable revalidate condition in `useFieldArray`

### DIFF
--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -423,14 +423,7 @@ export function useFieldArray<
         });
       } else {
         const field: Field = get(control._fields, name);
-        if (
-          field &&
-          field._f &&
-          !(
-            getValidationModes(control._options.reValidateMode).isOnSubmit &&
-            getValidationModes(control._options.mode).isOnSubmit
-          )
-        ) {
+        if (field && field._f) {
           validateField(
             field,
             control._names.disabled,


### PR DESCRIPTION
## Summary

Remove an unreachable condition inside `useFieldArray`'s re-validation effect. So, this PR doesn't include changing behaviour.

### Motivation

The re-validation effect in `src/useFieldArray.ts` guards the whole block like:

```ts
if (
  _actioned.current &&
  (!validationModes.isOnSubmit || control._formState.isSubmitted) &&
  !getValidationModes(control._options.reValidateMode).isOnSubmit &&
  !validationModes.isOnBlur
) {
```

Inside that block (non-resolver branch), the field validation call was additionally guarded like:

```ts
if (
  field &&
  field._f &&
  !(
    getValidationModes(control._options.reValidateMode).isOnSubmit &&
    getValidationModes(control._options.mode).isOnSubmit
  )
) {
```
By the time this inner if runs, the outer guard has already established that `getValidationModes(control._options.reValidateMode).isOnSubmit` is false. 
So, inner expression reduces to !(false && ...), which is always true. Therefore, the extra check can never evaluate to false and never skips validateField.

### Test Results
```bash
`pnpm test` — full suite passes (118 suites / 1229 tests), confirming the removal doesn't change behavior for any validation/reValidation mode combination.
`pnpm type` (`tsc --noEmit`) — no errors.
`pnpm lint` — no errors (pre-existing warnings unrelated to this change).
Run on Node 20 in a clean Docker container (`node:20`, pnpm 10).
```