### PR TITLE
fix: useWatch returns stale value on name change when new value is null

### DIFF
--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -989,6 +989,41 @@ describe('useWatch', () => {
       expect(result.current).toBe('value1');
     });
 
+    it('should return the new field value synchronously on the same render even when that value is null', () => {
+      type FormValues = {
+        a: string;
+        c: string | null;
+      };
+
+      const { result: formResult } = renderHook(() =>
+        useForm<FormValues>({
+          defaultValues: {
+            a: 'x',
+            c: null,
+          },
+        }),
+      );
+
+      const renders: (string | null)[] = [];
+
+      const Test = ({ name }: { name: 'a' | 'c' }) => {
+        const value = useWatch({
+          control: formResult.current.control,
+          name,
+        });
+        renders.push(value);
+        return null;
+      };
+
+      const { rerender } = render(<Test name="a" />);
+      rerender(<Test name="c" />);
+
+      // The render triggered directly by the name change must already
+      // reflect the new field's value (null), not the previous field's
+      // stale value ('x').
+      expect(renders[1]).toBe(null);
+    });
+
     it('should react to changing control', () => {
       type FormValues = {
         name: string;

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -378,18 +378,17 @@ export function useWatch<TFieldValues extends FieldValues>(
   const controlChanged = _prevControl.current !== control;
   const prevName = _prevName.current;
 
-  // Cache the computed output to avoid duplicate calls within the same render
-  // We include shouldReturnImmediate in deps to ensure proper recomputation
-  const computedOutput = React.useMemo(() => {
+  // `null`/`undefined` are valid watched values, so a boolean flag (rather
+  // than a sentinel return value) decides whether to return the freshly
+  // computed output instead of the possibly-stale state value.
+  const shouldReturnImmediate = React.useMemo(() => {
     if (disabled) {
-      return null;
+      return false;
     }
 
     const nameChanged = !controlChanged && !deepEqual(prevName, name);
-    const shouldReturnImmediate = controlChanged || nameChanged;
+    return controlChanged || nameChanged;
+  }, [disabled, controlChanged, name, prevName]);
 
-    return shouldReturnImmediate ? getCurrentOutput() : null;
-  }, [disabled, controlChanged, name, prevName, getCurrentOutput]);
-
-  return computedOutput !== null ? computedOutput : value;
+  return shouldReturnImmediate ? getCurrentOutput() : value;
 }


### PR DESCRIPTION
### Problem
- useWatch's synchronous name/control-change fast path used null as a sentinel meaning "no immediate value computed yet," then fell back to the possibly-stale state value whenever the computed output was null.

### Root cause
- A watched field's actual value can legitimately be null (or a compute function can return null). When name changed to such a field, the sentinel collided with that legitimate value, so the hook returned the previous field's stale value for one render — until a layout effect corrected it on the next tick. 
- This breaks the documented guarantee that callers like `useController` see the correct value immediately on the same render.

### What I Fixed
- Replaced the sentinel with an explicit boolean flag (shouldReturnImmediate), so a genuinely null/undefined computed value is never mistaken for not computed yet.

### Testing
- Added a regression test that renders a component watching field a, then re-renders it watching field c (whose value is null), asserting the render triggered by the name change already returns null.
- Verified the test fails on the pre-fix code (Received: "x") and passes after the fix.