### PR TITLE
fix(unregister): keepDirty inverted when broadcasting isDirty

### DIFF
--- a/src/__tests__/useForm/unregister.test.tsx
+++ b/src/__tests__/useForm/unregister.test.tsx
@@ -91,6 +91,94 @@ describe('unregister', () => {
     await waitFor(() => expect(isDirty).toBe(false));
   });
 
+  it('should recompute isDirty when a dirty field is unregistered', async () => {
+    let isDirty: boolean | null = null;
+    let dirtyFields: Record<string, unknown> = {};
+
+    const App = () => {
+      const [show, setShow] = React.useState(true);
+      const { register, unregister, formState } = useForm({
+        defaultValues: { firstName: 'bill', lastName: 'luo' },
+      });
+
+      isDirty = formState.isDirty;
+      dirtyFields = formState.dirtyFields;
+
+      return (
+        <form>
+          {show && <input {...register('firstName')} placeholder="firstName" />}
+          <input {...register('lastName')} placeholder="lastName" />
+          <button
+            type="button"
+            onClick={() => {
+              unregister('firstName');
+              setShow(false);
+            }}
+          >
+            unregister
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText('firstName'), {
+      target: { value: 'changed' },
+    });
+
+    await waitFor(() => expect(isDirty).toBe(true));
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(dirtyFields).toEqual({}));
+    expect(isDirty).toBe(false);
+  });
+
+  it('should preserve isDirty when a dirty field is unregistered with keepDirty', async () => {
+    let isDirty: boolean | null = null;
+    let dirtyFields: Record<string, unknown> = {};
+
+    const App = () => {
+      const [show, setShow] = React.useState(true);
+      const { register, unregister, formState } = useForm({
+        defaultValues: { firstName: 'bill', lastName: 'luo' },
+      });
+
+      isDirty = formState.isDirty;
+      dirtyFields = formState.dirtyFields;
+
+      return (
+        <form>
+          {show && <input {...register('firstName')} placeholder="firstName" />}
+          <input {...register('lastName')} placeholder="lastName" />
+          <button
+            type="button"
+            onClick={() => {
+              unregister('firstName', { keepDirty: true });
+              setShow(false);
+            }}
+          >
+            unregister
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText('firstName'), {
+      target: { value: 'changed' },
+    });
+
+    await waitFor(() => expect(isDirty).toBe(true));
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(dirtyFields).toEqual({ firstName: true }));
+    expect(isDirty).toBe(true);
+  });
+
   it('should not flip isDirty to true when a field with no defaultValue is registered from useEffect', async () => {
     let isDirty: boolean | null = null;
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1581,7 +1581,7 @@ export function createFormControl<
 
     _subjects.state.next({
       ..._formState,
-      ...(!options.keepDirty ? {} : { isDirty: _getDirty() }),
+      ...(options.keepDirty ? {} : { isDirty: _getDirty() }),
     });
 
     !options.keepIsValid && _setValid();


### PR DESCRIPTION
## Proposed Changes

`unregister`'s `keepDirty` option currently does the opposite of what it says, in both directions,
because the ternary that broadcasts `isDirty` carries its negation on the wrong side.

`createFormControl.ts:1584` reads:

```ts
_subjects.state.next({
  ..._formState,
  ...(!options.keepDirty ? {} : { isDirty: _getDirty() }),
});
```

so `isDirty` is recomputed **only when the caller asked to keep it**, and left stale when they did
not. The clearest symptom is on the option itself: `unregister('field', { keepDirty: true })`
correctly preserves `dirtyFields`, then recomputes `isDirty` and flips it to `false`. The option that
exists to preserve dirty state destroys half of it, and spends a `_getDirty()` pass to do so. On the
default path the inverse happens: `dirtyFields` is emptied at `:1568` while `isDirty` stays latched
at its previous value.

Every neighbouring line in the same block reads "unless the caller asked to keep it, clear or
recompute it":

```ts
!options.keepError && unset(_formState.errors, fieldName);
!options.keepDirty && unset(_formState.dirtyFields, fieldName);
!options.keepTouched && unset(_formState.touchedFields, fieldName);
...
!options.keepIsValid && _setValid();
```

`_reset` already spells the same option correctly at `:1962-1971`
(`keepStateOptions.keepDirty ? _formState.isDirty : <recompute>`). This one line is the odd one out,
and has been since the option was introduced.

The spread is the only thing that can refresh `isDirty` on this path: the emitted payload is merged
into `_formState` by `_setFormState`, and `useForm`'s resync effect depends on
`[control, formState.isDirty]`, so a value that never changes never retriggers it.

The fix deletes the negation, which makes `keepDirty` govern `isDirty` and `dirtyFields` identically
and makes `keepDirty: true` strictly cheaper than it is today, since it no longer runs `_getDirty()`.

**On the relationship to #13141 and #13162, which I looked at before opening this.** That discussion
was about `setValue(name, value, { shouldDirty: false })` leaving `dirtyFields` behind, and the
conclusion there was that keeping the two perfectly in step would mean recomputing on every
keystroke, which is not worth the cost. This change does not ask for that and adds no recomputation
at all: `_getDirty()` is already called on one of this ternary's two branches, and the fix only swaps
which branch gets it. The per-keystroke path is untouched. If the default-half of this is still
considered the documented trade-off, the `keepDirty: true` half stands on its own as a contract
violation and I am happy to narrow the change.

Two regression tests are added to `src/__tests__/useForm/unregister.test.tsx`, one per branch. Each
unmounts the input in the same click that unregisters it, so a still-mounted input cannot silently
re-register and mask the result. Against unpatched source they fail with `Expected: false, Received:
true` and `Expected: true, Received: false`; both `dirtyFields` assertions pass in that run, which is
what pins this as an `isDirty`-only inconsistency rather than a dirty-tracking failure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

Full suite is 1268 passed / 120 suites with the change, against 1266 before it. `tsc --noEmit`,
`eslint` on both changed files, and the `src/__typetest__` project all pass.
