### PR TITLE
fix: keep FileList intact in flatten, expand it in jsonToFormData, skip undefined

### DIFF
--- a/src/__tests__/utils/flatten.test.ts
+++ b/src/__tests__/utils/flatten.test.ts
@@ -66,4 +66,17 @@ describe('flatten', () => {
       'attachments.0': second,
     });
   });
+
+  it('should preserve FileList values as leaf nodes and not split them', () => {
+    const fileList = Object.create(FileList.prototype) as FileList;
+    const file = new File(['1'], 'first.pdf');
+
+    Object.defineProperty(fileList, 0, { value: file, enumerable: true });
+    Object.defineProperty(fileList, 'length', { value: 1 });
+
+    expect(flatten({ name: 'Alice', attachments: fileList })).toEqual({
+      name: 'Alice',
+      attachments: fileList,
+    });
+  });
 });

--- a/src/__tests__/utils/formData.test.ts
+++ b/src/__tests__/utils/formData.test.ts
@@ -1,0 +1,36 @@
+import { jsonToFormData } from '../../utils/formData';
+
+const createFileList = (files: File[]) => {
+  const fileList = Object.create(FileList.prototype) as FileList;
+
+  files.forEach((file, index) => {
+    Object.defineProperty(fileList, index, { value: file, enumerable: true });
+  });
+  Object.defineProperty(fileList, 'length', { value: files.length });
+
+  return fileList;
+};
+
+describe('jsonToFormData', () => {
+  it('should skip undefined values instead of stringifying them', () => {
+    const formData = jsonToFormData({ name: 'bill', nick: undefined });
+
+    expect(formData.get('name')).toBe('bill');
+    expect(formData.has('nick')).toBe(false);
+  });
+
+  it('should submit FileList values under their field name', () => {
+    const resume = createFileList([
+      new File(['a'], 'a.txt'),
+      new File(['b'], 'b.txt'),
+    ]);
+
+    const formData = jsonToFormData({
+      name: 'bill',
+      resume,
+    });
+
+    expect(formData.get('name')).toBe('bill');
+    expect(formData.getAll('resume')).toHaveLength(2);
+  });
+});

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -7,6 +7,9 @@ const isFileLike = (value: unknown) =>
   (typeof Blob !== 'undefined' && value instanceof Blob) ||
   (typeof File !== 'undefined' && value instanceof File);
 
+const isFileListLike = (value: unknown) =>
+  typeof FileList !== 'undefined' && value instanceof FileList;
+
 export const flatten = (obj: FieldValues) => {
   const output: FieldValues = {};
 
@@ -15,7 +18,8 @@ export const flatten = (obj: FieldValues) => {
       isObjectType(obj[key]) &&
       obj[key] !== null &&
       !isDateObject(obj[key]) &&
-      !isFileLike(obj[key])
+      !isFileLike(obj[key]) &&
+      !isFileListLike(obj[key])
     ) {
       const nested = flatten(obj[key]);
 

--- a/src/utils/formData.ts
+++ b/src/utils/formData.ts
@@ -1,4 +1,5 @@
 import { flatten } from './flatten';
+import isUndefined from './isUndefined';
 
 function jsonToFormData(json: any) {
   const result = new FormData();
@@ -6,7 +7,23 @@ function jsonToFormData(json: any) {
   const flattenFormValues = flatten(json);
 
   for (const key in flattenFormValues) {
-    result.append(key, flattenFormValues[key]);
+    const value = flattenFormValues[key];
+
+    if (isUndefined(value)) {
+      continue;
+    }
+
+    if (typeof FileList !== 'undefined' && value instanceof FileList) {
+      for (let index = 0; index < value.length; index++) {
+        const file = value[index];
+
+        file && result.append(key, file);
+      }
+
+      continue;
+    }
+
+    result.append(key, value);
   }
 
   return result;


### PR DESCRIPTION
Fixes #13724.

- `flatten()` now treats `FileList` as a leaf (same guard #13652 added for `File`/`Blob`), so file fields are no longer split into `field.0` keys.
- `jsonToFormData()` appends each file in a `FileList` under its own field name (matching native form submission) and skips `undefined` values instead of stringifying them.

Verified: new tests in `flatten.test.ts`/`formData.test.ts` fail on master (3 failures) and pass with the fix; neighbor suites (`form.test.tsx`, `extractFormValues`) pass, `tsc --noEmit` and `eslint` are clean.