### PR TITLE
fix: drop errors and touched state for rows removed by replace()

### DIFF
--- a/src/__tests__/useFieldArray/replace.test.tsx
+++ b/src/__tests__/useFieldArray/replace.test.tsx
@@ -259,6 +259,105 @@ describe('replace', () => {
     expect(await screen.findByText('This is required')).toBeVisible();
   });
 
+  it('should drop errors for rows removed by replace', async () => {
+    let errorsSnapshot: unknown;
+
+    const App = () => {
+      const {
+        register,
+        control,
+        trigger,
+        formState: { errors },
+      } = useForm({
+        defaultValues: {
+          test: [{ value: '' }, { value: '' }, { value: '' }],
+        },
+      });
+      const { fields, replace } = useFieldArray({
+        control,
+        name: 'test',
+      });
+
+      errorsSnapshot = errors;
+
+      React.useEffect(() => {
+        trigger();
+      }, [trigger]);
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <div key={field.id}>
+              <input
+                {...register(`test.${i}.value` as const, {
+                  required: 'This is required',
+                })}
+              />
+              <p>{errors?.test?.[i]?.value?.message as string}</p>
+            </div>
+          ))}
+          <button type={'button'} onClick={() => replace([{ value: 'valid' }])}>
+            replace
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    expect(await screen.findAllByText('This is required')).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect((errorsSnapshot as { test?: unknown[] })?.test).toHaveLength(1);
+    });
+  });
+
+  it('should drop touched state for rows removed by replace', () => {
+    let touched: unknown;
+
+    const Component = () => {
+      const { register, formState, control } = useForm({
+        defaultValues: {
+          test: [{ value: 'a' }, { value: 'b' }],
+        },
+      });
+      const { fields, replace } = useFieldArray({
+        control,
+        name: 'test',
+      });
+
+      touched = formState.touchedFields;
+
+      return (
+        <form>
+          {fields.map((field, i) => (
+            <input key={field.id} {...register(`test.${i}.value`)} />
+          ))}
+          <button type={'button'} onClick={() => replace([{ value: 'a' }])}>
+            replace
+          </button>
+        </form>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.blur(screen.getAllByRole('textbox')[0]);
+    fireEvent.blur(screen.getAllByRole('textbox')[1]);
+
+    expect(touched).toEqual({
+      test: [{ value: true }, { value: true }],
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(touched).toEqual({
+      test: [{ value: true }],
+    });
+  });
+
   it('should not affect other formState during replace action', () => {
     const ControlledInput = ({ index }: { index: number }) => {
       const { field } = useController({

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -362,10 +362,11 @@ export function useFieldArray<
     control._setFieldArray(
       name,
       [...updatedFieldArrayValues],
-      <T>(data: T): T => data,
+      (data: unknown) =>
+        Array.isArray(data)
+          ? data.slice(0, updatedFieldArrayValues.length)
+          : data,
       {},
-      true,
-      false,
     );
   };
 


### PR DESCRIPTION
Replacing a field array with a shorter one kept `formState.errors` and `formState.touchedFields` entries for rows that no longer exist.

Repro: three-row array with a `required` rule on each row, trigger validation, then `replace([{ value: 'valid' }])`. Before: `errors.test` still holds three entries (and `touchedFields` keeps both rows after a 2-to-1 replace), even though only one row is left. The ghosts linger until the next validation event, and `isValid` can read `true` while stale errors are still present.

`replace()` was the only array operation passing `shouldUpdateFieldsAndState: false` to `control._setFieldArray`, so the block that keeps field registrations, errors and touched state in sync with array operations was skipped entirely. (The same gap in `update()` was fixed in #13650.)

The fix passes a truncating sync method so `_setFieldArray` trims per-row state to the new array length. Same-length replaces are untouched — the existing "should not replace errors state" case still passes — and array-level `root` errors are preserved by the existing logic. Replacing with an empty array collapses to the same shapes `remove()` already produces (`{}` errors, `{ test: [] }` touched markers).

Verification: full jest suite passes (122 suites / 1353 tests), `tsc --noEmit` clean, eslint and prettier clean. Added two regression tests in `src/__tests__/useFieldArray/replace.test.tsx`; both fail without the fix.