### PR TITLE
🐞 fix(useForm): never reconciles when an Activity subtree is hidden on its first render

### DIFF
--- a/src/__tests__/useForm.test.tsx
+++ b/src/__tests__/useForm.test.tsx
@@ -38,6 +38,15 @@ import {
 
 jest.useFakeTimers();
 
+// Activity is a React 19.2+ API. Only run Activity-dependent tests when the
+// installed React actually provides it.
+const Activity = (React as unknown as { Activity?: unknown })
+  .Activity as React.ComponentType<{
+  mode: 'hidden' | 'visible';
+  children?: React.ReactNode;
+}>;
+const itWithActivity = Activity ? it : it.skip;
+
 describe('useForm', () => {
   describe('when component unMount', () => {
     it('should call unSubscribe', () => {
@@ -3014,6 +3023,65 @@ describe('useForm', () => {
         );
       });
     });
+
+    itWithActivity(
+      'should synchronize form state when an Activity subtree becomes visible for the first time',
+      () => {
+        type FormValues = { firstName: string };
+
+        const { formControl, setError } = createFormControl<FormValues>({
+          defaultValues: { firstName: '' },
+        });
+
+        const ActivityContent = () => {
+          const { formState } = useForm<FormValues>({ formControl });
+
+          return (
+            <p>
+              {formState.errors.firstName
+                ? formState.errors.firstName.message
+                : 'no error'}
+            </p>
+          );
+        };
+
+        const Component = () => {
+          const [mode, setMode] = React.useState<'hidden' | 'visible'>(
+            'hidden',
+          );
+
+          return (
+            <>
+              <button
+                type={'button'}
+                onClick={() =>
+                  setError('firstName', { message: 'firstName is required' })
+                }
+              >
+                Update
+              </button>
+              <button type={'button'} onClick={() => setMode('visible')}>
+                Show
+              </button>
+              <Activity mode={mode}>
+                <ActivityContent />
+              </Activity>
+            </>
+          );
+        };
+
+        render(
+          <React.StrictMode>
+            <Component />
+          </React.StrictMode>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+        expect(screen.getByText('firstName is required')).toBeVisible();
+      },
+    );
   });
 
   describe('When using defaultValues', () => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -95,16 +95,16 @@ export function useForm<
   const control = _formControl.current.control;
   control._options = props;
 
+  const getCurrentFormState = () => ({
+    ...control._formState,
+    defaultValues:
+      control._defaultValues as FormState<TFieldValues>['defaultValues'],
+  });
+
   const { resyncIfNeeded, snapshot } =
-    useResyncOnReconnect<FormState<TFieldValues>>();
+    useResyncOnReconnect<FormState<TFieldValues>>(getCurrentFormState);
 
   useIsomorphicLayoutEffect(() => {
-    const getCurrentFormState = () => ({
-      ...control._formState,
-      defaultValues:
-        control._defaultValues as FormState<TFieldValues>['defaultValues'],
-    });
-
     resyncIfNeeded(true, getCurrentFormState, updateFormState);
 
     const unsubscribe = control._subscribe({


### PR DESCRIPTION
## Proposed Changes

Follow-up to #13683 (`useWatch`) and #13687 (`useFormState`), applying the same seed to the last `useResyncOnReconnect` call site that was still missing it.

`useResyncOnReconnect` gates the resync on:

```ts
enabled &&
  (_connected.current || (_initialized.current && _renderCount.current > 1))
```

`_initialized.current` is only set when a `getInitialValue` is passed. `src/useForm.ts:98` calls `useResyncOnReconnect<FormState<TFieldValues>>()` with no argument, so `_initialized.current` stays `false` and the only path left is `_connected.current`, which requires a previous mount. A subtree hidden on its very first render never commits its effects, so the first reveal is a first connect and `useForm` re-reads nothing. Its `formState` keeps whatever the `useState` initialiser produced, however far the control has moved on.

`useWatch`, `useFormState` and `useFieldArray` all pass a getter today; `useForm` was the odd one out.

The fix hoists the existing `getCurrentFormState` out of the layout effect and passes it in. No other change.

### Reproduction

Most visible with a `formControl` created outside React, since that is the case where the control can be written to while the subtree is hidden:

```tsx
const { formControl, setError } = createFormControl({ defaultValues: { firstName: '' } });

const Content = () => {
  const { formState } = useForm({ formControl });
  return <p>{formState.errors.firstName?.message ?? 'no error'}</p>;
};

const App = () => {
  const [mode, setMode] = React.useState('hidden');
  return (
    <>
      <button onClick={() => setError('firstName', { message: 'firstName is required' })}>Update</button>
      <button onClick={() => setMode('visible')}>Show</button>
      <Activity mode={mode}><Content /></Activity>
    </>
  );
};
```

Click Update, then Show. Before this change the paragraph still reads `no error` even though `control._formState.errors` holds the error. `reset()` and `setValue()` on a hidden subtree are lost the same way.

### Cost

- Render counts are unchanged. `resyncIfNeeded` can now call `updateFormState` during the mount layout effect, but that effect already calls `updateFormState` for `isReady` immediately afterwards, so the two batch into the render that was going to happen anyway. Measured on a form with `register`, `Controller`, `useFieldArray`, `useWatch` and `useFormState`: mount / after change / after append is 4 / 4 / 6 in `StrictMode` and 2 / 2 / 3 outside it, identical before and after.
- One extra `cloneObject` of the initial form state per `useForm` mount, one time, no steady-state cost. Measured in isolation: 3.7us at 10 `defaultValues` keys, 22us at 200, 194us at 2000. `createFormControl` already clones `defaultValues` twice at construction.
- Bundle is 2 bytes smaller gzipped (13964 to 13962), since the closure moves out of the effect. `bundlewatch` budget is 14.0 kB.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

`pnpm test` 1287 passed (1286 before, plus the new one), `pnpm test:type`, `pnpm lint`, `pnpm type`, `pnpm build` and `pnpm api-extractor` all clean.

Counterfactual: reverting only `src/useForm.ts` and keeping the new test fails with `Unable to find an element with the text: firstName is required`, rendering `no error`. Restoring it passes.

`pnpm e2e` was run on both sides. `e2e/useFieldArrayUnregister.spec.ts` fails on unmodified `master` here too (3 of 3 runs, a `toEqual` on submitted data, not a render count), so it looks pre-existing and unrelated to this change. Every `expectRenderCountInRange` assertion passes.
