### PR TITLE
feat: return a cleanup function from `register()`'s ref for React 19

### DIFF
--- a/reports/api-extractor.api.md
+++ b/reports/api-extractor.api.md
@@ -536,7 +536,7 @@ export type ReadFormState = {
 export type Ref = FieldElement;
 
 // @public (undocumented)
-export type RefCallBack = (instance: any) => void;
+export type RefCallBack = (instance: any) => void | (() => void);
 
 // @public (undocumented)
 export type RegisterOptions<TFieldValues extends FieldValues = FieldValues, TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> = Partial<{

--- a/src/__tests__/useForm/register.test.tsx
+++ b/src/__tests__/useForm/register.test.tsx
@@ -54,6 +54,24 @@ describe('register', () => {
     });
   });
 
+  it('should return a cleanup function from ref for React 19 ref cleanup support', () => {
+    const { result } = renderHook(() =>
+      useForm<{ test: string }>({
+        defaultValues: {
+          test: 'testData',
+        },
+      }),
+    );
+
+    const { ref } = result.current.register('test');
+    const input = document.createElement('input');
+    input.name = 'test';
+
+    const cleanup = ref(input);
+
+    expect(typeof cleanup).toBe('function');
+  });
+
   test.each([['text'], ['radio'], ['checkbox']])(
     'should register field for %s type and remain its value after unmount',
     async (type) => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1657,7 +1657,19 @@ export function createFormControl<
       name,
       onChange,
       onBlur: onChange,
-      ref: (ref: HTMLInputElement | null): void => {
+      ref: (ref: HTMLInputElement | null): void | (() => void) => {
+        const cleanup = () => {
+          field = get(_fields, name, {});
+
+          if (field._f) {
+            field._f.mount = false;
+          }
+
+          (_options.shouldUnregister || options.shouldUnregister) &&
+            !(isNameInFieldArray(_names.array, name) && _state.action) &&
+            _names.unMount.add(name);
+        };
+
         if (ref) {
           _names.registerName.add(name);
           register(name, options);
@@ -1677,7 +1689,7 @@ export function createFormControl<
               ? refs.find((option: Ref) => option === fieldRef)
               : fieldRef === field._f.ref
           ) {
-            return;
+            return cleanup;
           }
 
           const newField = {
@@ -1700,16 +1712,10 @@ export function createFormControl<
           });
 
           updateValidAndValue(name, false, undefined, fieldRef);
+
+          return cleanup;
         } else {
-          field = get(_fields, name, {});
-
-          if (field._f) {
-            field._f.mount = false;
-          }
-
-          (_options.shouldUnregister || options.shouldUnregister) &&
-            !(isNameInFieldArray(_names.array, name) && _state.action) &&
-            _names.unMount.add(name);
+          cleanup();
         }
       },
     };

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -193,7 +193,7 @@ export type KeepStateOptions = Partial<{
 export type SetFieldValue<TFieldValues extends FieldValues> =
   FieldValue<TFieldValues>;
 
-export type RefCallBack = (instance: any) => void;
+export type RefCallBack = (instance: any) => void | (() => void);
 
 export type UseFormRegisterReturn<
   TFieldName extends InternalFieldName = InternalFieldName,


### PR DESCRIPTION
## Summary

`register()`'s ref callback now returns a cleanup function so it can take advantage of React 19's ref cleanup function support, instead of relying solely on the older called again with null convention.

### Motivation

React 19 introduced [cleanup functions for refs](https://react.dev/blog/2024/12/05/react-19#cleanup-functions-for-refs) a ref callback can return a function, and React calls that function on detach instead of calling the ref callback again with null. `register()`'s ref callback predates this and only implemented the null-argument style, so it never benefited from it.

Referred discussion #13084.

### What I have done

- Extracted the existing ref `===` null branch's unmount logic into a cleanup closure.
- Return cleanup from every return point inside the ref(elm) branch.
- Left the else (`ref === null`) branch calling the same`cleanup()` directly, unchanged, for React <19 — which ignores a ref callback's return value and still calls it again with null on unmount.
- Updated RefCallBack's type to `(instance: any) => void | (() => void)`.

### Test Plans

- `ref(elm)` returns a function (pins the new contract; fails against the previous implementation, which returned void).
- Full existing suite re-run to confirm no behavior change, including the `shouldUnregister` + real-unmount tests that already exercise `register()`'s ref teardown path end-to-end under the project's installed React 19.