### PR TITLE
fix: refresh criteriaMode flag when form options are updated at runtime

### DIFF
--- a/src/__tests__/useForm/criteriaMode.test.tsx
+++ b/src/__tests__/useForm/criteriaMode.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useForm } from '../../useForm';
+
+describe('criteriaMode', () => {
+  it('should report every error after switching criteriaMode to all at runtime', async () => {
+    let types: string[] = [];
+    let message: unknown = undefined;
+
+    const App = ({ criteriaMode }: { criteriaMode: 'firstError' | 'all' }) => {
+      const { register, formState, trigger } = useForm<{ test: string }>({
+        mode: 'onSubmit',
+        criteriaMode,
+      });
+      const error = formState.errors.test as unknown as
+        | { types?: Record<string, unknown>; message?: unknown }
+        | undefined;
+      types = error && error.types ? Object.keys(error.types) : [];
+      message = error?.message;
+
+      return (
+        <form>
+          <input
+            {...register('test', {
+              minLength: { value: 5, message: 'short' },
+              pattern: { value: /^[0-9]+$/, message: 'num' },
+            })}
+          />
+          <button type="button" onClick={() => trigger('test')}>
+            validate
+          </button>
+        </form>
+      );
+    };
+
+    const { rerender } = render(<App criteriaMode="firstError" />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'ab' } });
+    fireEvent.click(screen.getByText('validate'));
+
+    await waitFor(() => {
+      expect(message).toBe('short');
+    });
+    // firstError mode collects no `types` map
+    expect(types).toEqual([]);
+
+    rerender(<App criteriaMode="all" />);
+    fireEvent.click(screen.getByText('validate'));
+
+    await waitFor(() => {
+      expect(types).toEqual(expect.arrayContaining(['minLength', 'pattern']));
+    });
+  });
+
+  it('should narrow back to the first error after switching criteriaMode to firstError at runtime', async () => {
+    let types: string[] = [];
+    let message: unknown = undefined;
+
+    const App = ({ criteriaMode }: { criteriaMode: 'firstError' | 'all' }) => {
+      const { register, formState, trigger } = useForm<{ test: string }>({
+        mode: 'onSubmit',
+        criteriaMode,
+      });
+      const error = formState.errors.test as unknown as
+        | { types?: Record<string, unknown>; message?: unknown }
+        | undefined;
+      types = error && error.types ? Object.keys(error.types) : [];
+      message = error?.message;
+
+      return (
+        <form>
+          <input
+            {...register('test', {
+              minLength: { value: 5, message: 'short' },
+              pattern: { value: /^[0-9]+$/, message: 'num' },
+            })}
+          />
+          <button type="button" onClick={() => trigger('test')}>
+            validate
+          </button>
+        </form>
+      );
+    };
+
+    const { rerender } = render(<App criteriaMode="all" />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'ab' } });
+    fireEvent.click(screen.getByText('validate'));
+
+    await waitFor(() => {
+      expect(types).toEqual(expect.arrayContaining(['minLength', 'pattern']));
+    });
+
+    rerender(<App criteriaMode="firstError" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'abc' } });
+    fireEvent.click(screen.getByText('validate'));
+
+    await waitFor(() => {
+      expect(types).toEqual([]);
+      expect(message).toBe('short');
+    });
+  });
+});

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -225,7 +225,7 @@ export function createFormControl<
   let _setValidCallId = 0;
   let _resetCallId = 0;
 
-  const shouldDisplayAllAssociatedErrors =
+  let shouldDisplayAllAssociatedErrors =
     _options.criteriaMode === VALIDATION_MODE.all;
 
   const debounce =
@@ -2209,6 +2209,8 @@ export function createFormControl<
         _validationModeAfterSubmit = getValidationModes(
           _options.reValidateMode,
         );
+        shouldDisplayAllAssociatedErrors =
+          _options.criteriaMode === VALIDATION_MODE.all;
       },
     },
     subscribe,


### PR DESCRIPTION
Changing the criteriaMode prop after mount had no effect on validation output.

The shouldDisplayAllAssociatedErrors flag was captured once when the form control was created, while mode and reValidateMode are already refreshed whenever options are assigned. This change refreshes the criteriaMode-derived flag in the same setter, so switching between firstError and all at runtime takes effect on the next validation.

Verified with runtime-switch tests in both directions (firstError to all and back), plus the full test suite, tsc, and eslint.