### PR TITLE
🐞 fix(unregister): stop stripping a kept value from the submit payload

### DIFF
--- a/src/__tests__/useForm/unregister.test.tsx
+++ b/src/__tests__/useForm/unregister.test.tsx
@@ -250,4 +250,50 @@ describe('unregister', () => {
 
     jest.useRealTimers();
   });
+
+  it('should keep submitting a value retained by keepValue after a disabled field is unregistered', async () => {
+    const onSubmit = jest.fn();
+
+    const App = () => {
+      const [show, setShow] = React.useState(true);
+      const { register, unregister, handleSubmit } = useForm<{
+        test: string;
+        firstName: string;
+      }>({
+        defaultValues: { test: 'kept', firstName: 'bill' },
+      });
+
+      return (
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {show && <input {...register('test', { disabled: true })} />}
+          <input {...register('firstName')} />
+          <button
+            type="button"
+            onClick={() => {
+              setShow(false);
+              unregister('test', { keepValue: true });
+            }}
+          >
+            hide
+          </button>
+          <button>submit</button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'hide' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'submit' }));
+    });
+
+    // The field is no longer registered, so it is no longer a disabled field
+    // and handleSubmit must stop stripping the value keepValue retained.
+    expect(onSubmit).toHaveBeenCalledWith(
+      { test: 'kept', firstName: 'bill' },
+      expect.any(Object),
+    );
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1558,6 +1558,9 @@ export function createFormControl<
     for (const fieldName of name ? convertToArrayPayload(name) : _names.mount) {
       _names.mount.delete(fieldName);
       _names.array.delete(fieldName);
+      // An unregistered field is no longer disabled, otherwise handleSubmit
+      // keeps stripping its value from the payload.
+      _names.disabled.delete(fieldName);
 
       if (!options.keepValue) {
         unset(_fields, fieldName);

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1558,8 +1558,6 @@ export function createFormControl<
     for (const fieldName of name ? convertToArrayPayload(name) : _names.mount) {
       _names.mount.delete(fieldName);
       _names.array.delete(fieldName);
-      // An unregistered field is no longer disabled, otherwise handleSubmit
-      // keeps stripping its value from the payload.
       _names.disabled.delete(fieldName);
 
       if (!options.keepValue) {


### PR DESCRIPTION
## Proposed Changes

`unregister()` forgets to remove the field name from `_names.disabled`.

`src/logic/createFormControl.ts:1558-1560` cleans up two of the three name sets a registered field can be in:

```ts
for (const fieldName of name ? convertToArrayPayload(name) : _names.mount) {
  _names.mount.delete(fieldName);
  _names.array.delete(fieldName);
```

`_names.disabled` is written by `_setDisabledField` (`createFormControl.ts:1593`) whenever a field is registered with `disabled: true`, and it is read by `handleSubmit` at `createFormControl.ts:1772-1776`, which unsets every name in that set from the payload:

```ts
if (_names.disabled.size) {
  for (const name of _names.disabled) {
    unset(fieldValues, name);
  }
}
```

So once a disabled field is unregistered, the name stays in `_names.disabled` forever and `handleSubmit` keeps stripping it. `unregister(name, { keepValue: true })` is documented to retain the value, and `getValues()` does return it, but the submit payload silently loses it. The two APIs disagree about the same value.

Repro: a conditionally rendered `register('test', { disabled: true })` input, hidden with `unregister('test', { keepValue: true })`, then submit.

```
getValues()      -> { test: 'kept', firstName: 'bill' }
handleSubmit arg -> { firstName: 'bill' }
```

An unregistered field is not a disabled field any more, so the fix is to drop the name from the set alongside the other two.

## How this was verified

Regression test added to `src/__tests__/useForm/unregister.test.tsx`.

With the fix, `pnpm test src/__tests__/useForm/unregister.test.tsx` is green (9/9).

Source fix reverted, test kept (`git show HEAD:src/logic/createFormControl.ts > src/logic/createFormControl.ts`):

```
  Object {
    "firstName": "bill",
-   "test": "kept",
  },

Tests: 1 failed, 8 passed, 9 total
```

Restored: 9/9 green again.

## Checks

- `pnpm test`: 120 suites, 1295 tests, 8 snapshots, all passing
- `pnpm type`: clean
- `pnpm test:type`: clean
- `pnpm lint`: 0 errors (562 pre-existing warnings, unchanged); the two changed files report nothing
- `prettier --check` on both changed files: clean
- `pnpm build:esm` and `pnpm build:modern`: clean

## Render count and size budgets

The change is confined to `unregister`, so there is no hot path cost, and I measured rather than assumed it.

Full Playwright suite against the built bundle: **90 passed, 0 failed**, which covers every `expectRenderCountInRange` and exact `#renderCount` gate in `e2e/`.

The tightest budget, `e2e/watchUseFieldArrayNested.spec.ts:168` (`34..37`), measured on a fresh dev server, three runs each:

| build | run 1 | run 2 | run 3 | budget |
|---|---|---|---|---|
| master `61cd8d1` | 36 | 36 | 36 | 34..37 |
| with this fix | 36 | 36 | 36 | 34..37 |

Bundlewatch budget is 14.0 kB on `dist/index.cjs.js`. Gzipped size goes from 13980 to 13984 bytes, so 4 bytes for the extra `delete` call, still inside the budget.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
