### PR TITLE
fix: initialize useWatch compute cache with the initial output

### DIFF
--- a/e2e/useFieldArrayUnregister.spec.ts
+++ b/e2e/useFieldArrayUnregister.spec.ts
@@ -128,6 +128,14 @@ test.describe('useFieldArrayUnregister', () => {
 
     await page.locator('#move').click();
 
+    // Let the field-array reorder settle before clearing the moved input.
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        }),
+    );
+
     await page.locator('input[name="data.2.name"]').clear();
     await type(page.locator('input[name="data.2.name"]'), 'bill');
 

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -7,6 +7,13 @@ import { expect, type Locator } from '@playwright/test';
  * the end first makes repeated typing into the same field append correctly.
  */
 export async function type(locator: Locator, text: string) {
+  // Let pending render and error-focus effects finish before taking focus.
+  await locator.page().evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      }),
+  );
   await locator.focus();
   await locator.press('End');
   await locator.pressSequentially(text);

--- a/src/__tests__/useWatch.test.tsx
+++ b/src/__tests__/useWatch.test.tsx
@@ -2214,6 +2214,45 @@ describe('useWatch', () => {
   });
 
   describe('compute ', () => {
+    it('should update to undefined on the first computed value change', () => {
+      const Form = () => {
+        const { control, register } = useForm({
+          defaultValues: { test: 'initial' },
+        });
+        const value = useWatch({
+          control,
+          name: 'test',
+          compute: (text) => text || undefined,
+        });
+
+        return (
+          <>
+            <input {...register('test')} />
+            <p>{value === undefined ? 'empty' : value}</p>
+          </>
+        );
+      };
+
+      render(<Form />);
+      expect(screen.getByText('initial')).toBeVisible();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '' },
+      });
+
+      expect(screen.getByText('empty')).toBeVisible();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'updated' },
+      });
+      expect(screen.getByText('updated')).toBeVisible();
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '' },
+      });
+      expect(screen.getByText('empty')).toBeVisible();
+    });
+
     it('should only update when value changed within compute', () => {
       type FormValue = {
         test: string;
@@ -2258,7 +2297,7 @@ describe('useWatch', () => {
 
       screen.getByText('yes');
 
-      expect(renderCount).toEqual(4);
+      expect(renderCount).toEqual(3);
 
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: '12' },
@@ -2266,7 +2305,7 @@ describe('useWatch', () => {
 
       screen.getByText('no');
 
-      expect(renderCount).toEqual(5);
+      expect(renderCount).toEqual(4);
 
       fireEvent.change(screen.getByRole('textbox'), {
         target: { value: '1' },
@@ -2274,7 +2313,7 @@ describe('useWatch', () => {
 
       screen.getByText('no');
 
-      expect(renderCount).toEqual(5);
+      expect(renderCount).toEqual(4);
     });
   });
 });

--- a/src/useWatch.ts
+++ b/src/useWatch.ts
@@ -131,7 +131,6 @@ export function useWatch<TFieldValues extends FieldValues>(
   } = props || {};
   const _defaultValue = React.useRef(defaultValue);
   const _compute = React.useRef(compute);
-  const _computeFormValues = React.useRef<undefined | unknown>(undefined);
 
   const _prevControl = React.useRef(control);
   const _prevName = React.useRef(name);
@@ -148,6 +147,7 @@ export function useWatch<TFieldValues extends FieldValues>(
   };
 
   const [value, updateValue] = React.useState(getInitialOutput);
+  const _computeFormValues = React.useRef<unknown>(value);
 
   const getCurrentOutput = React.useCallback(
     (values?: TFieldValues) => {


### PR DESCRIPTION
## Proposed Changes

When a `useWatch` computation initially returns a defined value and its first update returns `undefined`, the hook keeps returning the initial value. For example, with `defaultValues: { text: 'initial' }` and `compute: text => text || undefined`, clearing the input leaves the watched output at `'initial'`.

The state contains the initial computed output, but the comparison ref starts at `undefined`. The first computed `undefined` therefore compares equal to the ref and skips the state update.

Initialize the comparison ref from the initial state value. Add a regression test covering clearing the field, entering another value, and clearing it again. Update the existing render-count assertions because an unchanged first computation now avoids an unnecessary render.

The problem also reproduces with the published `react-hook-form@7.87.0` package, with and without StrictMode. No public API or dependency changes are needed.

Synchronize E2E interactions with the next animation frame before typing and after the field-array move. This addresses local timing failures involving render and delayed focus updates without changing assertions or enabling retries.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Validation

All 1,347 unit tests, type checks, type tests, lint, build, and API extraction pass locally. The new regression test fails before the fix and passes afterward.

All 90 E2E tests pass locally with `pnpm e2e --workers=2 --retries=0`.