### PR TITLE
🐞 fix(cloneObject): guard `Blob` before `instanceof`

### DIFF
--- a/src/__tests__/utils/cloneObject.test.ts
+++ b/src/__tests__/utils/cloneObject.test.ts
@@ -148,6 +148,40 @@ describe('clone', () => {
     });
   });
 
+  describe('Blob not a constructor', () => {
+    const blob = globalThis.Blob;
+
+    afterEach(() => {
+      globalThis.Blob = blob;
+    });
+
+    it('should skip clone if Blob is undefined', () => {
+      // @ts-expect-error we want to test that clone skips if Blob is undefined.
+      globalThis.Blob = undefined;
+
+      const data = {
+        a: 1,
+        b: 2,
+      };
+
+      expect(() => cloneObject(data)).not.toThrow();
+      expect(cloneObject(data)).toEqual(data);
+    });
+
+    it('should skip clone if Blob is not defined', () => {
+      // @ts-expect-error we want to test that clone skips if Blob is not defined.
+      delete globalThis.Blob;
+
+      const data = {
+        a: 1,
+        b: 2,
+      };
+
+      expect(() => cloneObject(data)).not.toThrow();
+      expect(cloneObject(data)).toEqual(data);
+    });
+  });
+
   describe('in presence of Array polyfills', () => {
     beforeAll(() => {
       // @ts-expect-error we want to test that clone skips polyfill

--- a/src/utils/cloneObject.ts
+++ b/src/utils/cloneObject.ts
@@ -9,10 +9,11 @@ export default function cloneObject<T>(data: T): T {
     return new Date(data) as T;
   }
 
+  const isBlobInstance = typeof Blob !== 'undefined' && data instanceof Blob;
   const isFileListInstance =
     typeof FileList !== 'undefined' && data instanceof FileList;
 
-  if (isWeb && (data instanceof Blob || isFileListInstance)) {
+  if (isWeb && (isBlobInstance || isFileListInstance)) {
     return data;
   }
 


### PR DESCRIPTION
## Proposed Changes

`cloneObject` guards `FileList` with a `typeof` check but not `Blob`:

```ts
const isFileListInstance =
  typeof FileList !== 'undefined' && data instanceof FileList;

if (isWeb && (data instanceof Blob || isFileListInstance)) {
```

`isWeb` only tests `window`, `window.HTMLElement` and `document` — it says nothing about whether `Blob` exists. Where the global `Blob` is present but is not a constructor, `data instanceof Blob` throws `TypeError: Right-hand side of 'instanceof' is not an object`.

This is not a narrow edge case: `createFormControl` runs `cloneObject(DEFAULT_FORM_STATE)` unconditionally at `createFormControl.ts:168`, and `DEFAULT_FORM_STATE` is a plain object, so it clears the `typeof data !== 'object'` early return and reaches the `Blob` check. **Every `useForm()` call throws on first render in such an environment**, regardless of what the user passes. Confirmed against `master` and `v7.87.0`:

```
TypeError: Right-hand side of 'instanceof' is not an object
  at data (src/utils/cloneObject.ts:15:17)
```

### How it regressed

Both globals used to be checked individually:

```ts
} else if (globalThis.Blob && data instanceof Blob) {
} else if (globalThis.FileList && data instanceof FileList) {
```

#8406 (`d2a300c35`) replaced `globalThis.X &&` with `isWeb &&` for both, to fix #8404 (`globalThis` is ES2020 and broke Android 8). That swapped a per-global existence check for an environment check, and both guards became unsound in the same commit.

#12332 later restored the guard for `FileList` only, after it crashed in Adobe Photoshop UXP where `FileList` is undefined. `Blob` was left as-is, which is the asymmetry above. This PR closes it.

### Prior report

#12864 reported this exact error against this exact line in June 2025, with a second user confirming it in their Sentry. It was closed without a code change, I think because the reporter guessed their `defaultValues: undefined` was at fault — understandable, but the crash is independent of `defaultValues` (see `createFormControl.ts:168` above). That thread is now locked, so this PR references rather than closes it.

The reports are real traffic, not synthetic: both that reporter and I are seeing it from clients with a DOM but a broken `Blob`, all identifying as Chrome 116 on Linux. The user-visible effect is the whole React tree failing to render — in my case an error boundary replacing a public landing page.

### Why existing coverage misses it

The `'FileList not defined'` block added in #12332 does not exercise this. With `FileList` deleted but `Blob` intact, `data instanceof Blob` evaluates to `false` and the `||` short-circuits before any missing global is touched, so the test passes either way.

The two new cases fail differently, which is why both are included:

| Setup | Before this PR |
|---|---|
| `globalThis.Blob = undefined` | `TypeError: Right-hand side of 'instanceof' is not an object` |
| `delete globalThis.Blob` | `ReferenceError: Blob is not defined` |

The first reproduces the reported error exactly; the second covers environments that omit the global entirely, like the UXP case from #12332. `typeof` handles both, since it is the one operator that is safe on an undeclared identifier.

### One thing worth your call

`typeof Blob !== 'undefined'` matches the existing `FileList` line, but it is not a total guard: `Blob = null` or any non-`undefined` primitive still passes it and throws. `typeof Blob === 'function'` would close those too. I kept the weaker form for symmetry rather than diverge from the line above it — happy to switch both to `=== 'function'` if you would prefer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

Verified both tests fail on `master` with the two errors above and pass with the fix. Full suite green: 1288 tests / 120 suites. `pnpm lint` reports no new warnings, `pnpm test:type` and `pnpm build` pass, and both changed files are prettier-clean.

When `Blob` is a normal constructor the guard is `true` and behaviour is unchanged. When it is absent, no `Blob` instances can exist, so nothing that should be returned by reference is now cloned by mistake.
