### PR TITLE
fix: don't set parent error when trigger target has only nested errors

### DIFF
--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -1356,4 +1356,53 @@ describe('trigger', () => {
       expect(triggerErrors?.test).toBeUndefined();
     });
   });
+
+  it('should not set a parent error when trigger targets a field with only nested resolver errors', async () => {
+    type FormValues = {
+      test: string;
+    };
+
+    let triggerErrors: FieldErrors<FormValues> | undefined;
+
+    const resolver: Resolver<FormValues> = async () => ({
+      values: {},
+      errors: {
+        test: {
+          nested: {
+            type: 'nested',
+            message: 'nested bad',
+          },
+        },
+      } as never,
+    });
+
+    const App = () => {
+      const {
+        register,
+        trigger,
+        formState: { errors },
+      } = useForm<FormValues>({ resolver });
+
+      triggerErrors = errors;
+
+      return (
+        <>
+          <input {...register('test')} />
+          <button type="button" onClick={() => trigger('test')}>
+            trigger
+          </button>
+        </>
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+    });
+
+    await waitFor(() => {
+      expect(triggerErrors?.test).toBeUndefined();
+    });
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -648,17 +648,20 @@ export function createFormControl<
       for (const name of names) {
         const error = get(errors, name);
         cancelDelayedError(name);
-        error
-          ? _names.array.has(name) &&
-            isObject(error) &&
-            !Object.keys(error).some((key) => !Number.isNaN(Number(key)))
-            ? updateFieldArrayRootError(
-                _formState.errors,
-                { [name]: error } as Partial<Record<string, FieldError>>,
-                name,
-              )
-            : set(_formState.errors, name, error)
-          : unset(_formState.errors, name);
+        const isFieldArrayRootError =
+          _names.array.has(name) &&
+          isObject(error) &&
+          !Object.keys(error).some((key) => !Number.isNaN(Number(key)));
+
+        isFieldArrayRootError
+          ? updateFieldArrayRootError(
+              _formState.errors,
+              { [name]: error } as Partial<Record<string, FieldError>>,
+              name,
+            )
+          : error?.type || error?.message || Array.isArray(error)
+            ? set(_formState.errors, name, error)
+            : unset(_formState.errors, name);
       }
       _formState.errors = { ..._formState.errors };
     } else {


### PR DESCRIPTION
When a resolver returns errors only below a field (e.g. `{ test: { nested: {...} } }`), calling `trigger('test')` sets the whole container object as `errors.test`, even though it has no `type`/`message`. Same class of bug as #13727, but in the `executeSchemaAndUpdateState` path that `trigger()` uses.

The fix only sets the error when it has a `type`/`message` (or is an array, for field-array value errors) and unsets otherwise, mirroring #13727.

Repro: new test in `trigger.test.tsx` — resolver returns only a nested error for `test`, `trigger('test')` is clicked, `errors.test` must stay `undefined`. Fails before, passes after. Full suite 1347/1347 green, `tsc` and eslint clean.
