### PR TITLE
fix(unregister): recompute isValidating after clearing `validatingFields`

### DIFF
--- a/src/__tests__/useForm/unregister.test.tsx
+++ b/src/__tests__/useForm/unregister.test.tsx
@@ -296,4 +296,106 @@ describe('unregister', () => {
       expect.any(Object),
     );
   });
+
+  it('should recompute isValidating after unregistering a field with a pending validation', async () => {
+    let resolveValidate: (value: boolean) => void;
+
+    const App = () => {
+      const {
+        register,
+        unregister,
+        formState: { isValidating, validatingFields },
+      } = useForm<{ test: string }>({ mode: 'onChange' });
+
+      return (
+        <div>
+          <input
+            {...register('test', {
+              validate: () =>
+                new Promise<boolean>((resolve) => {
+                  resolveValidate = resolve;
+                }),
+            })}
+          />
+          <p>status:{isValidating ? 'validating' : 'idle'}</p>
+          <p>validatingFields:{Object.keys(validatingFields).join(',')}</p>
+          <button type="button" onClick={() => unregister('test')}>
+            unregister
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'x' },
+    });
+
+    await waitFor(() => screen.getByText('status:validating'));
+    expect(screen.getByText('validatingFields:test')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'unregister' }));
+
+    expect(screen.getByText('status:idle')).toBeInTheDocument();
+    expect(screen.getByText('validatingFields:')).toBeInTheDocument();
+
+    // the stale in-flight validator from before unregister finally settles
+    await act(async () => {
+      resolveValidate(true);
+    });
+
+    expect(screen.getByText('status:idle')).toBeInTheDocument();
+    expect(screen.getByText('validatingFields:')).toBeInTheDocument();
+  });
+
+  it('should keep isValidating when unregister is called with keepIsValidating option', async () => {
+    let resolveValidate: (value: boolean) => void;
+
+    const App = () => {
+      const {
+        register,
+        unregister,
+        formState: { isValidating, validatingFields },
+      } = useForm<{ test: string }>({ mode: 'onChange' });
+
+      return (
+        <div>
+          <input
+            {...register('test', {
+              validate: () =>
+                new Promise<boolean>((resolve) => {
+                  resolveValidate = resolve;
+                }),
+            })}
+          />
+          <p>status:{isValidating ? 'validating' : 'idle'}</p>
+          <p>validatingFields:{Object.keys(validatingFields).join(',')}</p>
+          <button
+            type="button"
+            onClick={() => unregister('test', { keepIsValidating: true })}
+          >
+            unregister
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'x' },
+    });
+
+    await waitFor(() => screen.getByText('status:validating'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'unregister' }));
+
+    expect(screen.getByText('status:validating')).toBeInTheDocument();
+    expect(screen.getByText('validatingFields:test')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveValidate(true);
+    });
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1601,6 +1601,9 @@ export function createFormControl<
     _subjects.state.next({
       ..._formState,
       ...(options.keepDirty ? {} : { isDirty: _getDirty() }),
+      ...(options.keepIsValidating
+        ? {}
+        : { isValidating: !isEmptyObject(_formState.validatingFields) }),
     });
 
     !options.keepIsValid && _setValid();


### PR DESCRIPTION
## Summary

### Motivation

`unregister` clears `validatingFields` but never recomputed `isValidating`. 
Unregistering a field mid-validation could leave `isValidating` stuck  type`true` forever.

For example, 

```
a dynamic form (`useFieldArray`, or a field conditionally shown/hidden) has a field with an async `validate` (e.g. a server-sideduplicate-email check). 
The user types, validation starts (`isValidating: true`), then the row is removed before the response comes back. `isValidating` stays stuck `true` forever — a submit button gated on it never re-enables, or a loading spinner never goes away.
```


### What I have done

After clearing `validatingFields`, recompute `isValidating` in the same call, gated on `keepIsValidating`. 
Same pattern as the existing `keepDirty`/`isDirty` override right above it.

### Test Plans

- Added two tests: one reproduces the stuck `isValidating` (fails without the fix, passes with it), one covers `keepIsValidating`. 
- Full suite passes (1306 tests).
