### PR TITLE
🧹refactor: use `continue` instead of `return` in setFieldValues' hasOwnProperty guard

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -551,6 +551,32 @@ describe('setValue', () => {
     });
   });
 
+  it('should apply every own property and skip only an inherited one', () => {
+    const { result } = renderHook(() =>
+      useForm<{
+        test: {
+          bill: string;
+          luo: string;
+        };
+      }>(),
+    );
+
+    result.current.register('test.bill');
+    result.current.register('test.luo');
+
+    const proto = { inherited: 'skip-me' };
+    const value = Object.create(proto);
+    value.bill = '1';
+    value.luo = '2';
+
+    act(() => result.current.setValue('test', value));
+
+    expect(result.current.getValues('test')).toEqual({
+      bill: '1',
+      luo: '2',
+    });
+  });
+
   it('should work for nested fields which are not registered', () => {
     const { result } = renderHook(() => useForm());
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -956,7 +956,7 @@ export function createFormControl<
 
     for (const fieldKey in value) {
       if (!value.hasOwnProperty(fieldKey)) {
-        return;
+        continue;
       }
       const fieldValue = value[fieldKey];
       const fieldName = name + '.' + fieldKey;


### PR DESCRIPTION
## Summary

### Motivation

#12731 added a `hasOwnProperty(fieldKey)` guard in `setFieldValues` to skip prototype-chain values, but used `return` instead of `continue` — aborting the whole loop on the first non-own key instead of skipping just that key.

Since `for...in` enumerates own keys before inherited ones, this hasn't dropped real data in practice, but a differently-shaped object could trigger the bug, and the intent wasn't clear from the code.

### What I have done

- Changed `return` to `continue` in the `hasOwnProperty` check inside `setFieldValues` (no behavior change for existing test coverage).
- Added a test asserting every own property is still applied and only an inherited one is skipped.

### Test Plans

- Added `should apply every own property and skip only an inherited one` to `src/__tests__/useForm/setValue.test.tsx`, covering an object created via `Object.create(proto)` with own + inherited enumerable properties.