### PR TITLE
refactor: remove unused abortEarly param from `iterateFieldsByAction`

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1743,7 +1743,6 @@ export function createFormControl<
           }
         },
         0,
-        false,
       );
     }
   };

--- a/src/logic/iterateFieldsByAction.ts
+++ b/src/logic/iterateFieldsByAction.ts
@@ -6,7 +6,6 @@ const iterateFieldsByAction = (
   fields: FieldRefs,
   action: (ref: Ref, name: string) => 1 | undefined | void,
   fieldsNames?: Set<InternalFieldName> | InternalFieldName[] | 0,
-  abortEarly?: boolean,
 ) => {
   for (const key of fieldsNames || Object.keys(fields)) {
     if (key === '_f') {
@@ -19,9 +18,9 @@ const iterateFieldsByAction = (
       const { _f } = field;
 
       if (_f) {
-        if (_f.refs && _f.refs[0] && action(_f.refs[0], key) && !abortEarly) {
+        if (_f.refs && _f.refs[0] && action(_f.refs[0], key)) {
           return true;
-        } else if (_f.ref && action(_f.ref, _f.name) && !abortEarly) {
+        } else if (_f.ref && action(_f.ref, _f.name)) {
           return true;
         } else {
           if (iterateFieldsByAction(field, action)) {


### PR DESCRIPTION
## Summary

### Motivation

`iterateFieldsByAction` accepts an `abortEarly?: boolean` param used to gate its two early-return checks (`&& !abortEarly`). No call site across the codebase has ever passed `true` — three call sites omit it entirely, and one (`_disableForm` in `createFormControl.ts`) passes `false`
explicitly. 
When `undefined` and `false` are both falsy, `!abortEarly` always evaluates to `true`, so the flag has never actually gated
anything. 

Therefore I think it's dead code that adds a misleading layer to the "did we already find a match" control flow.

### What I have done

- Removed the `abortEarly` parameter from `iterateFieldsByAction`.
- Simplified both early-return conditions to drop the now-redundant `&& !abortEarly`.
- Removed the one explicit `false` argument passed at the `_disableForm` call site in `createFormControl.ts`.

### Test Plans

- `yarn test` — full suite passes (120 suites / 1281 tests).
- No behavior change: the removed condition was always `true` at every call site, so this is a pure dead-code removal.