### PR TITLE
fix: keep resolver root errors on submit

### DIFF
--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -659,4 +659,70 @@ describe('handleSubmit', () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
   });
+
+  it('should not invoke onValid when the resolver reports a root-level error', async () => {
+    const { result } = renderHook(() =>
+      useForm<{ test: string }>({
+        resolver: async () => ({
+          values: {},
+          errors: {
+            root: {
+              type: 'cross-field',
+              message: 'passwords do not match',
+            },
+          },
+        }),
+      }),
+    );
+
+    result.current.register('test');
+
+    const onValid = jest.fn();
+    const onInvalid = jest.fn();
+
+    await act(async () => {
+      await result.current.handleSubmit(
+        onValid,
+        onInvalid,
+      )({
+        preventDefault: noop,
+        persist: noop,
+      } as React.SyntheticEvent);
+    });
+
+    expect(onValid).not.toHaveBeenCalled();
+    expect(onInvalid).toHaveBeenCalledTimes(1);
+    expect(onInvalid.mock.calls[0][0]).toEqual({
+      root: {
+        type: 'cross-field',
+        message: 'passwords do not match',
+      },
+    });
+  });
+
+  it('should still clear a manually set root error on submit without a resolver', async () => {
+    const { result } = renderHook(() => useForm<{ test: string }>());
+
+    result.current.register('test');
+    result.current.setValue('test', 'test');
+
+    await act(async () => {
+      result.current.setError('root.server', {
+        type: 'server',
+        message: 'stale server error',
+      });
+    });
+
+    const onValid = jest.fn();
+
+    await act(async () => {
+      await result.current.handleSubmit(onValid)({
+        preventDefault: noop,
+        persist: noop,
+      } as React.SyntheticEvent);
+    });
+
+    expect(onValid).toHaveBeenCalledTimes(1);
+    expect(result.current.getFieldState('test').error).toBeUndefined();
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1798,6 +1798,8 @@ export function createFormControl<
           fields: _fields,
           eventType: EVENTS.SUBMIT,
         });
+
+        unset(_formState.errors, ROOT_ERROR_TYPE);
       }
 
       if (_names.disabled.size) {
@@ -1805,8 +1807,6 @@ export function createFormControl<
           unset(fieldValues, name);
         }
       }
-
-      unset(_formState.errors, ROOT_ERROR_TYPE);
 
       if (isEmptyObject(_formState.errors)) {
         _subjects.state.next({


### PR DESCRIPTION
handleSubmit deletes the top-level root error before checking validity, so a resolver reporting a form-level error (for example a cross-field check as errors.root) still submits as valid.

Repro: useForm with a resolver returning { values: {}, errors: { root: { type: 'cross-field', message: '...' } } }. Before this change onValid is called; after, onInvalid is called with the root error intact.

The root cleanup now only runs for built-in validation, where no validation step produces root errors and it clears stale manually set ones (covered by a second test). No behavior change there.

Verification: new tests in handleSubmit.test.tsx fail before and pass after; full jest suite 122 suites / 1348 tests green, tsc and eslint clean.