### PR TITLE
🪅 feat: add OpaqueTypes registry for opaque leaf types

### DIFF
--- a/reports/api-extractor.api.md
+++ b/reports/api-extractor.api.md
@@ -132,26 +132,26 @@ export type CustomElement<TFieldValues extends FieldValues> = Partial<HTMLElemen
 };
 
 // @public (undocumented)
-export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends BrowserNativeObject | NestedValue | OpaqueTypes[keyof OpaqueTypes] ? TValue : T extends ReadonlyArray<infer U> ? Array<DeepMap<NonUndefined<U>, TValue> | undefined> : T extends object ? {
+export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends BrowserNativeObject | NestedValue | OpaqueType ? TValue : T extends ReadonlyArray<infer U> ? Array<DeepMap<NonUndefined<U>, TValue> | undefined> : T extends object ? {
     [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue>;
 } : TValue;
 
 // Warning: (ae-forgotten-export) The symbol "IsPrimitiveLike" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type DeepPartial<T> = IsPrimitiveLike<T> extends true ? T : T extends BrowserNativeObject | NestedValue | OpaqueTypes[keyof OpaqueTypes] ? T : {
+export type DeepPartial<T> = IsPrimitiveLike<T> extends true ? T : T extends BrowserNativeObject | NestedValue | OpaqueType ? T : {
     [K in keyof T]?: ExtractObjects<T[K]> extends never ? T[K] : DeepPartial<T[K]>;
 };
 
 // @public (undocumented)
-export type DeepPartialSkipArrayKey<T> = IsPrimitiveLike<T> extends true ? T : T extends BrowserNativeObject | NestedValue | OpaqueTypes[keyof OpaqueTypes] ? T : T extends ReadonlyArray<any> ? {
+export type DeepPartialSkipArrayKey<T> = IsPrimitiveLike<T> extends true ? T : T extends BrowserNativeObject | NestedValue | OpaqueType ? T : T extends ReadonlyArray<any> ? {
     [K in keyof T]: DeepPartialSkipArrayKey<T[K]>;
 } : {
     [K in keyof T]?: DeepPartialSkipArrayKey<T[K]>;
 };
 
 // @public (undocumented)
-export type DeepRequired<T> = T extends BrowserNativeObject | Blob | OpaqueTypes[keyof OpaqueTypes] ? T : {
+export type DeepRequired<T> = T extends BrowserNativeObject | Blob | OpaqueType ? T : {
     [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
 };
 
@@ -246,7 +246,7 @@ export type FieldErrors<T extends FieldValues = FieldValues> = Partial<FieldErro
 
 // @public (undocumented)
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-    [K in keyof T]?: T[K] extends BrowserNativeObject | Blob | OpaqueTypes[keyof OpaqueTypes] ? FieldError : K extends 'root' | `root.${string}` ? GlobalError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
+    [K in keyof T]?: T[K] extends BrowserNativeObject | Blob | OpaqueType ? FieldError : K extends 'root' | `root.${string}` ? GlobalError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
 };
 
 // @public (undocumented)
@@ -430,7 +430,7 @@ export type IsAny<T> = 0 extends 1 & T ? true : false;
 export type IsEqual<T1, T2> = T1 extends T2 ? (<G>() => G extends T1 ? 1 : 2) extends <G>() => G extends T2 ? 1 : 2 ? true : false : false;
 
 // @public (undocumented)
-export type IsFlatObject<T extends object> = Extract<Exclude<T[keyof T], NestedValue | Date | FileList_2 | OpaqueTypes[keyof OpaqueTypes]>, any[] | object> extends never ? true : false;
+export type IsFlatObject<T extends object> = Extract<Exclude<T[keyof T], NestedValue | Date | FileList_2 | OpaqueType>, any[] | object> extends never ? true : false;
 
 // @public
 export type IsNever<T> = [T] extends [never] ? true : false;
@@ -505,6 +505,9 @@ export type NonUndefined<T> = T extends undefined ? never : T;
 
 // @public (undocumented)
 export type Noop = () => void;
+
+// @public
+export type OpaqueType = OpaqueTypes[keyof OpaqueTypes];
 
 // @public
 export interface OpaqueTypes {

--- a/reports/api-extractor.api.md
+++ b/reports/api-extractor.api.md
@@ -430,7 +430,7 @@ export type IsAny<T> = 0 extends 1 & T ? true : false;
 export type IsEqual<T1, T2> = T1 extends T2 ? (<G>() => G extends T1 ? 1 : 2) extends <G>() => G extends T2 ? 1 : 2 ? true : false : false;
 
 // @public (undocumented)
-export type IsFlatObject<T extends object> = Extract<Exclude<T[keyof T], NestedValue | Date | FileList_2>, any[] | object> extends never ? true : false;
+export type IsFlatObject<T extends object> = Extract<Exclude<T[keyof T], NestedValue | Date | FileList_2 | OpaqueTypes[keyof OpaqueTypes]>, any[] | object> extends never ? true : false;
 
 // @public
 export type IsNever<T> = [T] extends [never] ? true : false;

--- a/reports/api-extractor.api.md
+++ b/reports/api-extractor.api.md
@@ -132,7 +132,7 @@ export type CustomElement<TFieldValues extends FieldValues> = Partial<HTMLElemen
 };
 
 // @public (undocumented)
-export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends BrowserNativeObject | NestedValue ? TValue : T extends ReadonlyArray<infer U> ? Array<DeepMap<NonUndefined<U>, TValue> | undefined> : T extends object ? {
+export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends BrowserNativeObject | NestedValue | OpaqueTypes[keyof OpaqueTypes] ? TValue : T extends ReadonlyArray<infer U> ? Array<DeepMap<NonUndefined<U>, TValue> | undefined> : T extends object ? {
     [K in keyof T]: DeepMap<NonUndefined<T[K]>, TValue>;
 } : TValue;
 

--- a/reports/api-extractor.api.md
+++ b/reports/api-extractor.api.md
@@ -139,19 +139,19 @@ export type DeepMap<T, TValue> = IsAny<T> extends true ? any : T extends Browser
 // Warning: (ae-forgotten-export) The symbol "IsPrimitiveLike" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type DeepPartial<T> = IsPrimitiveLike<T> extends true ? T : T extends BrowserNativeObject | NestedValue ? T : {
+export type DeepPartial<T> = IsPrimitiveLike<T> extends true ? T : T extends BrowserNativeObject | NestedValue | OpaqueTypes[keyof OpaqueTypes] ? T : {
     [K in keyof T]?: ExtractObjects<T[K]> extends never ? T[K] : DeepPartial<T[K]>;
 };
 
 // @public (undocumented)
-export type DeepPartialSkipArrayKey<T> = IsPrimitiveLike<T> extends true ? T : T extends BrowserNativeObject | NestedValue ? T : T extends ReadonlyArray<any> ? {
+export type DeepPartialSkipArrayKey<T> = IsPrimitiveLike<T> extends true ? T : T extends BrowserNativeObject | NestedValue | OpaqueTypes[keyof OpaqueTypes] ? T : T extends ReadonlyArray<any> ? {
     [K in keyof T]: DeepPartialSkipArrayKey<T[K]>;
 } : {
     [K in keyof T]?: DeepPartialSkipArrayKey<T[K]>;
 };
 
 // @public (undocumented)
-export type DeepRequired<T> = T extends BrowserNativeObject | Blob ? T : {
+export type DeepRequired<T> = T extends BrowserNativeObject | Blob | OpaqueTypes[keyof OpaqueTypes] ? T : {
     [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
 };
 
@@ -246,7 +246,7 @@ export type FieldErrors<T extends FieldValues = FieldValues> = Partial<FieldErro
 
 // @public (undocumented)
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-    [K in keyof T]?: T[K] extends BrowserNativeObject | Blob ? FieldError : K extends 'root' | `root.${string}` ? GlobalError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
+    [K in keyof T]?: T[K] extends BrowserNativeObject | Blob | OpaqueTypes[keyof OpaqueTypes] ? FieldError : K extends 'root' | `root.${string}` ? GlobalError : T[K] extends object ? Merge<FieldError, FieldErrorsImpl<T[K]>> : FieldError;
 };
 
 // @public (undocumented)
@@ -505,6 +505,10 @@ export type NonUndefined<T> = T extends undefined ? never : T;
 
 // @public (undocumented)
 export type Noop = () => void;
+
+// @public
+export interface OpaqueTypes {
+}
 
 // Warning: (ae-forgotten-export) The symbol "PathInternal" needs to be exported by the entry point index.d.ts
 //

--- a/src/__typetest__/opaqueTypes.test-d.ts
+++ b/src/__typetest__/opaqueTypes.test-d.ts
@@ -1,4 +1,6 @@
 import type {
+  ArrayPath,
+  DeepMap,
   DeepPartial,
   DeepPartialSkipArrayKey,
   DeepRequired,
@@ -24,6 +26,7 @@ interface OpaqueValue {
   [opaqueBrand]: true;
   unit: string;
   nested: { value: number };
+  entries: { id: string }[];
 }
 
 declare module '../types/utils' {
@@ -36,6 +39,32 @@ declare module '../types/utils' {
   /** it should treat registered opaque types as leaves in Path */ {
     const actual = _ as Path<{ foo: OpaqueValue; bar: { baz: string } }>;
     type _t = Expect<Equal<typeof actual, 'foo' | 'bar' | 'bar.baz'>>;
+  }
+
+  /** it should treat registered opaque types as leaves in ArrayPath */ {
+    const actual = _ as ArrayPath<{
+      foo: OpaqueValue;
+      bar: { baz: number }[];
+    }>;
+    type _t = Expect<Equal<typeof actual, 'bar'>>;
+  }
+
+  /** it should not produce an array path for arrays of registered opaque types */ {
+    const actual = _ as ArrayPath<{
+      foo: OpaqueValue[];
+      bar: { baz: number }[];
+    }>;
+    type _t = Expect<Equal<typeof actual, 'bar'>>;
+  }
+
+  /** it should map registered opaque types as a whole in DeepMap */ {
+    const actual = _ as DeepMap<
+      { foo: OpaqueValue; bar: { baz: string } },
+      boolean
+    >;
+    type _t = Expect<
+      Equal<typeof actual, { foo: boolean; bar: { baz: boolean } }>
+    >;
   }
 
   /** it should not recurse into registered opaque types in DeepPartial */ {

--- a/src/__typetest__/opaqueTypes.test-d.ts
+++ b/src/__typetest__/opaqueTypes.test-d.ts
@@ -1,0 +1,89 @@
+import type {
+  DeepPartial,
+  DeepPartialSkipArrayKey,
+  DeepRequired,
+  FieldError,
+  FieldErrors,
+  GlobalError,
+  Merge,
+  Path,
+} from '../types';
+
+import type { Equal, Expect } from './__fixtures__';
+import { _ } from './__fixtures__';
+
+declare const opaqueBrand: unique symbol;
+
+/**
+ * Stand-in for a rich third-party value type (Dayjs, Decimal, ...) whose
+ * members should never be addressed by a form path. The brand keeps the
+ * registration below from matching any other type in the typetests, since
+ * the interface merging applies program-wide.
+ */
+interface OpaqueValue {
+  [opaqueBrand]: true;
+  unit: string;
+  nested: { value: number };
+}
+
+declare module '../types/utils' {
+  interface OpaqueTypes {
+    opaqueValue: OpaqueValue;
+  }
+}
+
+/** {@link OpaqueTypes} */ {
+  /** it should treat registered opaque types as leaves in Path */ {
+    const actual = _ as Path<{ foo: OpaqueValue; bar: { baz: string } }>;
+    type _t = Expect<Equal<typeof actual, 'foo' | 'bar' | 'bar.baz'>>;
+  }
+
+  /** it should not recurse into registered opaque types in DeepPartial */ {
+    const actual = _ as DeepPartial<{
+      foo: OpaqueValue;
+      bar: { baz: string };
+    }>;
+    type _t = Expect<
+      Equal<typeof actual, { foo?: OpaqueValue; bar?: { baz?: string } }>
+    >;
+  }
+
+  /** it should not recurse into registered opaque types in DeepPartialSkipArrayKey */ {
+    const actual = _ as DeepPartialSkipArrayKey<{
+      foo: OpaqueValue[];
+      bar: { baz: string };
+    }>;
+    type _t = Expect<
+      Equal<typeof actual, { foo?: OpaqueValue[]; bar?: { baz?: string } }>
+    >;
+  }
+
+  /** it should keep registered opaque types intact in DeepRequired */ {
+    const actual = _ as DeepRequired<{
+      foo?: OpaqueValue;
+      bar?: { baz?: string };
+    }>;
+    type _t = Expect<
+      Equal<typeof actual, { foo: OpaqueValue; bar: { baz: string } }>
+    >;
+  }
+
+  /** it should produce a single FieldError for registered opaque types */ {
+    const actual = _ as FieldErrors<{
+      foo: OpaqueValue;
+      bar: { baz: string };
+    }>;
+    type _t = Expect<
+      Equal<
+        typeof actual,
+        {
+          foo?: FieldError;
+          bar?: Merge<FieldError, { baz?: FieldError }>;
+        } & {
+          root?: Record<string, GlobalError> & GlobalError;
+          form?: GlobalError;
+        }
+      >
+    >;
+  }
+}

--- a/src/__typetest__/opaqueTypes.test-d.ts
+++ b/src/__typetest__/opaqueTypes.test-d.ts
@@ -6,7 +6,9 @@ import type {
   DeepRequired,
   FieldError,
   FieldErrors,
+  FieldName,
   GlobalError,
+  IsFlatObject,
   Merge,
   Path,
 } from '../types';
@@ -55,6 +57,16 @@ declare module '../types/utils' {
       bar: { baz: number }[];
     }>;
     type _t = Expect<Equal<typeof actual, 'bar'>>;
+  }
+
+  /** it should keep an object flat for IsFlatObject when it only contains registered opaque leaves */ {
+    const actual = _ as IsFlatObject<{ foo: OpaqueValue; bar: string }>;
+    type _t = Expect<Equal<typeof actual, true>>;
+  }
+
+  /** it should preserve literal FieldName keys for forms with registered opaque fields */ {
+    const actual = _ as FieldName<{ foo: OpaqueValue; bar: string }>;
+    type _t = Expect<Equal<typeof actual, 'foo' | 'bar'>>;
   }
 
   /** it should map registered opaque types as a whole in DeepMap */ {

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -5,7 +5,7 @@ import type {
   IsAny,
   LiteralUnion,
   Merge,
-  OpaqueTypes,
+  OpaqueType,
 } from './utils';
 import type { RegisterOptions, ValidateResult } from './validator';
 
@@ -31,20 +31,14 @@ export type ErrorOption = {
   types?: MultipleFieldErrors;
 };
 
-export type DeepRequired<T> = T extends
-  | BrowserNativeObject
-  | Blob
-  | OpaqueTypes[keyof OpaqueTypes]
+export type DeepRequired<T> = T extends BrowserNativeObject | Blob | OpaqueType
   ? T
   : {
       [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
     };
 
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-  [K in keyof T]?: T[K] extends
-    | BrowserNativeObject
-    | Blob
-    | OpaqueTypes[keyof OpaqueTypes]
+  [K in keyof T]?: T[K] extends BrowserNativeObject | Blob | OpaqueType
     ? FieldError
     : K extends 'root' | `root.${string}`
       ? GlobalError

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,6 +1,12 @@
 import type { FieldValues, InternalFieldName, Ref } from './fields';
 import type { FieldPath, FieldPathValue } from './path';
-import type { BrowserNativeObject, IsAny, LiteralUnion, Merge } from './utils';
+import type {
+  BrowserNativeObject,
+  IsAny,
+  LiteralUnion,
+  Merge,
+  OpaqueTypes,
+} from './utils';
 import type { RegisterOptions, ValidateResult } from './validator';
 
 export type Message = string;
@@ -25,14 +31,20 @@ export type ErrorOption = {
   types?: MultipleFieldErrors;
 };
 
-export type DeepRequired<T> = T extends BrowserNativeObject | Blob
+export type DeepRequired<T> = T extends
+  | BrowserNativeObject
+  | Blob
+  | OpaqueTypes[keyof OpaqueTypes]
   ? T
   : {
       [K in keyof T]-?: NonNullable<DeepRequired<T[K]>>;
     };
 
 export type FieldErrorsImpl<T extends FieldValues = FieldValues> = {
-  [K in keyof T]?: T[K] extends BrowserNativeObject | Blob
+  [K in keyof T]?: T[K] extends
+    | BrowserNativeObject
+    | Blob
+    | OpaqueTypes[keyof OpaqueTypes]
     ? FieldError
     : K extends 'root' | `root.${string}`
       ? GlobalError

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -3,7 +3,7 @@ import type {
   BrowserNativeObject,
   IsAny,
   IsEqual,
-  OpaqueTypes,
+  OpaqueType,
   Primitive,
 } from '../utils';
 
@@ -32,7 +32,7 @@ type PathImpl<
   V,
   TraversedTypes,
   D extends number = 9,
-> = V extends Primitive | BrowserNativeObject | OpaqueTypes[keyof OpaqueTypes]
+> = V extends Primitive | BrowserNativeObject | OpaqueType
   ? `${K}`
   : // Check so that we don't recurse into the same type
     // by ensuring that the types are mutually assignable
@@ -90,12 +90,12 @@ type ArrayPathImpl<
   V,
   TraversedTypes,
   D extends number = 9,
-> = V extends Primitive | BrowserNativeObject | OpaqueTypes[keyof OpaqueTypes]
+> = V extends Primitive | BrowserNativeObject | OpaqueType
   ? IsAny<V> extends true
     ? string
     : never
   : V extends ReadonlyArray<infer U>
-    ? U extends Primitive | BrowserNativeObject | OpaqueTypes[keyof OpaqueTypes]
+    ? U extends Primitive | BrowserNativeObject | OpaqueType
       ? IsAny<V> extends true
         ? string
         : never

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -1,5 +1,11 @@
 import type { FieldValues } from '../fields';
-import type { BrowserNativeObject, IsAny, IsEqual, Primitive } from '../utils';
+import type {
+  BrowserNativeObject,
+  IsAny,
+  IsEqual,
+  OpaqueTypes,
+  Primitive,
+} from '../utils';
 
 import type { ArrayKey, IsTuple, Prev, TupleKeys } from './common';
 
@@ -26,7 +32,7 @@ type PathImpl<
   V,
   TraversedTypes,
   D extends number = 9,
-> = V extends Primitive | BrowserNativeObject
+> = V extends Primitive | BrowserNativeObject | OpaqueTypes[keyof OpaqueTypes]
   ? `${K}`
   : // Check so that we don't recurse into the same type
     // by ensuring that the types are mutually assignable

--- a/src/types/path/eager.ts
+++ b/src/types/path/eager.ts
@@ -90,12 +90,12 @@ type ArrayPathImpl<
   V,
   TraversedTypes,
   D extends number = 9,
-> = V extends Primitive | BrowserNativeObject
+> = V extends Primitive | BrowserNativeObject | OpaqueTypes[keyof OpaqueTypes]
   ? IsAny<V> extends true
     ? string
     : never
   : V extends ReadonlyArray<infer U>
-    ? U extends Primitive | BrowserNativeObject
+    ? U extends Primitive | BrowserNativeObject | OpaqueTypes[keyof OpaqueTypes]
       ? IsAny<V> extends true
         ? string
         : never

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -54,6 +54,12 @@ export type BrowserNativeObject = Date | FileList | File;
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface OpaqueTypes {}
 
+/**
+ * Union of all types registered in {@link OpaqueTypes}. `never` while the
+ * registry is empty.
+ */
+export type OpaqueType = OpaqueTypes[keyof OpaqueTypes];
+
 export type EmptyObject = { [K in string | number]: never };
 
 export type NonUndefined<T> = T extends undefined ? never : T;
@@ -73,10 +79,7 @@ type IsPrimitiveLike<T> = T extends Primitive ? true : false;
 export type DeepPartial<T> =
   IsPrimitiveLike<T> extends true
     ? T
-    : T extends
-          | BrowserNativeObject
-          | NestedValue
-          | OpaqueTypes[keyof OpaqueTypes]
+    : T extends BrowserNativeObject | NestedValue | OpaqueType
       ? T
       : {
           [K in keyof T]?: ExtractObjects<T[K]> extends never
@@ -87,10 +90,7 @@ export type DeepPartial<T> =
 export type DeepPartialSkipArrayKey<T> =
   IsPrimitiveLike<T> extends true
     ? T
-    : T extends
-          | BrowserNativeObject
-          | NestedValue
-          | OpaqueTypes[keyof OpaqueTypes]
+    : T extends BrowserNativeObject | NestedValue | OpaqueType
       ? T
       : T extends ReadonlyArray<any>
         ? { [K in keyof T]: DeepPartialSkipArrayKey<T[K]> }
@@ -140,10 +140,7 @@ export type IsEqual<T1, T2> = T1 extends T2
 export type DeepMap<T, TValue> =
   IsAny<T> extends true
     ? any
-    : T extends
-          | BrowserNativeObject
-          | NestedValue
-          | OpaqueTypes[keyof OpaqueTypes]
+    : T extends BrowserNativeObject | NestedValue | OpaqueType
       ? TValue
       : T extends ReadonlyArray<infer U>
         ? Array<DeepMap<NonUndefined<U>, TValue> | undefined>
@@ -153,10 +150,7 @@ export type DeepMap<T, TValue> =
 
 export type IsFlatObject<T extends object> =
   Extract<
-    Exclude<
-      T[keyof T],
-      NestedValue | Date | FileList | OpaqueTypes[keyof OpaqueTypes]
-    >,
+    Exclude<T[keyof T], NestedValue | Date | FileList | OpaqueType>,
     any[] | object
   > extends never
     ? true

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -153,7 +153,10 @@ export type DeepMap<T, TValue> =
 
 export type IsFlatObject<T extends object> =
   Extract<
-    Exclude<T[keyof T], NestedValue | Date | FileList>,
+    Exclude<
+      T[keyof T],
+      NestedValue | Date | FileList | OpaqueTypes[keyof OpaqueTypes]
+    >,
     any[] | object
   > extends never
     ? true

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -140,7 +140,10 @@ export type IsEqual<T1, T2> = T1 extends T2
 export type DeepMap<T, TValue> =
   IsAny<T> extends true
     ? any
-    : T extends BrowserNativeObject | NestedValue
+    : T extends
+          | BrowserNativeObject
+          | NestedValue
+          | OpaqueTypes[keyof OpaqueTypes]
       ? TValue
       : T extends ReadonlyArray<infer U>
         ? Array<DeepMap<NonUndefined<U>, TValue> | undefined>

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -33,6 +33,27 @@ export type Primitive =
 
 export type BrowserNativeObject = Date | FileList | File;
 
+/**
+ * Registry of types which the recursive type helpers ({@link Path},
+ * {@link DeepPartial}, FieldErrors, ...) treat as opaque leaf values
+ * instead of recursing into their properties.
+ *
+ * Empty by default, so it has no effect until a consumer registers a type
+ * via declaration merging. Useful for rich third-party value types (Dayjs,
+ * Decimal, Luxon DateTime, ...) whose members should never be addressed by
+ * a form path and can be expensive for the compiler to traverse.
+ * @example
+ * ```
+ * declare module 'react-hook-form' {
+ *   interface OpaqueTypes {
+ *     dayjs: Dayjs;
+ *   }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface OpaqueTypes {}
+
 export type EmptyObject = { [K in string | number]: never };
 
 export type NonUndefined<T> = T extends undefined ? never : T;
@@ -52,7 +73,10 @@ type IsPrimitiveLike<T> = T extends Primitive ? true : false;
 export type DeepPartial<T> =
   IsPrimitiveLike<T> extends true
     ? T
-    : T extends BrowserNativeObject | NestedValue
+    : T extends
+          | BrowserNativeObject
+          | NestedValue
+          | OpaqueTypes[keyof OpaqueTypes]
       ? T
       : {
           [K in keyof T]?: ExtractObjects<T[K]> extends never
@@ -63,7 +87,10 @@ export type DeepPartial<T> =
 export type DeepPartialSkipArrayKey<T> =
   IsPrimitiveLike<T> extends true
     ? T
-    : T extends BrowserNativeObject | NestedValue
+    : T extends
+          | BrowserNativeObject
+          | NestedValue
+          | OpaqueTypes[keyof OpaqueTypes]
       ? T
       : T extends ReadonlyArray<any>
         ? { [K in keyof T]: DeepPartialSkipArrayKey<T[K]> }


### PR DESCRIPTION
this pr allows you to mark certain types as opaque so that `react-hook-form` doesn't iterate through all the properties when present in a form.

this is a different implementation than #12308 - that one required wrapping each individual value in `Opaque<T>` but this one exposes a registry so that a client can register types to treat as opaque, eg
```ts
import type { Dayjs } from 'dayjs';

declare module 'react-hook-form' {
  interface OpaqueTypes {
    dayjs: Dayjs;
  }
}
```

we have ~200 `Dayjs` fields in our app so this is much simpler to implement.

closes #13677
