### PR TITLE
feat: add `shouldTouch` option to `trigger()`

### DIFF
--- a/reports/api-extractor.api.md
+++ b/reports/api-extractor.api.md
@@ -642,6 +642,7 @@ export type SubmitHandler<T, TResult = unknown> = (data: T, event?: React_2.Base
 // @public (undocumented)
 export type TriggerConfig = Partial<{
     shouldFocus: boolean;
+    shouldTouch: boolean;
 }>;
 
 // @public
@@ -1044,8 +1045,8 @@ export type WatchValue<TFieldName, TFieldValues extends FieldValues = FieldValue
 
 // Warnings were encountered during analysis:
 //
-// src/types/form.ts:583:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
-// src/types/form.ts:958:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:584:3 - (ae-forgotten-export) The symbol "Subscription" needs to be exported by the entry point index.d.ts
+// src/types/form.ts:959:3 - (ae-forgotten-export) The symbol "FormState_2" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -711,6 +711,76 @@ describe('trigger', () => {
     });
   });
 
+  it('should mark the targeted field as touched when shouldTouch is true', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ test: string }>({ defaultValues: { test: '' } }),
+    );
+
+    result.current.register('test', { required: true });
+
+    expect(result.current.formState.touchedFields.test).toBeUndefined();
+
+    await act(async () => {
+      await result.current.trigger('test', { shouldTouch: true });
+    });
+
+    expect(result.current.formState.touchedFields.test).toEqual(true);
+  });
+
+  it('should mark all triggered fields as touched when shouldTouch is true with an array of names', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ test1: string; test2: string; test3: string }>({
+        defaultValues: { test1: '', test2: '', test3: '' },
+      }),
+    );
+
+    result.current.register('test1');
+    result.current.register('test2');
+    result.current.register('test3');
+    result.current.formState.touchedFields;
+
+    await act(async () => {
+      await result.current.trigger(['test1', 'test2'], { shouldTouch: true });
+    });
+
+    expect(result.current.formState.touchedFields.test1).toEqual(true);
+    expect(result.current.formState.touchedFields.test2).toEqual(true);
+    expect(result.current.formState.touchedFields.test3).toBeUndefined();
+  });
+
+  it('should mark every mounted field as touched when shouldTouch is true and no name is provided', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ test1: string; test2: string }>({
+        defaultValues: { test1: '', test2: '' },
+      }),
+    );
+
+    result.current.register('test1');
+    result.current.register('test2');
+    result.current.formState.touchedFields;
+
+    await act(async () => {
+      await result.current.trigger(undefined, { shouldTouch: true });
+    });
+
+    expect(result.current.formState.touchedFields.test1).toEqual(true);
+    expect(result.current.formState.touchedFields.test2).toEqual(true);
+  });
+
+  it('should not mark the field as touched when shouldTouch is not supplied', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ test: string }>({ defaultValues: { test: '' } }),
+    );
+
+    result.current.register('test', { required: true });
+
+    await act(async () => {
+      await result.current.trigger('test');
+    });
+
+    expect(result.current.formState.touchedFields.test).toBeUndefined();
+  });
+
   it('should return isValid for the entire form', async () => {
     const App = () => {
       const [isValid, setIsValid] = React.useState(true);

--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -785,6 +785,92 @@ describe('trigger', () => {
     expect(result.current.formState.touchedFields.test).toEqual(true);
   });
 
+  it('should not overwrite a field array touchedFields entry with true when shouldTouch is true and no name is given', async () => {
+    type FormValues = { test: { value: string }[] };
+
+    // An empty array means `_names.mount` only holds the array's own name
+    // (from useFieldArray's `rules` registration) and no leaf field --
+    // nothing to incidentally rebuild the array shape afterwards, so this
+    // pins the corruption regardless of Set iteration order.
+    const { result } = renderHook(() => {
+      const form = useForm<FormValues>({ defaultValues: { test: [] } });
+      const fieldArray = useFieldArray({
+        control: form.control,
+        name: 'test',
+        rules: { minLength: 1 },
+      });
+      return { form, fieldArray };
+    });
+
+    result.current.form.formState.touchedFields;
+
+    await act(async () => {
+      await result.current.form.trigger(undefined, { shouldTouch: true });
+    });
+
+    // `test` is a field array container -- its touchedFields entry has to
+    // stay array-shaped (or unset) so `_setFieldArray` can keep shifting it
+    // on append/remove. It must never be clobbered into the boolean `true`.
+    expect(result.current.form.formState.touchedFields.test).not.toBe(true);
+  });
+
+  it('should mark each field array item as touched when shouldTouch is true and no name is given', async () => {
+    type FormValues = { test: { value: string }[] };
+
+    const { result } = renderHook(() => {
+      const form = useForm<FormValues>({
+        defaultValues: { test: [{ value: 'a' }, { value: 'b' }] },
+      });
+      const fieldArray = useFieldArray({
+        control: form.control,
+        name: 'test',
+        rules: { minLength: 1 },
+      });
+      return { form, fieldArray };
+    });
+
+    result.current.form.register('test.0.value');
+    result.current.form.register('test.1.value');
+    result.current.form.formState.touchedFields;
+
+    await act(async () => {
+      await result.current.form.trigger(undefined, { shouldTouch: true });
+    });
+
+    expect(result.current.form.formState.touchedFields.test).not.toBe(true);
+    expect(result.current.form.formState.touchedFields.test?.[0]?.value).toBe(
+      true,
+    );
+    expect(result.current.form.formState.touchedFields.test?.[1]?.value).toBe(
+      true,
+    );
+  });
+
+  it('should not overwrite a field array touchedFields entry with true when shouldTouch is true and the array name is passed directly', async () => {
+    type FormValues = { test: { value: string }[] };
+
+    const { result } = renderHook(() => {
+      const form = useForm<FormValues>({
+        defaultValues: { test: [{ value: 'a' }] },
+      });
+      const fieldArray = useFieldArray({
+        control: form.control,
+        name: 'test',
+        rules: { minLength: 1 },
+      });
+      return { form, fieldArray };
+    });
+
+    result.current.form.register('test.0.value');
+    result.current.form.formState.touchedFields;
+
+    await act(async () => {
+      await result.current.form.trigger('test', { shouldTouch: true });
+    });
+
+    expect(result.current.form.formState.touchedFields.test).not.toBe(true);
+  });
+
   it('should not mark the field as touched when shouldTouch is not supplied', async () => {
     const { result } = renderHook(() =>
       useForm<{ test: string }>({ defaultValues: { test: '' } }),

--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -767,6 +767,24 @@ describe('trigger', () => {
     expect(result.current.formState.touchedFields.test2).toEqual(true);
   });
 
+  it('should mark the field as touched when shouldTouch is true with schema validation', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ test: string }>({
+        defaultValues: { test: '' },
+        resolver: async (values) => ({ values, errors: {} }),
+      }),
+    );
+
+    result.current.register('test');
+    result.current.formState.touchedFields;
+
+    await act(async () => {
+      await result.current.trigger('test', { shouldTouch: true });
+    });
+
+    expect(result.current.formState.touchedFields.test).toEqual(true);
+  });
+
   it('should not mark the field as touched when shouldTouch is not supplied', async () => {
     const { result } = renderHook(() =>
       useForm<{ test: string }>({ defaultValues: { test: '' } }),

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1356,7 +1356,8 @@ export function createFormControl<
         ? {}
         : { name }),
       ...(_options.resolver || !name ? { isValid } : {}),
-      ...(options.shouldTouch
+      ...(options.shouldTouch &&
+      (_proxyFormState.touchedFields || _proxySubscribeFormState.touchedFields)
         ? { touchedFields: _formState.touchedFields }
         : {}),
       errors: _formState.errors,

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1339,11 +1339,6 @@ export function createFormControl<
 
     if (options.shouldTouch) {
       for (const fieldName of name ? fieldNames : _names.mount) {
-        // A field array's own name (e.g. `items`, registered for its own
-        // `rules`) is a container, not a leaf -- its touchedFields entry has
-        // to stay an array so `_setFieldArray` can keep shifting it on
-        // append/remove/etc. Marking it `true` here would overwrite that
-        // array and corrupt the field array's touched state.
         !_names.array.has(fieldName) &&
           set(_formState.touchedFields, fieldName, true);
       }

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1339,7 +1339,13 @@ export function createFormControl<
 
     if (options.shouldTouch) {
       for (const fieldName of name ? fieldNames : _names.mount) {
-        set(_formState.touchedFields, fieldName, true);
+        // A field array's own name (e.g. `items`, registered for its own
+        // `rules`) is a container, not a leaf -- its touchedFields entry has
+        // to stay an array so `_setFieldArray` can keep shifting it on
+        // append/remove/etc. Marking it `true` here would overwrite that
+        // array and corrupt the field array's touched state.
+        !_names.array.has(fieldName) &&
+          set(_formState.touchedFields, fieldName, true);
       }
     }
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1337,6 +1337,12 @@ export function createFormControl<
       }
     }
 
+    if (options.shouldTouch) {
+      for (const fieldName of name ? fieldNames : _names.mount) {
+        set(_formState.touchedFields, fieldName, true);
+      }
+    }
+
     _subjects.state.next({
       ...(!isString(name) ||
       ((_proxyFormState.isValid || _proxySubscribeFormState.isValid) &&
@@ -1344,6 +1350,9 @@ export function createFormControl<
         ? {}
         : { name }),
       ...(_options.resolver || !name ? { isValid } : {}),
+      ...(options.shouldTouch
+        ? { touchedFields: _formState.touchedFields }
+        : {}),
       errors: _formState.errors,
     });
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -90,6 +90,7 @@ export type SetValueConfig = Partial<{
 
 export type TriggerConfig = Partial<{
   shouldFocus: boolean;
+  shouldTouch: boolean;
 }>;
 
 export type ResetFieldConfig<
@@ -593,7 +594,7 @@ export type UseFormWatch<TFieldValues extends FieldValues> = {
  * [API](https://react-hook-form.com/docs/useform/trigger) • [Demo](https://codesandbox.io/s/react-hook-form-v7-ts-triggervalidation-forked-xs7hl) • [Video](https://www.youtube.com/watch?v=-bcyJCDjksE)
  *
  * @param name - Providing no argument will trigger the entire form validation; an array of field names will validate those fields, and a single field name will only trigger that field's validation.
- * @param options - Should focus on the error field.
+ * @param options - Should focus on the error field, and/or mark the triggered field(s) as touched.
  *
  * @returns Validation result.
  *


### PR DESCRIPTION
## Summary

Adds a shouldTouch option to `trigger()`, mirroring the option that setValue already has. So callers can mark validated field(s) as touched without a setValue-based workaround.

### Motivation

`setValue` already supports `shouldTouch` to mark a field as touched, but `trigger()` has no equivalent. 
Anyone who wants to run validation and mark the validated field(s) as touched (e.g. validate-on-mount, multi-step form navigation, "show all errors on demand") currently has to reimplement this themselves by looping setValue(name, value, { shouldTouch: true }) over every field, which also re-writes values and triggers extra dirty/render work they don't actually want.

Maybe Related discussion
- https://github.com/react-hook-form/react-hook-form/discussions/9830

### What I have done

- Added `shouldTouch` to the `TriggerConfig` type.
- `trigger()` now marks the targeted field(s) as touched when shouldTouch: true is passed, following the same name / no-name scoping shouldFocus already uses:

```ts
trigger('name', { shouldTouch: true });          // marks `name` as touched
trigger(['a', 'b'], { shouldTouch: true });       // marks `a` and `b` as touched
trigger(undefined, { shouldTouch: true });        // marks every mounted field as touched
trigger('name');                                  // unchanged: no touched-state side effect
```

- Only `touchedFields` is written — `_formValues` is untouched, therefore there's no extra dirty-checking or value re-render cost compared to the setValue workaround.

### Test Plans

- Single field name marked as touched.
- Array of field names all marked as touched, others left untouched.
- No name (whole form) marks every mounted field as touched.
- Default behavior (no `shouldTouch`) stays a no-op for `touchedFields`, to guard against regressions.

### Test Results

```bash
Test Suites: 120 passed, 120 total
Tests:       1271 passed, 1271 total
Snapshots:   8 passed, 8 total
Time:        22.455 s
Ran all test suites in 2 projects.
=== tsc ===
TSC_OK
=== eslint ===
ESLINT_OK
=== DONE ===
```