### PR TITLE
fix(useWatch): correct compute example's variable names in JSDoc

### DIFF
--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -201,7 +201,7 @@ export function useWatch<
  *     fieldA: "data",
  *     fieldB: 0
  *   },
- *   compute: ([fieldAValue, fieldBValue]) => fieldB === 2 ? fieldA : null,
+ *   compute: ([fieldAValue, fieldBValue]) => fieldBValue === 2 ? fieldAValue : null,
  *   exact: false,
  * })
  * ```


### PR DESCRIPTION
## Summary

### Motivation

The `@example` block in `useWatch`'s JSDoc destructures the compute callback's argument as `[fieldAValue, fieldBValue]`, but the callback body referenced `fieldB`/`fieldA`, instead of names that don't exist in scope. 
Copy-pasting the example as written throws a `ReferenceError`.

### What I have done

- Fixed the example to use the destructured names it actually declares like:
`compute: ([fieldAValue, fieldBValue]) => fieldBValue === 2 ? fieldAValue : null`.

### Test Plans

N/A