### PR TITLE
fix(validateField): stop calling setCustomValidity per key in validate-object mode

### DIFF
--- a/src/__tests__/logic/validateField.test.tsx
+++ b/src/__tests__/logic/validateField.test.tsx
@@ -2561,6 +2561,39 @@ describe('validateField', () => {
       expect(setCustomValidity).toHaveBeenLastCalledWith('');
       expect(reportValidity).toHaveBeenCalled();
     });
+
+    it('should not invoke setCustomValidity per key when collecting all criteria from a validate object', async () => {
+      const setCustomValidity = jest.fn();
+      const reportValidity = jest.fn();
+
+      await validateField(
+        {
+          _f: {
+            mount: true,
+            name: 'test',
+            ref: {
+              name: 'test',
+              setCustomValidity,
+              reportValidity,
+            },
+            validate: {
+              a: () => 'error A',
+              b: () => 'error B',
+              c: () => 'error C',
+            },
+          },
+        },
+        new Set(),
+        {
+          test: 'value',
+        },
+        true,
+        true,
+      );
+
+      expect(setCustomValidity).toHaveBeenCalledTimes(1);
+      expect(reportValidity).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should validate field array with required attribute', async () => {

--- a/src/logic/validateField.ts
+++ b/src/logic/validateField.ts
@@ -271,7 +271,9 @@ export default async <T extends FieldValues>(
             ...appendErrorsCurry(key, validateError.message),
           };
 
-          setCustomValidity(validateError.message);
+          if (!validateAllFieldCriteria) {
+            setCustomValidity(validateError.message);
+          }
 
           if (validateAllFieldCriteria) {
             error[name] = validationResult;


### PR DESCRIPTION
## Summary

### Motivation

When `validate` is an object, `setCustomValidity` was called once per failing key, not once overall.

For example, with `validate: { a, b, c }` all failing and `validateAllFieldCriteria: true`, the loop doesn't stop early:

- 3 calls inside the loop (one per failing key)
- 1 more call at the end of the function

That's **4 calls total instead of 1**.

So,  `setCustomValidity` also calls `reportValidity()` internally, the browser's native validation UI can flicker multiple times for a single validation pass.
The sibling `isFunction(validate)` branch only calls `setCustomValidity` when returning early (`!validateAllFieldCriteria`), so this was an inconsistency between the two branches rather than intentional behaviour.

### What I have done

- Wrapped the mid-loop `setCustomValidity` call in `!validateAllFieldCriteria`, matching the sibling branch. 
The final `setCustomValidity` call at the end of the function still sets the correct message in all cases.

### Test Plans

- Added a test asserting `setCustomValidity`/`reportValidity` are each called exactly once when `validateAllFieldCriteria: true` and three `validate` keys all fail. Confirmed it fails without the fix (4 calls instead of 1) and passes with it restored.