### PR TITLE
fix: keep dirtyFields consistent with isDirty when reset uses keepValues

### DIFF
--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -189,6 +189,28 @@ describe('reset', () => {
     act(() => result.current.reset({ test: 'test' }));
   });
 
+  it('should keep dirtyFields in sync with isDirty when reset with keepValues', () => {
+    const { result } = renderHook(() => {
+      const form = useForm({ defaultValues: { test: 'test1' } });
+      form.formState.isDirty;
+      form.formState.dirtyFields;
+      return form;
+    });
+
+    result.current.register('test');
+
+    act(() => {
+      result.current.setValue('test', 'test', { shouldDirty: true });
+    });
+
+    act(() => {
+      result.current.reset(undefined, { keepValues: true });
+    });
+
+    expect(result.current.formState.isDirty).toBeTruthy();
+    expect(result.current.formState.dirtyFields).toEqual({ test: true });
+  });
+
   it('should not reset form values when keepValues is specified', () => {
     const App = () => {
       const { register, reset } = useForm();

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1988,7 +1988,14 @@ export function createFormControl<
             ? getDirtyFields(_defaultValues, formValues, undefined, fieldRefs)
             : keepStateOptions.keepDirty
               ? _formState.dirtyFields
-              : {},
+              : keepStateOptions.keepValues
+                ? getDirtyFields(
+                    _defaultValues,
+                    _formValues,
+                    undefined,
+                    fieldRefs,
+                  )
+                : {},
       touchedFields: keepStateOptions.keepTouched
         ? _formState.touchedFields
         : {},


### PR DESCRIPTION
After editing a field, `reset(undefined, { keepValues: true })` leaves `isDirty` as `true` (correct — the kept values still differ from the defaults) but `dirtyFields` comes back `{}`, so the two contradict each other.

```js
// defaultValues: { test: 'test1' }
setValue('test', 'test', { shouldDirty: true }) // isDirty: true, dirtyFields: { test: true }
reset(undefined, { keepValues: true })
// isDirty: true, dirtyFields: {}   <- inconsistent
```

In `_reset`, the `isDirty` emit already has a `keepValues` branch that recomputes from the kept values via `_getDirty()`, but the `dirtyFields` emit next to it doesn't and falls through to `{}`. I added the matching branch so `dirtyFields` is recomputed the same way. Added a test.