### PR TITLE
fix: remove() leaves an empty touchedFields entry after its last row is removed

### DIFF
--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -427,7 +427,51 @@ describe('remove', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'remove all' }));
 
-    expect(touched).toEqual({ test: [] });
+    expect(touched).toEqual({});
+  });
+
+  it('should drop the touched entry once its last touched row is removed', () => {
+    let touched: any;
+    let isTouched: boolean | undefined;
+
+    const Component = () => {
+      const { register, formState, control, getFieldState } = useForm({
+        defaultValues: {
+          test: [{ value: 'a' }, { value: 'b' }],
+        },
+      });
+      const { fields, remove } = useFieldArray({
+        control,
+        name: 'test',
+      });
+
+      touched = formState.touchedFields;
+      isTouched = getFieldState('test', formState).isTouched;
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`test.${i}.value`)} />
+          ))}
+          <button type="button" onClick={() => remove(0)}>
+            remove
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.blur(screen.getAllByRole('textbox')[0]);
+
+    expect(touched).toEqual({
+      test: [{ value: true }],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+    expect(touched).toEqual({});
+    expect(isTouched).toBe(false);
   });
 
   it('should remove specific field if isValid is true', async () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -338,6 +338,7 @@ export function createFormControl<
       ) {
         const touchedFields = method(touchedFieldsArray, args.argA, args.argB);
         shouldSetValues && set(_formState.touchedFields, name, touchedFields);
+        unsetEmptyArray(_formState.touchedFields, name);
       }
 
       if (_isTracked('dirtyFields')) {


### PR DESCRIPTION
Blur an input inside a field array, then remove the row(s) so no touched row is left.
`formState.touchedFields` keeps a `{ items: [] }` ghost and `getFieldState('items').isTouched`
stays `true`, even though nothing is touched anymore.

Repro: two-row array, blur row 0, `remove(0)` (or blur both rows and `remove()`).
Before: `touchedFields` is `{ test: [] }`. After: `{}`, matching what `errors` already
does via `unsetEmptyArray` and what a fresh form reports.

The fix is one line in `_setFieldArray`: run the same `unsetEmptyArray` cleanup for
`touchedFields` that already exists for `errors` right above it.

Verification: full jest suite passes (122 suites / 1347 tests), `tsc` typetests pass,
eslint and prettier clean. Added a regression test in
`src/__tests__/useFieldArray/remove.test.tsx` and updated the old `{ test: [] }`
expectation to `{}`.