### PR TITLE
fix(setValue): compare transformed value for dirty state with valueAs/setValueAs

### DIFF
--- a/src/__tests__/useForm/setValue.test.tsx
+++ b/src/__tests__/useForm/setValue.test.tsx
@@ -954,6 +954,68 @@ describe('setValue', () => {
     );
   });
 
+  describe('with value transforms', () => {
+    it('should not mark field dirty when setValueAs output equals the default value', () => {
+      const { result } = renderHook(() =>
+        useForm<{ test: string }>({
+          defaultValues: { test: 'default' },
+        }),
+      );
+      // NOTE: read dirtyFields only (not isDirty): the stale-dirty bug shows
+      // when isDirty is untracked, because then the per-field fallback branch
+      // compares the raw (untransformed) value.
+      result.current.formState.dirtyFields;
+
+      result.current.register('test', {
+        setValueAs: (value: string) => value.trim(),
+      });
+
+      act(() =>
+        result.current.setValue('test', 'default ', { shouldDirty: true }),
+      );
+
+      expect(result.current.formState.dirtyFields).toEqual({});
+    });
+
+    it('should mark field dirty when setValueAs output differs from the default value', () => {
+      const { result } = renderHook(() =>
+        useForm<{ test: string }>({
+          defaultValues: { test: 'default' },
+        }),
+      );
+      result.current.formState.dirtyFields;
+
+      result.current.register('test', {
+        setValueAs: (value: string) => value.trim(),
+      });
+
+      act(() =>
+        result.current.setValue('test', 'changed ', { shouldDirty: true }),
+      );
+
+      expect(result.current.formState.dirtyFields.test).toBeTruthy();
+    });
+
+    it('should not mark field dirty when valueAsNumber output equals the default value', () => {
+      const { result } = renderHook(() =>
+        useForm<{ test: number }>({
+          defaultValues: { test: 25 },
+        }),
+      );
+      result.current.formState.dirtyFields;
+
+      result.current.register('test', { valueAsNumber: true });
+
+      act(() =>
+        result.current.setValue('test', '25' as unknown as number, {
+          shouldDirty: true,
+        }),
+      );
+
+      expect(result.current.formState.dirtyFields).toEqual({});
+    });
+  });
+
   describe('with touched', () => {
     it('should update touched with shouldTouched config', () => {
       const App = () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -943,7 +943,14 @@ export function createFormControl<
     (options.shouldDirty || options.shouldTouch) &&
       updateTouchAndDirty(
         name,
-        fieldValue,
+        field &&
+          field._f &&
+          !field._f.disabled &&
+          (field._f.valueAsNumber ||
+            field._f.valueAsDate ||
+            field._f.setValueAs)
+          ? getFieldValueAs(value, field._f)
+          : fieldValue,
         options.shouldTouch,
         options.shouldDirty,
         !skipRender,


### PR DESCRIPTION
`setValue` with `shouldDirty` compared the raw input against the default, ignoring `setValueAs`/`valueAsNumber` transforms that the `onChange` path applies.

Repro: a field with `setValueAs: trim` and default `'a'`, then `setValue('x', 'a ', { shouldDirty: true })` — the stored value equals the default after trimming, but the field was marked dirty. Typing the same text stayed pristine, so the two paths disagreed.

This passes the transformed value to the dirty check (only when the field configures a transform; everything else is untouched). The bug only shows when `isDirty` is untracked — the tracked path recomputes over stored values and masked it.

Tests: three new cases in `setValue.test.tsx` (`with value transforms`) fail on base and pass with the fix; full suite 1359 green, `tsc` and eslint clean.