### PR TITLE
fix(setValues): update fields registered under an object or array value

### DIFF
--- a/src/__tests__/useForm/setValues.test.tsx
+++ b/src/__tests__/useForm/setValues.test.tsx
@@ -573,6 +573,106 @@ describe('setValues', () => {
     expect(result.current.formState.errors.username).toBeDefined();
   });
 
+  it('should update a multiple select registered under an array value', async () => {
+    const Component = () => {
+      const { register, setValues } = useForm<{ tags: string[] }>({
+        defaultValues: { tags: ['a'] },
+      });
+
+      return (
+        <>
+          <select multiple {...register('tags')} aria-label="tags">
+            <option value="a">a</option>
+            <option value="b">b</option>
+            <option value="c">c</option>
+          </select>
+          <button type="button" onClick={() => setValues({ tags: ['b', 'c'] })}>
+            set
+          </button>
+        </>
+      );
+    };
+
+    render(<Component />);
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'set' }));
+    });
+
+    const select = screen.getByLabelText('tags') as HTMLSelectElement;
+
+    expect(
+      Array.from(select.selectedOptions, (option) => option.value),
+    ).toEqual(['b', 'c']);
+  });
+
+  it('should update a checkbox group registered under an array value', async () => {
+    const Component = () => {
+      const { register, setValues } = useForm<{ choices: string[] }>({
+        defaultValues: { choices: ['a'] },
+      });
+
+      return (
+        <>
+          <input
+            type="checkbox"
+            value="a"
+            {...register('choices')}
+            aria-label="a"
+          />
+          <input
+            type="checkbox"
+            value="b"
+            {...register('choices')}
+            aria-label="b"
+          />
+          <button type="button" onClick={() => setValues({ choices: ['b'] })}>
+            set
+          </button>
+        </>
+      );
+    };
+
+    render(<Component />);
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'set' }));
+    });
+
+    expect(screen.getByLabelText('a')).not.toBeChecked();
+    expect(screen.getByLabelText('b')).toBeChecked();
+  });
+
+  it('should clear a multiple select when an empty array is provided', async () => {
+    const Component = () => {
+      const { register, setValues } = useForm<{ tags: string[] }>({
+        defaultValues: { tags: ['a'] },
+      });
+
+      return (
+        <>
+          <select multiple {...register('tags')} aria-label="tags">
+            <option value="a">a</option>
+            <option value="b">b</option>
+          </select>
+          <button type="button" onClick={() => setValues({ tags: [] })}>
+            set
+          </button>
+        </>
+      );
+    };
+
+    render(<Component />);
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'set' }));
+    });
+
+    const select = screen.getByLabelText('tags') as HTMLSelectElement;
+
+    expect(select.selectedOptions).toHaveLength(0);
+  });
+
   it('should not validate when shouldValidate is not provided', async () => {
     const { result } = renderHook(() =>
       useForm<{ firstName: string }>({

--- a/src/__tests__/utils/has.test.ts
+++ b/src/__tests__/utils/has.test.ts
@@ -1,0 +1,58 @@
+import has from '../../utils/has';
+
+describe('has', () => {
+  it('should detect paths that resolve to a value', () => {
+    const test = {
+      bill: [1, 2, 3],
+      betty: { test: { test1: [{ test2: 'bill' }] } },
+      'dotted.filled': 'content',
+    };
+
+    expect(has(test, 'bill')).toBeTruthy();
+    expect(has(test, 'bill[0]')).toBeTruthy();
+    expect(has(test, 'betty.test.test1[0].test2')).toBeTruthy();
+    expect(has(test, 'dotted.filled')).toBeTruthy();
+  });
+
+  it('should detect paths that are absent', () => {
+    const test = {
+      bill: [1, 2, 3],
+      betty: { test: 'test' },
+    };
+
+    expect(has(test, 'luo')).toBeFalsy();
+    expect(has(test, 'bill[3]')).toBeFalsy();
+    expect(has(test, 'betty.test.test1')).toBeFalsy();
+    expect(has(test, 'dotted.empty')).toBeFalsy();
+  });
+
+  it('should detect a path that is present but holds an empty or nullish value', () => {
+    const test = {
+      empty: {},
+      list: [],
+      nothing: undefined,
+      nullish: null,
+    };
+
+    expect(has(test, 'empty')).toBeTruthy();
+    expect(has(test, 'list')).toBeTruthy();
+    expect(has(test, 'nothing')).toBeTruthy();
+    expect(has(test, 'nullish')).toBeTruthy();
+  });
+
+  it('should not report inherited properties', () => {
+    expect(has({}, 'toString')).toBeFalsy();
+    expect(has({}, 'constructor')).toBeFalsy();
+    expect(has({}, '__proto__')).toBeFalsy();
+    expect(has({ a: {} }, 'a.__proto__.b')).toBeFalsy();
+  });
+
+  it('should return false for an empty path or a non-traversable object', () => {
+    expect(has({ bill: 'test' }, '')).toBeFalsy();
+    expect(has({ bill: 'test' }, undefined)).toBeFalsy();
+    expect(has({ bill: 'test' }, null)).toBeFalsy();
+    expect(has(undefined, 'bill')).toBeFalsy();
+    expect(has(null, 'bill')).toBeFalsy();
+    expect(has('bill', 'bill')).toBeFalsy();
+  });
+});

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -61,8 +61,8 @@ import convertToArrayPayload from '../utils/convertToArrayPayload';
 import createSubject from '../utils/createSubject';
 import deepEqual from '../utils/deepEqual';
 import extractFormValues from '../utils/extractFormValues';
-import { flatten } from '../utils/flatten';
 import get from '../utils/get';
+import has from '../utils/has';
 import isBoolean from '../utils/isBoolean';
 import isCheckBoxInput from '../utils/isCheckBoxInput';
 import isDateObject from '../utils/isDateObject';
@@ -1089,13 +1089,11 @@ export function createFormControl<
         ...updatedFormValues,
       };
 
-      const flattenedUpdates = flatten(updatedFormValues as FieldValues);
-
       for (const fieldName of _names.mount) {
-        if (fieldName in flattenedUpdates) {
+        if (has(updatedFormValues, fieldName)) {
           _setValue(
             fieldName as FieldPath<TFieldValues>,
-            flattenedUpdates[fieldName],
+            get(updatedFormValues, fieldName),
             options,
             true,
             true,

--- a/src/utils/has.ts
+++ b/src/utils/has.ts
@@ -1,0 +1,27 @@
+import isKey from './isKey';
+import { isObjectType } from './isObject';
+import stringToPath from './stringToPath';
+
+const hasOwn = (value: unknown, key: string) =>
+  value !== null &&
+  isObjectType(value) &&
+  Object.prototype.hasOwnProperty.call(value, key);
+
+export default <T>(object: T, path?: string | null): boolean => {
+  if (!path) {
+    return false;
+  }
+
+  let result: unknown = object;
+
+  for (const key of isKey(path) ? [path] : stringToPath(path)) {
+    if (!hasOwn(result, key)) {
+      // `get` also resolves a path held as a single literal key, eg `{ 'a.b': 1 }`
+      return hasOwn(object, path);
+    }
+
+    result = (result as Record<string, unknown>)[key];
+  }
+
+  return true;
+};


### PR DESCRIPTION
## Proposed Changes

`setValues` does not update a field that is registered at a path holding an object or an array. The input keeps its previous value even though `getValues()` reports the new one.

The batch loop flattens the incoming values and then matches mounted field names against the resulting keys:

```ts
const flattenedUpdates = flatten(updatedFormValues as FieldValues);

for (const fieldName of _names.mount) {
  if (fieldName in flattenedUpdates) {
    _setValue(fieldName, flattenedUpdates[fieldName], options, true, true);
  }
}
```

`flatten` only emits leaf paths, so `{ tags: ['b', 'c'] }` becomes `{ 'tags.0': 'b', 'tags.1': 'c' }`. A field registered as `tags` is never in that map, so `_setValue` is skipped and the element is left alone. An empty array or object is worse: it flattens to no keys at all, so the update disappears entirely.

In practice this hits the DOM controls whose value is an array under a single field name:

- `<select multiple {...register('tags')} />` keeps its old selection
- a checkbox group sharing one name keeps its old checked state
- a container path registered directly by a `Controller` never receives the new value
- `setValues({ tags: [] })` does not clear anything

`setValue('tags', ['b', 'c'])` handles all of these correctly today, so the two APIs disagree.

This replaces the flatten-and-lookup with a path walk over the provided values, so a container value is passed to `_setValue` as-is. `_setValue` already knows how to apply object and array values. It routes them through `setFieldValue`/`setFieldValues`, which handle multiple selects, checkbox groups and nested objects.

Path presence is resolved with own properties rather than `in`, which keeps two existing behaviours intact: an explicitly provided `undefined` still propagates to a mounted field, and a field name that collides with an inherited property (`toString`) is not treated as provided. The new `has` util mirrors `get`'s path semantics, including a path stored as a single literal key such as `{ 'a.b': 1 }`, so `has` and `get` agree on what is present.

`flatten` itself is unchanged and still used by `jsonToFormData`, where leaf-only output is what is wanted.

No linked issue. Found while reading the `setValues` batch path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### Tests

Three regression tests in `setValues.test.tsx` cover a multiple select, a checkbox group, and clearing a multiple select with `[]`. All three fail on `master`:

```
● setValues › should update a multiple select registered under an array value
    - Expected  - 2
    + Received  + 1
      Array [
    -   "b",
    -   "c",
    +   "a",
      ]

● setValues › should update a checkbox group registered under an array value
    expect(element).not.toBeChecked()
    Received element is checked:
      <input aria-label="a" name="choices" type="checkbox" value="a" />

● setValues › should clear a multiple select when an empty array is provided
    Expected length: 0
    Received length: 1
    Received object: [<option value="a">a</option>]

Tests: 3 failed, 18 passed, 21 total
```

`has` also gets its own unit test alongside the other `src/utils` tests.

Full suite after the change:

```
pnpm test
Test Suites: 120 passed, 120 total
Tests:       1265 passed, 1265 total
Snapshots:   8 passed, 8 total
```

`pnpm lint` reports no new warnings, `pnpm type` and `pnpm test:type` are clean, and `pnpm build` succeeds. Bundle impact on `dist/index.cjs.js` is +45 B gzipped (13739 B to 13784 B), within the 14.0 kB bundlewatch budget.
