### PR TITLE
🧇 chore: scope the lock workflow to issues so its scheduled run can finish

### DIFF
--- a/.github/workflows/lock-issue.yml
+++ b/.github/workflows/lock-issue.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: 60
+          process-only: issues


### PR DESCRIPTION
## Proposed Changes

`dessant/lock-threads` iterates `['issue', 'pr', 'discussion']` unless `process-only` narrows it (`src/index.js`, v6 @ 89ae32b). This workflow grants only `issues: write`, so each run locks issues then fails on the first pull request lock with `Resource not accessible by integration`, never reaching discussions.

All 1650 retained runs have failed. Repo state: 4972 closed issues locked, none stale; 0 closed pull requests locked against 2346 closed over 365 days ago.

`process-only: issues` matches what the file name, the workflow name, the lone `issue-inactive-days` input and the permission block describe.

Rejected: granting `pull-requests: write` plus `discussions: write` per the action README. Also green, but the next run would lock 2346 old pull requests plus stale discussions. Scope decision, not a CI fix.

Limitation: a scheduled workflow cannot be run from a fork. I validated the `with:` block against the action's Joi schema at the pinned SHA: `process-only: issues` coerces to `['issue']`; absent, it resolves to all three.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes

Unticked: no test harness for workflow YAML. Self-review is for a human.
