### PR TITLE
fix(schemaErrorLookup): don't report nested containers as exact-name errors

### DIFF
--- a/src/__tests__/logic/schemaErrorLookup.test.ts
+++ b/src/__tests__/logic/schemaErrorLookup.test.ts
@@ -279,4 +279,43 @@ describe('errorsLookup', () => {
       name: 'test.0.nested.0.deepNested',
     });
   });
+
+  it('should not report a nested error container as the exact-name field error', () => {
+    expect(
+      schemaErrorLookup<{ test: { nested: string } }>(
+        {
+          test: {
+            nested: {
+              type: 'nested',
+              message: 'error',
+            },
+          },
+        } as never,
+        {},
+        'test',
+      ),
+    ).toEqual({
+      name: 'test',
+    });
+  });
+
+  it('should resolve an exact-name root error to the .root path', () => {
+    expect(
+      schemaErrorLookup<{ test: string[] }>(
+        {
+          test: {
+            root: {
+              type: 'minLength',
+              message: 'too few',
+            },
+          },
+        } as never,
+        {},
+        'test',
+      ),
+    ).toEqual({
+      error: { type: 'minLength', message: 'too few' },
+      name: 'test.root',
+    });
+  });
 });

--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -1313,4 +1313,47 @@ describe('trigger', () => {
       expect(triggerErrors?.items?.root).toBeUndefined();
     });
   });
+
+  it('should not set a parent error when only nested resolver errors exist', async () => {
+    type FormValues = {
+      test: string;
+    };
+
+    let triggerErrors: FieldErrors<FormValues> | undefined;
+
+    const resolver: Resolver<FormValues> = async () => ({
+      values: {},
+      errors: {
+        test: {
+          nested: {
+            type: 'nested',
+            message: 'nested bad',
+          },
+        },
+      } as never,
+    });
+
+    const App = () => {
+      const {
+        register,
+        formState: { errors },
+      } = useForm<FormValues>({ mode: VALIDATION_MODE.onChange, resolver });
+
+      triggerErrors = errors;
+
+      return <input {...register('test')} />;
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'hello' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(triggerErrors?.test).toBeUndefined();
+    });
+  });
 });

--- a/src/logic/schemaErrorLookup.ts
+++ b/src/logic/schemaErrorLookup.ts
@@ -1,6 +1,5 @@
 import type { FieldError, FieldErrors, FieldValues } from '../types';
 import get from '../utils/get';
-import isKey from '../utils/isKey';
 
 export default function schemaErrorLookup<T extends FieldValues = FieldValues>(
   errors: FieldErrors<T>,
@@ -12,7 +11,7 @@ export default function schemaErrorLookup<T extends FieldValues = FieldValues>(
 } {
   const error = get(errors, name);
 
-  if (error || isKey(name)) {
+  if (error?.type || error?.message || Array.isArray(error)) {
     return {
       error,
       name,


### PR DESCRIPTION
Fixes #13726.

Exact-name lookup returned any truthy object as the field's error, so a resolver with only nested errors (e.g. `{ test: { nested: {...} } }`) polluted `formState.errors.test` with a typeless container, and exact-name root errors never resolved to `test.root`. Now only `type`/`message` hits (or arrays) return early; containers fall through to the existing walk.

Verified: 3 new tests fail on master and pass with the fix; full suite 1316/1316 green, `tsc --noEmit` and eslint clean.