### PR TITLE
🤦🏻‍♂️ refactor(clearErrors): remove redundant optional chain

### DIFF
--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1421,10 +1421,9 @@ export function createFormControl<
   const clearErrors: UseFormClearErrors<TFieldValues> = (name) => {
     const names = name ? convertToArrayPayload(name) : undefined;
 
-    names?.forEach((inputName) => unset(_formState.errors, inputName));
-
     if (names) {
       names.forEach((inputName) => {
+        unset(_formState.errors, inputName);
         _subjects.state.next({
           name: inputName,
           errors: _formState.errors,


### PR DESCRIPTION
names?.forEach duplicated the if (names) check immediately below it; fold both loops into the single existing branch instead.