### PR TITLE
fix(iterateFieldsByAction): break out of every loop, not just one level

### DIFF
--- a/src/__tests__/logic/iterateFieldsByAction.test.ts
+++ b/src/__tests__/logic/iterateFieldsByAction.test.ts
@@ -203,4 +203,44 @@ describe('iterateFieldsByAction', () => {
     expect(notFocus).not.toHaveBeenCalledWith('phone'); // stopped
     expect(notFocus).not.toHaveBeenCalledWith('line1');
   });
+
+  it('should break out of all loops when the match is nested below a sibling top-level group', () => {
+    const focus = jest.fn();
+    const notFocus = jest.fn();
+    iterateFieldsByAction(
+      {
+        personal: {
+          name: {
+            last: {
+              _f: {
+                name: 'name.last',
+                ref: {
+                  name: 'last',
+                  focus,
+                },
+              },
+            },
+          },
+        },
+        work: {
+          email: {
+            _f: {
+              name: 'work.email',
+              ref: {
+                name: 'email',
+                focus: notFocus,
+              },
+            },
+          },
+        },
+      },
+      (ref, key) => {
+        // @ts-expect-error we want to test with what focus was called
+        ref.focus && ref.focus(ref.name);
+        return key === 'name.last' ? 1 : undefined;
+      },
+    );
+    expect(focus).toHaveBeenCalledWith('last');
+    expect(notFocus).not.toHaveBeenCalled();
+  });
 });

--- a/src/logic/iterateFieldsByAction.ts
+++ b/src/logic/iterateFieldsByAction.ts
@@ -24,12 +24,12 @@ const iterateFieldsByAction = (
           return true;
         } else {
           if (iterateFieldsByAction(field, action)) {
-            break;
+            return true;
           }
         }
       } else if (isObject(field) || Array.isArray(field)) {
         if (iterateFieldsByAction(field as FieldRefs, action)) {
-          break;
+          return true;
         }
       }
     }


### PR DESCRIPTION
`iterateFieldsByAction` stops one level short of where #11827 meant it to stop.

That PR set out, in its own words, to "recursively break out of all loops" once the action fires. A direct match does `return true` (`iterateFieldsByAction.ts:22,24`), but both recursive branches `break` instead (`:26` and `:31`), and the function then falls through to the bare `return;` at `:37`. The caller one level up gets `undefined`, reads it as "no match", and keeps iterating its remaining keys.

The existing test named "should recursively drill into objects and break out of all loops on first focus" passes only because its fixture has a single top-level key, so the dropped signal has no sibling left to leak into. Add a second top-level group and the symptom #11827 described comes back one level higher: the action fires on `name.last`, and then again on `work.email`.

The fix returns `true` where those two branches currently `break`.

- Added a case to `iterateFieldsByAction.test.ts` with two top-level groups. On `main` it fails with `Received number of calls: 1` against the second group's ref; it passes with the change, and the six existing cases in that file stay green.
- Full suite 120 suites / 1303 tests passing, `tsc --noEmit` and `eslint` both clean.

Worth flagging since it changes how you would weigh this: I could not reach the defect from a shipped call site. `_focusError` and `trigger` both pass `_names.mount`, a flat list of full paths, so neither takes the recursive branch, and `useFieldArray`'s focus action gates on a `name.` prefix that confines every match to a single subtree. So this reads as a latent correctness fix to the helper's contract rather than a user-visible bug today, and I would understand if you would rather it waited for a caller that needs it.