### PR TITLE
🐞 fix(useFieldArray): reconcile stale fields after an Activity subtree reconnects

### DIFF
--- a/src/__tests__/useFieldArray.test.tsx
+++ b/src/__tests__/useFieldArray.test.tsx
@@ -29,6 +29,15 @@ let i = 0;
 
 jest.mock('../logic/generateId', () => () => String(i++));
 
+// Activity is a React 19.2+ API. Only run Activity-dependent tests when the
+// installed React actually provides it.
+const Activity = (React as unknown as { Activity?: unknown })
+  .Activity as React.ComponentType<{
+  mode: 'hidden' | 'visible';
+  children?: React.ReactNode;
+}>;
+const itWithActivity = Activity ? it : it.skip;
+
 describe('useFieldArray', () => {
   beforeEach(() => {
     i = 0;
@@ -5503,4 +5512,104 @@ it('should propagate disabled to field objects when disabled is set', () => {
   expect(result.current.fieldArray.fields[1].disabled).toBe(true);
   expect(result.current.fieldArray.fields[0].value).toBe('a');
   expect(result.current.fieldArray.fields[1].value).toBe('b');
+});
+
+describe('useFieldArray with Activity', () => {
+  type FormValues = { test: { value: string }[] };
+
+  const ActivityContent = ({ control }: { control: Control<FormValues> }) => {
+    const { fields } = useFieldArray({ control, name: 'test' });
+
+    return (
+      <span data-testid="field-array">
+        {fields.map((field) => field.value).join(',')}
+      </span>
+    );
+  };
+
+  itWithActivity(
+    'should synchronize field array values when an Activity subtree becomes visible for the first time',
+    () => {
+      const Component = () => {
+        const { control, reset } = useForm<FormValues>({
+          defaultValues: { test: [{ value: 'a' }] },
+        });
+        const [mode, setMode] = useState<'hidden' | 'visible'>('hidden');
+
+        return (
+          <>
+            <button
+              type="button"
+              onClick={() => reset({ test: [{ value: 'b' }, { value: 'c' }] })}
+            >
+              Reset
+            </button>
+            <button type="button" onClick={() => setMode('visible')}>
+              Show
+            </button>
+            <Activity mode={mode}>
+              <ActivityContent control={control} />
+            </Activity>
+          </>
+        );
+      };
+
+      render(
+        <React.StrictMode>
+          <Component />
+        </React.StrictMode>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+      expect(screen.getByTestId('field-array')).toHaveTextContent('b,c');
+    },
+  );
+
+  itWithActivity(
+    'should synchronize field array values after Activity restoration',
+    () => {
+      const Component = () => {
+        const { control, setValue } = useForm<FormValues>({
+          defaultValues: { test: [{ value: 'a' }] },
+        });
+        const [mode, setMode] = useState<'hidden' | 'visible'>('visible');
+
+        return (
+          <>
+            <button
+              type="button"
+              onClick={() => setValue('test', [{ value: 'b' }, { value: 'c' }])}
+            >
+              Update
+            </button>
+            <button type="button" onClick={() => setMode('hidden')}>
+              Hide
+            </button>
+            <button type="button" onClick={() => setMode('visible')}>
+              Show
+            </button>
+            <Activity mode={mode}>
+              <ActivityContent control={control} />
+            </Activity>
+          </>
+        );
+      };
+
+      render(
+        <React.StrictMode>
+          <Component />
+        </React.StrictMode>,
+      );
+
+      expect(screen.getByTestId('field-array')).toHaveTextContent('a');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Hide' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+      expect(screen.getByTestId('field-array')).toHaveTextContent('b,c');
+    },
+  );
 });

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -144,9 +144,6 @@ export function useFieldArray<
       return;
     }
 
-    // A hidden `Activity` subtree keeps this state but destroys the
-    // subscription below, so reconcile against the live array first. A new
-    // `control`/`name` is a different subscription, not a reconnect.
     if (_prevControl.current === control && _prevName.current === name) {
       resyncIfNeeded(true, getCurrentFieldArray, (fieldValues) => {
         setFields(fieldValues);

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -43,6 +43,7 @@ import type {
 } from './types';
 import { useFormControlContext } from './useFormControlContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+import { useResyncOnReconnect } from './useResyncOnReconnect';
 
 /**
  * A custom hook that exposes convenient methods to perform operations with a list of dynamic inputs that need to be appended, updated, removed etc. • [Demo](https://codesandbox.io/s/react-hook-form-usefieldarray-ssugn) • [Video](https://youtu.be/4MrbfGSFY2A)
@@ -108,12 +109,19 @@ export function useFieldArray<
     shouldUnregister,
     rules,
   } = props;
-  const [fields, setFields] = React.useState(control._getFieldArray(name));
+  const getCurrentFieldArray = () => control._getFieldArray(name);
+
+  const [fields, setFields] = React.useState(getCurrentFieldArray);
   const ids = React.useRef<string[]>(
     control._getFieldArray(name).map(generateId),
   );
 
   const _actioned = React.useRef(false);
+
+  const { resyncIfNeeded, snapshot } =
+    useResyncOnReconnect(getCurrentFieldArray);
+  const _prevControl = React.useRef(control);
+  const _prevName = React.useRef(name);
 
   if (!disabled) {
     control._names.array.add(name);
@@ -136,7 +144,20 @@ export function useFieldArray<
       return;
     }
 
-    return control._subjects.array.subscribe({
+    // A hidden `Activity` subtree keeps this state but destroys the
+    // subscription below, so reconcile against the live array first. A new
+    // `control`/`name` is a different subscription, not a reconnect.
+    if (_prevControl.current === control && _prevName.current === name) {
+      resyncIfNeeded(true, getCurrentFieldArray, (fieldValues) => {
+        setFields(fieldValues);
+        ids.current = fieldValues.map(generateId);
+      });
+    } else {
+      _prevControl.current = control;
+      _prevName.current = name;
+    }
+
+    const unsubscribe = control._subjects.array.subscribe({
       next: ({
         values,
         name: fieldArrayName,
@@ -156,7 +177,12 @@ export function useFieldArray<
         }
       },
     }).unsubscribe;
-  }, [control, name, disabled]);
+
+    return () => {
+      unsubscribe();
+      snapshot(true, getCurrentFieldArray);
+    };
+  }, [control, name, disabled, resyncIfNeeded, snapshot]);
 
   const updateValues = React.useCallback(
     <


### PR DESCRIPTION
## Proposed Changes

`useFieldArray` is the last value-holding hook that is not wired into the `<Activity>` reconnect path that #13633, #13683 and #13687 added for `useWatch` and `useFormState`.

A hidden `Activity` subtree keeps its state but destroys its Effects, so the `control._subjects.array` subscription in `useFieldArray` is torn down while the `fields` state is preserved. A `reset()` or `setValue()` on the array while the subtree is hidden is therefore never delivered, and when the subtree becomes visible again the hook re-subscribes without reconciling. `fields` stays stale for the rest of the form's life.

This reuses the existing `useResyncOnReconnect` helper: snapshot the array on unsubscribe, and compare against the live array before re-subscribing. It covers both the hidden-on-first-render case and the hide/change/show case.

The resync is guarded on `control` and `name` being unchanged, mirroring the same guard in `useWatch`. A new `control`/`name` is a different subscription rather than a reconnect, so resyncing there would compare the previous name's snapshot against the new name's array, always find them different, and needlessly call `setFields` plus regenerate every `id`. That matters for nested arrays with a dynamic name such as `test.${index}.keyValue`, where a parent `remove()` shifts the name of every surviving child.

Two regression tests are added, guarded by the same `Activity` feature detection already used in `useWatch.test.tsx` and `useFormState.test.tsx`.

### Performance

The subscription callback and every array method are unchanged.

Per render this adds one closure and the helper's refs. Per effect run, which is mount plus `control`/`name`/`disabled` changes only, it adds one `deepEqual`, and one `cloneObject` on cleanup.

I measured renders of a nested `useFieldArray` with a dynamic name across two parent `remove()` calls, counting renders of the nested component:

| | mount | after remove 1 | after remove 2 |
| --- | --- | --- | --- |
| master | 12 | 16 | 18 |
| this PR | 12 | 16 | 18 |

Bundle impact is +57 B gzipped on `index.cjs.js` (13903 -> 13960). `bundlewatch` still passes, though that leaves roughly 0.4KB of headroom against the 14KB budget, so it seemed worth flagging.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
