### PR TITLE
fix(handleSubmit): ignore stale resolver result after reset

### DIFF
--- a/src/__tests__/useForm/handleSubmit.test.tsx
+++ b/src/__tests__/useForm/handleSubmit.test.tsx
@@ -725,4 +725,86 @@ describe('handleSubmit', () => {
     expect(onValid).toHaveBeenCalledTimes(1);
     expect(result.current.getFieldState('test').error).toBeUndefined();
   });
+
+  it('should ignore a stale resolver result when reset() runs mid-submit', async () => {
+    let resolveResolver!: (v: { errors: any; values: any }) => void;
+    const resolver = jest.fn(
+      () =>
+        new Promise<{ errors: any; values: any }>((resolve) => {
+          resolveResolver = resolve;
+        }),
+    );
+    const { result } = renderHook(() =>
+      useForm({ defaultValues: { test: 'before' }, resolver }),
+    );
+
+    const onValid = jest.fn();
+    const onInvalid = jest.fn();
+
+    let submitPromise: Promise<unknown>;
+    act(() => {
+      submitPromise = result.current.handleSubmit(
+        onValid,
+        onInvalid,
+      )({
+        preventDefault: noop,
+        persist: noop,
+      } as React.SyntheticEvent);
+    });
+
+    act(() => {
+      result.current.reset({ test: 'after' });
+    });
+
+    await act(async () => {
+      resolveResolver({
+        errors: { test: { type: 'validate', message: 'stale' } },
+        values: { test: 'before' },
+      });
+      await submitPromise;
+    });
+
+    expect(onValid).not.toHaveBeenCalled();
+    expect(onInvalid).not.toHaveBeenCalled();
+    expect(result.current.formState.errors).toEqual({});
+    expect(result.current.formState.submitCount).toBe(0);
+    expect(result.current.formState.isSubmitted).toBe(false);
+    expect(result.current.getValues()).toEqual({ test: 'after' });
+  });
+
+  it('should not invoke onValid with stale values when reset() runs mid-submit', async () => {
+    let resolveResolver!: (v: { errors: any; values: any }) => void;
+    const resolver = jest.fn(
+      () =>
+        new Promise<{ errors: any; values: any }>((resolve) => {
+          resolveResolver = resolve;
+        }),
+    );
+    const { result } = renderHook(() =>
+      useForm({ defaultValues: { test: 'before' }, resolver }),
+    );
+
+    const onValid = jest.fn();
+
+    let submitPromise: Promise<unknown>;
+    act(() => {
+      submitPromise = result.current.handleSubmit(onValid)({
+        preventDefault: noop,
+        persist: noop,
+      } as React.SyntheticEvent);
+    });
+
+    act(() => {
+      result.current.reset({ test: 'after' });
+    });
+
+    await act(async () => {
+      resolveResolver({ errors: {}, values: { test: 'before' } });
+      await submitPromise;
+    });
+
+    expect(onValid).not.toHaveBeenCalled();
+    expect(result.current.formState.submitCount).toBe(0);
+    expect(result.current.formState.isSubmitSuccessful).toBe(false);
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1797,7 +1797,13 @@ export function createFormControl<
       });
 
       if (_options.resolver) {
+        const resetCallId = _resetCallId;
         const { errors, values } = await _runSchema();
+
+        if (resetCallId !== _resetCallId) {
+          return;
+        }
+
         _updateIsValidating();
         Object.keys(delayErrorCallbacks).forEach(cancelDelayedError);
         _formState.errors = errors;


### PR DESCRIPTION
With an async resolver, if reset() runs while a submit is waiting on the resolver, the stale result was still applied: old errors written back into form state and onValid called with values from before the reset.

This guards the resolver branch in handleSubmit with the same reset check trigger() already uses, so a mid-submit reset wins and the stale submission is dropped.