### PR TITLE
fix: drop dirty state for rows removed from a field array

### DIFF
--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -10,11 +10,7 @@ import {
 
 import { VALIDATION_MODE } from '../../constants';
 import { Controller } from '../../controller';
-import type {
-  Control,
-  DeepMap,
-  FieldError,
-} from '../../types';
+import type { Control, DeepMap, FieldError } from '../../types';
 import { useController } from '../../useController';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';

--- a/src/__tests__/useFieldArray/remove.test.tsx
+++ b/src/__tests__/useFieldArray/remove.test.tsx
@@ -10,10 +10,15 @@ import {
 
 import { VALIDATION_MODE } from '../../constants';
 import { Controller } from '../../controller';
-import type { Control, DeepMap, FieldError } from '../../types';
+import type {
+  Control,
+  DeepMap,
+  FieldError,
+} from '../../types';
 import { useController } from '../../useController';
 import { useFieldArray } from '../../useFieldArray';
 import { useForm } from '../../useForm';
+import { useFormState } from '../../useFormState';
 import { useWatch } from '../../useWatch';
 import noop from '../../utils/noop';
 
@@ -973,6 +978,63 @@ describe('remove', () => {
     expect(
       (screen.getAllByRole('textbox')[0] as HTMLInputElement).value,
     ).toEqual('111');
+  });
+
+  it('should drop dirty state for removed rows so a re-added row matching defaults is pristine', async () => {
+    type FormValues = {
+      items: { value: string }[];
+    };
+
+    const App = () => {
+      const methods = useForm<FormValues>({
+        defaultValues: { items: [{ value: 'x' }] },
+      });
+      const { fields, append, remove } = useFieldArray({
+        control: methods.control,
+        name: 'items',
+      });
+      // Track only the form-level flag (e.g. a Save button), the way most
+      // apps do — per-field state below is read via getFieldState.
+      const { isDirty } = useFormState({ control: methods.control });
+      const fieldDirty = fields.length
+        ? methods.getFieldState('items.0.value').isDirty
+        : false;
+
+      return (
+        <form>
+          {fields.map((field, index) => (
+            <Controller
+              key={field.id}
+              control={methods.control}
+              name={`items.${index}.value` as const}
+              render={({ field: { ...rest } }) => <input {...rest} />}
+            />
+          ))}
+          <p>{`form-dirty:${isDirty}`}</p>
+          <p>{`field-dirty:${fieldDirty}`}</p>
+          <button type="button" onClick={() => remove(0)}>
+            remove
+          </button>
+          <button type="button" onClick={() => append({ value: 'x' })}>
+            append
+          </button>
+        </form>
+      );
+    };
+
+    render(<App />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'changed' },
+    });
+
+    expect(screen.getByText('field-dirty:true')).toBeVisible();
+
+    fireEvent.click(screen.getByText('remove'));
+    fireEvent.click(screen.getByText('append'));
+
+    expect(screen.getByText('form-dirty:false')).toBeVisible();
+    expect(screen.getByText('field-dirty:false')).toBeVisible();
   });
 
   describe('with resolver', () => {

--- a/src/logic/createFormControl.ts
+++ b/src/logic/createFormControl.ts
@@ -350,6 +350,14 @@ export function createFormControl<
         shouldSetValues && set(_formState.touchedFields, name, touchedFields);
       }
 
+      const dirtyFieldsArray = get(_formState.dirtyFields, name);
+      if (shouldUpdateFieldsAndState && Array.isArray(dirtyFieldsArray)) {
+        const dirtyFields =
+          method(dirtyFieldsArray, args.argA, args.argB) || dirtyFieldsArray;
+
+        shouldSetValues && set(_formState.dirtyFields, name, dirtyFields);
+      }
+
       if (_isTracked('dirtyFields')) {
         _updateDirtyFields();
       }


### PR DESCRIPTION
Removing a field array row kept its `dirtyFields` entry, so a re-added row matching `defaultValues` still reported `isDirty: true` via `getFieldState`.

Repro: one-row array with default `{ value: 'x' }`, change it to `'changed'`, `remove(0)`, then `append({ value: 'x' })`. Before: `getFieldState('items.0.value').isDirty` stays `true` even though values equal defaults (and form-level `isDirty` correctly reads `false`). `remove()` shifts `errors` and `touchedFields` entries through `control._setFieldArray`, but the `dirtyFields` array was only recomputed when something subscribed to it — otherwise the ghost entry lingered.

The fix applies the same array operation to the `dirtyFields` array, mirroring the `errors` block right above it (unconditional, so `getFieldState` readers see correct state even with nothing subscribed). When `dirtyFields` is tracked, the existing full recompute still runs afterwards and overwrites it.

How to test:

1. `npx jest --config ./scripts/jest/jest.config.js src/__tests__/useFieldArray/remove.test.tsx` — the new test `should drop dirty state for removed rows so a re-added row matching defaults is pristine` fails without the fix (`field-dirty:true` lingers) and passes with it.
2. Full `src/__tests__/useFieldArray/` suite (154 tests) and the `formState`/`useFormState`/`getFieldState`/`setValues`/`logic` suites (250 tests) all pass.