### PR TITLE
🐞 fix(reset): clear isValidating and validatingFields

### DIFF
--- a/src/__tests__/useForm/reset.test.tsx
+++ b/src/__tests__/useForm/reset.test.tsx
@@ -2288,4 +2288,135 @@ describe('reset', () => {
 
     jest.useRealTimers();
   });
+
+  it('should clear isValidating when reset is called while a validation is pending', async () => {
+    let resolveResolver: (() => void) | undefined;
+
+    const App = () => {
+      const [visible, setVisible] = React.useState(true);
+      const {
+        register,
+        reset,
+        formState: { isValid, isValidating, validatingFields },
+      } = useForm<{ test: string }>({
+        defaultValues: { test: '' },
+        resolver: async (values) => {
+          await new Promise<void>((resolve) => {
+            resolveResolver = resolve;
+          });
+          return { values, errors: {} };
+        },
+      });
+
+      return (
+        <div>
+          {visible && <input {...register('test')} />}
+          <p>{`valid:${isValid}`}</p>
+          <p>{`status:${isValidating ? 'validating' : 'idle'}`}</p>
+          <p>{`tracked:${Object.keys(validatingFields).join(',')}`}</p>
+          <button
+            type="button"
+            onClick={() => {
+              reset();
+              setVisible(false);
+            }}
+          >
+            reset
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      resolveResolver && resolveResolver();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'a' },
+      });
+    });
+
+    expect(screen.getByText(/^status:/).textContent).toEqual(
+      'status:validating',
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+
+    expect(screen.getByText(/^status:/).textContent).toEqual('status:idle');
+    expect(screen.getByText(/^tracked:/).textContent).toEqual('tracked:');
+
+    // The field is gone, so the in-flight resolver has no mounted name left to
+    // clear and cannot undo a stale flag on its own.
+    await act(async () => {
+      resolveResolver && resolveResolver();
+    });
+
+    expect(screen.getByText(/^status:/).textContent).toEqual('status:idle');
+    expect(screen.getByText(/^tracked:/).textContent).toEqual('tracked:');
+  });
+
+  it('should keep isValidating when reset is called with keepIsValidating option', async () => {
+    let resolveResolver: (() => void) | undefined;
+
+    const App = () => {
+      const [visible, setVisible] = React.useState(true);
+      const {
+        register,
+        reset,
+        formState: { isValid, isValidating, validatingFields },
+      } = useForm<{ test: string }>({
+        defaultValues: { test: '' },
+        resolver: async (values) => {
+          await new Promise<void>((resolve) => {
+            resolveResolver = resolve;
+          });
+          return { values, errors: {} };
+        },
+      });
+
+      return (
+        <div>
+          {visible && <input {...register('test')} />}
+          <p>{`valid:${isValid}`}</p>
+          <p>{`status:${isValidating ? 'validating' : 'idle'}`}</p>
+          <p>{`tracked:${Object.keys(validatingFields).join(',')}`}</p>
+          <button
+            type="button"
+            onClick={() => {
+              reset(undefined, { keepIsValidating: true });
+              setVisible(false);
+            }}
+          >
+            reset
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      resolveResolver && resolveResolver();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'a' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+
+    expect(screen.getByText(/^status:/).textContent).toEqual(
+      'status:validating',
+    );
+    expect(screen.getByText(/^tracked:/).textContent).toEqual('tracked:test');
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -2000,6 +2000,12 @@ export function createFormControl<
       touchedFields: keepStateOptions.keepTouched
         ? _formState.touchedFields
         : {},
+      validatingFields: keepStateOptions.keepIsValidating
+        ? _formState.validatingFields
+        : {},
+      isValidating: keepStateOptions.keepIsValidating
+        ? _formState.isValidating
+        : false,
       errors: keepStateOptions.keepErrors ? _formState.errors : {},
       isSubmitSuccessful: keepStateOptions.keepIsSubmitSuccessful
         ? _formState.isSubmitSuccessful


### PR DESCRIPTION
## Proposed Changes

`reset()` restores every form state slice except `validatingFields` / `isValidating`, and the `keepIsValidating` flag that `KeepStateOptions` advertises for `reset` is never read (only `unregister` honours it).

Most of the time this only shows up as a brief wrong reading, but with an async resolver it becomes permanent:

1. A form with an async `resolver` subscribes to `isValid` and `isValidating`.
2. The user types, which starts a schema run and marks the field as validating.
3. Before the run settles, the form is reset and the field goes away (dialog closed, wizard step changed, section hidden).
4. `_reset` replaces `_names.mount` with an empty set, so when the in-flight run finishes, `_updateIsValidating()` has no names left to unset.

`formState.isValidating` stays `true` and `formState.validatingFields` keeps the stale entry for the rest of the form's life, so anything gated on `isValidating` (a disabled submit button, a spinner) never recovers.

Root cause: `_reset`'s final state notification lists `touchedFields`, `errors`, `isSubmitting` and friends but omits `validatingFields` and `isValidating`, so nothing clears them and `keepIsValidating` has no effect.

The fix emits both from `_reset`, gated on `keepIsValidating` in the same shape as the neighbouring `keepTouched` / `keepErrors` entries.

## Tests

Two tests in `src/__tests__/useForm/reset.test.tsx`:

- `should clear isValidating when reset is called while a validation is pending` reproduces the scenario above and asserts the status paragraph reads `status:idle` and `validatingFields` is empty both right after the reset and after the in-flight resolver settles. Without the source change it fails with `Expected: "status:idle" / Received: "status:validating"`.
- `should keep isValidating when reset is called with keepIsValidating option` covers the other branch: the flag and the tracked field survive the reset.

Full suite (1300 tests), `tsc --noEmit`, eslint and prettier all pass.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
