### PR TITLE
fix(delayError): cleared errors come back once the pending timer fires

### DIFF
--- a/src/__tests__/useForm/clearErrors.test.tsx
+++ b/src/__tests__/useForm/clearErrors.test.tsx
@@ -372,4 +372,66 @@ describe('clearErrors', () => {
     // FieldB should NOT have re-rendered for clearErrors('a') - this is the bug fix!
     expect(afterClearErrorRenderB).toBe(afterSetErrorRenderB);
   });
+
+  it('should cancel a pending delayError timer so the cleared error does not come back', async () => {
+    jest.useFakeTimers();
+
+    const message = 'too long.';
+
+    const App = () => {
+      const {
+        register,
+        clearErrors,
+        formState: { errors },
+      } = useForm<{ test: string }>({
+        delayError: 500,
+        mode: 'onChange',
+      });
+
+      return (
+        <div>
+          <input {...register('test', { maxLength: 4 })} />
+          <button type="button" onClick={() => clearErrors('test')}>
+            clear
+          </button>
+          {errors.test && <p>{message}</p>}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    // Schedule a delayed error, then clear it before the delay elapses.
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '123456' },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    // The delay itself must still work, otherwise the assertion above would
+    // pass even if no timer had been scheduled in the first place.
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '654321' },
+      });
+    });
+
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText(message)).toBeVisible();
+
+    jest.useRealTimers();
+  });
 });

--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -2204,4 +2204,66 @@ describe('reset', () => {
     expect(screen.getByText('is valid: true')).toBeInTheDocument();
     expect(formState).toEqual({ isValid: true });
   });
+
+  it('should cancel a pending delayError timer so the reset error does not come back', async () => {
+    jest.useFakeTimers();
+
+    const message = 'too long.';
+
+    const App = () => {
+      const {
+        register,
+        reset,
+        formState: { errors },
+      } = useForm<{ test: string }>({
+        delayError: 500,
+        mode: 'onChange',
+      });
+
+      return (
+        <div>
+          <input {...register('test', { maxLength: 4 })} />
+          <button type="button" onClick={() => reset()}>
+            reset
+          </button>
+          {errors.test && <p>{message}</p>}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    // Schedule a delayed error, then reset the form before the delay elapses.
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '123456' },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    // The delay itself must still work, otherwise the assertion above would
+    // pass even if no timer had been scheduled in the first place.
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '654321' },
+      });
+    });
+
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText(message)).toBeVisible();
+
+    jest.useRealTimers();
+  });
 });

--- a/src/__tests__/useForm/unregister.test.tsx
+++ b/src/__tests__/useForm/unregister.test.tsx
@@ -202,4 +202,52 @@ describe('unregister', () => {
 
     await waitFor(() => expect(isDirty).toBe(false));
   });
+
+  it('should cancel a pending delayError timer when the field is unregistered', async () => {
+    jest.useFakeTimers();
+
+    const message = 'too long.';
+
+    const App = () => {
+      const [show, setShow] = React.useState(true);
+      const {
+        register,
+        formState: { errors },
+      } = useForm<{ test: string }>({
+        delayError: 500,
+        mode: 'onChange',
+        shouldUnregister: true,
+      });
+
+      return (
+        <div>
+          {show && <input {...register('test', { maxLength: 4 })} />}
+          <button type="button" onClick={() => setShow(false)}>
+            hide
+          </button>
+          {errors.test && <p>{message}</p>}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    // Schedule a delayed error, then unmount the field before the delay elapses.
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '123456' },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'hide' }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // The field is gone, so this error would be impossible for a user to clear.
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -233,6 +233,12 @@ export function createFormControl<
       timers[name] = setTimeout(callback, wait);
     };
 
+  const cancelDelayedError = (name: InternalFieldName) => {
+    clearTimeout(timers[name]);
+    delete timers[name];
+    delete delayErrorCallbacks[name];
+  };
+
   const _setValid = async (shouldUpdateValid?: boolean) => {
     if (_state.keepIsValid) {
       return;
@@ -1421,7 +1427,10 @@ export function createFormControl<
   const clearErrors: UseFormClearErrors<TFieldValues> = (name) => {
     const names = name ? convertToArrayPayload(name) : undefined;
 
-    names?.forEach((inputName) => unset(_formState.errors, inputName));
+    names?.forEach((inputName) => {
+      cancelDelayedError(inputName);
+      unset(_formState.errors, inputName);
+    });
 
     if (names) {
       names.forEach((inputName) => {
@@ -1431,6 +1440,7 @@ export function createFormControl<
         });
       });
     } else {
+      Object.keys(delayErrorCallbacks).forEach(cancelDelayedError);
       _formState.errors = {};
       _subjects.state.next({
         errors: _formState.errors,
@@ -1575,7 +1585,10 @@ export function createFormControl<
         unset(_formValues, fieldName);
       }
 
-      !options.keepError && unset(_formState.errors, fieldName);
+      if (!options.keepError) {
+        cancelDelayedError(fieldName);
+        unset(_formState.errors, fieldName);
+      }
       !options.keepDirty && unset(_formState.dirtyFields, fieldName);
       !options.keepTouched && unset(_formState.touchedFields, fieldName);
       !options.keepIsValidating &&
@@ -1857,6 +1870,10 @@ export function createFormControl<
     const isEmptyResetValues = isEmptyObject(formValues);
     const values = cloneUpdatedValues;
     const fieldRefs = _fields;
+
+    if (!keepStateOptions.keepErrors) {
+      Object.keys(delayErrorCallbacks).forEach(cancelDelayedError);
+    }
 
     if (!keepStateOptions.keepDefaultValues) {
       _defaultValues = updatedValues;


### PR DESCRIPTION
## Proposed Changes

Clearing an error while its `delayError` timer is still pending puts the error back once the delay
elapses. `clearErrors`, `reset` and `unregister` all empty `_formState.errors` without touching the
scheduled callback.

`shouldRenderByError` schedules the display through `debounce` at `createFormControl.ts:590-596`:

```ts
if (_options.delayError && error) {
  delayErrorCallbacks[name] = debounce(name, () => updateErrors(name, error));
  delayErrorCallbacks[name](_options.delayError);
} else {
  clearTimeout(timers[name]);
  delete delayErrorCallbacks[name];
```

The cancellation lives in the `else` branch, so it only runs when the same field is revalidated and
comes back clean. Nothing else that empties `errors` goes through here:

```tsx
const { register, reset, formState: { errors } } = useForm<{ email: string }>({
  mode: 'onChange',
  delayError: 500,
});

// type an invalid value  -> timer scheduled for +500ms
// reset()                -> errors is {}, timer untouched
// +500ms                 -> errors.email is back, on an input that is now empty
```

`reset()` clears the input through the native `form.reset()` at `:1886-1901`, so the field ends up
empty while still carrying a validation error for the value the user just discarded.

`unregister` is the worse one. With `shouldUnregister` the field is gone by the time the callback
runs, so the error belongs to an input that is no longer on screen. `isValid` reads `true` alongside
it, since `_setValid` recomputes over `_fields` and `unregister` has already removed the field from
there, and nothing the user can do will clear the error.

The change adds `cancelDelayedError` next to `debounce` and calls it from the three paths, gated on
the `keepError` and `keepErrors` options they already honour:

```ts
const cancelDelayedError = (name: InternalFieldName) => {
  clearTimeout(timers[name]);
  delete timers[name];
  delete delayErrorCallbacks[name];
};
```

Dropping `delayErrorCallbacks[name]` is doing real work here, not tidying up. The blur path at
`:1162` reads that map and flushes whatever it finds:

```ts
const pendingDelayError = delayErrorCallbacks[name];
pendingDelayError && pendingDelayError(0);
```

With only the `clearTimeout`, a `clearErrors()` followed by the user tabbing out of the field brings
the error straight back through that flush. I checked by cutting the two `delete` lines and rerunning:
the error is gone right after `clearErrors` and back after the blur.

Existing coverage is closer than it looks. `formState.test.tsx:1150` and `:1268` do exercise
cancellation, through revalidation and through `setValue`, which is why I am reading this as three
paths that were missed rather than a deliberate choice. #6186 reported the same class for the
revalidation path in 2021 and was fixed by adding the `clearTimeout` that is still sitting in that
`else` branch today.

The blur flush and the `else` branch are untouched, and `keepError: true` / `keepErrors: true` keep
their timers along with their errors. Forms that do not pass `delayError` never populate
`delayErrorCallbacks`, so the added calls iterate an empty object.

No linked issue — found while reading `createFormControl`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

The three new tests fail on unpatched source, one per path. The `clearErrors` and `reset` ones go on
to raise a fresh delayed error after the assertion, since "no error is rendered" would also hold if
the test never managed to schedule a timer. Full suite is 1289 passed / 120 suites. `pnpm test:type`,
`pnpm lint` and `pnpm build` pass on Node 22 / pnpm 11, with the same 562 lint warnings as master and
none in the touched files. Gzipped ESM goes from 27,706 to 27,775 bytes.