### PR TITLE
fix: cancel nested delayError timers when a parent is cleared or unregistered

### DIFF
--- a/src/__tests__/useForm/clearErrors.test.tsx
+++ b/src/__tests__/useForm/clearErrors.test.tsx
@@ -434,4 +434,96 @@ describe('clearErrors', () => {
 
     jest.useRealTimers();
   });
+
+  it('should cancel pending delayError timers for nested fields when their parent is cleared', async () => {
+    jest.useFakeTimers();
+
+    const message = 'too long.';
+
+    const App = () => {
+      const {
+        register,
+        clearErrors,
+        formState: { errors },
+      } = useForm<{ parent: { child: string } }>({
+        delayError: 500,
+        mode: 'onChange',
+      });
+
+      return (
+        <div>
+          <input {...register('parent.child', { maxLength: 4 })} />
+          <button type="button" onClick={() => clearErrors('parent')}>
+            clear
+          </button>
+          {errors.parent?.child && <p>{message}</p>}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    // Schedule a delayed error, then clear the parent before the delay elapses.
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '123456' },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  it('should not cancel a pending delayError timer for a field that only shares a name prefix', async () => {
+    jest.useFakeTimers();
+
+    const message = 'too long.';
+
+    const App = () => {
+      const {
+        register,
+        clearErrors,
+        formState: { errors },
+      } = useForm<{ test: string; test1: string }>({
+        delayError: 500,
+        mode: 'onChange',
+      });
+
+      return (
+        <div>
+          <input {...register('test', { maxLength: 4 })} />
+          <input {...register('test1', { maxLength: 4 })} />
+          <button type="button" onClick={() => clearErrors('test')}>
+            clear
+          </button>
+          {errors.test1 && <p>{message}</p>}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.change(screen.getAllByRole('textbox')[1], {
+        target: { value: '123456' },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText(message)).toBeVisible();
+
+    jest.useRealTimers();
+  });
 });

--- a/src/__tests__/useForm/unregister.test.tsx
+++ b/src/__tests__/useForm/unregister.test.tsx
@@ -251,6 +251,52 @@ describe('unregister', () => {
     jest.useRealTimers();
   });
 
+  it('should cancel pending delayError timers for nested fields when their parent is unregistered', async () => {
+    jest.useFakeTimers();
+
+    const message = 'too long.';
+
+    const App = () => {
+      const {
+        register,
+        unregister,
+        formState: { errors },
+      } = useForm<{ parent: { child: string } }>({
+        delayError: 500,
+        mode: 'onChange',
+      });
+
+      return (
+        <div>
+          <input {...register('parent.child', { maxLength: 4 })} />
+          <button type="button" onClick={() => unregister('parent')}>
+            unregister
+          </button>
+          {errors.parent?.child && <p>{message}</p>}
+        </div>
+      );
+    };
+
+    render(<App />);
+
+    // Schedule a delayed error, then unregister the parent before the delay elapses.
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: '123456' },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'unregister' }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
   it('should keep submitting a value retained by keepValue after a disabled field is unregistered', async () => {
     const onSubmit = jest.fn();
 

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -241,6 +241,16 @@ export function createFormControl<
     delete delayErrorCallbacks[name];
   };
 
+  const cancelDelayedErrorTree = (name: InternalFieldName) => {
+    cancelDelayedError(name);
+
+    const prefix = `${name}.`;
+
+    for (const key of Object.keys(delayErrorCallbacks)) {
+      key.startsWith(prefix) && cancelDelayedError(key);
+    }
+  };
+
   const _setValid = async (shouldUpdateValid?: boolean) => {
     if (_state.keepIsValid) {
       return;
@@ -1438,7 +1448,7 @@ export function createFormControl<
 
     if (names) {
       names.forEach((inputName) => {
-        cancelDelayedError(inputName);
+        cancelDelayedErrorTree(inputName);
         unset(_formState.errors, inputName);
         _subjects.state.next({
           name: inputName,
@@ -1601,7 +1611,7 @@ export function createFormControl<
       }
 
       if (!options.keepError) {
-        cancelDelayedError(fieldName);
+        cancelDelayedErrorTree(fieldName);
         unset(_formState.errors, fieldName);
       }
       !options.keepDirty && unset(_formState.dirtyFields, fieldName);


### PR DESCRIPTION
## Proposed Changes

Clearing or unregistering a parent field removes the whole nested error subtree from `errors`, but a pending `delayError` timer for a nested child (keyed by its full path, e.g. `parent.child`) survived and put the error back once the delay elapsed. This adds a `cancelDelayedErrorTree` helper that cancels the exact name plus any nested `name.`-prefixed timers, and uses it in `clearErrors` and `unregister`. The dot boundary keeps sibling fields like `test1` untouched when `test` is cleared.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Self-review

- [x] Added regression tests in `clearErrors.test.tsx` (nested cascade + prefix-boundary guard) and `unregister.test.tsx` (nested cascade); verified they fail without the fix.
- [x] Full jest suite passes (122 suites / 1358 tests), `tsc` and `eslint` clean.