### PR TITLE
fix(trigger): keep registered nested errors when trigger targets their parent

### DIFF
--- a/src/__tests__/useForm/trigger.test.tsx
+++ b/src/__tests__/useForm/trigger.test.tsx
@@ -1405,4 +1405,63 @@ describe('trigger', () => {
       expect(triggerErrors?.test).toBeUndefined();
     });
   });
+
+  it('should keep registered nested resolver errors when trigger targets their parent', async () => {
+    type FormValues = {
+      address: {
+        street: string;
+      };
+    };
+
+    let triggerErrors: FieldErrors<FormValues> | undefined;
+    let triggerResult: boolean | undefined;
+
+    const resolver: Resolver<FormValues> = async () => ({
+      values: {},
+      errors: {
+        address: {
+          street: {
+            type: 'required',
+            message: 'street_required',
+          },
+        },
+      },
+    });
+
+    const App = () => {
+      const {
+        register,
+        trigger,
+        formState: { errors },
+      } = useForm<FormValues>({ resolver });
+
+      triggerErrors = errors;
+
+      return (
+        <>
+          <input {...register('address.street')} />
+          <button
+            type="button"
+            onClick={async () => {
+              triggerResult = await trigger('address');
+            }}
+          >
+            trigger
+          </button>
+        </>
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+    });
+
+    await waitFor(() => {
+      expect(triggerResult).toBe(false);
+    });
+
+    expect(triggerErrors?.address?.street?.message).toBe('street_required');
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -652,6 +652,9 @@ export function createFormControl<
           _names.array.has(name) &&
           isObject(error) &&
           !Object.keys(error).some((key) => !Number.isNaN(Number(key)));
+        const field = get(_fields, name);
+        const hasNestedFields =
+          isObject(field) && Object.keys(field).some((key) => key !== '_f');
 
         isFieldArrayRootError
           ? updateFieldArrayRootError(
@@ -659,7 +662,10 @@ export function createFormControl<
               { [name]: error } as Partial<Record<string, FieldError>>,
               name,
             )
-          : error?.type || error?.message || Array.isArray(error)
+          : error?.type ||
+              error?.message ||
+              Array.isArray(error) ||
+              (isObject(error) && hasNestedFields)
             ? set(_formState.errors, name, error)
             : unset(_formState.errors, name);
       }


### PR DESCRIPTION
Triggering a parent name (e.g. trigger('address')) with a resolver wiped that whole error subtree from form state, even when nested fields like address.street were registered and invalid. Trigger returned false while errors showed nothing, so no message could render.

This keeps the previous orphan-container fix intact: the parent container is only skipped when no registered field exists beneath it.