### PR TITLE
🐞 fix(getFieldState): read isValidating from the supplied form state

### DIFF
--- a/src/__tests__/useForm/getFieldState.test.tsx
+++ b/src/__tests__/useForm/getFieldState.test.tsx
@@ -520,6 +520,42 @@ describe('getFieldState', () => {
 
         expect(screen.getByText('error undefined')).toBeVisible();
       });
+
+      it('should display isValidating state', async () => {
+        const App = () => {
+          const { register, getFieldState, formState } = useForm({
+            mode: 'onChange',
+            defaultValues: {
+              test: '',
+            },
+          });
+
+          const { isValidating } = getFieldState('test', formState);
+
+          return (
+            <form>
+              <input
+                {...register('test', {
+                  validate: () =>
+                    new Promise((resolve) =>
+                      setTimeout(() => resolve(true), 10),
+                    ),
+                })}
+              />
+              <p>{isValidating ? 'validating' : 'idle'}</p>
+            </form>
+          );
+        };
+
+        render(<App />);
+
+        fireEvent.change(screen.getByRole('textbox'), {
+          target: { value: 'test' },
+        });
+
+        expect(await screen.findByText('validating')).toBeVisible();
+        expect(await screen.findByText('idle')).toBeVisible();
+      });
     });
 
     describe('when input is nested data type', () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1399,7 +1399,7 @@ export function createFormControl<
       invalid: !!error,
       isDirty: !!get(targetFormState.dirtyFields, name),
       error,
-      isValidating: !!get(_formState.validatingFields, name),
+      isValidating: !!get(targetFormState.validatingFields, name),
       isTouched: !!get(targetFormState.touchedFields, name),
     };
   };


### PR DESCRIPTION
## Proposed Changes

`getFieldState(name, formState)` accepts a form state object as its second argument so a consumer can read field state without having subscribed to the root `formState` first. Four of the five returned fields honour that argument:

```ts
const targetFormState = formState || _formState;
const error = get(targetFormState.errors, name);

return {
  invalid: !!error,
  isDirty: !!get(targetFormState.dirtyFields, name),
  error,
  isValidating: !!get(_formState.validatingFields, name), // <- reads internal state
  isTouched: !!get(targetFormState.touchedFields, name),
};
```

`isValidating` reads `_formState` directly instead of `targetFormState`.

The object passed in is a proxy built by `getProxyFormState`, and its getters are what flip `_proxyFormState` / the local subscribe state to `true`. Because `isValidating` never touches the proxy, no `validatingFields` subscription is ever registered. `_updateIsValidating` is gated behind `_isTracked('isValidating', 'validatingFields')`, so it never writes to `_formState.validatingFields` either, and `getFieldState(name, formState).isValidating` stays `false` for the whole lifetime of the form.

Reading from `targetFormState` fixes both halves: the read registers the subscription, which opens the `_updateIsValidating` gate and re-renders the consumer when validation starts and finishes. When no form state is passed, `targetFormState` is `_formState`, so the single-argument call site is unchanged.

Added a test in `src/__tests__/useForm/getFieldState.test.tsx` covering an async field validator. Without the fix it fails with the field stuck on `idle`:

```
● getFieldState › with form state and field name supplied › when input is primitive data type › should display isValidating state

  Unable to find an element with the text: validating.
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
