### PR TITLE
fix(generateWatchOutput): defaultValue is ignored for an array of names

### DIFF
--- a/src/__tests__/useForm/watch.test.tsx
+++ b/src/__tests__/useForm/watch.test.tsx
@@ -160,7 +160,7 @@ describe('watch', () => {
 
     expect(results).toEqual([
       ['default', 'test'],
-      [undefined, undefined],
+      ['default', 'test'],
     ]);
   });
 

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -149,6 +149,34 @@ describe('useWatch', () => {
     expect(result.current).toEqual(['test', 'test1']);
   });
 
+  it('should keep its own default value for array of inputs after a value change', async () => {
+    const Form = () => {
+      const { control, setValue } = useForm<{ test: string; test1: string }>(
+        {},
+      );
+      const [test, test1] = useWatch({
+        control,
+        name: ['test', 'test1'],
+        defaultValue: {
+          test: 'test',
+          test1: 'test1',
+        },
+      });
+
+      React.useEffect(() => {
+        setValue('test', 'changed');
+      }, [setValue]);
+
+      return <>{`${test},${test1}`}</>;
+    };
+
+    render(<Form />);
+
+    await waitFor(() => {
+      screen.getByText('changed,test1');
+    });
+  });
+
   it('should return default value when name is undefined', () => {
     const { result } = renderHook(() => {
       const { control } = useForm<{ test: string; test1: string }>({

--- a/src/logic/generateWatchOutput.ts
+++ b/src/logic/generateWatchOutput.ts
@@ -18,7 +18,7 @@ export default <T>(
     return names.map(
       (fieldName) => (
         isGlobal && _names.watch.add(fieldName),
-        get(formValues, fieldName)
+        get(formValues, fieldName, get(defaultValue, fieldName))
       ),
     );
   }


### PR DESCRIPTION
## Proposed Changes

`useWatch`'s `defaultValue` is dropped when `name` is an array. Writing the same subscription as
separate string names keeps the fallback, so the two ways of asking for one thing disagree.

`generateWatchOutput.ts:14` passes the fallback through for a string name:

```ts
return get(formValues, names, defaultValue);
```

`:21` does not, even though `defaultValue` is the function's fifth parameter and both `useWatch` and
`_getWatch` hand it in:

```ts
get(formValues, fieldName)
```

Every watched path the form holds no value for therefore comes back as `undefined`. `watch()` reaches
the same branch through `_getWatch`, so it behaves the same way.

The first render hides this. `createFormControl.ts:834-838` builds the value source out of
`defaultValue` itself when the form has not mounted and the names are an array, so the lookup is
effectively `get(defaultValue, fieldName)` and lands on the right values without a fallback argument.
Once mounted the source is `_formValues` and the missing argument shows up on the next recomputation:

```tsx
const { control, setValue } = useForm<{ qty: number; price: number }>();

const [qty, price] = useWatch({
  control,
  name: ['qty', 'price'],
  defaultValue: { qty: 1, price: 1000 },
});

// first render             -> [1, 1000]
// after setValue('qty', 5) -> [5, undefined]
```

`price` was never touched. It loses its fallback because a different name in the same array changed.
`reset()` takes out both entries at once since it notifies every subscriber. Whatever reads those
values goes down with them, so `qty * price` turns into `NaN`.

The fix passes the matching slice:

```ts
get(formValues, fieldName, get(defaultValue, fieldName))
```

`defaultValue` for an array of names is keyed by path, so the slice has to be looked up rather than
handed straight over. Leaning on `get` for that also means a nested `defaultValue` such as
`{ a: { b: 1 } }` for `name: ['a.b']` resolves the way the watched path does.

The string branch is untouched, no public API moves, and `api-extractor` reports no change. The
source swap at `:834-838` is now redundant for this case, but I left it alone to keep the diff to the
one line.

What convinced me this is an omission rather than a deliberate difference: `useWatch.test.tsx:136`
already asserts the array form returns its own default value. It only looks at the first render,
which is the one case that source swap covers, so it has been green all along. The new test at `:152`
is that same setup carried one step further. The fallback argument itself arrived in `cf5a81f8`
(#9622) and only the string branch got it in that commit.

`watch.test.tsx:144` expected `[undefined, undefined]` for the second render. That second entry was
added in `047cd734` (#12568) alongside `isReady`, which changed how many times the component renders,
and it recorded the output as it stood. The string-form test right above it was extended in the same
commit to `['default', 'default']`, keeping its fallback across both renders. With the fallback
applied the array form now matches it:

```diff
  expect(results).toEqual([
    ['default', 'test'],
-   [undefined, undefined],
+   ['default', 'test'],
  ]);
```

If you would rather leave that expectation as documented behaviour for `watch()`, say so and I will
look at narrowing the change.

No linked issue — found while reading `generateWatchOutput`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

Against unpatched source the new test fails with `changed,undefined` where `changed,test1` is
expected. Full suite is 1282 passed / 120 suites with the change. `pnpm test:type`, `pnpm lint`,
`pnpm build` and `pnpm api-extractor` all pass on Node 22 / pnpm 11.
