### PR TITLE
fix(useFormState): re-subscribe when control changes

### DIFF
--- a/src/__tests__/useFormState.test.tsx
+++ b/src/__tests__/useFormState.test.tsx
@@ -855,6 +855,42 @@ describe('useFormState', () => {
     });
   });
 
+  it('should re-subscribe when the control prop changes identity', async () => {
+    function Consumer({ control }: { control: Control<{ test: string }> }) {
+      const { isDirty } = useFormState({ control });
+      return <p>{isDirty ? 'dirty' : 'pristine'}</p>;
+    }
+
+    function App() {
+      const formA = useForm({ defaultValues: { test: '' } });
+      const formB = useForm({ defaultValues: { test: '' } });
+      const [active, setActive] = React.useState<'a' | 'b'>('a');
+
+      return (
+        <>
+          <input data-testid="inputA" {...formA.register('test')} />
+          <input data-testid="inputB" {...formB.register('test')} />
+          <button onClick={() => setActive('b')}>switch</button>
+          <Consumer control={active === 'a' ? formA.control : formB.control} />
+        </>
+      );
+    }
+
+    render(<App />);
+
+    expect(screen.getByText('pristine')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('switch'));
+
+    fireEvent.change(screen.getByTestId('inputB'), {
+      target: { value: 'changed' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('dirty')).toBeInTheDocument();
+    });
+  });
+
   describe('with Activity', () => {
     itWithActivity(
       'should resync isSubmitting after Activity restoration when a submit resolves while hidden',

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -98,7 +98,7 @@ export function useFormState<
       unsubscribe();
       snapshot(!disabled, getCurrentFormState);
     };
-  }, [name, disabled, exact, resyncIfNeeded, snapshot]);
+  }, [control, name, disabled, exact, resyncIfNeeded, snapshot]);
 
   React.useEffect(() => {
     _localProxyFormState.current.isValid && control._setValid(true);


### PR DESCRIPTION
## Summary

### Motivation

The `useIsomorphicLayoutEffect` that subscribes via `control._subscribe(...)` reads `control._formState` and `control._defaultValues` too, but `control` was missing from its dependency array. 
The sibling hook `useWatch` has the equivalent effect with `control` correctly included in its deps (`[control, exact, name, disabled, resyncIfNeeded, snapshot]`), so this was an asymmetry rather than an intentional omission.

### What I have done

- Added `control` to the effect's dependency array, so the hook re-subscribes when the `control` prop's identity changes instead of continuing to read from a stale `control` reference.

### Test Plans

- Added a regression test switching `useFormState`'s `control` prop mid-test and asserting the newly-active control's changes are observed. 
Confirmed it fails without the fix (reverted `control` from the deps array locally) and passes with it restored.
- `yarn test` — full suite passes (120 suites / 1293 tests).

