### PR TITLE
fix(useFieldArray): focus a checkbox or radio in the appended row

### DIFF
--- a/src/__tests__/useFieldArray/focus.test.tsx
+++ b/src/__tests__/useFieldArray/focus.test.tsx
@@ -217,4 +217,41 @@ describe('useFieldArray focus', () => {
 
     expect(document.activeElement).toEqual(screen.getAllByRole('textbox')[0]);
   });
+
+  it('should focus on a checkbox input of the appended field', () => {
+    const Component = () => {
+      const { register, control } = useForm<{
+        test: { checked: boolean }[];
+      }>({
+        defaultValues: {
+          test: [{ checked: false }],
+        },
+      });
+      const { fields, append } = useFieldArray({
+        name: 'test',
+        control,
+      });
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <input
+              key={field.id}
+              type="checkbox"
+              {...register(`test.${i}.checked` as const)}
+            />
+          ))}
+          <button type="button" onClick={() => append({ checked: false })}>
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button', { name: /append/i }));
+
+    expect(document.activeElement).toEqual(screen.getAllByRole('checkbox')[1]);
+  });
 });

--- a/src/logic/iterateFieldsByAction.ts
+++ b/src/logic/iterateFieldsByAction.ts
@@ -18,7 +18,7 @@ const iterateFieldsByAction = (
       const { _f } = field;
 
       if (_f) {
-        if (_f.refs && _f.refs[0] && action(_f.refs[0], key)) {
+        if (_f.refs && _f.refs[0] && action(_f.refs[0], _f.name)) {
           return true;
         } else if (_f.ref && action(_f.ref, _f.name)) {
           return true;


### PR DESCRIPTION
Appending to a field array never focuses a checkbox or a radio in the new row, so keyboard and screen-reader focus stays where it was.

`iterateFieldsByAction` passes `key`, the loop variable, to the action on line 21, while the sibling branch one line below passes `_f.name`. In recursive mode `key` is the local object key rather than the full path, so a checkbox registered as `test.1.checked` reaches the action as `"checked"`. `useFieldArray` then matches on `key.startsWith(control._names.focus)` with `_names.focus` set to `"test.1."`, which is false, and the fallback branch passes the right name but a `_f.ref` that is the synthetic `{ type, name }` object radio and checkbox fields get in `createFormControl`, with no `focus` method on it. Both branches miss and nothing is focused.

The fix makes line 21 symmetric with line 23.

This only affects the recursive callers. `_focusError` passes `_names.mount` and `trigger` passes `convertToArrayPayload(name)`, so in flat mode `key` is already the full name and error focus on a checkbox is unaffected; `_disableForm` recurses but its action always returns `undefined`, so it falls through to the correct name and disabling is unaffected.

- Added `should focus on a checkbox input of the appended field` to `src/__tests__/useFieldArray/focus.test.tsx`. It fails on current `master` with `document.activeElement` as `<body>`, and passes with the change. Full suite 1296 -> 1297, no other test moved.

One thing worth flagging: in flat mode the action now receives the registered name instead of the caller-supplied string. Those are the same string on every path in the repo, since the field is located with `get(fields, key)` and `register` stores `_f.name = name`, which is why nothing else moved. Happy to narrow it to the `refs` branch under a recursion flag if you would rather not change what `_focusError` and `trigger` see.