### PR TITLE
fix(resetField): clear stale validating state for the field

### DIFF
--- a/src/__tests__/useForm/resetField.test.tsx
+++ b/src/__tests__/useForm/resetField.test.tsx
@@ -579,4 +579,66 @@ describe('resetField', () => {
 
     expect(await screen.findByText('valid')).toBeVisible();
   });
+
+  it('should clear stale validating state when reset does not revalidate', async () => {
+    let resolveValidate: (value: boolean) => void;
+
+    const App = () => {
+      const {
+        register,
+        trigger,
+        resetField,
+        getFieldState,
+        formState: { isValidating, validatingFields },
+      } = useForm<{ test: string }>();
+
+      return (
+        <div>
+          <input
+            {...register('test', {
+              validate: async () =>
+                new Promise<boolean>((resolve) => {
+                  resolveValidate = resolve;
+                }),
+            })}
+          />
+          <p>status:{isValidating ? 'validating' : 'idle'}</p>
+          <p>validatingFields:{Object.keys(validatingFields).join(',')}</p>
+          <p>
+            fieldValidating:
+            {getFieldState('test').isValidating ? 'yes' : 'no'}
+          </p>
+          <button type="button" onClick={() => resetField('test')}>
+            resetField
+          </button>
+          <button type="button" onClick={() => trigger('test')}>
+            trigger
+          </button>
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    // default mode: resetField's internal setValue does not start a new
+    // validation pass, so the trigger-started entry would leak without a fix
+    fireEvent.click(screen.getByRole('button', { name: 'trigger' }));
+
+    expect(await screen.findByText('status:validating')).toBeVisible();
+    expect(screen.getByText('validatingFields:test')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'resetField' }));
+
+    expect(await screen.findByText('status:idle')).toBeVisible();
+    expect(screen.getByText('validatingFields:')).toBeInTheDocument();
+    expect(screen.getByText('fieldValidating:no')).toBeInTheDocument();
+
+    // the stale in-flight validator from before resetField finally settles
+    await act(async () => {
+      resolveValidate(true);
+    });
+
+    expect(screen.getByText('status:idle')).toBeInTheDocument();
+    expect(screen.getByText('validatingFields:')).toBeInTheDocument();
+  });
 });

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -1856,6 +1856,8 @@ export function createFormControl<
 
   const resetField: UseFormResetField<TFieldValues> = (name, options = {}) => {
     if (get(_fields, name)) {
+      unset(_formState.validatingFields, name);
+
       if (isUndefined(options.defaultValue)) {
         setValue(name, cloneObject(get(_defaultValues, name)));
       } else {
@@ -1883,7 +1885,10 @@ export function createFormControl<
         _setValid();
       }
 
-      _subjects.state.next({ ..._formState });
+      _subjects.state.next({
+        ..._formState,
+        isValidating: !isEmptyObject(_formState.validatingFields),
+      });
     }
   };
 


### PR DESCRIPTION
Calling resetField while a field has an async validation in flight left its validatingFields entry behind, so formState.isValidating and getFieldState(name).isValidating stayed true even though nothing was pending anymore. unregister and reset already clear this state; resetField was the odd one out.

The clear runs before resetField's internal setValue, so when the reset itself starts a new validation pass the fresh entry is kept and isValidating correctly stays true. The final emit now recomputes isValidating from validatingFields, mirroring unregister.