### PR TITLE
🐞 fix(useFormState): never reconciles when an Activity subtree is hidden on its first render

### DIFF
--- a/src/__tests__/useFormState.test.tsx
+++ b/src/__tests__/useFormState.test.tsx
@@ -939,5 +939,136 @@ describe('useFormState', () => {
         expect(screen.getByTestId('submitting')).toHaveTextContent('no');
       },
     );
+
+    itWithActivity(
+      'should synchronize form state when an Activity subtree becomes visible for the first time',
+      () => {
+        type FormValues = { name: string };
+
+        const ActivityContent = ({
+          control,
+        }: {
+          control: Control<FormValues>;
+        }) => {
+          const { isDirty } = useFormState({ control });
+
+          return (
+            <span data-testid="dirty">{isDirty ? 'dirty' : 'pristine'}</span>
+          );
+        };
+
+        const Component = () => {
+          const { control, setValue } = useForm<FormValues>({
+            defaultValues: { name: 'initial' },
+          });
+          const [mode, setMode] = React.useState<'hidden' | 'visible'>(
+            'hidden',
+          );
+
+          return (
+            <>
+              <button
+                type="button"
+                onClick={() =>
+                  setValue('name', 'updated', { shouldDirty: true })
+                }
+              >
+                Update
+              </button>
+              <button type="button" onClick={() => setMode('visible')}>
+                Show
+              </button>
+              <Activity mode={mode}>
+                <ActivityContent control={control} />
+              </Activity>
+            </>
+          );
+        };
+
+        render(
+          <React.StrictMode>
+            <Component />
+          </React.StrictMode>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+        expect(screen.getByTestId('dirty')).toHaveTextContent('dirty');
+      },
+    );
+
+    itWithActivity(
+      'should synchronize Controller field state when an Activity subtree becomes visible for the first time',
+      () => {
+        type FormValues = { name: string };
+
+        const ActivityContent = ({
+          control,
+        }: {
+          control: Control<FormValues>;
+        }) => (
+          <Controller
+            control={control}
+            name="name"
+            render={({ field, fieldState }) => (
+              <>
+                <input {...field} />
+                <span data-testid="error">
+                  {fieldState.error?.message || 'no-error'}
+                </span>
+              </>
+            )}
+          />
+        );
+
+        const Component = () => {
+          const { control, setError, clearErrors } = useForm<FormValues>({
+            defaultValues: { name: 'initial' },
+          });
+          const [mode, setMode] = React.useState<'hidden' | 'visible' | null>(
+            null,
+          );
+
+          return (
+            <>
+              <button
+                type="button"
+                onClick={() => setError('name', { message: 'Server said no.' })}
+              >
+                Set error
+              </button>
+              <button type="button" onClick={() => setMode('hidden')}>
+                Mount hidden
+              </button>
+              <button type="button" onClick={() => clearErrors()}>
+                Clear errors
+              </button>
+              <button type="button" onClick={() => setMode('visible')}>
+                Show
+              </button>
+              {mode && (
+                <Activity mode={mode}>
+                  <ActivityContent control={control} />
+                </Activity>
+              )}
+            </>
+          );
+        };
+
+        render(
+          <React.StrictMode>
+            <Component />
+          </React.StrictMode>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Set error' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Mount hidden' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Clear errors' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+        expect(screen.getByTestId('error')).toHaveTextContent('no-error');
+      },
+    );
   });
 });

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -53,13 +53,15 @@ export function useFormState<
     TTransformedValues
   >();
   const { control = formControl, disabled, name, exact } = props || {};
-  const [formState, updateFormState] = React.useState<FormState<TFieldValues>>(
-    () => ({
-      ...control._formState,
-      defaultValues:
-        control._defaultValues as FormState<TFieldValues>['defaultValues'],
-    }),
-  );
+
+  const getCurrentFormState = () => ({
+    ...control._formState,
+    defaultValues:
+      control._defaultValues as FormState<TFieldValues>['defaultValues'],
+  });
+
+  const [formState, updateFormState] =
+    React.useState<FormState<TFieldValues>>(getCurrentFormState);
   const _localProxyFormState = React.useRef({
     isDirty: false,
     isLoading: false,
@@ -72,15 +74,9 @@ export function useFormState<
   });
 
   const { resyncIfNeeded, snapshot } =
-    useResyncOnReconnect<FormState<TFieldValues>>();
+    useResyncOnReconnect<FormState<TFieldValues>>(getCurrentFormState);
 
   useIsomorphicLayoutEffect(() => {
-    const getCurrentFormState = () => ({
-      ...control._formState,
-      defaultValues:
-        control._defaultValues as FormState<TFieldValues>['defaultValues'],
-    });
-
     resyncIfNeeded(!disabled, getCurrentFormState, updateFormState);
 
     const unsubscribe = control._subscribe({


### PR DESCRIPTION
## Proposed Changes

`useFormState` never reconciles when its subtree is first rendered inside a hidden `<Activity>`. Form
state that changes while the subtree is hidden is missing once it becomes visible, and it stays
missing until something else pushes an update.

`useResyncOnReconnect` only marks itself initialized when it is handed an initializer:

```ts
// useResyncOnReconnect.ts:14
if (!_initialized.current && getInitialValue) {
  _initialized.current = true;
  _prevValue.current = cloneObject(getInitialValue());
}
```

`useFormState.ts:74-75` called it with no argument, so `_initialized` stayed `false` and the
first-connect branch added in #13683 could never fire:

```ts
// useResyncOnReconnect.ts:27-28
_connected.current || (_initialized.current && _renderCount.current > 1)
```

`useWatch.ts:331` does pass an initializer, which is why #13683 landed for `useWatch` and left the
sibling case behind. `Controller` inherits it through `useController.ts:92`, which builds `fieldState`
out of `useFormState`.

The fix hoists the `useState` initializer into `getCurrentFormState` and hands it to
`useResyncOnReconnect`, the same shape as `useWatch`. The layout effect now reuses that function
instead of redefining an identical one.

Two tests in the existing `with Activity` block, both failing on `master`:

- `useFormState` reading `isDirty`, with `setValue(..., { shouldDirty: true })` called while hidden.
  Reports `pristine` on master.
- `Controller` reading `fieldState.error`, mounted hidden while an error is set, then `clearErrors()`
  while still hidden. Keeps the stale message on master.

The `Controller` case has to go through an error object that gets replaced rather than mutated.
`setError` mutates `_formState.errors` in place, and the `useState` snapshot holds that same
reference, so a mutation is visible to the hidden subtree without any resync and hides the defect.
`clearErrors()` assigns a fresh object, which is what actually leaves the snapshot stale.

Full suite: 1284 passed / 120 suites (1282 before). `tsc --noEmit`, `tsc -p src/__typetest__` and
eslint clean.
