### PR TITLE
refactor: extract `_isTracked` helper for proxy/subscribe form state checks (partial)

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -472,7 +472,7 @@ export function createFormControl<
         if (
           wasUnsetInFormValues &&
           _formState.isDirty &&
-          (_proxyFormState.isDirty || _proxySubscribeFormState.isDirty)
+          _isTracked('isDirty')
         ) {
           const isDirty = _getDirty();
           if (!isDirty) {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -214,6 +214,8 @@ export function createFormControl<
   let _proxySubscribeFormState = {
     ..._proxyFormState,
   };
+  const _isTracked = (key: keyof ReadFormState) =>
+    _proxyFormState[key] || _proxySubscribeFormState[key];
   const _subjects: Subjects<TFieldValues> = {
     array: createSubject(),
     state: createSubject(),
@@ -342,7 +344,7 @@ export function createFormControl<
         shouldSetValues && set(_formState.touchedFields, name, touchedFields);
       }
 
-      if (_proxyFormState.dirtyFields || _proxySubscribeFormState.dirtyFields) {
+      if (_isTracked('dirtyFields')) {
         _updateDirtyFields();
       }
 
@@ -515,7 +517,7 @@ export function createFormControl<
           fieldValue,
         );
 
-        if (_proxyFormState.isDirty || _proxySubscribeFormState.isDirty) {
+        if (_isTracked('isDirty')) {
           isPreviousDirty = _formState.isDirty;
 
           _formState.isDirty = output.isDirty =
@@ -581,7 +583,7 @@ export function createFormControl<
   ) => {
     const previousFieldError = get(_formState.errors, name);
     const shouldUpdateValid =
-      (_proxyFormState.isValid || _proxySubscribeFormState.isValid) &&
+      _isTracked('isValid') &&
       isBoolean(isValid) &&
       _formState.isValid !== isValid;
 
@@ -1180,7 +1182,7 @@ export function createFormControl<
       if (shouldSkipValidation) {
         if (
           (!hasNoValidationEffect || !_formState.isValid) &&
-          (_proxyFormState.isValid || _proxySubscribeFormState.isValid)
+          _isTracked('isValid')
         ) {
           if (_options.mode === 'onBlur') {
             if (isBlurEvent) {
@@ -1346,13 +1348,11 @@ export function createFormControl<
 
     _subjects.state.next({
       ...(!isString(name) ||
-      ((_proxyFormState.isValid || _proxySubscribeFormState.isValid) &&
-        isValid !== _formState.isValid)
+      (_isTracked('isValid') && isValid !== _formState.isValid)
         ? {}
         : { name }),
       ...(_options.resolver || !name ? { isValid } : {}),
-      ...(options.shouldTouch &&
-      (_proxyFormState.touchedFields || _proxySubscribeFormState.touchedFields)
+      ...(options.shouldTouch && _isTracked('touchedFields')
         ? { touchedFields: _formState.touchedFields }
         : {}),
       errors: _formState.errors,


### PR DESCRIPTION
## Summary

### Motivation

`_proxyFormState.X || _proxySubscribeFormState.X` — checking whether either the render-proxy or the subscribe-proxy has a given form-state key tracked — is repeated throughout `createFormControl.ts` with only the key varying.

### What I have done

- Added a one-line `_isTracked(key: keyof ReadFormState)` helper.
- Applied it at the single-key, single-line call sites: `dirtyFields`, `isDirty`, `isValid`, `touchedFields` (6 occurrences).
- Left the remaining call sites as-is for this PR — several combine multiple keys or both proxies across multi-line `&&` chains (e.g. `isValidating`/`validatingFields` together, `isDirty`/`dirtyFields` together), and deserve closer review on their own.


#### Notes
**This is intentionally a partial/first pass.** If it lands cleanly, I'll follow up with a second PR extending `_isTracked` to the remaining multi-key/multi-line sites.

### Test Plans

- `yarn test` — full suite passes (120 suites / 1286 tests).
- Pure extraction of an existing OR-of-two-reads expression — no behaviour change.
