### PR TITLE
fix(setError): types from a previous validation survive an overwrite

### DIFF
--- a/src/__tests__/useForm/setError.test.tsx
+++ b/src/__tests__/useForm/setError.test.tsx
@@ -12,7 +12,9 @@ import type {
   DeepMap,
   ErrorOption,
   FieldError,
+  FieldErrors,
   GlobalError,
+  UseFormSetError,
 } from '../../types';
 import { useForm } from '../../useForm';
 import { FormProvider, useFormContext } from '../../useFormContext';
@@ -262,6 +264,55 @@ describe('setError', () => {
         },
       },
     });
+  });
+
+  it('should replace types from a previous validation when overwriting an error', async () => {
+    type FormValues = { password: string };
+
+    let currentErrors: FieldErrors<FormValues> = {};
+    let setError: UseFormSetError<FormValues>;
+
+    const App = () => {
+      const form = useForm<FormValues>({
+        criteriaMode: 'all',
+        mode: 'onChange',
+      });
+
+      currentErrors = form.formState.errors;
+      setError = form.setError;
+
+      return (
+        <input
+          {...form.register('password', {
+            minLength: { value: 8, message: 'too short' },
+            pattern: { value: /[0-9]/, message: 'needs a digit' },
+          })}
+        />
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'abc' },
+      });
+    });
+
+    expect(currentErrors.password?.types).toEqual({
+      minLength: 'too short',
+      pattern: 'needs a digit',
+    });
+
+    await act(async () => {
+      setError('password', { type: 'server', message: 'breached password' });
+    });
+
+    // criteriaMode: 'all' consumers render from `types`, so keeping the previous
+    // validation's entries there shows resolved rules and hides the new error.
+    expect(currentErrors.password?.types).toBeUndefined();
+    expect(currentErrors.password?.type).toBe('server');
+    expect(currentErrors.password?.message).toBe('breached password');
   });
 });
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1440,7 +1440,13 @@ export function createFormControl<
     const ref = (get(_fields, name, { _f: {} })._f || {}).ref;
     const currentError = get(_formState.errors, name) || {};
 
-    const { ref: currentRef, message, type, ...restOfErrorTree } = currentError;
+    const {
+      ref: currentRef,
+      message,
+      type,
+      types,
+      ...restOfErrorTree
+    } = currentError;
 
     set(_formState.errors, name, {
       ...restOfErrorTree,


### PR DESCRIPTION
## Proposed Changes

`setError` leaves the previous validation's `types` on the error it just replaced. `type` and
`message` update, so the object looks right in a log, but under `criteriaMode: 'all'` it is `types`
that gets rendered.

`createFormControl.ts:1443` pulls three keys off the existing error before merging the new one on:

```ts
const { ref: currentRef, message, type, ...restOfErrorTree } = currentError;

set(_formState.errors, name, {
  ...restOfErrorTree,
  ...error,
  ref,
});
```

`FieldError` (`types/errors.ts:20`) declares `type`, `root`, `ref`, `types` and `message`, but the
object stored at a name also carries a key per nested field under it — `address` holds a `city`
alongside its own `type` and `message`. That is what `restOfErrorTree` is for. The destructure takes
out three of the keys belonging to the error itself and leaves the fourth, `types`, to ride along
with the nested ones:

```tsx
const { register, setError, formState: { errors } } = useForm<{ password: string }>({
  criteriaMode: 'all',
  mode: 'onChange',
});

register('password', {
  minLength: { value: 8, message: 'too short' },
  pattern: { value: /[0-9]/, message: 'needs a digit' },
});

// type 'abc'
//   -> types { minLength: 'too short', pattern: 'needs a digit' }
//
// setError('password', { type: 'server', message: 'breached password' })
//   -> type    'server'
//      message 'breached password'
//      types   { minLength: 'too short', pattern: 'needs a digit' }
```

A checklist rendered off `types` — which is the reason to turn `criteriaMode: 'all'` on at all —
therefore keeps listing rules the user has already satisfied and never shows the server error that
replaced them. Fixing the password to `abcd1234` doesn't clear them either, since nothing recomputes
those entries; they are just the last validation's output sitting where the new error should be.

The fix adds `types` to the destructure:

```diff
- const { ref: currentRef, message, type, ...restOfErrorTree } = currentError;
+ const {
+   ref: currentRef,
+   message,
+   type,
+   types,
+   ...restOfErrorTree
+ } = currentError;
```

Prettier splits the line at that width; the change itself is the one word. None of those names are
read — they are there to keep their keys out of `restOfErrorTree`, which is why the repo turns on
`ignoreRestSiblings` (`eslint.config.mjs:61`).

I read this as an omission rather than a decision because of the comment #11888 (`48f88228`) put on
the destructure when it added it, since removed in `cee92e2b`:

```
// Don't override existing error messages elsewhere in the object tree.
```

Those are the nested fields, and they still come through untouched — `address` keeps its `city` when
overwritten. `types` is not one of them; it belongs to the error being overwritten, so it should
leave with the other three.

The fix doesn't synthesise a replacement `types` either. `ErrorOption` (`types/errors.ts:28`) accepts
one, so a caller wanting the server error in the checklist passes it and the spread order puts it
last:

```ts
setError('password', {
  type: 'server',
  message: 'breached password',
  types: { server: 'breached password' },
});
```

That already worked before this change, since `...error` overwrites whatever `restOfErrorTree`
brought in. Only the case where the caller passes no `types` behaves differently.

`setError` is the only place that merges into an existing error. Every other write to
`_formState.errors` (`:328`, `:359`, `:601`, `:653`, `:790`) sets a freshly built object, and
`appendErrors` accumulates into a local owned by `validateField`, so there is no second site to
carry the same fix to.

Existing coverage misses this because `criteriaMode` did not appear once in `setError.test.tsx`
before this change, and the only other test in the repo that turns it on is in `useWatch.test.tsx`,
unrelated to `setError`. What #11888 was actually for is pinned at `:182` and `:224`, and both still
pass — overwriting a parent still keeps its nested errors.

No linked issue — found while reading `setError`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

Against unpatched source the new test fails with `{"minLength": "too short", "pattern": "needs a
digit"}` where `undefined` is expected. Full suite is 1303 passed / 120 suites, up from 1302 on
master. `pnpm test:type`, `pnpm lint` and `pnpm build` pass on Node 22 / pnpm 11, with the same 562
lint warnings as master and none in the touched files. Gzipped ESM goes from 27,830 to 27,833 bytes.