### PR TITLE
fix(validateField): pass the field error to setCustomValidity when criteriaMode is all

### DIFF
--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -2468,6 +2468,99 @@ describe('validateField', () => {
         ),
       ).toEqual({});
     });
+
+    it('should invoke setCustomValidity with the required message when all criteria are collected', async () => {
+      const setCustomValidity = jest.fn();
+      const reportValidity = jest.fn();
+
+      await validateField(
+        {
+          _f: {
+            name: 'test',
+            ref: {
+              setCustomValidity,
+              reportValidity,
+              name: 'test',
+              value: '',
+            },
+            value: '',
+            required: 'something is wrong',
+            mount: true,
+          },
+        },
+        new Set(),
+        {
+          test: '',
+        },
+        true,
+        true,
+      );
+
+      expect(setCustomValidity).toHaveBeenLastCalledWith('something is wrong');
+      expect(reportValidity).toHaveBeenCalled();
+    });
+
+    it('should invoke setCustomValidity with the validate message when all criteria are collected', async () => {
+      const setCustomValidity = jest.fn();
+      const reportValidity = jest.fn();
+
+      await validateField(
+        {
+          _f: {
+            name: 'test',
+            ref: {
+              setCustomValidity,
+              reportValidity,
+              name: 'test',
+              value: 'bill',
+            },
+            value: 'bill',
+            validate: () => 'this is not allowed',
+            mount: true,
+          },
+        },
+        new Set(),
+        {
+          test: 'bill',
+        },
+        true,
+        true,
+      );
+
+      expect(setCustomValidity).toHaveBeenLastCalledWith('this is not allowed');
+      expect(reportValidity).toHaveBeenCalled();
+    });
+
+    it('should invoke setCustomValidity with an empty string for a valid input when all criteria are collected', async () => {
+      const setCustomValidity = jest.fn();
+      const reportValidity = jest.fn();
+
+      await validateField(
+        {
+          _f: {
+            name: 'test',
+            ref: {
+              setCustomValidity,
+              reportValidity,
+              name: 'test',
+              value: 'bill',
+            },
+            value: 'bill',
+            required: 'something is wrong',
+            mount: true,
+          },
+        },
+        new Set(),
+        {
+          test: 'bill',
+        },
+        true,
+        true,
+      );
+
+      expect(setCustomValidity).toHaveBeenLastCalledWith('');
+      expect(reportValidity).toHaveBeenCalled();
+    });
   });
 
   it('should validate field array with required attribute', async () => {

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -291,6 +291,9 @@ export default async <T extends FieldValues>(
     }
   }
 
-  setCustomValidity(true);
+  const fieldError = error[name];
+
+  setCustomValidity(fieldError ? fieldError.message : true);
+
   return error;
 };


### PR DESCRIPTION
## Proposed Changes

`validateField` ends with an unconditional tail call:

```ts
setCustomValidity(true);
```

`true` is the "this field is valid" signal: it passes `''` to `setCustomValidity` on the field's ref, or on every ref of a radio or checkbox group, and then calls `reportValidity()`. Reaching that line clears the field's custom error regardless of what validation just found.

Under the default `criteriaMode: 'firstError'` this is harmless, because the tail is only reached when the field really is valid: each rule branch that records an error reports its own message and returns immediately. Those early returns are guarded by `!validateAllFieldCriteria`, so `criteriaMode: 'all'` removes them and validation always runs through to the tail, which then discards the error it has just collected. The one branch that does still report a message in that mode, the per-key `validate` object, has its message overwritten by the tail a moment later.

```tsx
useForm({ shouldUseNativeValidation: true, criteriaMode: 'all' });

register('name', { validate: () => 'this is not allowed' });
// formState.errors.name.message === 'this is not allowed'
// setCustomValidity was called with '', so there is no bubble and no :invalid
```

Both flags come straight from the `useForm` options at every `validateField` call site, so the change/blur handler, `trigger` and submit are all affected.

The fix makes the tail report the collected error instead of clearing it. `error[name].message` is the same message that ends up in `formState.errors[name].message`, so the native message and the error RHF exposes stay in agreement. With no error to report the tail still passes `true`, which leaves `criteriaMode: 'firstError'` behaving exactly as before.

Tests were added to the `with Browser native validation` block in `src/__tests__/logic/validateField.test.tsx`, covering a failing `required`, a failing `validate`, and a valid field that must still clear the message.
