### PR TITLE
fix(resetField): isValid not recomputed for subscribe-only consumers

### DIFF
--- a/src/__tests__/useForm/resetField.test.tsx
+++ b/src/__tests__/useForm/resetField.test.tsx
@@ -529,4 +529,54 @@ describe('resetField', () => {
       expect(await screen.findByText('isDirty')).toBeVisible();
     });
   });
+
+  it('should update isValid state for a subscribe only consumer', async () => {
+    const App = () => {
+      const { register, resetField, subscribe } = useForm({
+        defaultValues: {
+          test: 'test',
+        },
+        mode: 'onChange',
+      });
+      const [isValid, setIsValid] = React.useState(false);
+
+      React.useEffect(() => {
+        return subscribe({
+          formState: {
+            isValid: true,
+          },
+          callback: (formState) => setIsValid(formState.isValid),
+        });
+      }, [subscribe]);
+
+      return (
+        <form>
+          <input {...register('test', { required: true })} />
+          <p>{isValid ? 'valid' : 'NotValid'}</p>
+          <button
+            type={'button'}
+            onClick={() => {
+              resetField('test');
+            }}
+          >
+            reset
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: {
+        value: '',
+      },
+    });
+
+    expect(await screen.findByText('NotValid')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByText('valid')).toBeVisible();
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1842,7 +1842,7 @@ export function createFormControl<
 
       if (!options.keepError) {
         unset(_formState.errors, name);
-        _proxyFormState.isValid && _setValid();
+        _setValid();
       }
 
       _subjects.state.next({ ..._formState });


### PR DESCRIPTION
## Proposed Changes

`resetField(name)` clears the field's error but leaves `formState.isValid` stale for a consumer that subscribes through `control.subscribe({ formState: { isValid: true } })`.

`createFormControl.ts:1845` gates the recompute on `_proxyFormState.isValid`, which is written only by `getProxyFormState` when a key is read off the render proxy. `subscribe()` writes `_proxySubscribeFormState` instead (`:1553-1566`), so the gate is false and `_setValid()` never runs, while the `_subjects.state.next({ ..._formState })` on the following line still notifies the subscriber, carrying the old value.

The gate is also redundant. `_setValid` already self-gates on `_proxyFormState.isValid || _proxySubscribeFormState.isValid || shouldUpdateValid` (`:234-243`), so dropping the outer check widens nothing beyond the subscribe case and costs one boolean test when nobody is listening.

The two sibling APIs in this file already call it ungated: `unregister` at `:1598` and `resetDefaultValues` at `:2086`.

Existing coverage misses this because `resetField.test.tsx:426` reads `isValid` off `useForm().formState`. `useFormState({ control })` is also unaffected, since `getProxyFormState` sets the render-proxy flag when `isRoot` is false.

The added test uses `subscribe` only. Full suite is 1280 passing, types and lint clean.
